### PR TITLE
Reorganizing treeview to make it easier to support keyboard navigation

### DIFF
--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
@@ -116,6 +116,7 @@ export class SideNavComponent{
 
                 this.rootNode = new TreeNode(this, null, null);
                 this.rootNode.children = [appsNode];
+                this.rootNode.isExpanded = true;
 
                 // Need to allow the appsNode to wire up its subscriptions
                 setTimeout(() =>{
@@ -175,6 +176,7 @@ export class SideNavComponent{
 
             this.rootNode = new TreeNode(this, null, null);
             this.rootNode.children = [appNode];
+            this.rootNode.isExpanded = true;
         })
     }
 

--- a/AzureFunctions.AngularClient/src/app/tree-view/app-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/app-node.ts
@@ -421,7 +421,6 @@ export class AppNode extends TreeNode implements Disposable, Removable, CustomSe
     the initialization fails
 */
 export class SlotNode extends AppNode {
-    public showExpandIcon = false;
     constructor(
         sideBar: SideNavComponent,
         siteArmCacheObj: ArmObj<Site>,

--- a/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
@@ -44,7 +44,7 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
         this.newDashboardType = sideNav.configService.isStandalone() ? DashboardType.createApp : null;
         this.inSelectedTree = !!this.newDashboardType;
 
-        this.iconClass = "root-node-collection-icon"
+        this.iconClass = "tree-node-collection-icon"
         this.iconUrl = "images/BulletList.svg";
         this.showExpandIcon = false;
         this.childrenStream.subscribe(children =>{

--- a/AzureFunctions.AngularClient/src/app/tree-view/functions-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/functions-node.ts
@@ -26,6 +26,7 @@ export class FunctionsNode extends TreeNode implements MutableCollection, Dispos
     public title = this.sideNav.translateService.instant(PortalResources.functions);
     public dashboardType = DashboardType.functions;
     public newDashboardType = DashboardType.createFunctionAutoDetect;
+    public nodeClass = "tree-node collection-node";
     public action: Action;
 
     constructor(

--- a/AzureFunctions.AngularClient/src/app/tree-view/proxies-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/proxies-node.ts
@@ -23,6 +23,7 @@ export class ProxiesNode extends TreeNode implements MutableCollection, Disposab
     public title = "Proxies (preview)";
     public dashboardType = DashboardType.proxies;
     public newDashboardType = DashboardType.createProxy;
+    public nodeClass = "tree-node collection-node";
 
     constructor(
         sideNav : SideNavComponent,

--- a/AzureFunctions.AngularClient/src/app/tree-view/proxy-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/proxy-node.ts
@@ -18,7 +18,6 @@ export class ProxyNode extends TreeNode implements CanBlockNavChange, Disposable
     public title = "Proxy";
     public dashboardType = DashboardType.proxy;
     public showExpandIcon = false;
-    public nodeClass = "tree-node proxy-node";
 
     constructor(
         sideNav : SideNavComponent,

--- a/AzureFunctions.AngularClient/src/app/tree-view/slots-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/slots-node.ts
@@ -20,6 +20,7 @@ export class SlotsNode extends TreeNode {
     public dashboardType = DashboardType.slots;
     public newDashboardType = DashboardType.createSlot;
     public title = this.sideNav.translateService.instant(PortalResources.appFunctionSettings_slotsOptinSettings);
+    public nodeClass = "tree-node collection-node";
 
     constructor(
         sideNav: SideNavComponent,
@@ -58,5 +59,9 @@ export class SlotsNode extends TreeNode {
 
         this._removeHelper(removeIndex, callRemoveOnChild);
          this.sideNav.cacheService.clearArmIdCachePrefix('/slots');
+    }
+
+    public dispose(newSelectedNode? : TreeNode){
+        this.parent.dispose(newSelectedNode);
     }
 }

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
@@ -1,3 +1,4 @@
+import { TreeViewComponent } from './tree-view.component';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/observable/of';
@@ -54,6 +55,8 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
     public supportsScope = false;
     public disabled = false;
     public inSelectedTree = false;
+
+    public treeView : TreeViewComponent;
 
     constructor(
         public sideNav : SideNavComponent,

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
@@ -56,8 +56,6 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
     public disabled = false;
     public inSelectedTree = false;
 
-    public treeView : TreeViewComponent;
-
     constructor(
         public sideNav : SideNavComponent,
         public resourceId : string,

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.html
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.html
@@ -1,68 +1,61 @@
-<ul class="tree">
-  <li *ngFor="let child of node.children"
-    [class.selected-first-level-node]="level === 1 && child.inSelectedTree && !showTryView"
-    [class.try-root-node]="level === 0 && showTryView">
+<div *ngIf="level > 0"
+     class="tree-node"
+     [style.padding-left]="paddingLeft"
+     [class]="node.nodeClass"
+     [class.clickable]="!node.disabled"
+     [class.selected]="node.sideNav && node.sideNav.resourceId === node.resourceId"
+     [class.try-root-node]="level === 0 && showTryView"
+     (mouseenter)="node.showMenu = true"
+     (mouseleave)="node.showMenu = false"
+     (click)="node.select()">
 
-    <div (mouseenter)="child.showMenu = true"
-         (mouseleave)="child.showMenu = false"
-         [class]="child.nodeClass"
-         [class.clickable]="!child.disabled"
-         [class.tree-node-selected]="child.sideNav && child.sideNav.resourceId === child.resourceId"
-         (click)="child.select()">
+  <!-- Expand node icon -->
+  <i *ngIf="node.showExpandIcon"
+    class="fa"
+    [class.fa-caret-right]="!node.isExpanded"
+    [class.fa-caret-down]="node.isExpanded"
+    (click)="node.toggle($event)"></i>
 
-        <span class="tree-node-content" [style.margin-left]="margin">
+  <!-- Custom icon per node -->
+  <i *ngIf="node.iconClass" [class]="node.iconClass">
+    <img *ngIf="node.iconUrl" [src]="node.iconUrl" />
+  </i>
 
-            <!-- Expand node icon -->
-            <i *ngIf="child.showExpandIcon"
-              class="fa"
-              [class.fa-caret-right]="!child.isExpanded"
-              [class.fa-caret-down]="child.isExpanded"
-              (click)="child.toggle($event)"></i>
+  {{node.title}}
 
-            <!-- Custom icon per node -->
-            <i *ngIf="child.iconClass" [class]="child.iconClass">
-              <img *ngIf="child.iconUrl" [src]="child.iconUrl" />
-            </i>
+  <i *ngIf="node.isLoading" class="fa fa-refresh fa-spin fa-fw margin-bottom"></i>
 
-            <span [class.tree-node-disabled]="child.disabled" class="tree-node-title">
-                  {{ child.title }}
-            </span>
+  <!-- Optional menu icons that show up on right side of each node -->
+  <span class="tree-node-menu">
 
-            <!-- Loading icon right.  Only shows if expanded or root -->
-            <i *ngIf="child.isLoading" class="fa fa-refresh fa-spin fa-fw margin-bottom"></i>
+    <span *ngIf="node.showMenu || node.inSelectedTree">
+      
+      <i *ngIf="node.disabled"
+        class="fa fa-info-circle"
+        title="You either do not have access to this app or there are orphaned slots associated with it"></i>
 
-            <!-- Optional menu icons that show up on right side of each node -->
-            <span class="tree-node-menu">
+      <i *ngIf="!!node.newDashboardType"
+          (click)="node.openCreateNew($event)"
+          class="fa fa-plus"
+          title="New"></i>
 
-              <span *ngIf="child.showMenu || child.inSelectedTree">
-                <i *ngIf="child.disabled"
-                  class="fa fa-info-circle"
-                  title="You either do not have access to this app or there are orphaned slots associated with it"></i>
+      <i *ngIf="node.supportsRefresh"
+        (click)="node.refresh($event)"
+        class="fa fa-refresh tree-node-refresh-icon"
+        title="Refresh"></i>
 
-                <i *ngIf="!!child.newDashboardType"
-                    (click)="child.openCreateNew($event)"
-                    class="fa fa-plus"
-                    title="New"></i>
+      <i *ngIf="node.supportsScope && !showTryView"
+        class="fa fa-angle-double-right tree-node-scope-icon"
+        (click)="node.scopeToNode()"
+        title="Scope to this app"></i>
+    </span>
+  </span>
+</div>
 
-                <i *ngIf="child.supportsRefresh"
-                  (click)="child.refresh($event)"
-                  class="fa fa-refresh tree-node-refresh-icon"
-                  title="Refresh"></i>
+<hr *ngIf="level === 1 && !showTryView" class="tree-node-separator" />
 
-                <i *ngIf="child.supportsScope && !showTryView"
-                  class="fa fa-angle-double-right tree-node-scope-icon"
-                  (click)="child.scopeToNode()"
-                  title="Scope to this app"></i>
-              </span>
-            </span>
-        </span>
-    </div>
-
-    <hr *ngIf="level === 0 && !showTryView" class="tree-node-separator" />
-
-    <!-- Child nodes in the tree if the current node expands -->
-    <div *ngIf="child.isExpanded" [class.tree-node-children]="level === 0">
-      <tree-view [node]="child" [levelInput]="level + 1"></tree-view>
-    </div>
-  </li>
-</ul>
+<div *ngIf="node.isExpanded" [class.top-level-children]="level === 1">
+  <tree-view *ngFor="let child of node.children"
+              [node]="child"
+              [levelInput]="level + 1"></tree-view>
+</div>

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.scss
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.scss
@@ -1,103 +1,50 @@
 @import '../../sass/main';
 
-.fa-caret-right{
-    margin-left: 2px;
-}
-
-.tree{
-    margin: 0px;
-    list-style-type: none;
-    padding-left: 0px;
-    line-height: 25px;
-
-    li{
-        list-style-type: none;
-    }
-}
-
-hr.tree-node-separator{
-    width: 90%;
-    margin: 0px 10px;
-    border-top: $border;
-    border-top-color: darken($border-color, 10%);
-}
-
-.selected-first-level-node{
-    background-color: $body-bg-color;
-    border-top: $border;
-    border-bottom: $border;
-    margin-right: 1px;
-}
-
-.try-root-node{
-    @extend .selected-first-level-node;
-    padding-top: 5px;
-}
-
-// Styles for regular nodes
 .tree-node{
     height: 34px;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+    padding-top: 8px;
+    cursor: pointer;
     position: relative;
-    padding-top: 4px;
-
-    .tree-node-content{
-        top: 2px;
-
-        .fa.fa-caret-right, .fa.fa-caret-down{
-            font-size: 18px;
-            vertical-align: middle;
-        }
-
-        .fa.fa-caret-right{
-            margin-right: 2px;
-        }
-    }
 
     &:hover{
         background-color: $tree-node-hover-color;
     }
-}
 
-.app-node{
-    padding-right: 51px;
-}
+    &.selected{
+        background-color: $tree-node-selection-color;
+    }
 
-.proxy-node{
-    padding-right: 10px;
-}
+    .fa.fa-caret-right, .fa.fa-caret-down{
+        font-size: 18px;
+        vertical-align: middle;
+    }
 
-.tree-node-selected{
-    background-color: $tree-node-selection-color !important;
-}
+    .fa.fa-caret-down{
+        margin-left: 2px;
+    }
 
-.tree-node-advanced-enabled{
-    color : $primary-color;
-}
+    .fa.fa-caret-right{
+        margin-right: 2px;
+        margin-left: 4px;
+    }
 
-.tree-node-children{
-    max-height: calc(100% - 104px);
-    width: $sidenav-width;
-    overflow-y: auto;
-    position: absolute;
-    margin-top: 1px;
-}
+    &.app-node{
+        padding-right: 51px;
+    }
 
-.tree-node-disabled{
-    color : darken($border-color, 30%);
-}
-
-.tree-node-title{
-    margin-left: 2px;
+    &.collection-node{
+        padding-right: 22px;
+    }
 }
 
 .tree-node-menu{
-    margin-right: 10px;
     font-size: 20px;
     color: $primary-color;
     position: absolute;
+    top: 4px;
     right: 5px;
 
     i{
@@ -107,6 +54,20 @@ hr.tree-node-separator{
             color: $primary-color-hover;
         }
     }
+}
+
+.top-level-children{
+    max-height: calc(100% - 109px);
+    overflow-y: auto;
+    position: absolute;
+    width: 100%;
+}
+
+hr.tree-node-separator{
+    width: 90%;
+    margin: 0px 10px;
+    border-top: $border;
+    border-top-color: darken($border-color, 10%);
 }
 
 .tree-node-function-edit-icon{
@@ -144,9 +105,4 @@ hr.tree-node-separator{
         margin-top: -1px;
         margin-left: 2px;
     }
-}
-
-.root-node-collection-icon{
-    @extend .tree-node-collection-icon;
-    margin-left: 5px;
 }

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.ts
@@ -12,7 +12,7 @@ import {TreeNode} from './tree-node';
 
 export class TreeViewComponent{
     node : TreeNode;
-    margin : string;
+    paddingLeft : string;
     level : number;
 
     public showTryView = false;
@@ -22,12 +22,12 @@ export class TreeViewComponent{
     }
 
     set levelInput(level : number){
-        if(level >= 1){
-            let margin = level * 11;
-            this.margin = margin + "px";
+        if(level > 2){
+            let padding = level * 10 - 10;
+            this.paddingLeft = padding + "px";
         }
         else{
-            this.margin = "5px";
+            this.paddingLeft = "10px";
         }
 
         this.level = level;


### PR DESCRIPTION
Currently the TreeView component has a 1 to many relationship with Tree-Nodes.  In order to support keyboard navigation, we need to be able to isolate the UI which represents each node in the tree.  The current design makes this difficult so I reorganized it a bit so that there will be a 1:1 relationship between TreeView components and TreeNode objects.  Overall  I think the new design is also bit simpler.

I tested the Try experience with Chrome, and the normal Ibiza experience with Chrome, Firefox, and Edge and it seems to be fine.