### PR TITLE
Adding support in portal service to handle query strings

### DIFF
--- a/AzureFunctions.AngularClient/src/app/shared/Utilities/url.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/Utilities/url.ts
@@ -1,0 +1,21 @@
+export class Url{
+    public static getParameterByName(url, name) {
+        if (url === null) {
+            url = window.location.href;
+        }
+
+        name = name.replace(/[\[\]]/g, '\\$&');
+        let regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)');
+        let results = regex.exec(url);
+
+        if (!results) {
+            return null;
+        }
+
+        if (!results[2]) {
+            return '';
+        }
+
+        return decodeURIComponent(results[2].replace(/\+/g, ' '));
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/shared/function-app.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/function-app.ts
@@ -262,35 +262,6 @@ export class FunctionApp {
             .retryWhen(this.retryAntares);
     }
 
-    getParameterByName(url, name) {
-        if (url === null) {
-            url = window.location.href;
-        }
-
-        name = name.replace(/[\[\]]/g, '\\$&');
-        let regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)');
-        let results = regex.exec(url);
-
-        if (!results) {
-            return null;
-        }
-
-        if (!results[2]) {
-            return '';
-        }
-
-        return decodeURIComponent(results[2].replace(/\+/g, ' '));
-    }
-
-    //setScmParams(fc: FunctionContainer) {
-    //     this._scmUrl = `https://${fc.properties.hostNameSslStates.find(s => s.hostType === 1).name}`;
-    //     this.mainSiteUrl = `https://${fc.properties.defaultHostName}`;
-    //     this.siteName = fc.name;
-    //     if (fc.tryScmCred != null) {
-    //         this._globalStateService.ScmCreds = fc.tryScmCred;
-    //     }
-    // }
-
     getFunctions() {
         return this._cacheService.get(`${this._scmUrl}/api/functions`, false, this.getScmSiteHeaders())
             .catch(e => this._http.get(`${this._scmUrl}/api/functions`, { headers: this.getScmSiteHeaders() }))

--- a/AzureFunctions.AngularClient/src/app/shared/services/portal.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/portal.service.ts
@@ -1,3 +1,4 @@
+import { Url } from './../Utilities/url';
 import {Injectable} from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -47,8 +48,7 @@ export class PortalService {
 
     initializeIframe(): void {
 
-        this.shellSrc = window.location.search.match(/=(.+)/)[1];
-
+        this.shellSrc = Url.getParameterByName(window.location.href, "trustedAuthority");
         window.addEventListener(Verbs.message, this.iframeReceivedMsg.bind(this), false);
 
         let appsvc = window.appsvc;


### PR DESCRIPTION
Related to #1443

If we pass a query string on portal load, we need to make sure we're parsing the trustedAuthority properly or postMessages back to Ibiza won't work.