### PR TITLE
Fixes: 1411 - [Accessibility] Add keyboard navigation to side nav

### DIFF
--- a/AzureFunctions.AngularClient/src/app/search-box/search-box.component.html
+++ b/AzureFunctions.AngularClient/src/app/search-box/search-box.component.html
@@ -4,7 +4,8 @@
            [class.has-value]="!!value && warning"
            [(ngModel)]="value"
            placeholder="{{placeholder}}"
-           (keyup)="onKeyUp($event)" />
+           (keyup)="onKeyUp($event)"
+           #searchTextBox/>
     <span class="right">
         <i *ngIf="value" class="fa fa-times" (click)="onClearClick($event)"></i>
     </span>

--- a/AzureFunctions.AngularClient/src/app/search-box/search-box.component.ts
+++ b/AzureFunctions.AngularClient/src/app/search-box/search-box.component.ts
@@ -1,4 +1,4 @@
-import { Component, Output, Input } from '@angular/core';
+import { Component, Output, Input, ViewChild } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 
 @Component({
@@ -13,7 +13,10 @@ export class SearchBoxComponent {
     @Output() onInputChange = new Subject<string>();
     @Output() onClear = new Subject<void>();
 
-  constructor() { }
+    @ViewChild('searchTextBox') searchTextBox;
+
+
+  constructor() {}
 
   onKeyUp(event: any) {
       if (event.keyCode === 27) { // ESC
@@ -26,6 +29,10 @@ export class SearchBoxComponent {
   onClearClick(event: any) {
       this.value = "";
       this.onClear.next(null);
+  }
+
+  focus(){
+    this.searchTextBox.nativeElement.focus();
   }
 
 }

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -116,3 +116,11 @@ export class Order {
         'ExternalTable-'
     ]
 }
+
+export class KeyCodes{
+    public static enter = 13;
+    public static arrowLeft = 37;
+    public static arrowUp = 38;
+    public static arrowRight = 39;
+    public static arrowDown = 40;
+}

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -118,9 +118,9 @@ export class Order {
 }
 
 export class KeyCodes{
-    public static enter = 13;
-    public static arrowLeft = 37;
-    public static arrowUp = 38;
-    public static arrowRight = 39;
-    public static arrowDown = 40;
+    public static readonly enter = 13;
+    public static readonly arrowLeft = 37;
+    public static readonly arrowUp = 38;
+    public static readonly arrowRight = 39;
+    public static readonly arrowDown = 40;
 }

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.html
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.html
@@ -19,7 +19,12 @@
     </div>
 
     <!--<div *ngIf="selectedSubscriptions.length > 0">-->
-    <div tabindex="0" #treeViewContainer id="tree-view-container">
+    <div tabindex="0"
+         #treeViewContainer
+         id="tree-view-container"
+         (focus)="onFocus($event)"
+         (blur)="onBlur($event)"
+         (keydown)="onKeyDown($event)">
         <tree-view *ngIf="rootNode" [node]="rootNode" [levelInput]="0"></tree-view>
     </div>
 

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.html
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.html
@@ -7,9 +7,7 @@
                     [value]="searchTerm"
                     [placeholder]="'search' | translate"
                     [warning]="true">
-        </search-box>        
-
-
+        </search-box>
 
         <div id="sidenav-subs">
             <multi-drop-down
@@ -21,7 +19,7 @@
     </div>
 
     <!--<div *ngIf="selectedSubscriptions.length > 0">-->
-    <div>
+    <div tabindex="0" #treeViewContainer id="tree-view-container">
         <tree-view *ngIf="rootNode" [node]="rootNode" [levelInput]="0"></tree-view>
     </div>
 

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.scss
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.scss
@@ -25,12 +25,16 @@
     }
 }
 
-
-
 #sidenav-subs{
     margin-top: 5px;
 }
 
 :host /deep/ multi-drop-down .multi-drop-down-container{
     width: $sidenav-width;
+}
+
+#tree-view-container{
+    &:focus{
+        outline: none;
+    }
 }

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
@@ -1,6 +1,6 @@
 import { SearchBoxComponent } from './../search-box/search-box.component';
 import { TreeNodeIterator } from './../tree-view/tree-node-iterator';
-import { Component, OnInit, EventEmitter, OnDestroy, Output, Input, ViewChild, Renderer2, AfterViewInit } from '@angular/core';
+import { Component, OnInit, EventEmitter, OnDestroy, Output, Input, ViewChild, AfterViewInit } from '@angular/core';
 import {Http} from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -46,7 +46,7 @@ import {SlotsService} from './../shared/services/slots.service';
   styleUrls: ['./side-nav.component.scss'],
   inputs: ['tryFunctionAppInput']
 })
-export class SideNavComponent implements OnInit, AfterViewInit {
+export class SideNavComponent implements AfterViewInit {
     @Output() treeViewInfoEvent: EventEmitter<TreeViewInfo>;
     @ViewChild('treeViewContainer') treeViewContainer;
     @ViewChild(SearchBoxComponent) searchBox : SearchBoxComponent;
@@ -98,8 +98,7 @@ export class SideNavComponent implements OnInit, AfterViewInit {
         public portalService : PortalService,
         public languageService : LanguageService,
         public authZService : AuthzService,
-        public slotsService: SlotsService,
-        private _renderer: Renderer2){
+        public slotsService: SlotsService){
 
         this.treeViewInfoEvent = new EventEmitter<TreeViewInfo>();
 
@@ -190,12 +189,6 @@ export class SideNavComponent implements OnInit, AfterViewInit {
         })
     }
 
-    ngOnInit() {
-        this._renderer.listen(this.treeViewContainer.nativeElement, 'focus', this._onFocus.bind(this));
-        this._renderer.listen(this.treeViewContainer.nativeElement, 'blur', this._onBlur.bind(this));
-        this._renderer.listen(this.treeViewContainer.nativeElement, 'keydown', this._onKeyDown.bind(this));
-    }
-
     ngAfterViewInit(){
         // Search box is not available for Try Functions
         if(this.searchBox){
@@ -203,7 +196,7 @@ export class SideNavComponent implements OnInit, AfterViewInit {
         }
     }
 
-    private _onFocus(event : FocusEvent){
+    onFocus(event : FocusEvent){
         if(!this._focusedNode){
             this._focusedNode = this.rootNode.children[0];
             this._iterator = new TreeNodeIterator(this._focusedNode);
@@ -212,7 +205,7 @@ export class SideNavComponent implements OnInit, AfterViewInit {
         this._focusedNode.isFocused = true;
     }
 
-    private _onBlur(event : FocusEvent){
+    onBlur(event : FocusEvent){
         if(this._focusedNode){
 
             // Keep the focused node around in case user navigates back to it
@@ -220,7 +213,7 @@ export class SideNavComponent implements OnInit, AfterViewInit {
         }
     }
 
-    private _onKeyDown(event : KeyboardEvent){
+    onKeyDown(event : KeyboardEvent){
         if(event.keyCode === KeyCodes.arrowDown){
             this._moveDown();
         }

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit, EventEmitter, OnDestroy, Output, Input } from '@angular/core';
+import { SearchBoxComponent } from './../search-box/search-box.component';
+import { TreeNodeIterator } from './../tree-view/tree-node-iterator';
+import { Component, OnInit, EventEmitter, OnDestroy, Output, Input, ViewChild, Renderer2, AfterViewInit } from '@angular/core';
 import {Http} from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -13,7 +15,7 @@ import { FunctionApp } from './../shared/function-app';
 import { PortalResources } from './../shared/models/portal-resources';
 import { AuthzService } from './../shared/services/authz.service';
 import { LanguageService } from './../shared/services/language.service';
-import { Arm } from './../shared/models/constants';
+import { Arm, KeyCodes } from './../shared/models/constants';
 import { SiteDescriptor, Descriptor } from './../shared/resourceDescriptors';
 import { PortalService } from './../shared/services/portal.service';
 import { ArmArrayResult } from './../shared/models/arm/arm-obj';
@@ -44,8 +46,10 @@ import {SlotsService} from './../shared/services/slots.service';
   styleUrls: ['./side-nav.component.scss'],
   inputs: ['tryFunctionAppInput']
 })
-export class SideNavComponent{
+export class SideNavComponent implements OnInit, AfterViewInit {
     @Output() treeViewInfoEvent: EventEmitter<TreeViewInfo>;
+    @ViewChild('treeViewContainer') treeViewContainer;
+    @ViewChild(SearchBoxComponent) searchBox : SearchBoxComponent;
 
     public rootNode : TreeNode;
     public subscriptionOptions: DropDownElement<Subscription>[] = [];
@@ -57,10 +61,13 @@ export class SideNavComponent{
 
     public searchTerm = "";
     public hasValue = false;
+    public tryFunctionApp : FunctionApp;
 
     public selectedNode : TreeNode;
     public selectedDashboardType : DashboardType;
-    public firstLevelOrDescendentIsSelected : boolean;
+
+    private _focusedNode : TreeNode;    // For keyboard navigation
+    private _iterator : TreeNodeIterator;
 
     private _savedSubsKey = "/subscriptions/selectedIds";
     private _subscriptionsStream = new ReplaySubject<Subscription[]>(1);
@@ -69,8 +76,6 @@ export class SideNavComponent{
     private _initialized = false;
 
     private _tryFunctionAppStream = new Subject<FunctionApp>();
-    // public tryFunctions = false;
-    public tryFunctionApp : FunctionApp;
 
     set tryFunctionAppInput(functionApp : FunctionApp){
         if(functionApp){
@@ -93,7 +98,8 @@ export class SideNavComponent{
         public portalService : PortalService,
         public languageService : LanguageService,
         public authZService : AuthzService,
-        public slotsService: SlotsService){
+        public slotsService: SlotsService,
+        private _renderer: Renderer2){
 
         this.treeViewInfoEvent = new EventEmitter<TreeViewInfo>();
 
@@ -108,15 +114,19 @@ export class SideNavComponent{
                 // this.resourceId = !!this.resourceId ? this.resourceId : info.resourceId;
                 this.initialResourceId = info.resourceId;
 
+                this.rootNode = new TreeNode(this, null, null);
+
                 let appsNode = new AppsNode(
                     this,
+                    this.rootNode,
                     this._subscriptionsStream,
                     this._searchTermStream,
                     this.resourceId);
 
-                this.rootNode = new TreeNode(this, null, null);
                 this.rootNode.children = [appsNode];
                 this.rootNode.isExpanded = true;
+
+                appsNode.parent = this.rootNode;
 
                 // Need to allow the appsNode to wire up its subscriptions
                 setTimeout(() =>{
@@ -168,7 +178,7 @@ export class SideNavComponent{
             let appNode = new AppNode(
                 this,
                 this.tryFunctionApp.site,
-                null,
+                this.rootNode,
                 [],
                 false);
 
@@ -178,6 +188,93 @@ export class SideNavComponent{
             this.rootNode.children = [appNode];
             this.rootNode.isExpanded = true;
         })
+    }
+
+    ngOnInit() {
+        this._renderer.listen(this.treeViewContainer.nativeElement, 'focus', this._onFocus.bind(this));
+        this._renderer.listen(this.treeViewContainer.nativeElement, 'blur', this._onBlur.bind(this));
+        this._renderer.listen(this.treeViewContainer.nativeElement, 'keydown', this._onKeyDown.bind(this));
+    }
+
+    ngAfterViewInit(){
+        // Search box is not available for Try Functions
+        if(this.searchBox){
+            this.searchBox.focus();
+        }
+    }
+
+    private _onFocus(event : FocusEvent){
+        if(!this._focusedNode){
+            this._focusedNode = this.rootNode.children[0];
+            this._iterator = new TreeNodeIterator(this._focusedNode);
+        }
+
+        this._focusedNode.isFocused = true;
+    }
+
+    private _onBlur(event : FocusEvent){
+        if(this._focusedNode){
+
+            // Keep the focused node around in case user navigates back to it
+            this._focusedNode.isFocused = false;
+        }
+    }
+
+    private _onKeyDown(event : KeyboardEvent){
+        if(event.keyCode === KeyCodes.arrowDown){
+            this._moveDown();
+        }
+        else if(event.keyCode === KeyCodes.arrowUp){
+            this._moveUp();
+        }
+        else if(event.keyCode === KeyCodes.enter){
+            this._focusedNode.select();
+        }
+        else if(event.keyCode === KeyCodes.arrowRight){
+            if(this._focusedNode.showExpandIcon && !this._focusedNode.isExpanded){
+                this._focusedNode.toggle(event);
+            }
+            else{
+                this._moveDown();
+            }
+        }
+        else if(event.keyCode === KeyCodes.arrowLeft){
+            if(this._focusedNode.showExpandIcon && this._focusedNode.isExpanded){
+                this._focusedNode.toggle(event);
+            }
+            else{
+                this._moveUp();
+            }
+        }
+    }
+
+    private _moveDown(){
+        let nextNode = this._iterator.next();
+        if(nextNode){
+            this._focusedNode.isFocused = false;
+            this._focusedNode = nextNode;
+        }
+
+        this._focusedNode.isFocused = true;
+    }
+
+    private _moveUp(){
+        let prevNode = this._iterator.previous();
+        if(prevNode){
+            this._focusedNode.isFocused = false;
+            this._focusedNode = prevNode;
+        }
+
+        this._focusedNode.isFocused = true;
+    }
+
+    private _changeFocus(node : TreeNode){
+        if(this._focusedNode){
+            this._focusedNode.isFocused = false;
+            node.isFocused = true;
+            this._iterator = new TreeNodeIterator(node);
+            this._focusedNode = node;
+        }
     }
 
     updateView(newSelectedNode : TreeNode, newDashboardType : DashboardType, force? : boolean) : Observable<boolean>{
@@ -213,6 +310,8 @@ export class SideNavComponent{
         this.treeViewInfoEvent.emit(viewInfo);
         this._updateTitle(newSelectedNode);
         this.portalService.closeBlades();
+
+        this._changeFocus(newSelectedNode);
         return newSelectedNode.handleSelection();
     }
 

--- a/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
@@ -35,11 +35,12 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
 
     constructor(
         sideNav: SideNavComponent,
+        rootNode: TreeNode,
         private _subscriptionsStream : Subject<Subscription[]>,
         private _searchTermStream : Subject<string>,
         private _initialResourceId : string) {  // Should only be used for when the iframe is open on a specific app
 
-        super(sideNav, null, null);
+        super(sideNav, null, rootNode);
 
         this.newDashboardType = sideNav.configService.isStandalone() ? DashboardType.createApp : null;
         this.inSelectedTree = !!this.newDashboardType;

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-node-iterator.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-node-iterator.ts
@@ -1,0 +1,84 @@
+import { TreeNode } from './tree-node';
+export class TreeNodeIterator{
+    constructor(private _curNode : TreeNode){
+    }
+
+    public next() : TreeNode{
+
+        // If node has any immediate children
+        if(this._curNode.children.length > 0 && this._curNode.isExpanded){
+            this._curNode = this._curNode.children[0];
+        }
+        else{
+            let curIndex = this._curNode.parent.children.indexOf(this._curNode);
+            
+            // If node has a lower sibling
+            if(curIndex < this._curNode.parent.children.length - 1){
+                this._curNode = this._curNode.parent.children[curIndex + 1];
+            }
+            else if(this._curNode.parent.parent){
+                let nextAncestor = this._findNextAncestor(this._curNode);
+                if(nextAncestor){
+                    this._curNode = nextAncestor;
+                }
+                else{
+                    // You're at the end, but don't set node to null because
+                    // a user may expand the current node, which will allow you
+                    // to continue iterating if called again later.
+                    return null;
+                }
+            }
+            else{
+                return null;
+            }
+        }
+
+        return this._curNode;
+    }
+
+    public previous() : TreeNode{
+        let curIndex = this._curNode.parent.children.indexOf(this._curNode);
+
+        // If node has higher sibling
+        if(curIndex > 0){
+            let prevSibling = this._curNode.parent.children[curIndex - 1];
+            this._curNode = this._findLastDescendant(prevSibling);
+        }
+        else if(this._curNode.parent.parent){
+
+            // Check to make sure we don't set curNode to a parent if it's
+            // the root node which has no UI
+            this._curNode = this._curNode.parent;
+        }
+
+        else{
+            return null;
+        }
+
+        return this._curNode;
+    }
+
+    private _findNextAncestor(curNode : TreeNode) : TreeNode{
+       
+        if(curNode.parent.parent){
+            let parentIndex = curNode.parent.parent.children.indexOf(curNode.parent);
+            if(parentIndex < curNode.parent.parent.children.length - 1){
+                return curNode.parent.parent.children[parentIndex + 1];
+            }
+            else{
+                return this._findNextAncestor(curNode.parent);
+            }
+        }
+
+        return null;
+    }
+
+    private _findLastDescendant(node : TreeNode){
+        if(node.isExpanded && node.children.length > 0){
+            return this._findLastDescendant(node.children[node.children.length-1]);
+        }
+        else{
+            return node;
+        }
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
@@ -55,6 +55,7 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
     public supportsScope = false;
     public disabled = false;
     public inSelectedTree = false;
+    public isFocused = false;
 
     constructor(
         public sideNav : SideNavComponent,

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.html
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.html
@@ -5,6 +5,7 @@
      [class.clickable]="!node.disabled"
      [class.selected]="node.sideNav && node.sideNav.resourceId === node.resourceId"
      [class.try-root-node]="level === 0 && showTryView"
+     [class.focused]="node.isFocused"
      (mouseenter)="node.showMenu = true"
      (mouseleave)="node.showMenu = false"
      (click)="node.select()">

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.scss
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.scss
@@ -9,12 +9,21 @@
     cursor: pointer;
     position: relative;
 
+    // Necessary for getting the bottom/top borders showing when the
+    // first/last node in the tree when the node has keyboard focus
+    margin-top: 1px;
+    margin-bottom: 1px;
+
     &:hover{
         background-color: $tree-node-hover-color;
     }
 
     &.selected{
         background-color: $tree-node-selection-color;
+    }
+
+    &.focused{
+        outline: $border-focus;
     }
 
     .fa.fa-caret-right, .fa.fa-caret-down{

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.spec.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.spec.ts
@@ -1,3 +1,6 @@
+import { StartupInfo } from './../shared/models/portal';
+import { TreeNodeIterator } from './tree-node-iterator';
+import { TreeNode } from './tree-node';
 import { AppModule } from './../app.module';
 /* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
@@ -24,4 +27,117 @@ describe('TreeViewComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should return the next sibling when not expanded', () =>{
+    let root = getMockTree();
+    let iterator = new TreeNodeIterator(root.children[0]);
+
+    let results : string[] = ['a', 'b', null];
+    runTest(root.children[0], results, true /* forward */);
+  })
+
+  it('should return the next siblings children when expanded', () =>{
+    let root = getMockTree();
+    expandAllDescendants(root);
+
+    let results : string[] = ['a', 'a1', 'a2', 'a2x', 'a3', 'b', 'b1', null];
+    runTest(root.children[0], results, true /* forward */);
+  })
+
+  it('should return the previous sibling when not expanded', () =>{
+    let root = getMockTree();
+    let startNode = root.children[root.children.length - 1];
+    let iterator = new TreeNodeIterator(startNode);
+
+    let results : string[] = ['b', 'a', null];
+    runTest(startNode, results, false /* backward */);
+  })
+
+  it('should return the previous siblings descendents when expanded', () =>{
+    let root = getMockTree();
+    expandAllDescendants(root);
+    
+    let startNode = getLastDescendantNode(root);
+    let iterator = new TreeNodeIterator(startNode);
+
+    let results : string[] = ['b1', 'b', 'a3', 'a2x', 'a2', 'a1', 'a', null];
+    runTest(startNode, results, false /* backward */);
+  })
+
+
+  function getMockTree(){
+    let root = new TreeNode(null, null, null);
+    root.title = "root";
+
+    let a = new TreeNode(null, null, root);
+    a.title = "a";
+
+    let a1 = new TreeNode(null, null, a);
+    a1.title = "a1";
+
+    let a2 = new TreeNode(null, null, a);
+    a2.title = "a2";
+
+    let a2x = new TreeNode(null, null, a2);
+    a2x.title = "a2x";
+
+    let a3 = new TreeNode(null, null, a);
+    a3.title = "a3";
+
+    let b = new TreeNode(null, null, root);
+    b.title = "b";
+
+    let b1 = new TreeNode(null, null, b);
+    b1.title = "b1";
+
+    root.children = [a, b];
+    a.children = [a1, a2, a3];
+    a2.children = [a2x];
+    b.children = [b1];
+
+    return root;
+  }
+
+  function runTest(startNode : TreeNode, results : string[], forward : boolean){
+    let iterator = new TreeNodeIterator(startNode);
+    let curNode : TreeNode;;
+    let testNum = 1;
+
+    do{
+      if(forward){
+        curNode = iterator.next();
+      }
+      else{
+        curNode = iterator.previous();
+      }
+
+      if(curNode){
+        expect(curNode.title).toEqual(results[testNum]);
+      }
+      else{
+        expect(results[testNum]).toBeNull();
+      }
+
+      testNum++;
+    }while(curNode && testNum < results.length);
+
+    expect(testNum).toEqual(results.length);
+  }
+
+  function expandAllDescendants(node : TreeNode){
+    node.isExpanded = true;
+
+    node.children.forEach(c => {
+      expandAllDescendants(c);
+    });
+  }
+
+  function getLastDescendantNode(node : TreeNode){
+    if(node.children.length > 0){
+      return getLastDescendantNode(node.children[node.children.length - 1]);
+    }
+    else{
+      return node;
+    }
+  }
 });

--- a/AzureFunctions.AngularClient/src/sass/common/_variables.scss
+++ b/AzureFunctions.AngularClient/src/sass/common/_variables.scss
@@ -8,6 +8,7 @@ $qs-footer-link-color: #9cdcff;
 $chrome-color : #f7f9fa;
 
 $border-selection-color: #419BF3;
+$border-focus: #00bcf2 dashed 1px;
 
 $sidenav-width: 250px;
 $top-bar-height: 40px;


### PR DESCRIPTION
If you click or tab to a node in the tree nav, it will take focus.  From there, you can use the up/down arrow to move up/down in the tree.  Or left/right arrows to collapse/expand a node in the tree.  These actions follow the rules defined for ARIA TreeView navigation controls (https://www.w3.org/WAI/GL/wiki/Using_ARIA_trees).  While it doesn't implement all of the possible actions, it does cover the main ones.

Also for now I'm just focusing on keyboard navigation and am planning on getting to the screen ready support later.

![treeview-keynav](https://user-images.githubusercontent.com/5695405/27038875-1a4fb530-4f41-11e7-81dc-38025302de77.gif)
