### PR TITLE
FW:[HOTFIX] pointing all settings to the new overview blade

### DIFF
--- a/AzureFunctions.AngularClient/src/app/site/site-manage/site-manage.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-manage/site-manage.component.ts
@@ -279,7 +279,7 @@ export class SiteManageComponent {
                 this._translateService.instant(PortalResources.feature_allSettingsInfo),
                 "images/webapp.svg",
                 {
-                    detailBlade : "WebsiteBlade",
+                    detailBlade : "AppsOverviewBlade",
                     detailBladeInputs : {
                         id : site.id
                     }


### PR DESCRIPTION
We have a portal release earlier today that was updated to use the new overview blade - since function still points to the old blade, when we click All settings from 'platform features', the menu blade doesn't show up. The fix is to launch the new overview blade when clicking 'All Settings'