### PR TITLE
Fixes #1255 - Refreshed function list could not update new created function automatically

### DIFF
--- a/AzureFunctions.AngularClient/src/app/api-new/api-new.component.ts
+++ b/AzureFunctions.AngularClient/src/app/api-new/api-new.component.ts
@@ -209,6 +209,9 @@ export class ApiNewComponent implements OnInit {
 
                 this.functionApp.saveApiProxy(ApiProxy.toJson(this.apiProxies, this._translateService)).subscribe(() => {
                     this._globalStateService.clearBusyState();
+                    
+                    // If someone refreshed the app, it would created a new set of child nodes under the app node.
+                    this._proxiesNode = <ProxiesNode>this.appNode.children.find(node => node.title === this._proxiesNode.title);
                     this._proxiesNode.addChild(newApiProxy);
                     this._aiService.trackEvent('/actions/proxy/create');
                 });

--- a/AzureFunctions.AngularClient/src/app/function-new/function-new.component.ts
+++ b/AzureFunctions.AngularClient/src/app/function-new/function-new.component.ts
@@ -274,7 +274,9 @@ export class FunctionNewComponent {
             .subscribe(res => {
                 this._portalService.logAction("new-function", "success", { template: this.selectedTemplate.id, name: this.functionName });
                 this._aiService.trackEvent("new-function", { template: this.selectedTemplate.id, result: "success", first: "false" });
-                // this._broadcastService.broadcast(BroadcastEvent.FunctionAdded, res);
+
+                // If someone refreshed the app, it would created a new set of child nodes under the app node.
+                this.functionsNode = <FunctionsNode>this.appNode.children.find(node => node.title === this.functionsNode.title);
                 this.functionsNode.addChild(res);
                 this._globalStateService.clearBusyState();
             },

--- a/AzureFunctions.AngularClient/src/app/slot-new/slot-new.component.ts
+++ b/AzureFunctions.AngularClient/src/app/slot-new/slot-new.component.ts
@@ -157,7 +157,11 @@ export class SlotNewComponent implements OnInit {
                     true,
                     this._translateService.instant(PortalResources.slotNew_startCreateSuccessNotifyTitle).format(newSlotName));
                 let slotsNode = <SlotsNode>this._viewInfo.node;
+
+                // If someone refreshed the app, it would created a new set of child nodes under the app node.
+                slotsNode = <SlotsNode>this._viewInfo.node.parent.children.find(node => node.title === slotsNode.title);
                 slotsNode.addChild(<ArmObj<Site>>r.json());
+                slotsNode.isExpanded = true;
             }, err => {
                 this._globalStateService.clearBusyState();
                 this._portalService.stopNotification(


### PR DESCRIPTION
If a user refreshes the app after opening the "new function" experience, it will create a new set of nodes in the tree.  However the "new function" component already has a reference to the old "Functions" node, so when it adds a node to it at the end, it doesn't reflect in the UI.

I worked around the problem by making sure we have the latest reference in the tree before adding the new node.  However this doesn't seem like a great solution.  I have to think a bit more on what would be a better solution but for now this seems to work.