### PR TITLE
Fix issue where selecting less subs doesn't update tree properly

### DIFF
--- a/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
@@ -69,6 +69,12 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
             if(!result.subscriptions || result.subscriptions.length === 0){
                 return Observable.of(null);
             }
+
+            // Purposely not calling next on childrenStream because that would cause appsListComponent
+            // to think that loading is complete with empty children, when really you want it to
+            // only update when we get responses from the server.
+            this.children = [];
+
             this.isLoading = true;
             this._subscriptions = result.subscriptions;
             return this._doSearch(<AppNode[]>this.children, result.searchTerm, result.subscriptions, 0, null);


### PR DESCRIPTION
If you have 2 subs selected, then you select only 1 sub, the tree doesn't update to have less items.  This is a regression from my previous commit #1518 