### PR TITLE
Use FrontEndAuthProvider instead of LocalAuthProvider for OnPrem

### DIFF
--- a/AzureFunctions/Authentication/SecurityManager.cs
+++ b/AzureFunctions/Authentication/SecurityManager.cs
@@ -21,7 +21,7 @@ namespace AzureFunctions.Authentication
 
         private static IAuthProvider GetAuthProvider(HttpContextBase context)
         {
-            return context.Request.Url.IsLoopback || _settings.RuntimeType == RuntimeType.OnPrem
+            return context.Request.Url.IsLoopback
                 ? _localhostAuthProvider
                 : _frontEndAuthProvider;
         }

--- a/AzureFunctions/Global.asax.cs
+++ b/AzureFunctions/Global.asax.cs
@@ -79,7 +79,8 @@ namespace AzureFunctions
                 context.Response.End();
                 return;
             }
-            else if (context.Request.Url.AbsolutePath.Equals("/api/ping", StringComparison.OrdinalIgnoreCase))
+
+            if (context.Request.Url.AbsolutePath.Equals("/api/ping", StringComparison.OrdinalIgnoreCase))
             {
                 context.Response.Write("success");
                 context.Response.StatusCode = 200;
@@ -108,7 +109,10 @@ namespace AzureFunctions
                     context.Response.Headers["LoginUrl"] = SecurityManager.GetLoginUrl(context);
                     context.Response.StatusCode = 403; // Forbidden
                 }
-                else if (!isFile && !context.Request.RawUrl.StartsWith("/api/"))
+                // For OnPrem, the Functions portal will always be hosted as part of the Azure portal.
+                // So we don't need to proactively redirect unauthenticated requests to the signin page.
+                // Worry about authentication only when an unauthenticated call is made to a protected API.
+                else if (settings.RuntimeType != RuntimeType.OnPrem && !context.Request.RawUrl.StartsWith("/api/"))
                 {
                     context.Response.RedirectLocation = Environment.GetEnvironmentVariable("ACOM_MARKETING_PAGE") ?? $"{context.Request.Url.GetLeftPart(UriPartial.Authority)}/signin";
                     context.Response.StatusCode = 302;


### PR DESCRIPTION
- LocalAuthProvider is a very primitive implementation. This commit contains changes to start using the FrontEndAuthProvider instead of LocalAuthProvider for OnPrem, just like we do for Azure.

Background:
- The FrontEndAuthProvider relies on either the X-MS-* headers or the 'portal-token' header for authentication
- The X-MS-* are sent by the front end
- 'portal-token' is sent only when running in an iframe within the Azure Portal
- As per the current implementation, unauthenticated calls to protected endpoints (APIs) return 403 and unauthenticated calls to unprotected endpoints that are not APIs (static content) result in a redirect to the marketing page or the signin page. This commit changes this behavior.

Commit description:
- For OnPrem, as the Functions portal will always be hosted in the Azure Stack Portal, we don't want to proactively redirect any unauthenticated calls to unprotected endpoints (APIs and static content) to the signin / marketing page. Instead, we will worry about authentication when a protected endpoint is requested.