### PR TITLE
[Accessibility] Add keyboard navigation to tbl component

### DIFF
--- a/AzureFunctions.AngularClient/AzureFunctions.AngularClient.csproj
+++ b/AzureFunctions.AngularClient/AzureFunctions.AngularClient.csproj
@@ -94,7 +94,6 @@
     <Content Include="src\app\breadcrumbs\breadcrumbs.component.html" />
     <Content Include="src\app\busy-state\busy-state.component.scss" />
     <Content Include="src\app\busy-state\busy-state.component.html" />
-    <Content Include="src\app\controls\tbl\tbl-th\tbl-th.component.scss" />
     <None Include="src\app\copy-pre\copy-pre.component.scss" />
     <Content Include="src\app\controls\click-to-edit\click-to-edit.component.html" />
     <Content Include="src\app\controls\command-bar\command\command.component.html" />

--- a/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.html
+++ b/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.html
@@ -11,7 +11,7 @@
   </tr>
 
   <tr *ngFor="let item of table.items">
-    <td class="link" (click)="clickRow(item)">{{item.title}}</td>
+    <td><span class="link" (click)="clickRow(item)">{{item.title}}</span></td>
     <td>{{item.subscription}}</td>
     <td>{{item.resourceGroup}}</td>
     <td>{{item.location}}</td>    

--- a/AzureFunctions.AngularClient/src/app/controls/tbl/tbl-th/tbl-th.component.scss
+++ b/AzureFunctions.AngularClient/src/app/controls/tbl/tbl-th/tbl-th.component.scss
@@ -1,3 +1,0 @@
-﻿ .chevron{
-    font-size: 11px;
-}

--- a/AzureFunctions.AngularClient/src/app/controls/tbl/tbl-th/tbl-th.component.ts
+++ b/AzureFunctions.AngularClient/src/app/controls/tbl/tbl-th/tbl-th.component.ts
@@ -9,15 +9,14 @@ import { Component, OnInit, Directive, HostListener, Input, ElementRef } from '@
       <i class="fa chevron"
           [class.fa-chevron-up]="table.sortedColName === name && table.sortAscending"
           [class.fa-chevron-down]="(table.sortedColName === name && !table.sortAscending) || !table.sortedColName"></i>
-    </div>`,
-  styleUrls: ['./tbl-th.component.scss']
+    </div>`
 })
 export class TblThComponent implements OnInit {
 
   @Input() name: string;
 
   constructor(
-    public table : TblComponent,
+    public table: TblComponent,
     private _el: ElementRef) {
   }
 
@@ -25,34 +24,34 @@ export class TblThComponent implements OnInit {
   }
 
   ngAfterContentInit() {
-    let element = this._el.nativeElement;
-    if(element.parentElement
+    const element = <HTMLElement>this._el.nativeElement;
+    if (element.parentElement
       && element.parentElement.parentElement
-      && element.parentElement.parentElement.tagName === "TR"){
+      && element.parentElement.parentElement.tagName === 'TR') {
 
-      element.parentElement.parentElement.classList.add("header-row");
+      element.parentElement.parentElement.classList.add('header-row');
     }
   }
 
   sort() {
-    let table = this.table;
+    const table = this.table;
 
     // Make a copy so that we don't sort the original list
-    if(table.items === table.origItems){
+    if (table.items === table.origItems) {
       table.items = [].concat(table.origItems);
     }
 
-    if(table.sortedColName && table.sortedColName === this.name){
+    if (table.sortedColName && table.sortedColName === this.name) {
       table.sortAscending = !table.sortAscending;
     }
-    else{
+    else {
       table.sortedColName = this.name;
       table.sortAscending = true;
     }
 
-    table.items = table.items.sort((a : TblItem, b : TblItem) => {
-      let aCol : any;
-      let bCol : any;
+    table.items = table.items.sort((a: TblItem, b: TblItem) => {
+      let aCol: any;
+      let bCol: any;
 
       aCol = Object.byString(a, this.name);
       bCol = Object.byString(b, this.name);
@@ -60,12 +59,25 @@ export class TblThComponent implements OnInit {
       aCol = typeof aCol === "string" ? aCol : aCol.toString();
       bCol = typeof bCol === "string" ? bCol : bCol.toString();
 
-      if(table.sortAscending){
+      if (table.sortAscending) {
         return aCol.localeCompare(bCol);
       }
-      else{
+      else {
         return bCol.localeCompare(aCol);
       }
-    })
+    });
+  }
+
+  setFocused(isSet: boolean) {
+    const element = <HTMLElement>this._el.nativeElement;
+    if (element.parentElement) {
+      const th = <HTMLTableHeaderCellElement>element.parentElement;
+      if (isSet) {
+        th.classList.add('focused');
+      }
+      else {
+        th.classList.remove('focused');
+      }
+    }
   }
 }

--- a/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
+++ b/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
@@ -111,6 +111,10 @@ export class TblComponent implements OnInit, OnChanges {
       const curCell = this._getCurrentCellOrReset(rows);
       if (curCell) {
         curCell.click();
+
+        setTimeout(() =>{
+          this._setFocusOnCell(rows, this._focusedRowIndex, this._focusedCellIndex);
+        }, 0);
       }
     }
 

--- a/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
+++ b/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
@@ -2,7 +2,7 @@ import { Dom } from './../../shared/Utilities/dom';
 import { KeyCodes } from './../../shared/models/constants';
 import { TblThComponent } from './tbl-th/tbl-th.component';
 import { FormGroup } from '@angular/forms';
-import { Input, OnChanges, SimpleChange, ElementRef, ViewChild, AfterViewInit, ViewChildren, ContentChild, ContentChildren, QueryList } from '@angular/core';
+import { Input, OnChanges, SimpleChange, ElementRef, ViewChild, AfterViewInit, ViewChildren, ContentChild, ContentChildren, QueryList, Inject } from '@angular/core';
 import { Component, OnInit, forwardRef } from '@angular/core';
 
 export interface TblItem {
@@ -90,12 +90,14 @@ export class TblComponent implements OnInit, OnChanges {
       const rows = this._getRows();
       this._clearFocusOnCell(rows, this._focusedRowIndex, this._focusedCellIndex);
       this._setFocusOnCell(rows, this._focusedRowIndex + 1, this._focusedCellIndex);
+      this._scrollIntoView(rows[this._focusedRowIndex]);
 
     } else if (event.keyCode === KeyCodes.arrowUp) {
 
       const rows = this._getRows();
       this._clearFocusOnCell(rows, this._focusedRowIndex, this._focusedCellIndex);
       this._setFocusOnCell(rows, this._focusedRowIndex - 1, this._focusedCellIndex);
+      this._scrollIntoView(rows[this._focusedRowIndex]);
 
     } else if (event.keyCode === KeyCodes.enter) {
 
@@ -126,6 +128,10 @@ export class TblComponent implements OnInit, OnChanges {
     }
 
     return null;
+  }
+
+  private _scrollIntoView(elem: HTMLElement) {
+      Dom.scrollIntoView(elem, window.document.body);
   }
 
   private _getRows() {

--- a/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
+++ b/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
@@ -1,40 +1,190 @@
+import { KeyCodes } from './../../shared/models/constants';
+import { TblThComponent } from './tbl-th/tbl-th.component';
 import { FormGroup } from '@angular/forms';
 import { Input, OnChanges, SimpleChange, ElementRef, ViewChild, AfterViewInit, ViewChildren, ContentChild, ContentChildren, QueryList } from '@angular/core';
-import { Component, OnInit, Directive, ComponentFactoryResolver } from '@angular/core';
+import { Component, OnInit, forwardRef } from '@angular/core';
 
-export interface TblItem{
-  data : any
+export interface TblItem {
+  data: any
+}
+
+interface Coordinates {
+  rowIndex: number;
+  cellIndex: number;
 }
 
 @Component({
   selector: 'tbl',
-  template: `<table [class]="tblClass"><ng-content></ng-content></table>`,
-  exportAs: "tbl"
+  template: `
+  <table
+    #tbl
+    [class]='tblClass'
+    tabindex='0'
+    (focus)='onFocus($event)'
+    (keydown)="onKeyPress($event)">
+      <ng-content></ng-content>
+  </table>`,
+  exportAs: 'tbl'
 })
 export class TblComponent implements OnInit, OnChanges {
-  @Input() tblClass = "tbl";
-
-  public sortedColName : string;
-  public sortAscending : boolean;
-
+  @Input() tblClass = 'tbl';
   @Input() items: TblItem[];
-  private _origItems : any[];
+  @ContentChildren(forwardRef(() => TblThComponent)) headers: QueryList<TblThComponent>;
 
-  constructor(private _componentFactoryResolver: ComponentFactoryResolver) {
+  @ViewChild('tbl') table: ElementRef;
+
+  public sortedColName: string;
+  public sortAscending: boolean;
+
+  private _origItems: any[];
+  private _focusedRowIndex = -1;
+  private _focusedCellIndex = -1;
+
+  constructor() {
   }
 
   ngOnInit() {
   }
 
-  ngOnChanges(changes: {[key: string]: SimpleChange}) {
-      let items = changes['items'];
-      if (items) {
-        this.items = items.currentValue;
-        this._origItems = items.currentValue;
-      }
+  ngOnChanges(changes: { [key: string]: SimpleChange }) {
+    const items = changes['items'];
+    if (items) {
+      this.items = items.currentValue;
+      this._origItems = items.currentValue;
+    }
   }
 
-  get origItems(){
+  onFocus(event: FocusEvent) {
+    if (this._focusedRowIndex === -1 && this._focusedCellIndex === -1) {
+      const rows = this._getRows();
+      if (rows.length > 0) {
+        const row = rows[0];
+
+        const cells = this._getCells(row);
+
+        if (cells.length > 0) {
+          cells[0].classList.add('focused');
+        }
+
+        this._focusedRowIndex = 0;
+        this._focusedCellIndex = 0;
+      }
+    }
+  }
+
+  onKeyPress(event: KeyboardEvent) {
+    if (event.keyCode === KeyCodes.arrowRight) {
+
+      const rows = this._getRows();
+      this._clearFocusOnCell(rows, this._focusedRowIndex, this._focusedCellIndex);
+      this._setFocusOnCell(rows, this._focusedRowIndex, this._focusedCellIndex + 1);
+
+    } else if (event.keyCode === KeyCodes.arrowLeft) {
+
+      const rows = this._getRows();
+      this._clearFocusOnCell(rows, this._focusedRowIndex, this._focusedCellIndex);
+      this._setFocusOnCell(rows, this._focusedRowIndex, this._focusedCellIndex - 1);
+
+    } else if (event.keyCode === KeyCodes.arrowDown) {
+
+      const rows = this._getRows();
+      this._clearFocusOnCell(rows, this._focusedRowIndex, this._focusedCellIndex);
+      this._setFocusOnCell(rows, this._focusedRowIndex + 1, this._focusedCellIndex);
+
+    } else if (event.keyCode === KeyCodes.arrowUp) {
+
+      const rows = this._getRows();
+      this._clearFocusOnCell(rows, this._focusedRowIndex, this._focusedCellIndex);
+      this._setFocusOnCell(rows, this._focusedRowIndex - 1, this._focusedCellIndex);
+
+    }
+
+    event.preventDefault();
+  }
+
+  private _getRows() {
+    return (<HTMLTableElement>this.table.nativeElement).querySelectorAll('tr');
+  }
+
+  private _getCells(row: HTMLTableRowElement) {
+    const cells = row.querySelectorAll('th');
+    return cells.length > 0 ? cells : row.querySelectorAll('td');
+  }
+
+  private _clearFocusOnCell(
+    rows: NodeListOf<HTMLTableRowElement>,
+    rowIndex: number,
+    cellIndex: number){
+
+    let srcRow: HTMLTableRowElement;
+    const coordinates: Coordinates = {
+      rowIndex: -1,
+      cellIndex: -1
+    };
+
+    if (rowIndex >= 0 && rowIndex < rows.length) {
+      srcRow = rows[rowIndex];
+    }
+
+    if (srcRow) {
+      const srcCells = this._getCells(srcRow);
+
+      if (cellIndex >= 0 && cellIndex < srcCells.length) {
+        srcCells[cellIndex].classList.remove('focused');
+      }
+    }
+  }
+
+  private _setFocusOnCell(
+    rows: NodeListOf<HTMLTableRowElement>,
+    rowIndex: number,
+    cellIndex: number
+  ){
+    let destRow: HTMLTableRowElement;
+    let finalRowIndex = -1;
+    let finalCellIndex = -1;
+
+    if (rowIndex >= 0 && rowIndex < rows.length) {
+      finalRowIndex = rowIndex;
+      destRow = rows[finalRowIndex];
+    } else if (rows.length > 0) {
+      if (rowIndex === -1) {
+        finalRowIndex = 0;
+        destRow = rows[0];
+      } else {
+        finalRowIndex = rows.length - 1;
+        destRow = rows[finalRowIndex];
+      }
+    }
+
+    if (destRow) {
+      const destCells = this._getCells(destRow);
+      let destCell: HTMLTableCellElement;
+
+      if (cellIndex >= 0 && cellIndex < destCells.length) {
+        finalCellIndex = cellIndex;
+        destCell = destCells[finalCellIndex];
+      } else if (destCells.length > 0) {
+        if (cellIndex === -1) {
+          finalCellIndex = 0;
+          destCell = destCells[0];
+        } else {
+          finalCellIndex = destCells.length - 1;
+          destCell = destCells[finalCellIndex];
+        }
+
+      }
+
+      if (destCell) {
+        destCell.classList.add('focused');
+      }
+    }
+
+    this._focusedRowIndex = finalRowIndex;
+    this._focusedCellIndex = finalCellIndex;
+  }
+
+  get origItems() {
     return this._origItems;
   }
 }

--- a/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
+++ b/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
@@ -52,7 +52,11 @@ export class TblComponent implements OnInit, OnChanges {
     }
   }
 
+  // Gets called if a user either "tabs" over to a table, or clicks somewhere
+  // within the table.
   onFocus(event: FocusEvent) {
+
+    // If the table hasn't received focus yet
     if (this._focusedRowIndex === -1 && this._focusedCellIndex === -1) {
       this._focusedRowIndex = 0;
       this._focusedCellIndex = 0;
@@ -65,6 +69,9 @@ export class TblComponent implements OnInit, OnChanges {
     }
   }
 
+  // Gets called if a user "tabs" or clicks away from a table.  In this case
+  // we'll keep the currently selected cells state but just remove the focus
+  // on it.
   onBlur(event?: FocusEvent) {
     const rows = this._getRows();
     const curCell = this._getCurrentCellOrReset(rows);
@@ -73,11 +80,15 @@ export class TblComponent implements OnInit, OnChanges {
     }
   }
 
-  // For now we'll just hide the focused element on click.
+  // Gets called specifically on click for a table.  For now we'll just
+  // hide the focused element on click.
   onClick(e: MouseEvent){
     this.onBlur(null);
   }
 
+  // Gets called for any keypresses that occur whenever the focus is currently
+  // on the table.  Most of the handling here should be for keyboard navigation
+  // like up/down/left/right and enter keys.
   onKeyPress(event: KeyboardEvent) {
     if (event.keyCode === KeyCodes.arrowRight) {
 
@@ -118,11 +129,14 @@ export class TblComponent implements OnInit, OnChanges {
       }
     }
 
+    // Only allow "tab" key events to bubble outside of table
     if (event.keyCode !== KeyCodes.tab) {
       event.preventDefault();
     }
   }
 
+  // Get the current selected cell from list of rows.  If the table has
+  // changed for some reason and the cell doesn't exist, then just reset the selection.
   private _getCurrentCellOrReset(rows: NodeListOf<HTMLTableRowElement>) {
     if (this._focusedRowIndex >= 0 && this._focusedRowIndex < rows.length) {
       const rowCells = this._getCells(rows[this._focusedRowIndex]);
@@ -148,6 +162,7 @@ export class TblComponent implements OnInit, OnChanges {
     return (<HTMLTableElement>this.table.nativeElement).querySelectorAll('tr');
   }
 
+  // Grab either TH or TD cells
   private _getCells(row: HTMLTableRowElement) {
     const cells = row.querySelectorAll('th');
     return cells.length > 0 ? cells : row.querySelectorAll('td');
@@ -179,6 +194,10 @@ export class TblComponent implements OnInit, OnChanges {
     cellIndex: number
   ) {
     let destRow: HTMLTableRowElement;
+
+    // We have to recompute the "final" row and cell indices because it's
+    // possible that the table has changed since the last time we set
+    // rowIndex/cellIndex.
     let finalRowIndex = -1;
     let finalCellIndex = -1;
 
@@ -186,6 +205,8 @@ export class TblComponent implements OnInit, OnChanges {
       finalRowIndex = rowIndex;
       destRow = rows[finalRowIndex];
     } else if (rows.length > 0) {
+      // The # of rows in table has changed and rowIndex no longer exists.
+
       if (rowIndex === -1) {
         finalRowIndex = 0;
         destRow = rows[0];
@@ -203,6 +224,9 @@ export class TblComponent implements OnInit, OnChanges {
         finalCellIndex = cellIndex;
         destCell = destCells[finalCellIndex];
       } else if (destCells.length > 0) {
+        // The # of cells in the current row has either changed, or we've
+        // navigated up/down to a row with a different # of cells.
+
         if (cellIndex === -1) {
           finalCellIndex = 0;
           destCell = destCells[0];
@@ -214,6 +238,8 @@ export class TblComponent implements OnInit, OnChanges {
       }
 
       if (destCell) {
+        // A cell can contain a "tab-able" control within it.  So search within
+        // the cell and set focus on it instead of the cell if one is found.
         const control = Dom.getTabbableControl(destCell);
         Dom.setFocus(control);
       }

--- a/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
+++ b/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
@@ -17,6 +17,7 @@ export interface TblItem {
     [class]='tblClass'
     tabindex='0'
     (focus)='onFocus($event)'
+    (click)='onClick($event)'
     (blur)='onBlur($event)'
     (keydown)="onKeyPress($event)">
       <ng-content></ng-content>
@@ -64,12 +65,17 @@ export class TblComponent implements OnInit, OnChanges {
     }
   }
 
-  onBlur(event: FocusEvent) {
+  onBlur(event?: FocusEvent) {
     const rows = this._getRows();
     const curCell = this._getCurrentCellOrReset(rows);
     if (curCell) {
       Dom.clearFocus(curCell);
     }
+  }
+
+  // For now we'll just hide the focused element on click.
+  onClick(e: MouseEvent){
+    this.onBlur(null);
   }
 
   onKeyPress(event: KeyboardEvent) {

--- a/AzureFunctions.AngularClient/src/app/shared/Utilities/dom.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/Utilities/dom.ts
@@ -1,0 +1,23 @@
+
+export class Dom {
+    public static setFocus(element: HTMLElement){
+        element.classList.add('focused');
+    }
+
+    public static clearFocus(element: HTMLElement){
+        element.classList.remove('focused');
+    }
+
+    // This isn't comprehensive but is good enough for our current scenarios.  To get more context, checkout these links:
+    // https://stackoverflow.com/questions/7208161/focus-next-element-in-tab-index
+    // https://stackoverflow.com/questions/7668525/is-there-a-jquery-selector-to-get-all-elements-that-can-get-focus
+    public static getTabbableControl(element: HTMLElement): HTMLElement {
+
+        const controls = element.querySelectorAll('input, select, textarea, button, object, a, area, .link, div.sortable');
+        if (controls.length === 0) {
+            return element;
+        } else {
+            return <HTMLElement>controls[0];
+        }
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/shared/Utilities/dom.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/Utilities/dom.ts
@@ -1,10 +1,10 @@
 
 export class Dom {
-    public static setFocus(element: HTMLElement){
+    public static setFocus(element: HTMLElement) {
         element.classList.add('focused');
     }
 
-    public static clearFocus(element: HTMLElement){
+    public static clearFocus(element: HTMLElement) {
         element.classList.remove('focused');
     }
 
@@ -19,5 +19,54 @@ export class Dom {
         } else {
             return <HTMLElement>controls[0];
         }
+    }
+
+    //https://stackoverflow.com/questions/5598743/finding-elements-position-relative-to-the-document
+    public static getElementCoordinates(elem: HTMLElement) {
+        const box = elem.getBoundingClientRect();
+
+        const body = document.body;
+        const docEl = document.documentElement;
+
+        const scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop;
+        const scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft;
+
+        const clientTop = docEl.clientTop || body.clientTop || 0;
+        const clientLeft = docEl.clientLeft || body.clientLeft || 0;
+
+        const top = box.top + scrollTop - clientTop;
+        const left = box.left + scrollLeft - clientLeft;
+
+        return { top: Math.round(top), left: Math.round(left) };
+    }
+
+    public static scrollIntoView(elem: HTMLElement, container: HTMLElement) {
+        const viewBottom = container.scrollTop + container.clientHeight;
+        let elemCoordinates: { top: number };
+
+        if (container.tagName === 'BODY') {
+            elemCoordinates = Dom.getElementCoordinates(elem);
+        } else {
+            elemCoordinates = {
+                top: elem.offsetTop
+            };
+        }
+
+        if (elemCoordinates.top + elem.clientHeight > viewBottom) {
+            // If view is scrolled way out of view, then scroll so that selected is top
+            if (viewBottom + elem.clientHeight < elem.offsetTop) {
+                container.scrollTop = elem.offsetTop;
+            } else {
+                container.scrollTop += elem.clientHeight + 1;  // +1 for margin
+            }
+        } else if (elemCoordinates.top < container.scrollTop) {
+            // If view needs to scroll up
+            if (container.scrollTop - elem.clientHeight > elem.offsetTop) {
+                container.scrollTop = elemCoordinates.top;
+            } else {
+                container.scrollTop -= elem.clientHeight - 1;   // -1 for margin
+            }
+        }
+
     }
 }

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
@@ -1,3 +1,4 @@
+import { Dom } from './../shared/Utilities/dom';
 import { SearchBoxComponent } from './../search-box/search-box.component';
 import { TreeNodeIterator } from './../tree-view/tree-node-iterator';
 import { Component, OnInit, EventEmitter, OnDestroy, Output, Input, ViewChild, AfterViewInit } from '@angular/core';
@@ -281,39 +282,17 @@ export class SideNavComponent implements AfterViewInit {
 
     private _scrollIntoView(){
         setTimeout(() =>{
-            let view = this._getViewContainer();
-            if(!view){
+            const containerElement = this._getViewContainer();
+            if(!containerElement){
                 return;
             }
 
-            let node = <HTMLDivElement>view.querySelector('div.tree-node.focused');
+            const node = <HTMLDivElement>containerElement.querySelector('div.tree-node.focused');
             if(!node){
                 return;
             }
 
-            let viewBottom = view.scrollTop + view.clientHeight;
-
-            // If view needs to scroll down
-            if(node.offsetTop + node.clientHeight > viewBottom){
-
-                // If view is scrolled way out of view, then scroll so that selected is top
-                if(viewBottom + node.clientHeight < node.offsetTop){
-                    view.scrollTop = node.offsetTop;
-                }
-                else{
-                    view.scrollTop += node.clientHeight + 1;  // +1 for margin
-                }
-            }
-            else if(node.offsetTop < view.scrollTop){
-                // If view needs to scroll up
-                if(view.scrollTop - node.clientHeight > node.offsetTop){
-                    view.scrollTop = node.offsetTop;
-                }
-                else{
-                    view.scrollTop -= node.clientHeight - 1;   // -1 for margin
-                }
-            }
-
+            Dom.scrollIntoView(node, containerElement);
         }, 0);
     }
 

--- a/AzureFunctions.AngularClient/src/sass/controls/_tbl.scss
+++ b/AzureFunctions.AngularClient/src/sass/controls/_tbl.scss
@@ -67,6 +67,10 @@
         width: 100%;
     }
 
+    &:focus{
+        outline: none;
+    }
+
     .drop-down-selected-value{
         height: 22px;
     }


### PR DESCRIPTION
Fixes: #1498  - [Accessibility] Add keyboard navigation to apps list component

1. Hitting enter on a sortable header will sort the column.
2. Use up/down/left/right navigation keys to move around in table
3. Focusing on a cell with a control will highlight the first "tab-able" control.  (Currently only support single control per cell)
4. Hitting enter on a link within a cell will open that link.

![2017-07-12_08-53-50](https://user-images.githubusercontent.com/5695405/28126923-cad1aa70-66df-11e7-8809-50bc9c8d7243.gif)
