### PR TITLE
Adding ability to open a function in a new browser tab

### DIFF
--- a/AzureFunctions.AngularClient/src/app/app.component.ts
+++ b/AzureFunctions.AngularClient/src/app/app.component.ts
@@ -55,7 +55,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 
         this.showTryLanding = window.location.pathname.endsWith('/try');
 
-        if (_userService.inIFrame || window.location.protocol === 'http:') {
+        if (_userService.inIFrame || window.location.protocol === 'http:' || _userService.inTab) {
             this.gettingStarted = false;
             return;
         } else {

--- a/AzureFunctions.AngularClient/src/app/function-dev/function-dev.component.ts
+++ b/AzureFunctions.AngularClient/src/app/function-dev/function-dev.component.ts
@@ -35,6 +35,7 @@ import { ErrorIds } from '../shared/models/error-ids';
 import { HttpRunModel, Param } from '../shared/models/http-run';
 import { FunctionKey, FunctionKeys } from '../shared/models/function-key';
 import { FunctionAppEditMode } from "app/shared/models/function-app-edit-mode";
+import { LocalStorageService } from "app/shared/services/local-storage.service";
 
 
 @Component({
@@ -89,6 +90,7 @@ export class FunctionDevComponent implements OnChanges, OnDestroy {
     public masterKey: string;
 
     public isStandalone: boolean;
+    public inTab: boolean;
 
     public disabled: Observable<boolean>;
 
@@ -111,6 +113,8 @@ export class FunctionDevComponent implements OnChanges, OnDestroy {
 
         this.functionInvokeUrl = this._translateService.instant(PortalResources.functionDev_loading);
         this.isStandalone = configService.isStandalone();
+        this.inTab = PortalService.inTab();
+
         this.selectedFileStream = new Subject<VfsObject>();
         this.selectedFileStream
             .switchMap(file => {
@@ -348,7 +352,10 @@ export class FunctionDevComponent implements OnChanges, OnDestroy {
         if (changes['selectedFunction']) {
             delete this.updatedTestContent;
             delete this.runResult;
-            this.functionSelectStream.next(changes['selectedFunction'].currentValue);
+            const selectedFunction = changes['selectedFunction'].currentValue;
+            if(selectedFunction){
+                this.functionSelectStream.next(changes['selectedFunction'].currentValue);
+            }
         }
     }
 

--- a/AzureFunctions.AngularClient/src/app/main/main.component.html
+++ b/AzureFunctions.AngularClient/src/app/main/main.component.html
@@ -1,13 +1,13 @@
-<top-bar></top-bar>    
+<top-bar></top-bar>
 <busy-state name='dashboard'></busy-state>
 
 <div id="content">
-    
+
     <side-nav (treeViewInfoEvent)="updateViewInfo($event)" [tryFunctionAppInput]="tryFunctionApp" *ngIf="!inTab"></side-nav>
-    
+
     <function-dev *ngIf="inTab" [selectedFunction]="selectedFunction"></function-dev>
 
-    <div id="dashboard" *ngIf="!!viewInfo" class="padded">
+    <div id="dashboard" *ngIf="!!viewInfo">
 
         <apps-list [viewInfoInput]="viewInfo" *ngIf="trialExpired === false && dashboardType === 'apps'"></apps-list>
         <create-app [viewInfoInput]="viewInfo" *ngIf="trialExpired === false && dashboardType === 'createApp'"></create-app>
@@ -16,22 +16,18 @@
         <proxies-list [viewInfoInput]="viewInfo" *ngIf="trialExpired === false && dashboardType === 'proxies'"></proxies-list>
         <slots-list [viewInfoInput]="viewInfo" *ngIf="trialExpired === false && dashboardType === 'slots'"></slots-list>
 
-        <function-edit
-            [viewInfoInput]="viewInfo"
-            *ngIf="trialExpired === false && (dashboardType === 'function'
+        <function-edit [viewInfoInput]="viewInfo" *ngIf="trialExpired === false && (dashboardType === 'function'
                     || dashboardType === 'functionIntegrate'
                     || dashboardType === 'functionManage'
                     || dashboardType === 'functionMonitor')"></function-edit>
 
-        <create-function-wrapper
-            [viewInfoInput]="viewInfo"
-            *ngIf="trialExpired === false && (dashboardType === 'createFunctionAutoDetect'
+        <create-function-wrapper [viewInfoInput]="viewInfo" *ngIf="trialExpired === false && (dashboardType === 'createFunctionAutoDetect'
                     || dashboardType === 'createFunction'
                     || dashboardType === 'createFunctionQuickstart')"></create-function-wrapper>
 
-        <api-new [viewInfoInput]="viewInfo"  *ngIf="trialExpired === false && dashboardType === 'createProxy'"></api-new>
+        <api-new [viewInfoInput]="viewInfo" *ngIf="trialExpired === false && dashboardType === 'createProxy'"></api-new>
         <api-details [viewInfoInput]="viewInfo" *ngIf="trialExpired === false && dashboardType === 'proxy'"></api-details>
-        <slot-new [viewInfoInput] ="viewInfo" *ngIf="trialExpired === false && dashboardType === 'createSlot'"></slot-new>
+        <slot-new [viewInfoInput]="viewInfo" *ngIf="trialExpired === false && dashboardType === 'createSlot'"></slot-new>
         <trial-expired *ngIf="trialExpired === true "></trial-expired>
     </div>
 </div>

--- a/AzureFunctions.AngularClient/src/app/main/main.component.html
+++ b/AzureFunctions.AngularClient/src/app/main/main.component.html
@@ -2,9 +2,12 @@
 <busy-state name='dashboard'></busy-state>
 
 <div id="content">
-    <side-nav (treeViewInfoEvent)="updateViewInfo($event)" [tryFunctionAppInput]="tryFunctionApp"></side-nav>
+    
+    <side-nav (treeViewInfoEvent)="updateViewInfo($event)" [tryFunctionAppInput]="tryFunctionApp" *ngIf="!inTab"></side-nav>
+    
+    <function-dev *ngIf="inTab" [selectedFunction]="selectedFunction"></function-dev>
 
-    <div id="dashboard" *ngIf="!!viewInfo">
+    <div id="dashboard" *ngIf="!!viewInfo" class="padded">
 
         <apps-list [viewInfoInput]="viewInfo" *ngIf="trialExpired === false && dashboardType === 'apps'"></apps-list>
         <create-app [viewInfoInput]="viewInfo" *ngIf="trialExpired === false && dashboardType === 'createApp'"></create-app>

--- a/AzureFunctions.AngularClient/src/app/main/main.component.scss
+++ b/AzureFunctions.AngularClient/src/app/main/main.component.scss
@@ -3,12 +3,6 @@
     background-color: $body-bg-color;
 }
 
-.side-nav-spacer {
-    position: absolute;
-    padding-left: $sidenav-width;
-    width: $sidenav-width;
-}
-
 #content {
     position: absolute;
     width: 100%;

--- a/AzureFunctions.AngularClient/src/app/main/main.component.scss
+++ b/AzureFunctions.AngularClient/src/app/main/main.component.scss
@@ -3,12 +3,20 @@
     background-color: $body-bg-color;
 }
 
+.side-nav-spacer {
+    position: absolute;
+    padding-left: $sidenav-width;
+    width: $sidenav-width;
+}
+
 #content {
     position: absolute;
     width: 100%;
     height: 100%;
     background-color: $body-bg-color;
-    padding-left: $sidenav-width;
+    .padded {
+        padding-left: $sidenav-width;
+    }
     #dashboard {
         height: 100%;
     }

--- a/AzureFunctions.AngularClient/src/app/main/main.component.scss
+++ b/AzureFunctions.AngularClient/src/app/main/main.component.scss
@@ -14,10 +14,8 @@
     width: 100%;
     height: 100%;
     background-color: $body-bg-color;
-    .padded {
-        padding-left: $sidenav-width;
-    }
     #dashboard {
         height: 100%;
+        padding-left: $sidenav-width;
     }
 }

--- a/AzureFunctions.AngularClient/src/app/main/main.component.ts
+++ b/AzureFunctions.AngularClient/src/app/main/main.component.ts
@@ -72,7 +72,7 @@ export class MainComponent implements AfterViewInit {
         }
     }
 
-    initializeChildWindow(_userService: UserService,
+    private initializeChildWindow(_userService: UserService,
         _globalStateService: GlobalStateService,
         _cacheService: CacheService,
         _ngHttp: Http,
@@ -112,7 +112,7 @@ export class MainComponent implements AfterViewInit {
                         const targetName: string = fnDescriptor.functionName
                         const selectedFunction = functions.find(f => f.name === targetName);
 
-                        if (selectedFunction !== undefined) {
+                        if (selectedFunction) {
                             this.selectedFunction = selectedFunction;
                         } else {
                             // handle the error

--- a/AzureFunctions.AngularClient/src/app/main/main.component.ts
+++ b/AzureFunctions.AngularClient/src/app/main/main.component.ts
@@ -8,6 +8,20 @@ import { UserService } from '../shared/services/user.service';
 import { GlobalStateService } from '../shared/services/global-state.service';
 import { FunctionEditComponent } from '../function-edit/function-edit.component';
 import { BusyStateComponent } from '../busy-state/busy-state.component';
+import { CacheService } from "app/shared/services/cache.service";
+import { ArmObj } from "app/shared/models/arm/arm-obj";
+import { Site } from "app/shared/models/arm/site";
+import { SiteDescriptor, Descriptor, FunctionDescriptor } from "app/shared/resourceDescriptors";
+import { Http } from "@angular/http";
+import { TranslateService, TranslatePipe } from '@ngx-translate/core';;
+import { BroadcastService } from "app/shared/services/broadcast.service";
+import { LanguageService } from "app/shared/services/language.service";
+import { SlotsService } from "app/shared/services/slots.service";
+import { ArmService } from "app/shared/services/arm.service";
+import { ConfigService } from "app/shared/services/config.service";
+import { AuthzService } from "app/shared/services/authz.service";
+import { AiService } from "app/shared/services/ai.service";
+import { FunctionInfo } from "app/shared/models/function-info";
 
 @Component({
     selector: 'main',
@@ -15,15 +29,101 @@ import { BusyStateComponent } from '../busy-state/busy-state.component';
     styleUrls: ['./main.component.scss']
 })
 export class MainComponent implements AfterViewInit {
+    public resourceId: string;
     public viewInfo: TreeViewInfo;
     public dashboardType: string;
     public inIFrame: boolean;
+    public inTab: boolean;
+    public selectedFunction: FunctionInfo;
+
     @ViewChild(BusyStateComponent) busyStateComponent: BusyStateComponent;
 
     @Input() tryFunctionApp: FunctionApp;
 
-    constructor(private _userService: UserService, private _globalStateService: GlobalStateService) {
+    constructor(private _userService: UserService,
+        private _globalStateService: GlobalStateService,
+        private _cacheService: CacheService,
+        _ngHttp: Http,
+        _translateService: TranslateService,
+        _broadcastService: BroadcastService,
+        _armService: ArmService,
+        _languageService: LanguageService,
+        _authZService: AuthzService,
+        _configService: ConfigService,
+        _slotsService: SlotsService,
+        _aiService: AiService) {
+
         this.inIFrame = _userService.inIFrame;
+        this.inTab = _userService.inTab; // are we in a tab
+
+        if (this.inTab) {
+            this.initializeChildWindow(_userService,
+                _globalStateService,
+                _cacheService,
+                _ngHttp,
+                _translateService,
+                _broadcastService,
+                _armService,
+                _languageService,
+                _authZService,
+                _configService,
+                _slotsService,
+                _aiService);
+        }
+    }
+
+    initializeChildWindow(_userService: UserService,
+        _globalStateService: GlobalStateService,
+        _cacheService: CacheService,
+        _ngHttp: Http,
+        _translateService: TranslateService,
+        _broadcastService: BroadcastService,
+        _armService: ArmService,
+        _languageService: LanguageService,
+        _authZService: AuthzService,
+        _configService: ConfigService,
+        _slotsService: SlotsService,
+        _aiService: AiService) {
+        this._userService.getStartupInfo()
+            .subscribe(info => {
+                // get list of functions from function app listed in resourceID
+                let siteDescriptor: SiteDescriptor = new SiteDescriptor(info.resourceId);
+
+                this._cacheService.getArm(siteDescriptor.getResourceId())
+                    .mergeMap(response => {
+                        let site = <ArmObj<Site>>response.json();
+                        let functionApp: FunctionApp = new FunctionApp(site,
+                            _ngHttp,
+                            _userService,
+                            _globalStateService,
+                            _translateService,
+                            _broadcastService,
+                            _armService,
+                            _cacheService,
+                            _languageService,
+                            _authZService,
+                            _aiService,
+                            _configService,
+                            _slotsService);
+                        return functionApp.getFunctions()
+                    })
+                    .subscribe(functions => {
+                        const fnDescriptor: FunctionDescriptor = new FunctionDescriptor(info.resourceId);
+                        const targetName: string = fnDescriptor.functionName
+                        const selectedFunction = functions.find(f => f.name === targetName);
+
+                        if (selectedFunction !== undefined) {
+                            this.selectedFunction = selectedFunction;
+                        } else {
+                            // handle the error
+                            _aiService.trackEvent(
+                                '/main-component/error', {
+                                    error: `Failed to find target function`
+                                }
+                            )
+                        }
+                    })
+            })
     }
 
     updateViewInfo(viewInfo: TreeViewInfo) {

--- a/AzureFunctions.AngularClient/src/app/shared/Utilities/logger.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/Utilities/logger.ts
@@ -1,0 +1,11 @@
+import { Url } from "app/shared/Utilities/url";
+
+export class Logger {
+    static debugging: any; boolean = (Url.getParameterByName(null, "appsvc.log") === 'debug');
+
+    public static debug(obj: any) {
+        if (this.debugging) {
+            console.log(obj);
+        }
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/shared/directives/monaco-editor.directive.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/directives/monaco-editor.directive.ts
@@ -184,6 +184,12 @@ export class MonacoEditorDirective {
 
                 that._globalStateService.clearBusyState();
 
+                // TODO: that._editor.addcommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_T, () => {
+                    // open existing function in new tab
+                    // if dirty ask to save? or save for them?
+                    // change view to to open in new tab
+                // });
+
             });
         };
 

--- a/AzureFunctions.AngularClient/src/app/shared/function-app.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/function-app.ts
@@ -271,7 +271,9 @@ export class FunctionApp {
             .retryWhen(this.retryAntares)
             .map((r: Response) => {
                 try {
-                    return <FunctionInfo[]>r.json();
+                    const fcs = <FunctionInfo[]>r.json();
+                    fcs.forEach(fc => fc.functionApp = this);
+                    return fcs;
                 } catch (e) {
                     // We have seen this happen when kudu was returning JSON that contained
                     // comments because Json.NET is okay with comments in the JSON file.

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -41,6 +41,15 @@ export class Constants {
     public static ReadOnlyMode = 'readOnly'.toLocaleLowerCase();
 }
 
+export class TabCommunicationVerbs {
+    public static getStartInfo = "get-startup-info";
+    public static sentStartInfo = "startup-info";
+    public static updatedFile = "updated-file-notice"
+    public static newToken = "new-token";
+    public static parentClosed = "parent-window-closed";
+}
+
+
 export type EnableTabFeature = 'tabs' | 'inplace' | null;
 
 export class SiteTabIds {

--- a/AzureFunctions.AngularClient/src/app/shared/models/localStorage/local-storage.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/localStorage/local-storage.ts
@@ -23,3 +23,7 @@ export interface TabMessage<T> extends StorageItem {
     verb: string;
     data: T;
 }
+
+export interface GetModel {
+    something: number;
+}

--- a/AzureFunctions.AngularClient/src/app/shared/models/localStorage/local-storage.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/localStorage/local-storage.ts
@@ -23,7 +23,3 @@ export interface TabMessage<T> extends StorageItem {
     verb: string;
     data: T;
 }
-
-export interface GetModel {
-    something: number;
-}

--- a/AzureFunctions.AngularClient/src/app/shared/models/localStorage/local-storage.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/localStorage/local-storage.ts
@@ -1,5 +1,6 @@
 import { StorageItem } from './local-storage';
 import { EnabledFeature } from './enabled-features';
+import { Guid } from "app/shared/Utilities/Guid";
 
 export interface StorageItem {
     id: string;
@@ -15,4 +16,10 @@ export interface QuickstartSettings extends StorageItem {
 
 export interface TabSettings extends StorageItem {
     dynamicTabIds: (string | null)[];
+}
+export interface TabMessage<T> extends StorageItem {
+    source_id: string;
+    dest_id: string | null;
+    verb: string;
+    data: T;
 }

--- a/AzureFunctions.AngularClient/src/app/shared/resourceDescriptors.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/resourceDescriptors.ts
@@ -73,8 +73,18 @@ export class SiteDescriptor extends Descriptor {
         }
     }
 
-    getWebsiteId(): WebsiteId {
-        if (!this._websiteId) {
+    getResourceId() : string{
+        // resource id without slot information
+        let resource : string = `/subscriptions/${this.subscription}/resourceGroups/${this.resourceGroup}/providers/Microsoft.Web/sites/${this.site}`;
+        // add slots if available
+        if (this.slot) {
+            resource = `${resource}/slots/${this.slot}`;
+        }
+        return resource
+    }
+
+    getWebsiteId() : WebsiteId{
+        if(!this._websiteId){
             let name = !this.slot ? this.site : `${this.site}(${this.slot})`;
             this._websiteId = {
                 Name: name,

--- a/AzureFunctions.AngularClient/src/app/shared/services/background-tasks.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/background-tasks.service.ts
@@ -35,13 +35,15 @@ export class BackgroundTasksService {
         private _aiService: AiService,
         private _applicationRef: ApplicationRef,
         private _translateService: TranslateService) {
-        if (!this._userService.inIFrame) {
-            this.runNonIFrameTasks();
-        }
-        if (this.isIE()) {
-            console.log('Detected IE, running zone.js workaround');
-            setInterval(() => this._applicationRef.tick(), 1000);
-        }
+            // background tasks should not be run for a tabbed function
+            // it recieves token updates from the parent window
+            if (!this._userService.inIFrame && !this._userService.inTab) {
+                this.runNonIFrameTasks();
+            }
+            if (this.isIE()) {
+                console.log('Detected IE, running zone.js workaround');
+                setInterval(() => this._applicationRef.tick(), 1000);
+            }
     }
 
     runNonIFrameTasks() {

--- a/AzureFunctions.AngularClient/src/app/shared/services/local-storage.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/local-storage.service.ts
@@ -1,16 +1,16 @@
 import { LocalStorageKeys } from './../models/constants';
-import { PortalService } from './portal.service';
 import { LogEntryLevel } from '../models/portal';
 import { Injectable, EventEmitter } from '@angular/core';
 import { StorageItem } from '../models/localStorage/local-storage';
 import { EnabledFeature, Feature } from '../models/localStorage/enabled-features';
+import { AiService } from "app/shared/services/ai.service";
 
 @Injectable()
 export class LocalStorageService {
     private _apiVersion = "2017-07-01";
     private _apiVersionKey = "appsvc-api-version";
 
-    constructor(private _portalService: PortalService) {
+    constructor(private _aiService: AiService) {
         let apiVersion = localStorage.getItem(this._apiVersionKey);
         if (!apiVersion || apiVersion !== this._apiVersion) {
             this._resetStorage();
@@ -29,7 +29,10 @@ export class LocalStorageService {
             localStorage.setItem(key, JSON.stringify(item));
         }
         catch (e) {
-            this._portalService.logMessage(LogEntryLevel.Debug, `Clearing local storage with ${localStorage.length} items.  ${e}`);
+            this._aiService.trackEvent(
+                '/storage-service/error', {
+                    error: `Clearing local storage with ${localStorage.length} items.  ${e}`
+                });
 
             this._resetStorage();
 
@@ -37,15 +40,39 @@ export class LocalStorageService {
                 localStorage.setItem(key, JSON.stringify(item));
             }
             catch (e2) {
-                this._portalService.logMessage(LogEntryLevel.Error, "Failed to save to local storage on 2nd attempt. ${e2}");
+                this._aiService.trackEvent(
+                    '/storage-service/error', {
+                        error: `Failed to save to local storage on 2nd attempt. ${e2}`
+                    });
             }
         }
     }
 
     removeItem(key: string) {
-        localStorage.removeItem(key);
+        try {
+            localStorage.removeItem(key);
+        }
+        catch (e) {
+            this._aiService.trackEvent(
+                '/storage-service/error', {
+                    error: `Failed to remove from local storage.  ${e}`
+                });
+        }
     }
 
+    public addEventListener(handler: (StorageEvent) => void, caller : any) {
+        try {
+            window.addEventListener("storage", handler.bind(caller));
+        }
+        catch (e) {
+            this._aiService.trackEvent(
+                '/storage-service/error', {
+                    error: `Failed to add local storage event listener. ${e}`
+                }
+            )
+        }
+    }
+    
     private _resetStorage() {
         localStorage.clear();
         localStorage.setItem(this._apiVersionKey, this._apiVersion);

--- a/AzureFunctions.AngularClient/src/app/shared/services/portal.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/portal.service.ts
@@ -18,6 +18,7 @@ import { Guid } from "../Utilities/Guid";
 import { TabCommunicationVerbs } from "../models/constants";
 import { FunctionApp } from "app/shared/function-app";
 import { TabMessage } from "app/shared/models/localStorage/local-storage";
+import { Logger } from "app/shared/utilities/logger";
 
 @Injectable()
 export class PortalService {
@@ -369,15 +370,5 @@ export class PortalService {
     // what feature is being looked at currently
     public static feature(): string {
         return (Url.getParameterByName(null, "feature"));
-    }
-}
-
-class Logger {
-    static debugging: any; boolean = (Url.getParameterByName(null, "appsvc.log") === 'debug');
-
-    public static debug(obj: any) {
-        if (this.debugging) {
-            console.log(obj);
-        }
     }
 }

--- a/AzureFunctions.AngularClient/src/app/shared/services/user.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/user.service.ts
@@ -22,6 +22,7 @@ import { StartupInfo } from '../models/portal';
 @Injectable()
 export class UserService {
     public inIFrame: boolean;
+    public inTab: boolean;
     private _startupInfoStream: ReplaySubject<StartupInfo>;
     private _startupInfo: StartupInfo;
     private _inTry: boolean;
@@ -35,6 +36,7 @@ export class UserService {
 
         this._startupInfoStream = new ReplaySubject<StartupInfo>(1);
         this.inIFrame = PortalService.inIFrame();
+        this.inTab = PortalService.inTab();
         this._inTry = window.location.pathname.endsWith('/try');
 
         this._startupInfo = {
@@ -46,7 +48,7 @@ export class UserService {
             resourceId: null
         };
 
-        if (this.inIFrame) {
+        if (this.inIFrame || this.inTab) {
             this._portalService.getStartupInfo()
                 .mergeMap(info => {
                     return Observable.zip(

--- a/AzureFunctions.AngularClient/src/app/top-bar/top-bar.component.html
+++ b/AzureFunctions.AngularClient/src/app/top-bar/top-bar.component.html
@@ -2,9 +2,13 @@
     <try-now *ngIf="showTryView && !gettingStarted"></try-now>
     <div *ngIf="visible" class="top-bar" [class.top-bar-getting-started]="gettingStarted">
 
-        <div *ngIf="!inIFrame" class="azure-logo left">
-            <div *ngIf="!isStandalone" class="vertical-align-center logo">{{ 'azureFunctions' | translate }}</div>
+        <div *ngIf="!inIFrame" class="azure-logo" [class.right]="inTab" [class.left]="isStandalone">
+            <div *ngIf="!isStandalone" class="vertical-align-center logo" [class.tabbed-logo]="inTab">{{ 'azureFunctions' | translate }}</div>
             <div *ngIf="isStandalone" class="vertical-align-center logo-standalone">{{ 'azureFunctionsRuntime' | translate }}</div>
+        </div>
+
+        <div *ngIf="!inIFrame" class="left vertical-align-center">
+            <div *ngIf="!isStandalone" class=" function-information"><h4>{{ appName }} - {{ fnName }}</h4></div>
         </div>
 
         <div class="left vertical-align-center" [class.info-azure]="!isStandalone" [class.info-standalone]="isStandalone" [class.info-no-iframe]="!inIFrame">
@@ -20,7 +24,7 @@
         </div>
 
         <div class="top-bar-tools right vertical-align-center">
-            <span *ngIf="user && currentTenant && !inIFrame"
+            <span *ngIf="user && currentTenant && !inIFrame && !inTab"
                   class="top-bar-tool clickable"
                   [class.top-bar-tool-selected]="showUserMenu"
                   (click)="showUserMenu = !showUserMenu">

--- a/AzureFunctions.AngularClient/src/app/top-bar/top-bar.component.scss
+++ b/AzureFunctions.AngularClient/src/app/top-bar/top-bar.component.scss
@@ -7,10 +7,20 @@
     margin-left: 15px;
 }
 
+.tabbed-logo {
+    margin-left: 0px;
+    margin-right: 15px;
+    padding-right: 10px;
+}
+
 .logo-standalone{
     @extend .logo;
     font-size: 18px;
     margin-left: 265px;
+}
+
+.function-information {
+    margin-left: 15px;
 }
 
 // .top-bar-container {

--- a/AzureFunctions.AngularClient/src/app/top-bar/top-bar.component.ts
+++ b/AzureFunctions.AngularClient/src/app/top-bar/top-bar.component.ts
@@ -1,18 +1,19 @@
 import { ConfigService } from './../shared/services/config.service';
 import { TopBarNotification } from './top-bar-models';
-import { Component, OnInit, EventEmitter, Input, Output } from '@angular/core';
-import { UserService } from '../shared/services/user.service';
-import { User } from '../shared/models/user';
-import { TenantInfo } from '../shared/models/tenant-info';
-import { BroadcastService } from '../shared/services/broadcast.service';
-import { BroadcastEvent } from '../shared/models/broadcast-event'
-import { PortalService } from '../shared/services/portal.service';
-import { TutorialEvent, TutorialStep } from '../shared/models/tutorial';
-import { FunctionsService } from '../shared/services/functions.service';
-import { Constants } from '../shared/models/constants';
-import { GlobalStateService } from '../shared/services/global-state.service';
-import { TranslateService, TranslatePipe } from '@ngx-translate/core';
-import { PortalResources } from '../shared/models/portal-resources';
+import {Component, OnInit, EventEmitter, Input, Output} from '@angular/core';
+import {UserService} from '../shared/services/user.service';
+import {User} from '../shared/models/user';
+import {TenantInfo} from '../shared/models/tenant-info';
+import {BroadcastService} from '../shared/services/broadcast.service';
+import {BroadcastEvent} from '../shared/models/broadcast-event'
+import {PortalService} from '../shared/services/portal.service';
+import {TutorialEvent, TutorialStep} from '../shared/models/tutorial';
+import {FunctionsService} from '../shared/services/functions.service';
+import {Constants} from '../shared/models/constants';
+import {GlobalStateService} from '../shared/services/global-state.service';
+import {TranslateService, TranslatePipe} from '@ngx-translate/core';
+import {PortalResources} from '../shared/models/portal-resources';
+import { SiteDescriptor, Descriptor, FunctionDescriptor } from '../shared/resourceDescriptors';
 
 @Component({
     selector: 'top-bar',
@@ -26,12 +27,17 @@ export class TopBarComponent implements OnInit {
     public tenants: TenantInfo[];
     public currentTenant: TenantInfo;
     public inIFrame: boolean;
-    public isStandalone: boolean;
+    public inTab :boolean;
+    public isStandalone : boolean;
     // public needUpdateExtensionVersion;
     private _isFunctionSelected: boolean;
 
     public visible = false;
     public topBarNotifications: TopBarNotification[] = [];
+
+    public resourceId : string;
+    public appName : string;
+    public fnName : string;
 
     // @Output() private functionAppSettingsClicked: EventEmitter<any>;
 
@@ -45,7 +51,20 @@ export class TopBarComponent implements OnInit {
     ) {
         // this.functionAppSettingsClicked = new EventEmitter<any>();
         this.inIFrame = this._userService.inIFrame;
+        this.inTab = this._userService.inTab;
         this.isStandalone = this._configService.isStandalone();
+
+        if (this.inTab) {
+            _userService.getStartupInfo()
+            .first()
+            .subscribe(info =>{
+                this.resourceId = info.resourceId;
+                let descriptor = <SiteDescriptor>Descriptor.getDescriptor(this.resourceId);
+                this.appName = descriptor.site;
+                let fnDescriptor = new FunctionDescriptor(this.resourceId);
+                this.fnName = fnDescriptor.functionName;
+            });
+        }
 
         this._globalStateService.topBarNotificationsStream
             .subscribe(topBarNotifications => {

--- a/AzureFunctions.AngularClient/src/app/tree-view/function-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/function-node.ts
@@ -10,13 +10,16 @@ import { SideNavComponent } from '../side-nav/side-nav.component';
 import { DashboardType } from './models/dashboard-type';
 import { Site } from '../shared/models/arm/site';
 import { ArmObj } from '../shared/models/arm/arm-obj';
-import { FunctionContainer } from '../shared/models/function-container';
-import { BroadcastEvent } from '../shared/models/broadcast-event';
-import { PortalResources } from '../shared/models/portal-resources';
-import { FunctionInfo } from '../shared/models/function-info';
+import {FunctionContainer} from '../shared/models/function-container';
+import {BroadcastEvent} from '../shared/models/broadcast-event';
+import {PortalResources} from '../shared/models/portal-resources';
+import {FunctionInfo} from '../shared/models/function-info';
+import { Url } from "app/shared/Utilities/url";
 
 export class FunctionNode extends TreeNode implements CanBlockNavChange, Disposable, CustomSelection {
     public dashboardType = DashboardType.function;
+    public supportsTab: boolean;
+
     constructor(
         sideNav: SideNavComponent,
         private _functionsNode: FunctionsNode,
@@ -28,7 +31,9 @@ export class FunctionNode extends TreeNode implements CanBlockNavChange, Disposa
             parentNode);
         this.iconClass = "tree-node-svg-icon";
         this.iconUrl = "images/function_f.svg";
+        const disabledStr = this.sideNav.translateService.instant(PortalResources.disabled).toLocaleLowerCase();
 
+        this.supportsTab = (Url.getParameterByName(window.location.href, "appsvc.feature") === 'tabbed');
     }
 
     // This will be called on every change detection run. So I'm making sure to always

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
@@ -57,6 +57,7 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
     public inSelectedTree = false;
     public isFocused = false;
     public showMenu = false;
+    public supportsTab = false;
 
     constructor(
         public sideNav: SideNavComponent,

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.html
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.html
@@ -49,6 +49,11 @@
         class="fa fa-angle-double-right tree-node-scope-icon"
         (click)="node.scopeToNode()"
         title="Scope to this app"></i>
+
+      <i *ngIf="node.supportsTab"
+        class="fa fa-external-link"
+        (click)="openNewTab()"
+        title="Open in new tab"></i>
     </span>
   </span>
 </div>

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.scss
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.scss
@@ -18,6 +18,9 @@
 
     &:hover{
         background-color: $tree-node-hover-color;
+        .fa.fa-external-link{
+            display: inline-block;
+        }
     }
 
     &.selected{

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.ts
@@ -1,7 +1,8 @@
 import { GlobalStateService } from './../shared/services/global-state.service';
-import { Component, OnInit, EventEmitter, Input, Output } from '@angular/core';
-import { ArmService } from '../shared/services/arm.service';
-import { TreeNode } from './tree-node';
+import {Component, OnInit, EventEmitter, Input, Output} from '@angular/core';
+import {ArmService} from '../shared/services/arm.service';
+import {TreeNode} from './tree-node';
+import { Url } from "app/shared/Utilities/url";
 
 @Component({
     selector: 'tree-view',
@@ -29,7 +30,17 @@ export class TreeViewComponent {
         else {
             this.paddingLeft = "10px";
         }
-
         this.level = level;
+    }
+
+    openNewTab() {
+        //open a new tab with the rousource information
+        let windowLocation : string = `${window.location.hostname}`;
+        if (window.location.port) {
+            windowLocation += `:${window.location.port}`
+        }
+        window.open(`https://${windowLocation}/?tabbed=true&rid=${this.node.resourceId}`, '_blank');
+        // window.open(`https://localhost:44300/?tabbed=true&rid=${this.node.resourceId}`, '_blank');
+        
     }
 }

--- a/AzureFunctions.AngularClient/src/sass/controls/_monaco.scss
+++ b/AzureFunctions.AngularClient/src/sass/controls/_monaco.scss
@@ -2,3 +2,7 @@
     border:1px solid #ccc;
     box-sizing: border-box;
 }
+
+.view-line{
+    font-family: Consolas, "Courier New", monospace;
+}


### PR DESCRIPTION
This PR is for the implementation of opening a function in a new tab. When a function is opened in a new tab, the child window receives startup information from the parent window and adds the resource ID passed through the URL. This line of communication can later be used in notifying the parent or child window to update its code when changes have been made in the other. As shown in the images below, a function can be opened by clicking the button that appears when you hover over a function. The tab opened allows access to the function file opened as well as all the files in its file explorer and maximizes the use of screen real estate. This is currently hidden with a query string until more feedback in gathered on the feature. The query string to enable it is 'appsvc.feature=tabbed'

![27663539-ab79f524-5c17-11e7-9125-f8927f6ba616](https://user-images.githubusercontent.com/28014472/28132183-ee7554f2-66f0-11e7-89f2-6fde56aa6d18.png)
![27663542-ab7db38a-5c17-11e7-95c8-7b459e4555ba](https://user-images.githubusercontent.com/28014472/28132188-f01e7892-66f0-11e7-895e-49a46226b9a8.png)
![27663540-ab7b9a3c-5c17-11e7-8ab5-9b49039518d3](https://user-images.githubusercontent.com/28014472/28132191-f2c650d8-66f0-11e7-9be0-50ebdbc7dc76.png)
![27663541-ab7d8810-5c17-11e7-8102-5864e55e075c](https://user-images.githubusercontent.com/28014472/28132195-f585ef36-66f0-11e7-96b9-44620a834dc8.png)
