### PR TITLE
Fixes #1558 - [Accessbility] Add screen reader support to apps list component

### DIFF
--- a/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.html
+++ b/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.html
@@ -2,7 +2,7 @@
 <img src="images/functions.svg" />
 <span class="text-level1-heading">{{ 'functionApps' | translate }}</span><i *ngIf="appsNode?.isLoading" class="fa fa-refresh fa-spin fa-fw"></i>
 
-<tbl [items]="apps" #table="tbl" id="apps-list">
+<tbl [items]="apps" #table="tbl" id="apps-list" [name]='Resources.functionApps | translate'>
   <tr>
     <th><tbl-th name="title">{{ '_name' | translate }}</tbl-th></th>
     <th><tbl-th name="subscription">{{ 'subscription' | translate }}</tbl-th></th>
@@ -10,12 +10,12 @@
     <th><tbl-th name="location">{{ 'location' | translate }}</tbl-th></th>
   </tr>
 
-  <tr *ngFor="let item of table.items">
+   <tr *ngFor="let item of table.items">
     <td><span class="link" (click)="clickRow(item)">{{item.title}}</span></td>
     <td>{{item.subscription}}</td>
     <td>{{item.resourceGroup}}</td>
     <td>{{item.location}}</td>    
-  </tr>
+  </tr> 
 
   <tr *ngIf="isLoading">
     <td *ngIf="isLoading" colspan="4">{{'functionMonitor_loading' | translate}}</td>

--- a/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.ts
+++ b/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { PortalResources } from './../shared/models/portal-resources';
+import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import { Subscription as RxSubscription } from 'rxjs/Subscription';
 import 'rxjs/add/operator/distinctUntilChanged';
@@ -12,46 +13,45 @@ import { TreeViewInfo } from './../tree-view/models/tree-view-info';
   selector: 'apps-list',
   templateUrl: './apps-list.component.html',
   styleUrls: ['./apps-list.component.scss'],
-  inputs: ['viewInfoInput']
 })
 export class AppsListComponent implements OnInit, OnDestroy {
-  public viewInfoStream : Subject<TreeViewInfo>;
-  public apps : AppNode[] = [];
-  public appsNode : AppsNode;
+  public viewInfoStream: Subject<TreeViewInfo>;
+  public apps: AppNode[] = [];
+  public appsNode: AppsNode;
+  public Resources = PortalResources;
 
   public isLoading = true;
 
-  private _viewInfoSubscription : RxSubscription;
+  private _viewInfoSubscription: RxSubscription;
 
   constructor() {
-      this.viewInfoStream = new Subject<TreeViewInfo>();
+    this.viewInfoStream = new Subject<TreeViewInfo>();
 
-      this._viewInfoSubscription = this.viewInfoStream
+    this._viewInfoSubscription = this.viewInfoStream
       .distinctUntilChanged()
-      .switchMap(viewInfo =>{
+      .switchMap(viewInfo => {
         this.appsNode = (<AppsNode>viewInfo.node);
         this.isLoading = true;
         return (<AppsNode>viewInfo.node).childrenStream;
       })
-      .subscribe(children =>{
+      .subscribe(children => {
         this.apps = children;
         this.isLoading = false;
       });
-
-   }
+  }
 
   ngOnInit() {
   }
 
-  ngOnDestroy(): void{
+  ngOnDestroy(): void {
     this._viewInfoSubscription.unsubscribe();
   }
 
-  set viewInfoInput(viewInfo : TreeViewInfo){
-      this.viewInfoStream.next(viewInfo);
+  @Input() set viewInfoInput(viewInfo: TreeViewInfo) {
+    this.viewInfoStream.next(viewInfo);
   }
 
-  clickRow(item : AppNode){
+  clickRow(item: AppNode) {
     item.sideNav.searchExact(item.title);
   }
 }

--- a/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
+++ b/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
@@ -81,8 +81,8 @@ export class TblComponent implements OnInit, OnChanges {
 
     if (row && cell) {
       const rows = this._getRows();
-      const rowIndex = this._findElemIndex(<HTMLElement[]><any>rows, row);
-      const cells: HTMLTableCellElement[] = <any>this._getCells(row);
+      const rowIndex = this._findElemIndex(rows, row);
+      const cells = this._getCells(row);
       const cellIndex = this._findElemIndex(cells, cell);
 
       if (rowIndex && cellIndex) {
@@ -157,7 +157,8 @@ export class TblComponent implements OnInit, OnChanges {
   // types for some reason, so you can't use methods like "find" or "findIndex".
   // I'm not sure what the proper type is so I'm just treating it like an array
   // without "findIndex"
-  private _findElemIndex(elems: HTMLElement[], elem: HTMLElement) {
+  private _findElemIndex(elems: NodeList, elem: HTMLElement) {
+
     for (let i = 0; i < elems.length; i++) {
       if (elems[i] === elem) {
         return i;

--- a/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
+++ b/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
@@ -18,13 +18,15 @@ export interface TblItem {
     tabindex='0'
     (focus)='onFocus($event)'
     (click)='onClick($event)'
-    (blur)='onBlur($event)'
-    (keydown)="onKeyPress($event)">
+    (keydown)="onKeyPress($event)"
+    role="grid"
+    [attr.aria-label]="name">
       <ng-content></ng-content>
   </table>`,
   exportAs: 'tbl'
 })
 export class TblComponent implements OnInit, OnChanges {
+  @Input() name: string | null;
   @Input() tblClass = 'tbl';
   @Input() items: TblItem[];
   @ContentChildren(forwardRef(() => TblThComponent)) headers: QueryList<TblThComponent>;
@@ -69,21 +71,25 @@ export class TblComponent implements OnInit, OnChanges {
     }
   }
 
-  // Gets called if a user "tabs" or clicks away from a table.  In this case
-  // we'll keep the currently selected cells state but just remove the focus
-  // on it.
-  onBlur(event?: FocusEvent) {
-    const rows = this._getRows();
-    const curCell = this._getCurrentCellOrReset(rows);
-    if (curCell) {
-      Dom.clearFocus(curCell);
-    }
-  }
+  onClick(e: MouseEvent) {
 
-  // Gets called specifically on click for a table.  For now we'll just
-  // hide the focused element on click.
-  onClick(e: MouseEvent){
-    this.onBlur(null);
+    // If someone clicks on a cell directly, then we'll have to figure out
+    // which cell and row that click event belonged to and update our
+    // knowledge of it.
+    const cell = this._findParentCell(<HTMLElement>e.srcElement);
+    const row = this._findParentRow(<HTMLElement>e.srcElement);
+
+    if (row && cell) {
+      const rows = this._getRows();
+      const rowIndex = this._findElemIndex(<HTMLElement[]><any>rows, row);
+      const cells: HTMLTableCellElement[] = <any>this._getCells(row);
+      const cellIndex = this._findElemIndex(cells, cell);
+
+      if (rowIndex && cellIndex) {
+        this._clearFocusOnCell(rows, this._focusedRowIndex, this._focusedCellIndex);
+        this._setFocusOnCell(rows, rowIndex, cellIndex);
+      }
+    }
   }
 
   // Gets called for any keypresses that occur whenever the focus is currently
@@ -118,14 +124,26 @@ export class TblComponent implements OnInit, OnChanges {
 
     } else if (event.keyCode === KeyCodes.enter) {
 
+      // On "enter", we'll "click" on the current cell
       const rows = this._getRows();
       const curCell = this._getCurrentCellOrReset(rows);
       if (curCell) {
         curCell.click();
 
-        setTimeout(() =>{
+        setTimeout(() => {
           this._setFocusOnCell(rows, this._focusedRowIndex, this._focusedCellIndex);
         }, 0);
+      }
+
+    } else if (event.keyCode === KeyCodes.escape) {
+
+      // If a control within a cell is currently selected, hitting escape will cause the 
+      // focus to switch to the containing cell instead.
+      const rows = this._getRows();
+      const curCell = this._getCurrentCellOrReset(rows, true /* force set focus on cell */);
+      if (curCell) {
+        this._clearFocusOnCell(rows, this._focusedRowIndex, this._focusedCellIndex);
+        Dom.setFocus(curCell);
       }
     }
 
@@ -135,13 +153,56 @@ export class TblComponent implements OnInit, OnChanges {
     }
   }
 
+  // elems is not exactly an array, and Angular doesn't give us the proper
+  // types for some reason, so you can't use methods like "find" or "findIndex".
+  // I'm not sure what the proper type is so I'm just treating it like an array
+  // without "findIndex"
+  private _findElemIndex(elems: HTMLElement[], elem: HTMLElement) {
+    for (let i = 0; i < elems.length; i++) {
+      if (elems[i] === elem) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
+  private _findParentCell(elem: HTMLElement): HTMLTableCellElement {
+    while (elem) {
+      if (elem.tagName === 'TH' || elem.tagName === 'TD') {
+        return <HTMLTableCellElement>elem;
+      }
+
+      elem = elem.parentElement;
+    }
+
+    return null;
+  }
+
+  private _findParentRow(elem: HTMLElement): HTMLTableRowElement {
+    while (elem) {
+      if (elem.tagName === 'TR') {
+        return <HTMLTableRowElement>elem;
+      }
+
+      elem = elem.parentElement;
+    }
+
+    return null;
+  }
+
   // Get the current selected cell from list of rows.  If the table has
   // changed for some reason and the cell doesn't exist, then just reset the selection.
-  private _getCurrentCellOrReset(rows: NodeListOf<HTMLTableRowElement>) {
+  private _getCurrentCellOrReset(rows: NodeListOf<HTMLTableRowElement>, forceCellSelection?: boolean) {
     if (this._focusedRowIndex >= 0 && this._focusedRowIndex < rows.length) {
       const rowCells = this._getCells(rows[this._focusedRowIndex]);
       if (this._focusedCellIndex >= 0 && this._focusedCellIndex < rowCells.length) {
-        return Dom.getTabbableControl(rowCells[this._focusedCellIndex]);
+        if (forceCellSelection) {
+          return rowCells[this._focusedCellIndex];
+        } else {
+          return Dom.getTabbableControl(rowCells[this._focusedCellIndex]);
+        }
+
       } else {
         this._focusedRowIndex = -1;
         this._focusedCellIndex = -1;
@@ -155,7 +216,7 @@ export class TblComponent implements OnInit, OnChanges {
   }
 
   private _scrollIntoView(elem: HTMLElement) {
-      Dom.scrollIntoView(elem, window.document.body);
+    Dom.scrollIntoView(elem, window.document.body);
   }
 
   private _getRows() {

--- a/AzureFunctions.AngularClient/src/app/shared/Utilities/dom.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/Utilities/dom.ts
@@ -1,11 +1,12 @@
 
 export class Dom {
     public static setFocus(element: HTMLElement) {
-        element.classList.add('focused');
+        element.tabIndex = 0;
+        element.focus();
     }
 
     public static clearFocus(element: HTMLElement) {
-        element.classList.remove('focused');
+        element.tabIndex = -1;
     }
 
     // This isn't comprehensive but is good enough for our current scenarios.  To get more context, checkout these links:

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -125,6 +125,7 @@ export class Order {
 export class KeyCodes{
     public static readonly tab = 9;
     public static readonly enter = 13;
+    public static readonly shiftLeft = 16;
     public static readonly space = 32;
     public static readonly escape = 27;
     public static readonly arrowLeft = 37;

--- a/AzureFunctions.AngularClient/src/sass/base/_base.scss
+++ b/AzureFunctions.AngularClient/src/sass/base/_base.scss
@@ -42,7 +42,7 @@ pre {
     text-decoration: underline;
 }
 
-.focused{
+:focus{
     outline: $border-focus;
 }
 


### PR DESCRIPTION
The Tbl component will now read off each cell.  To get this to work, I had to change the way that I focus on cells.  The way that it works now is when you select a cell, we'll change the tabindex to 0 so that it's "focus-able", and then focus on it.  When you move away, we'll change the tabindex of the current cell to -1 and choose the next cell.

I had to also add some extra logic to handle some of the funky behaviors of a screen reader where you can get "stuck" within a cell.  So if you hit "escape" when you've selected a control within a cell, it will change the focus to select the cell itself instead.