### PR TITLE
[Accessibility] Add screen reader support for side nav

### DIFF
--- a/AzureFunctions.AngularClient/src/app/multi-drop-down/multi-drop-down.component.ts
+++ b/AzureFunctions.AngularClient/src/app/multi-drop-down/multi-drop-down.component.ts
@@ -24,6 +24,7 @@ export class MultiDropDownComponent<T> implements OnInit {
   public selectedValues = new ReplaySubject<T[]>(1);
   private _selectAllOption: MultiDropDownElement<T>;
   private _focusedIndex = -1;
+  private _initialized = false;
 
   constructor(private _eref: ElementRef, private _ts: TranslateService) {
     this._selectAllOption = {
@@ -228,12 +229,35 @@ export class MultiDropDownComponent<T> implements OnInit {
     }
 
     this.displayText = displayText;
-    this.selectedValues.next(selectedValues);
+    this._compareAndUpdateIfDifferent(selectedValues);
   }
 
   private _updateAllSelected(allSelected: boolean) {
     this.options.forEach(option => {
       option.isSelected = allSelected;
-    })
+    });
+  }
+
+  private _compareAndUpdateIfDifferent(newValues: T[]) {
+    if (!this._initialized) {
+      this.selectedValues.next(newValues);
+      this._initialized = true;
+    } else {
+      this.selectedValues
+        .first()
+        .subscribe(currentValues => {
+          if (currentValues.length === newValues.length) {
+
+            for (let i = 0; i < currentValues.length; i++) {
+              if (currentValues[i] !== newValues[i]) {
+                this.selectedValues.next(newValues);
+                break;
+              }
+            }
+          } else {
+            this.selectedValues.next(newValues);
+          }
+        });
+    }
   }
 }

--- a/AzureFunctions.AngularClient/src/app/search-box/search-box.component.html
+++ b/AzureFunctions.AngularClient/src/app/search-box/search-box.component.html
@@ -5,7 +5,8 @@
            [(ngModel)]="value"
            placeholder="{{placeholder}}"
            (keyup)="onKeyUp($event)"
-           #searchTextBox/>
+           #searchTextBox
+           [attr.aria-label]="ariaLabel"/>
     <span class="right">
         <i *ngIf="value" class="fa fa-times" (click)="onClearClick($event)"></i>
     </span>

--- a/AzureFunctions.AngularClient/src/app/search-box/search-box.component.ts
+++ b/AzureFunctions.AngularClient/src/app/search-box/search-box.component.ts
@@ -8,8 +8,9 @@ import { Subject } from 'rxjs/Subject';
 })
 export class SearchBoxComponent {
     @Input() placeholder: string;
-    @Input() value: string = "";
-    @Input() warning: boolean = false;
+    @Input() value = '';
+    @Input() warning = false;
+    @Input() ariaLabel: string | null;
     @Output() onInputChange = new Subject<string>();
     @Output() onClear = new Subject<void>();
 

--- a/AzureFunctions.AngularClient/src/app/shared/Utilities/dom.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/Utilities/dom.ts
@@ -1,5 +1,9 @@
 
 export class Dom {
+    public static setFocusable(element: HTMLElement){
+        element.tabIndex = 0;
+    }
+
     public static setFocus(element: HTMLElement) {
         element.tabIndex = 0;
         element.focus();
@@ -53,19 +57,19 @@ export class Dom {
             };
         }
 
-        if (elemCoordinates.top + elem.clientHeight > viewBottom) {
+        if (elemCoordinates.top + elem.clientHeight + 2 > viewBottom) {
             // If view is scrolled way out of view, then scroll so that selected is top
             if (viewBottom + elem.clientHeight < elem.offsetTop) {
                 container.scrollTop = elem.offsetTop;
             } else {
                 container.scrollTop += elem.clientHeight + 1;  // +1 for margin
             }
-        } else if (elemCoordinates.top < container.scrollTop) {
+        } else if (elemCoordinates.top - 1 <= container.scrollTop) {
             // If view needs to scroll up
             if (container.scrollTop - elem.clientHeight > elem.offsetTop) {
                 container.scrollTop = elemCoordinates.top;
             } else {
-                container.scrollTop -= elem.clientHeight - 1;   // -1 for margin
+                container.scrollTop -= elem.clientHeight;
             }
         }
 

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -142,3 +142,8 @@ export class KeyCodes {
     public static readonly arrowRight = 39;
     public static readonly arrowDown = 40;
 }
+
+export class DomEvents{
+    public static readonly keydown = 'keydown';
+    public static readonly click = 'click';
+}

--- a/AzureFunctions.AngularClient/src/app/shared/models/portal-resources.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/portal-resources.ts
@@ -82,7 +82,9 @@ export class PortalResources
     public static sideBar_newFunction: string = "sideBar_newFunction";
     public static sideBar_refresh: string = "sideBar_refresh";
     public static search: string = "search";
+    public static scopeToItem: string = "scopeToItem";
     public static searchFeatures: string = "searchFeatures";
+    public static searchFunctionApps: string = "searchFunctionApps";
     public static subscription: string = "subscription";
     public static subscriptionName: string = "subscriptionName";
     public static resourceGroup: string = "resourceGroup";
@@ -569,6 +571,7 @@ export class PortalResources
     public static slotNew_dynamicQuotaReached: string = "slotNew_dynamicQuotaReached";
     public static functionsList_searchFunctions: string = "functionsList_searchFunctions";
     public static new_: string = "new_";
+    public static createNew: string = "createNew";
     public static functionManage_deleteFunction: string = "functionManage_deleteFunction";
     public static functionService_clientCertEnabled: string = "functionService_clientCertEnabled";
     public static readOnlySlots: string = "readOnlySlots";

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.html
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.html
@@ -24,7 +24,8 @@
          id="tree-view-container"
          (focus)="onFocus($event)"
          (blur)="onBlur($event)"
-         (keydown)="onKeyPress($event)">
+         (keydown)="onKeyPress($event)"
+         role="tree">
         <tree-view *ngIf="rootNode" [node]="rootNode" [levelInput]="0"></tree-view>
     </div>
 

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.html
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.html
@@ -6,7 +6,8 @@
                     (onClear)="clearSearch()"
                     [value]="searchTerm"
                     [placeholder]="'search' | translate"
-                    [warning]="true">
+                    [warning]="true"
+                    [ariaLabel]="'searchFunctionApps' | translate">
         </search-box>
 
         <div id="sidenav-subs">
@@ -18,15 +19,11 @@
 
     </div>
 
-    <!--<div *ngIf="selectedSubscriptions.length > 0">-->
-    <div tabindex="0"
-         #treeViewContainer
+    <div #treeViewContainer
          id="tree-view-container"
-         (focus)="onFocus($event)"
-         (blur)="onBlur($event)"
-         (keydown)="onKeyPress($event)"
-         role="tree">
-        <tree-view *ngIf="rootNode" [node]="rootNode" [levelInput]="0"></tree-view>
+         role="tree"
+         [attr.aria-label]="'functionApps' | translate">
+        <tree-view *ngIf="rootNode" [node]="rootNode" [level]="0"></tree-view>
     </div>
 
 </div>

--- a/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
@@ -103,6 +103,11 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
                     // not any other listeners.
                     this.childrenStream.next(<AppNode[]>result.children);
                     this.children = filteredChildren;
+
+                    // Scoping to an app will cause the currently focused item in the tree to be
+                    // recreated.  In that case, we'll just refocus on the root node.  It's probably
+                    // not ideal but simple for us to do.
+                    this.treeView.setFocus(this);
                 }
 
                 this.isLoading = false;

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
@@ -1,3 +1,4 @@
+import { DomEvents, KeyCodes } from './../shared/models/constants';
 import { TreeViewComponent } from './tree-view.component';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/do';
@@ -58,6 +59,7 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
     public isFocused = false;
     public showMenu = false;
     public supportsTab = false;
+    public treeView: TreeViewComponent;
 
     constructor(
         public sideNav: SideNavComponent,
@@ -96,7 +98,13 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
     }
 
     // Virtual
-    public refresh(event?: any) {
+    public refresh(event?: UIEvent) {
+        if(event && event.type === DomEvents.keydown){
+            if((<KeyboardEvent>event).keyCode !== KeyCodes.enter){
+                return;
+            }
+        }
+
         this.isLoading = true;
         this.handleRefresh()
             .do(null, e => {
@@ -111,6 +119,8 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
 
                 this.isLoading = false;
             });
+
+        this.treeView.setFocus(this);
 
         if (event) {
             event.stopPropagation();
@@ -170,7 +180,13 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
             });
     }
 
-    public openCreateNew(event?: any) {
+    public openCreateNew(event?: UIEvent) {
+        if(event && event.type === DomEvents.keydown){
+            if((<KeyboardEvent>event).keyCode !== KeyCodes.enter){
+                return;
+            }
+        }
+
         this.sideNav.updateView(this, this.newDashboardType)
             .do(null, e => {
                 this.sideNav.aiService.trackException(e, "/errors/tree-node/open-create/update-view");
@@ -221,7 +237,13 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
         return path;
     }
 
-    public scopeToNode() {
+    public scopeToNode(event?: UIEvent) {
+        if(event && event.type === DomEvents.keydown){
+            if((<KeyboardEvent>event).keyCode !== KeyCodes.enter){
+                return;
+            }
+        }
+
         this.sideNav.searchExact(this.title);
     }
 

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.html
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.html
@@ -8,7 +8,9 @@
      [class.focused]="node.isFocused"
      (mouseenter)="node.showMenu = true"
      (mouseleave)="node.showMenu = false"
-     (click)="node.select()">
+     (click)="node.select()"
+     role="treeitem"
+     [attr.aria-expanded]="node.showExpandIcon && node.isExpanded ? true : node.showExpandIcon ? false : null">
 
   <!-- Expand node icon -->
   <i *ngIf="node.showExpandIcon"
@@ -60,7 +62,7 @@
 
 <hr *ngIf="level === 1 && !showTryView" class="tree-node-separator" />
 
-<div *ngIf="node?.isExpanded" [class.top-level-children]="level === 1">
+<div *ngIf="node?.isExpanded" [class.top-level-children]="level === 1" role="group">
   <tree-view *ngFor="let child of node.children"
               [node]="child"
               [levelInput]="level + 1"></tree-view>

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.html
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.html
@@ -1,16 +1,17 @@
 <div *ngIf="level > 0"
-     class="tree-node"
+     #item
      [style.padding-left]="paddingLeft"
+     class="tree-node"
      [class]="node.nodeClass"
      [class.clickable]="!node.disabled"
      [class.selected]="node.sideNav && node.sideNav.resourceId === node.resourceId"
      [class.try-root-node]="level === 0 && showTryView"
-     [class.focused]="node.isFocused"
-     (mouseenter)="node.showMenu = true"
-     (mouseleave)="node.showMenu = false"
      (click)="node.select()"
      role="treeitem"
-     [attr.aria-expanded]="node.showExpandIcon && node.isExpanded ? true : node.showExpandIcon ? false : null">
+     [attr.aria-expanded]="node.showExpandIcon && node.isExpanded ? true : node.showExpandIcon ? false : null"
+     (mouseenter)="node.showMenu = true"
+     (mouseleave)="node.showMenu = false"
+     (keydown)="onKeyPress($event)">
 
   <!-- Expand node icon -->
   <i *ngIf="node.showExpandIcon"
@@ -34,23 +35,29 @@
     <span *ngIf="node.showMenu || node.inSelectedTree">
 
       <i *ngIf="node.disabled"
-        class="fa fa-info-circle"
+        class="fa fa-info-circle tree-node-menu-item"
         title="You either do not have access to this app or there are orphaned slots associated with it"></i>
 
       <i *ngIf="!!node.newDashboardType"
           (click)="node.openCreateNew($event)"
+          (keydown)="node.openCreateNew($event)"
           class="fa fa-plus"
-          title="New"></i>
+          [title]="'createNew' | translate"
+          [tabindex]="node.isFocused ? 0 : -1"></i>
 
       <i *ngIf="node.supportsRefresh"
         (click)="node.refresh($event)"
+        (keydown)="node.refresh($event)"
         class="fa fa-refresh tree-node-refresh-icon"
-        title="Refresh"></i>
+        [title]="'sideBar_refresh' | translate"
+        [tabindex]="node.isFocused ? 0 : -1"></i>
 
       <i *ngIf="node.supportsScope && !showTryView"
-        class="fa fa-angle-double-right tree-node-scope-icon"
-        (click)="node.scopeToNode()"
-        title="Scope to this app"></i>
+         class="fa fa-angle-double-right tree-node-scope-icon"
+         (click)="node.scopeToNode($event)"
+         (keydown)="node.scopeToNode($event)"
+         [title]="'scopeToItem' | translate"
+         [tabindex]="node.isFocused ? 0 : -1"></i>
 
       <i *ngIf="node.supportsTab"
         class="fa fa-external-link"
@@ -65,5 +72,5 @@
 <div *ngIf="node?.isExpanded" [class.top-level-children]="level === 1" role="group">
   <tree-view *ngFor="let child of node.children"
               [node]="child"
-              [levelInput]="level + 1"></tree-view>
+              [level]="level + 1"></tree-view>
 </div>

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.scss
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.scss
@@ -27,10 +27,6 @@
         background-color: $tree-node-selection-color;
     }
 
-    &.focused{
-        outline: $border-focus;
-    }
-
     .fa.fa-caret-right, .fa.fa-caret-down{
         font-size: 18px;
         vertical-align: middle;

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.ts
@@ -1,36 +1,135 @@
+import { KeyCodes } from './../shared/models/constants';
+import { TreeNodeIterator } from './tree-node-iterator';
+import { Dom } from './../shared/Utilities/dom';
+import { SideNavComponent } from './../side-nav/side-nav.component';
 import { GlobalStateService } from './../shared/services/global-state.service';
-import {Component, OnInit, EventEmitter, Input, Output} from '@angular/core';
-import {ArmService} from '../shared/services/arm.service';
-import {TreeNode} from './tree-node';
 import { Url } from "app/shared/Utilities/url";
+import { DashboardType } from "app/tree-view/models/dashboard-type";
+import { Component, OnInit, EventEmitter, Input, Output, ViewChild, OnChanges, SimpleChange, ElementRef, AfterContentInit } from '@angular/core';
+import { ArmService } from '../shared/services/arm.service';
+import { TreeNode } from './tree-node';
 
 @Component({
     selector: 'tree-view',
     templateUrl: './tree-view.component.html',
-    styleUrls: ['./tree-view.component.scss'],
-    inputs: ['node', 'levelInput']
+    styleUrls: ['./tree-view.component.scss']
 })
 
-export class TreeViewComponent {
-    node: TreeNode;
+export class TreeViewComponent implements OnChanges, AfterContentInit {
+    @Input() node: TreeNode;
+    @Input() level: number;
+
     paddingLeft: string;
-    level: number;
 
     public showTryView = false;
+    @ViewChild('item') item: ElementRef;
 
-    constructor(globalStateService: GlobalStateService) {
+    constructor(
+        globalStateService: GlobalStateService,
+        private _sideNavComponent: SideNavComponent) {
+
         this.showTryView = globalStateService.showTryView;
     }
 
-    set levelInput(level: number) {
-        if (level > 2) {
-            let padding = level * 10 - 10;
-            this.paddingLeft = padding + "px";
+    ngOnChanges(changes: { [key: string]: SimpleChange }) {
+        const nodeChange = changes['node'];
+        const levelChange = changes['level'];
+
+        if (nodeChange && this.node) {
+            this.node.treeView = this;
         }
-        else {
-            this.paddingLeft = "10px";
+
+        if (levelChange && Number.isInteger(this.level)) {
+
+            if (this.level > 2) {
+                const padding = this.level * 10 - 10;
+                this.paddingLeft = padding + 'px';
+            } else {
+                this.paddingLeft = '10px';
+            }
         }
-        this.level = level;
+    }
+
+    ngAfterContentInit() {
+        // When the tree initially loads, we make sure that the "Apps" node
+        // is the only node that's initially focus-able.
+        if (this.node && this.node.dashboardType === DashboardType.apps) {
+            setTimeout(() => {
+                Dom.setFocusable(this.item.nativeElement);
+            }, 0);
+        }
+    }
+
+    // Down - Navigates down an item in the tree
+    // Up - Navigates up an item in the tree
+    // Left - Collapses an item in the tree
+    // Right - Expands an item in the tree
+    // Enter - Selects the current node in the tree, or selects the current nodes
+    //         menu item, like "create new", "refresh", etc...
+    onKeyPress(event: KeyboardEvent) {
+        if (event.keyCode === KeyCodes.arrowDown) {
+            this._moveFocusedItemDown();
+        } else if (event.keyCode === KeyCodes.arrowUp) {
+            this._moveFocusedItemUp();
+        } else if (event.keyCode === KeyCodes.enter) {
+
+            // Need to check if the user hit enter on the tree item, or on a menu item
+            // that's contained within the tree item
+            if (document.activeElement === this.item.nativeElement) {
+                this.node.select();
+            } else {
+                return;
+            }
+        } else if (event.keyCode === KeyCodes.arrowRight) {
+
+            if (this.node.showExpandIcon && !this.node.isExpanded) {
+                this.node.toggle(event);
+            } else {
+                this._moveFocusedItemDown();
+            }
+
+        } else if (event.keyCode === KeyCodes.arrowLeft) {
+            if (this.node.showExpandIcon && this.node.isExpanded) {
+                this.node.toggle(event);
+            } else {
+                this._moveFocusedItemUp();
+            }
+        }
+
+        if (event.keyCode !== KeyCodes.tab) {
+            // Prevents the entire page from scrolling on up/down key press
+            event.preventDefault();
+        }
+    }
+
+    private _moveFocusedItemDown() {
+
+        const nextNode = new TreeNodeIterator(this.node).next();
+        if (nextNode) {
+            this._clearFocus(this.node);
+            this.setFocus(nextNode);
+        }
+    }
+
+    private _moveFocusedItemUp() {
+        const prevNode = new TreeNodeIterator(this.node).previous();
+        if (prevNode) {
+            this._clearFocus(this.node);
+            this.setFocus(prevNode);
+        }
+    }
+
+    public setFocus(node: TreeNode) {
+        Dom.setFocus(node.treeView.item.nativeElement);
+        (<HTMLElement>node.treeView.item.nativeElement).setAttribute('aria-selected', 'true');
+        node.isFocused = true;
+        this.node.sideNav.scrollIntoView();
+    }
+
+    private _clearFocus(node: TreeNode) {
+        Dom.clearFocus(node.treeView.item.nativeElement);
+        (<HTMLElement>node.treeView.item.nativeElement).removeAttribute('aria-selected');
+        node.isFocused = false;
     }
 
     openNewTab() {

--- a/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/Resources.resx
@@ -358,8 +358,14 @@
   <data name="search" xml:space="preserve">
     <value>Search</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>Scope to this item</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>Search features</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>Search Function apps</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>Subscription ID</value>
@@ -1821,6 +1827,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
   </data>
   <data name="new_" xml:space="preserve">
     <value>New</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
+    <value>Create new</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
     <value>Delete function</value>


### PR DESCRIPTION
Follow aria rules for tree view - https://www.w3.org/TR/wai-aria-practices/#TreeView
Example here - https://www.w3.org/TR/wai-aria-practices/examples/treeview/treeview-2/treeview-2b.html

Changes:
1. Moved keyboard navigation into tree view and away from sidenav.  This is to allow each node to have its own individual tabindex.
2. Added aria roles to match rules defined by links above
3. Fixed some auto scroll issues