### PR TITLE
Updated app-level timers to include full-ready timings

### DIFF
--- a/AzureFunctions.AngularClient/src/app/api-details/api-details.component.ts
+++ b/AzureFunctions.AngularClient/src/app/api-details/api-details.component.ts
@@ -38,7 +38,7 @@ export class ApiDetailsComponent implements OnInit {
     private selectedNode: ProxyNode;
     private proxiesNode: ProxiesNode;
 
-    set viewInfoInput(viewInfoInput: TreeViewInfo) {
+    set viewInfoInput(viewInfoInput: TreeViewInfo<any>) {
         this._globalStateService.setBusyState();
         this.selectedNode = <ProxyNode>viewInfoInput.node;
         this.proxiesNode = (<ProxiesNode>this.selectedNode.parent);

--- a/AzureFunctions.AngularClient/src/app/api-new/api-new.component.ts
+++ b/AzureFunctions.AngularClient/src/app/api-new/api-new.component.ts
@@ -43,7 +43,7 @@ export class ApiNewComponent implements OnInit {
     public functionsInfo: FunctionInfo[];
     public appNode: AppNode;
     private _proxiesNode: ProxiesNode;
-    private _viewInfoStream = new Subject<TreeViewInfo>();
+    private _viewInfoStream = new Subject<TreeViewInfo<any>>();
 
     constructor(fb: FormBuilder,
         private _globalStateService: GlobalStateService,
@@ -102,7 +102,7 @@ export class ApiNewComponent implements OnInit {
             })
     }
 
-    set viewInfoInput(viewInfoInput: TreeViewInfo) {
+    set viewInfoInput(viewInfoInput: TreeViewInfo<any>) {
         this._viewInfoStream.next(viewInfoInput);
     }
 

--- a/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.ts
+++ b/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.ts
@@ -15,7 +15,7 @@ import { TreeViewInfo } from './../tree-view/models/tree-view-info';
   styleUrls: ['./apps-list.component.scss'],
 })
 export class AppsListComponent implements OnInit, OnDestroy {
-  public viewInfoStream: Subject<TreeViewInfo>;
+  public viewInfoStream: Subject<TreeViewInfo<any>>;
   public apps: AppNode[] = [];
   public appsNode: AppsNode;
   public Resources = PortalResources;
@@ -25,7 +25,7 @@ export class AppsListComponent implements OnInit, OnDestroy {
   private _viewInfoSubscription: RxSubscription;
 
   constructor() {
-    this.viewInfoStream = new Subject<TreeViewInfo>();
+    this.viewInfoStream = new Subject<TreeViewInfo<any>>();
 
     this._viewInfoSubscription = this.viewInfoStream
       .distinctUntilChanged()
@@ -47,7 +47,7 @@ export class AppsListComponent implements OnInit, OnDestroy {
     this._viewInfoSubscription.unsubscribe();
   }
 
-  @Input() set viewInfoInput(viewInfo: TreeViewInfo) {
+  @Input() set viewInfoInput(viewInfo: TreeViewInfo<any>) {
     this.viewInfoStream.next(viewInfo);
   }
 

--- a/AzureFunctions.AngularClient/src/app/breadcrumbs/breadcrumbs.component.ts
+++ b/AzureFunctions.AngularClient/src/app/breadcrumbs/breadcrumbs.component.ts
@@ -13,7 +13,7 @@ export class BreadcrumbsComponent {
 
     constructor() { }
 
-    set viewInfoInput(viewInfo: TreeViewInfo) {
+    set viewInfoInput(viewInfo: TreeViewInfo<any>) {
         let pathNames = viewInfo.node.getTreePathNames();
         let path = "";
 

--- a/AzureFunctions.AngularClient/src/app/create-function-wrapper/create-function-wrapper.component.ts
+++ b/AzureFunctions.AngularClient/src/app/create-function-wrapper/create-function-wrapper.component.ts
@@ -22,9 +22,9 @@ import { DashboardType } from '../tree-view/models/dashboard-type';
 })
 export class CreateFunctionWrapperComponent implements OnInit, OnDestroy {
 
-  private _viewInfoStream = new Subject<TreeViewInfo>();
+  private _viewInfoStream = new Subject<TreeViewInfo<any>>();
   public dashboardType: string;
-  public viewInfo: TreeViewInfo;
+  public viewInfo: TreeViewInfo<any>;
   private _subscription: RxSubscription;
 
   constructor(
@@ -76,7 +76,7 @@ export class CreateFunctionWrapperComponent implements OnInit, OnDestroy {
       });
   }
 
-  set viewInfoInput(viewInfo: TreeViewInfo) {
+  set viewInfoInput(viewInfo: TreeViewInfo<any>) {
     this._viewInfoStream.next(viewInfo);
   }
 

--- a/AzureFunctions.AngularClient/src/app/function-edit/function-edit.component.ts
+++ b/AzureFunctions.AngularClient/src/app/function-edit/function-edit.component.ts
@@ -29,7 +29,7 @@ export class FunctionEditComponent {
 
     @ViewChild(FunctionDevComponent) functionDevComponent: FunctionDevComponent;
     public selectedFunction: FunctionInfo;
-    public viewInfo: TreeViewInfo;
+    public viewInfo: TreeViewInfo<any>;
     public inIFrame: boolean;
     public editorType: string = "standard";
     public disabled: boolean;
@@ -40,7 +40,7 @@ export class FunctionEditComponent {
     public ManageTab: string;
     public tabId: string = "";
 
-    private _viewInfoStream: Subject<TreeViewInfo>;
+    private _viewInfoStream: Subject<TreeViewInfo<any>>;
 
     private appNode: AppNode;
     private functionApp: FunctionApp;
@@ -57,7 +57,7 @@ export class FunctionEditComponent {
         this.MonitorTab = _translateService.instant("tabNames_monitor");
         this.ManageTab = _translateService.instant("tabNames_manage");
 
-        this._viewInfoStream = new Subject<TreeViewInfo>();
+        this._viewInfoStream = new Subject<TreeViewInfo<any>>();
         this._viewInfoStream
             .subscribe(viewInfo => {
                 this.viewInfo = viewInfo;
@@ -74,7 +74,7 @@ export class FunctionEditComponent {
             });
     }
 
-    set viewInfoInput(viewInfo: TreeViewInfo) {
+    set viewInfoInput(viewInfo: TreeViewInfo<any>) {
         this._viewInfoStream.next(viewInfo);
     }
 

--- a/AzureFunctions.AngularClient/src/app/function-integrate-v2/function-integrate-v2.component.ts
+++ b/AzureFunctions.AngularClient/src/app/function-integrate-v2/function-integrate-v2.component.ts
@@ -26,7 +26,7 @@ import { TreeViewInfo } from '../tree-view/models/tree-view-info';
 export class FunctionIntegrateV2Component {
     @Output() save = new EventEmitter<FunctionInfo>();
     @Output() changeEditor = new EventEmitter<string>();
-    @Input() public viewInfo: TreeViewInfo;
+    @Input() public viewInfo: TreeViewInfo<any>;
 
     public model: BindingList = new BindingList();
     public pickerType: TemplatePickerType = TemplatePickerType.none;

--- a/AzureFunctions.AngularClient/src/app/function-manage/function-manage.component.ts
+++ b/AzureFunctions.AngularClient/src/app/function-manage/function-manage.component.ts
@@ -34,7 +34,7 @@ export class FunctionManageComponent {
     public isStandalone: boolean;
     public isHttpFunction: boolean = false;
 
-    private _viewInfoStream: Subject<TreeViewInfo>;
+    private _viewInfoStream: Subject<TreeViewInfo<any>>;
     private _functionNode: FunctionManageNode;
     private functionStateValueChange: Subject<boolean>;
 
@@ -46,7 +46,7 @@ export class FunctionManageComponent {
 
         this.isStandalone = configService.isStandalone();
 
-        this._viewInfoStream = new Subject<TreeViewInfo>();
+        this._viewInfoStream = new Subject<TreeViewInfo<any>>();
         this._viewInfoStream
             .retry()
             .subscribe(viewInfo => {
@@ -84,7 +84,7 @@ export class FunctionManageComponent {
             });
     }
 
-    set viewInfoInput(viewInfo: TreeViewInfo) {
+    set viewInfoInput(viewInfo: TreeViewInfo<any>) {
         this._viewInfoStream.next(viewInfo);
     }
 

--- a/AzureFunctions.AngularClient/src/app/function-new/function-new.component.ts
+++ b/AzureFunctions.AngularClient/src/app/function-new/function-new.component.ts
@@ -64,7 +64,7 @@ export class FunctionNewComponent {
     ];
     private _action: Action;
 
-    private _viewInfoStream = new Subject<TreeViewInfo>();
+    private _viewInfoStream = new Subject<TreeViewInfo<any>>();
     public appNode: AppNode;
 
     constructor(
@@ -104,7 +104,7 @@ export class FunctionNewComponent {
         })
     }
 
-    set viewInfoInput(viewInfoInput : TreeViewInfo){
+    set viewInfoInput(viewInfoInput : TreeViewInfo<any>){
         this._viewInfoStream.next(viewInfoInput);
     }
 

--- a/AzureFunctions.AngularClient/src/app/function-quickstart/function-quickstart.component.ts
+++ b/AzureFunctions.AngularClient/src/app/function-quickstart/function-quickstart.component.ts
@@ -41,7 +41,7 @@ export class FunctionQuickstartComponent {
 
     public functionApp: FunctionApp;
     private functionsNode: FunctionsNode;
-    private _viewInfoStream = new Subject<TreeViewInfo>();
+    private _viewInfoStream = new Subject<TreeViewInfo<any>>();
 
     constructor(private _functionsService: FunctionsService,
         private _broadcastService: BroadcastService,
@@ -73,7 +73,7 @@ export class FunctionQuickstartComponent {
             })
     }
 
-    set viewInfoInput(viewInfoInput: TreeViewInfo) {
+    set viewInfoInput(viewInfoInput: TreeViewInfo<any>) {
         this._viewInfoStream.next(viewInfoInput);
 
     }

--- a/AzureFunctions.AngularClient/src/app/functions-list/functions-list.component.ts
+++ b/AzureFunctions.AngularClient/src/app/functions-list/functions-list.component.ts
@@ -28,7 +28,7 @@ import { ErrorType, ErrorEvent } from "app/shared/models/error-event";
     styleUrls: ['./functions-list.component.scss']
 })
 export class FunctionsListComponent implements OnInit, OnDestroy {
-    public viewInfoStream: Subject<TreeViewInfo>;
+    public viewInfoStream: Subject<TreeViewInfo<any>>;
     public functions: FunctionNode[] = [];
     public isLoading: boolean;
     public functionApp: FunctionApp;
@@ -43,7 +43,7 @@ export class FunctionsListComponent implements OnInit, OnDestroy {
         private _translateService: TranslateService,
         private _broadcastService: BroadcastService
     ) {
-        this.viewInfoStream = new Subject<TreeViewInfo>();
+        this.viewInfoStream = new Subject<TreeViewInfo<any>>();
 
         this._viewInfoSubscription = this.viewInfoStream
             .distinctUntilChanged()
@@ -67,7 +67,7 @@ export class FunctionsListComponent implements OnInit, OnDestroy {
         this._viewInfoSubscription.unsubscribe();
     }
 
-    @Input() set viewInfoInput(viewInfo: TreeViewInfo) {
+    @Input() set viewInfoInput(viewInfo: TreeViewInfo<any>) {
         this.viewInfoStream.next(viewInfo);
     }
 

--- a/AzureFunctions.AngularClient/src/app/main/main.component.ts
+++ b/AzureFunctions.AngularClient/src/app/main/main.component.ts
@@ -30,7 +30,7 @@ import { FunctionInfo } from "app/shared/models/function-info";
 })
 export class MainComponent implements AfterViewInit {
     public resourceId: string;
-    public viewInfo: TreeViewInfo;
+    public viewInfo: TreeViewInfo<any>;
     public dashboardType: string;
     public inIFrame: boolean;
     public inTab: boolean;
@@ -126,7 +126,7 @@ export class MainComponent implements AfterViewInit {
             })
     }
 
-    updateViewInfo(viewInfo: TreeViewInfo) {
+    updateViewInfo(viewInfo: TreeViewInfo<any>) {
         if (!viewInfo) {
             this.viewInfo = viewInfo;
             return;

--- a/AzureFunctions.AngularClient/src/app/proxies-list/proxies-list.component.ts
+++ b/AzureFunctions.AngularClient/src/app/proxies-list/proxies-list.component.ts
@@ -22,7 +22,7 @@ interface ProxyItem {
   inputs: ['viewInfoInput']
 })
 export class ProxiesListComponent implements OnInit {
-  public viewInfoStream: Subject<TreeViewInfo>;
+  public viewInfoStream: Subject<TreeViewInfo<any>>;
   public proxies: ProxyItem[] = [];
   public isLoading: boolean;
 
@@ -31,7 +31,7 @@ export class ProxiesListComponent implements OnInit {
   private _proxiesNode: ProxiesNode;
 
   constructor() {
-    this.viewInfoStream = new Subject<TreeViewInfo>();
+    this.viewInfoStream = new Subject<TreeViewInfo<any>>();
 
     this._viewInfoSubscription = this.viewInfoStream
       .distinctUntilChanged()
@@ -60,7 +60,7 @@ export class ProxiesListComponent implements OnInit {
     this._viewInfoSubscription.unsubscribe();
   }
 
-  set viewInfoInput(viewInfo: TreeViewInfo) {
+  set viewInfoInput(viewInfo: TreeViewInfo<any>) {
     this.viewInfoStream.next(viewInfo);
   }
 

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
@@ -47,7 +47,7 @@ import { SlotsService } from './../shared/services/slots.service';
     inputs: ['tryFunctionAppInput']
 })
 export class SideNavComponent implements AfterViewInit {
-    @Output() treeViewInfoEvent: EventEmitter<TreeViewInfo>;
+    @Output() treeViewInfoEvent: EventEmitter<TreeViewInfo<any>>;
     @ViewChild('treeViewContainer') treeViewContainer;
     @ViewChild(SearchBoxComponent) searchBox: SearchBoxComponent;
 
@@ -97,7 +97,7 @@ export class SideNavComponent implements AfterViewInit {
         public authZService: AuthzService,
         public slotsService: SlotsService) {
 
-        this.treeViewInfoEvent = new EventEmitter<TreeViewInfo>();
+        this.treeViewInfoEvent = new EventEmitter<TreeViewInfo<any>>();
 
         userService.getStartupInfo().subscribe(info => {
 
@@ -245,7 +245,7 @@ export class SideNavComponent implements AfterViewInit {
         this.selectedDashboardType = newDashboardType;
         this.resourceId = newSelectedNode.resourceId;
 
-        const viewInfo = <TreeViewInfo>{
+        const viewInfo = <TreeViewInfo<any>>{
             resourceId: newSelectedNode.resourceId,
             dashboardType: newDashboardType,
             node: newSelectedNode,

--- a/AzureFunctions.AngularClient/src/app/site/create-app/create-app.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/create-app/create-app.component.ts
@@ -30,10 +30,10 @@ import { BroadcastEvent } from 'app/shared/models/broadcast-event';
 export class CreateAppComponent implements OnInit {
   public Resources = PortalResources;
   public group: FormGroup;
-  public viewInfoStream: Subject<TreeViewInfo>;
+  public viewInfoStream: Subject<TreeViewInfo<any>>;
   public FwdLinks = Links;
 
-  private _viewInfo: TreeViewInfo;
+  private _viewInfo: TreeViewInfo<any>;
   private _subscriptionId: string;
 
   constructor(
@@ -68,7 +68,7 @@ export class CreateAppComponent implements OnInit {
         });
       });
 
-    this.viewInfoStream = new Subject<TreeViewInfo>();
+    this.viewInfoStream = new Subject<TreeViewInfo<any>>();
     this.viewInfoStream
       .subscribe(viewInfo => {
         this._viewInfo = viewInfo;
@@ -76,7 +76,7 @@ export class CreateAppComponent implements OnInit {
 
   }
 
-  @Input() set viewInfoInput(viewInfo: TreeViewInfo) {
+  @Input() set viewInfoInput(viewInfo: TreeViewInfo<any>) {
     this.viewInfoStream.next(viewInfo);
   }
 

--- a/AzureFunctions.AngularClient/src/app/site/function-runtime/function-runtime.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/function-runtime/function-runtime.component.ts
@@ -21,7 +21,7 @@ import { CacheService } from './../../shared/services/cache.service';
 import { Site } from './../../shared/models/arm/site';
 import { ArmObj } from './../../shared/models/arm/arm-obj';
 import { AppNode } from './../../tree-view/app-node';
-import { TreeViewInfo } from './../../tree-view/models/tree-view-info';
+import { TreeViewInfo, SiteData } from './../../tree-view/models/tree-view-info';
 import { ArmService } from '../../shared/services/arm.service';
 import { PortalService } from '../../shared/services/portal.service';
 import { BroadcastService } from '../../shared/services/broadcast.service';
@@ -64,8 +64,8 @@ export class FunctionRuntimeComponent implements OnDestroy {
   private functionEditModeValueStream: Subject<boolean>;
   public showTryView: boolean;
 
-  private _viewInfoStream = new Subject<TreeViewInfo>();
-  private _viewInfo: TreeViewInfo;
+  private _viewInfoStream = new Subject<TreeViewInfo<SiteData>>();
+  private _viewInfo: TreeViewInfo<SiteData>;
   private _viewInfoSub: RxSubscription;
   private _appNode: AppNode;
 
@@ -174,8 +174,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
           this.functionAppEditMode = true;
         }
         this._busyState.clearBusyState();
-        let traceKey = this._viewInfo.data.siteTraceKey;
-        this._aiService.stopTrace('/site/function-runtime-tab-ready', traceKey);
+        this._aiService.stopTrace('/timings/site/tab/function-runtime/revealed', this._viewInfo.data.siteTabRevealedTraceKey);
 
         //settings for enabling slots, display if there are no slots && appSetting property for slot is set
         this.slotsAppSetting = appSettings.properties[Constants.slotsSecretStorageSettingsName];
@@ -263,6 +262,10 @@ export class FunctionRuntimeComponent implements OnDestroy {
       // getFunctionAppEditMode returns a subject and updates it on demand.
       .mergeMap(_ => this.functionApp.getFunctionAppEditMode())
       .subscribe(fi => {
+
+        this._aiService.stopTrace('/timings/site/tab/function-runtime/full-ready',
+        this._viewInfo.data.siteTabFullReadyTraceKey);
+
         this._busyState.clearBusyState();
       });
 
@@ -288,7 +291,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
     });
   }
 
-  @Input('viewInfoInput') set viewInfoInput(viewInfo: TreeViewInfo) {
+  @Input('viewInfoInput') set viewInfoInput(viewInfo: TreeViewInfo<any>) {
     this._viewInfoStream.next(viewInfo);
   }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.ts
@@ -16,7 +16,7 @@ import { CustomFormGroup, CustomFormControl } from './../../controls/click-to-ed
 import { ArmObj } from './../../shared/models/arm/arm-obj';
 import { TblItem } from './../../controls/tbl/tbl.component';
 import { CacheService } from './../../shared/services/cache.service';
-import { TreeViewInfo } from './../../tree-view/models/tree-view-info';
+import { TreeViewInfo, SiteData } from './../../tree-view/models/tree-view-info';
 import { UniqueValidator } from 'app/shared/validators/uniqueValidator';
 import { RequiredValidator } from 'app/shared/validators/requiredValidator';
 
@@ -26,7 +26,7 @@ import { RequiredValidator } from 'app/shared/validators/requiredValidator';
   styleUrls: ['./site-config.component.scss']
 })
 export class SiteConfigComponent implements OnInit {
-  public viewInfoStream: Subject<TreeViewInfo>;
+  public viewInfoStream: Subject<TreeViewInfo<SiteData>>;
 
   public mainForm: FormGroup;
   public connectionStringTypes: DropDownElement<ConnectionStringType>[];
@@ -51,7 +51,7 @@ export class SiteConfigComponent implements OnInit {
   ) {
     this._busyState = tabsComponent.busyState;
 
-    this.viewInfoStream = new Subject<TreeViewInfo>();
+    this.viewInfoStream = new Subject<TreeViewInfo<SiteData>>();
     this._viewInfoSubscription = this.viewInfoStream
       .distinctUntilChanged()
       .switchMap(viewInfo => {
@@ -150,7 +150,7 @@ export class SiteConfigComponent implements OnInit {
     return connectionStringDropDownTypes;
   }
 
-  @Input() set viewInfoInput(viewInfo: TreeViewInfo) {
+  @Input() set viewInfoInput(viewInfo: TreeViewInfo<SiteData>) {
     this.viewInfoStream.next(viewInfo);
   }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-dashboard.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-dashboard.component.ts
@@ -1,3 +1,4 @@
+import { SiteData } from './../../tree-view/models/tree-view-info';
 import { Url } from './../../shared/Utilities/url';
 import { LocalStorageService } from './../../shared/services/local-storage.service';
 import { Component, OnInit, EventEmitter, Input, ViewChild } from '@angular/core';
@@ -45,8 +46,8 @@ export class SiteDashboardComponent {
     // If we end up doing a full tabs implementation, it would have to be dynamic
     public dynamicTabIds: (string | null)[] = [null, null];
     public site: ArmObj<Site>;
-    public viewInfoStream: Subject<TreeViewInfo>;
-    public viewInfo: TreeViewInfo;
+    public viewInfoStream: Subject<TreeViewInfo<SiteData>>;
+    public viewInfo: TreeViewInfo<SiteData>;
     public TabIds = SiteTabIds;
     public Resources = PortalResources;
     public isStandalone = false;
@@ -67,9 +68,9 @@ export class SiteDashboardComponent {
         private _storageService: LocalStorageService) {
 
         this.isStandalone = _configService.isStandalone();
-        this.tabsFeature = <EnableTabFeature>Url.getParameterByName(window.location.href, "appsvc.feature.tabs");
+        this.tabsFeature = <EnableTabFeature>Url.getParameterByName(window.location.href, 'appsvc.feature.tabs');
 
-        this.viewInfoStream = new Subject<TreeViewInfo>();
+        this.viewInfoStream = new Subject<TreeViewInfo<SiteData>>();
         this.viewInfoStream
             .switchMap(viewInfo => {
 
@@ -85,7 +86,8 @@ export class SiteDashboardComponent {
                     this._traceOnTabSelection = false;
                 }
 
-                viewInfo.data.siteTraceKey = this._aiService.startTrace();
+                viewInfo.data.siteTabRevealedTraceKey = this._aiService.startTrace();
+                viewInfo.data.siteTabFullReadyTraceKey = this._aiService.startTrace();
 
                 this._globalStateService.setBusyState();
 
@@ -139,14 +141,15 @@ export class SiteDashboardComponent {
             });
     }
 
-    set viewInfoInput(viewInfo: TreeViewInfo) {
+    set viewInfoInput(viewInfo: TreeViewInfo<SiteData>) {
         this.viewInfoStream.next(viewInfo);
     }
 
     onTabSelected(selectedTab: TabComponent) {
 
         if (this._traceOnTabSelection) {
-            this.viewInfo.data.siteTraceKey = this._aiService.startTrace();
+            this.viewInfo.data.siteTabRevealedTraceKey = this._aiService.startTrace();
+            this.viewInfo.data.siteTabFullReadyTraceKey = this._aiService.startTrace();
         }
 
         this._tabsLoaded = true;

--- a/AzureFunctions.AngularClient/src/app/site/site-summary/site-summary.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-summary/site-summary.component.ts
@@ -29,7 +29,7 @@ import { AiService } from './../../shared/services/ai.service';
 import { AppsNode } from './../../tree-view/apps-node';
 import { ArmObj } from './../../shared/models/arm/arm-obj';
 import { AppNode, SlotNode } from './../../tree-view/app-node';
-import { TreeViewInfo } from './../../tree-view/models/tree-view-info';
+import { TreeViewInfo, SiteData } from './../../tree-view/models/tree-view-info';
 import { ArmService } from './../../shared/services/arm.service';
 import { GlobalStateService } from './../../shared/services/global-state.service';
 
@@ -82,8 +82,8 @@ export class SiteSummaryComponent implements OnDestroy {
     public Resources = PortalResources;
     public showDownloadFunctionAppModal = false;
 
-    private _viewInfoStream: Subject<TreeViewInfo>;
-    private _viewInfo: TreeViewInfo;
+    private _viewInfoStream: Subject<TreeViewInfo<SiteData>>;
+    private _viewInfo: TreeViewInfo<SiteData>;
     private _subs: Subscription[];
     private _blobUrl: string;
     private _isSlot: boolean;
@@ -112,7 +112,7 @@ export class SiteSummaryComponent implements OnDestroy {
                 this._subs = info.subscriptions;
             });
 
-        this._viewInfoStream = new Subject<TreeViewInfo>();
+        this._viewInfoStream = new Subject<TreeViewInfo<SiteData>>();
         this._viewInfoStream
             .switchMap(viewInfo => {
                 this._viewInfo = viewInfo;
@@ -124,9 +124,9 @@ export class SiteSummaryComponent implements OnDestroy {
                 return this._cacheService.getArm(viewInfo.resourceId);
             })
             .mergeMap(r => {
-                let site: ArmObj<Site> = r.json();
+                const site: ArmObj<Site> = r.json();
                 this.site = site;
-                let descriptor = new SiteDescriptor(site.id);
+                const descriptor = new SiteDescriptor(site.id);
 
                 this.subscriptionId = descriptor.subscription;
 
@@ -153,20 +153,20 @@ export class SiteSummaryComponent implements OnDestroy {
                 this.scmType = null;
                 this.publishProfileLink = null;
 
-                let serverFarm = site.properties.serverFarmId.split('/')[8];
+                const serverFarm = site.properties.serverFarmId.split('/')[8];
                 this.plan = `${serverFarm} (${site.properties.sku.replace("Dynamic", "Consumption")})`;
                 this._isSlot = SlotsService.isSlot(site.id);
 
-                let configId = `${site.id}/config/web`;
+                const configId = `${site.id}/config/web`;
 
                 let availabilityId = `${site.id}/providers/Microsoft.ResourceHealth/availabilityStatuses/current`;
                 if (this._isSlot) {
                     let resourceId = site.id.substring(0, site.id.indexOf("/slots"));
                     availabilityId = `${resourceId}/providers/Microsoft.ResourceHealth/availabilityStatuses/current`;
                 }
+
                 this._busyState.clearBusyState();
-                let traceKey = this._viewInfo.data.siteTraceKey;
-                this._aiService.stopTrace("/site/overview-tab-ready", traceKey);
+                this._aiService.stopTrace('/timings/site/tab/overview/revealed', this._viewInfo.data.siteTabRevealedTraceKey);
 
                 this.hideAvailability = this._isSlot || site.properties.sku === "Dynamic";
 
@@ -244,6 +244,7 @@ export class SiteSummaryComponent implements OnDestroy {
                     timerAction: 'stop'
                 });
                 this.scmType = res.config.properties.scmType;
+                this._aiService.stopTrace('/timings/site/tab/overview/full-ready', this._viewInfo.data.siteTabFullReadyTraceKey);
 
                 if (this.hasWriteAccess) {
                     this.publishingUserName = res.publishCreds.properties.publishingUserName;
@@ -258,7 +259,7 @@ export class SiteSummaryComponent implements OnDestroy {
         return this._globalStateService.showTryView;
     }
 
-    set viewInfoInput(viewInfo: TreeViewInfo) {
+    set viewInfoInput(viewInfo: TreeViewInfo<SiteData>) {
         if (!viewInfo) {
             return;
         }

--- a/AzureFunctions.AngularClient/src/app/site/swagger-definition/swagger-definition.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/swagger-definition/swagger-definition.component.ts
@@ -32,7 +32,7 @@ import { ErrorIds } from '../../shared/models/error-ids';
 import { ErrorEvent, ErrorType } from '../../shared/models/error-event';
 import { FunctionApp } from '../../shared/function-app';
 import { CacheService } from '../../shared/services/cache.service';
-import { TreeViewInfo } from './../../tree-view/models/tree-view-info';
+import { TreeViewInfo, SiteData } from './../../tree-view/models/tree-view-info';
 import { AppNode } from './../../tree-view/app-node';
 import { ArmObj } from './../../shared/models/arm/arm-obj';
 import { Site } from './../../shared/models/arm/site';
@@ -61,9 +61,9 @@ export class SwaggerDefinitionComponent implements OnDestroy {
     private swaggerDocument: any;
 
 
-    private _viewInfoStream = new Subject<TreeViewInfo>();
+    private _viewInfoStream = new Subject<TreeViewInfo<SiteData>>();
     private _viewInfoSub: RxSubscription;
-    private _viewInfo: TreeViewInfo;
+    private _viewInfo: TreeViewInfo<SiteData>;
     private _appNode: AppNode;
     private _busyState: BusyStateComponent;
 
@@ -117,8 +117,9 @@ export class SwaggerDefinitionComponent implements OnDestroy {
             })
             .subscribe(swaggerEnabled => {
                 this._busyState.clearBusyState();
-                let traceKey = this._viewInfo.data.siteTraceKey;
-                this._aiService.stopTrace("/site/function-definition-tab-ready", traceKey);
+
+                this._aiService.stopTrace('/timings/site/tab/api-definition/revealed', this._viewInfo.data.siteTabRevealedTraceKey);
+                this._aiService.stopTrace('/timings/site/tab/api-definition/full-ready', this._viewInfo.data.siteTabFullReadyTraceKey);
             });
 
         this.swaggerStatusOptions = [
@@ -147,7 +148,7 @@ export class SwaggerDefinitionComponent implements OnDestroy {
             });
     }
 
-    set viewInfoInput(viewInfo: TreeViewInfo) {
+    set viewInfoInput(viewInfo: TreeViewInfo<SiteData>) {
         this._viewInfoStream.next(viewInfo);
     }
 

--- a/AzureFunctions.AngularClient/src/app/slot-new/slot-new.component.ts
+++ b/AzureFunctions.AngularClient/src/app/slot-new/slot-new.component.ts
@@ -50,8 +50,8 @@ export class SlotNewComponent implements OnInit {
     public isLoading: boolean = true;
 
     private _slotsNode: SlotsNode;
-    private _viewInfoStream = new Subject<TreeViewInfo>();
-    private _viewInfo: TreeViewInfo;
+    private _viewInfoStream = new Subject<TreeViewInfo<any>>();
+    private _viewInfo: TreeViewInfo<any>;
     private _siteId: string;
     private _appSettings: any;
     private _slotsList: ArmObj<Site>[];
@@ -124,7 +124,7 @@ export class SlotNewComponent implements OnInit {
             })
     }
 
-    set viewInfoInput(viewInfoInput: TreeViewInfo) {
+    set viewInfoInput(viewInfoInput: TreeViewInfo<any>) {
         this._viewInfoStream.next(viewInfoInput);
     }
 

--- a/AzureFunctions.AngularClient/src/app/slots-list/slots-list.component.ts
+++ b/AzureFunctions.AngularClient/src/app/slots-list/slots-list.component.ts
@@ -27,7 +27,7 @@ interface SlotItem {
     inputs: ['viewInfoInput']
 })
 export class SlotsListComponent implements OnInit {
-    public viewInfoStream: Subject<TreeViewInfo>;
+    public viewInfoStream: Subject<TreeViewInfo<any>>;
     public slots: SlotItem[] = [];
     public isLoading: boolean;
 
@@ -38,7 +38,7 @@ export class SlotsListComponent implements OnInit {
         private _broadcastService: BroadcastService,
         private _translateService: TranslateService
     ) {
-        this.viewInfoStream = new Subject<TreeViewInfo>();
+        this.viewInfoStream = new Subject<TreeViewInfo<any>>();
 
         this._viewInfoSubscription = this.viewInfoStream.distinctUntilChanged()
             .switchMap(viewInfo => {
@@ -71,7 +71,7 @@ export class SlotsListComponent implements OnInit {
     ngOnInit() {
     }
 
-    set viewInfoInput(viewInfo: TreeViewInfo) {
+    set viewInfoInput(viewInfo: TreeViewInfo<any>) {
         this.viewInfoStream.next(viewInfo);
     }
 

--- a/AzureFunctions.AngularClient/src/app/tree-view/models/tree-view-info.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/models/tree-view-info.ts
@@ -1,9 +1,14 @@
 import { DashboardType } from './dashboard-type';
 import { TreeNode } from '../tree-node';
 
-export interface TreeViewInfo {
+export interface TreeViewInfo<T> {
     resourceId: string;
     dashboardType: DashboardType;
     node: TreeNode;
-    data: any;
+    data: T;
+}
+
+export interface SiteData{
+    siteTabRevealedTraceKey?: string;
+    siteTabFullReadyTraceKey?: string;
 }


### PR DESCRIPTION
I added some timers to make sure that we're also calculating the equivalent of "full-ready" for any tabbed features at the app-level.  There's a lot of changes here because I changed the definition of TreeViewInfo, but the only files that have real changes are:

1. Site-dashboard.component.ts
2. site-summary.component.ts
3. site-manage.component.ts
4. function-runtime.component.ts
5. api-definition.component.ts