### PR TITLE
Fixing issue where shift-tab doesn't work for tbl components

### DIFF
--- a/AzureFunctions.AngularClient/.angular-cli.json
+++ b/AzureFunctions.AngularClient/.angular-cli.json
@@ -10,8 +10,8 @@
       "assets": [
         "assets",
         "images",
-        "sass/main.scss",
-        "../node_modules/swagger-editor"
+        "../node_modules/swagger-editor",
+        "sass/main.scss"
       ],
       "index": "index.html",
       "main": "main.ts",

--- a/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.html
+++ b/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.html
@@ -11,7 +11,7 @@
   </tr>
 
    <tr *ngFor="let item of table.items">
-    <td><span class="link" (click)="clickRow(item)">{{item.title}}</span></td>
+    <td><a (click)="clickRow(item)">{{item.title}}</a></td>
     <td>{{item.subscription}}</td>
     <td>{{item.resourceGroup}}</td>
     <td>{{item.location}}</td>    

--- a/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
+++ b/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
@@ -15,7 +15,6 @@ export interface TblItem {
   <table
     #tbl
     [class]='tblClass'
-    tabindex='0'
     (focus)='onFocus($event)'
     (click)='onClick($event)'
     (keydown)="onKeyPress($event)"
@@ -51,18 +50,20 @@ export class TblComponent implements OnInit, OnChanges {
     if (items) {
       this.items = items.currentValue;
       this._origItems = items.currentValue;
+
+      (<HTMLTableElement>this.table.nativeElement).tabIndex = 0;
     }
   }
 
-  // Gets called if a user either "tabs" over to a table, or clicks somewhere
-  // within the table.
+  // A table should only get focus on the first time someone has tabbed over
+  // to the table, or if the table has updated by receiving a new "items" property.
+  // After that, each individual cell will get its own focus, but the parent
+  // tbl component will continue to get the keypress and mouse click events thrown.
   onFocus(event: FocusEvent) {
 
-    // If the table hasn't received focus yet
-    if (this._focusedRowIndex === -1 && this._focusedCellIndex === -1) {
-      this._focusedRowIndex = 0;
-      this._focusedCellIndex = 0;
-    }
+    (<HTMLTableElement>this.table.nativeElement).tabIndex = -1;
+    this._focusedRowIndex = 0;
+    this._focusedCellIndex = 0;
 
     const rows = this._getRows();
     const cell = this._getCurrentCellOrReset(rows);

--- a/AzureFunctions.AngularClient/src/sass/base/_base.scss
+++ b/AzureFunctions.AngularClient/src/sass/base/_base.scss
@@ -38,10 +38,6 @@ pre {
     color: $primary-color;
 }
 
-.hover-underline:hover{
-    text-decoration: underline;
-}
-
 :focus{
     outline: $border-focus;
 }

--- a/AzureFunctions.AngularClient/src/sass/base/_typography.scss
+++ b/AzureFunctions.AngularClient/src/sass/base/_typography.scss
@@ -1,5 +1,6 @@
-a {
-    text-decoration: none;
+a{
+    cursor: pointer;
+    color: $primary-color;
 }
 
 h1, h2, h3, h4{


### PR DESCRIPTION
Fixed an issue where shift-tab wouldn't change focus to the previous control in the tab order.  The problem was that since the table always intercepted the focus, it would never allow you to go to a previous control from a cell.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/azure-functions-ux/1575)
<!-- Reviewable:end -->
