### PR TITLE
Fixes #1609 - Bread-crumbs are broken

### DIFF
--- a/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
+++ b/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
@@ -88,7 +88,7 @@ export class TblComponent implements OnInit, OnChanges {
       const cells = this._getCells(row);
       const cellIndex = this._findElemIndex(cells, cell);
 
-      if (rowIndex && cellIndex) {
+      if (rowIndex >= 0 && cellIndex >= 0) {
         this._clearFocusOnCell(rows, this._focusedRowIndex, this._focusedCellIndex);
         this._setFocusOnCell(rows, rowIndex, cellIndex);
       }

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
@@ -223,7 +223,7 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
         const path: string[] = [];
         let curNode: TreeNode = this;
 
-        while (curNode) {
+        while (curNode && curNode.title) {
             path.splice(0, 0, curNode.title);
             curNode = curNode.parent;
         }


### PR DESCRIPTION
For the breadcrumbs issue, the problem was that the tree node path changed so that the root node would have an undefined title.  So adding a null check where we build the path fixes the bread-crumbs.

I also added a fix for the Tbl component so that you can click on the first column in a table.  The issue here was that the onClick callback was interpreting a 0 index as false. 