### PR TITLE
Fixing GeneralSettingsComponent so that permissions shields don't cover "General settings" and "Debugging" headings

### DIFF
--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.html
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.html
@@ -165,8 +165,8 @@
       </div>
     </div>
 
-    <div *ngIf="(!hasWritePermissions || !group) && !!loadingFailureMessage" class="shield">
-      <div *ngIf="!group" class="shield-message">
+    <div *ngIf="!hasWritePermissions || (!group && !!loadingFailureMessage)" class="shield">
+      <div *ngIf="!group && !!loadingFailureMessage" class="shield-message">
         {{loadingFailureMessage}}
       </div>
     </div>
@@ -203,8 +203,8 @@
       </div>
     </div>
 
-    <div *ngIf="(!hasWritePermissions || !group) && !!loadingFailureMessage" class="shield">
-      <div *ngIf="!group" class="shield-message">
+    <div *ngIf="!hasWritePermissions || (!group && !!loadingFailureMessage)" class="shield">
+      <div *ngIf="!group && !!loadingFailureMessage" class="shield-message">
         {{loadingFailureMessage}}
       </div>
     </div>

--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
@@ -130,7 +130,6 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
         this._aiService.trackEvent('/errors/general-settings', error);
         this._setupForm(this._webConfigArm, this._siteConfigArm);
         this.loadingFailureMessage = this._translateService.instant(PortalResources.loading);
-        this.showPermissionsMessage = true;
         this._busyStateScopeManager.clearBusy();
       })
       .retry()
@@ -143,7 +142,6 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
         }
         this._processSkuAndKind(this._siteConfigArm);
         this._setupForm(this._webConfigArm, this._siteConfigArm);
-        this.showPermissionsMessage = true;
         this._busyStateScopeManager.clearBusy();
       });
   }
@@ -182,6 +180,7 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
     }
 
     this.hasWritePermissions = writePermission && !readOnlyLock;
+    this.showPermissionsMessage = true;
   }
 
   private _resetSupportedControls() {

--- a/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.scss
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.scss
@@ -60,10 +60,6 @@ h3{
     }
 }
 
-.transparent{
-    background: transparent;
-}
-
 .shield{
     position: absolute;
     left: 0;
@@ -143,4 +139,8 @@ h3{
             width: 255px;
         }
     }
+}
+
+.transparent{
+    background: transparent;
 }


### PR DESCRIPTION
# Before:

![image](https://user-images.githubusercontent.com/5387224/28942849-a505d3a6-7851-11e7-9868-6abff5e6df29.png)
![image](https://user-images.githubusercontent.com/5387224/28942878-b546ecc8-7851-11e7-85ca-be90f3cc1b33.png)


# After:

![image](https://user-images.githubusercontent.com/5387224/28942755-5fb46538-7851-11e7-8d9e-16cfd5722822.png)
![image](https://user-images.githubusercontent.com/5387224/28942771-6f3b0886-7851-11e7-9f43-34672f06cf15.png)

