### PR TITLE
Enable dash in the query string parameters and headers, fix #1666

### DIFF
--- a/AzureFunctions.AngularClient/src/app/run-http/run-http.component.ts
+++ b/AzureFunctions.AngularClient/src/app/run-http/run-http.component.ts
@@ -118,7 +118,7 @@ export class RunHttpComponent {
     paramChanged() {
         // iterate all params and set valid property depends of params name
 
-        const regex = new RegExp('^$|[^A-Za-z0-9-]');
+        const regex = new RegExp('^$|[^A-Za-z0-9-_]');
         this.valid = true;
         this.model.queryStringParams.concat(this.model.headers).forEach((item => {
             item.valid = !regex.test(item.name);

--- a/AzureFunctions.AngularClient/src/app/run-http/run-http.component.ts
+++ b/AzureFunctions.AngularClient/src/app/run-http/run-http.component.ts
@@ -118,7 +118,7 @@ export class RunHttpComponent {
     paramChanged() {
         // iterate all params and set valid property depends of params name
 
-        const regex = new RegExp('^$|[^A-Za-z0-9]');
+        const regex = new RegExp('^$|[^A-Za-z0-9-]');
         this.valid = true;
         this.model.queryStringParams.concat(this.model.headers).forEach((item => {
             item.valid = !regex.test(item.name);


### PR DESCRIPTION
Here is an attempt to fix #1666 that does not enable dash in query string parameters and headers names.