### PR TITLE
Enable application setting tab by default

### DIFF
--- a/AzureFunctions.AngularClient/src/app/site/function-runtime/function-runtime.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/function-runtime/function-runtime.component.ts
@@ -22,7 +22,6 @@ import { ArmObj } from './../../shared/models/arm/arm-obj';
 import { AppNode } from './../../tree-view/app-node';
 import { TreeViewInfo, SiteData } from './../../tree-view/models/tree-view-info';
 import { ArmService } from '../../shared/services/arm.service';
-import { PortalService } from '../../shared/services/portal.service';
 import { BroadcastService } from '../../shared/services/broadcast.service';
 import { BroadcastEvent } from '../../shared/models/broadcast-event'
 import { GlobalStateService } from '../../shared/services/global-state.service';
@@ -33,7 +32,6 @@ import { FunctionApp } from './../../shared/function-app';
 import { FunctionAppEditMode } from '../../shared/models/function-app-edit-mode';
 import { SlotsService } from '../../shared/services/slots.service';
 import { HostStatus } from './../../shared/models/host-status';
-import { Url } from "app/shared/Utilities/url";
 
 @Component({
   selector: 'function-runtime',
@@ -81,7 +79,6 @@ export class FunctionRuntimeComponent implements OnDestroy {
   constructor(
     private _armService: ArmService,
     private _cacheService: CacheService,
-    private _portalService: PortalService,
     private _broadcastService: BroadcastService,
     private _globalStateService: GlobalStateService,
     private _aiService: AiService,
@@ -381,16 +378,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
   }
 
   openAppSettings() {
-    if (Url.getParameterByName(window.location.href, 'appsvc.feature.appsettingstab') === 'true') { // DEBUG: conditionally showing application settings tab
-      this._broadcastService.broadcast<string>(BroadcastEvent.OpenTab, SiteTabIds.applicationSettings);
-    } else {
-      this._portalService.openBlade({
-        detailBlade: 'WebsiteConfigSiteSettings',
-        detailBladeInputs: {
-          resourceUri: this.site.id,
-        }
-      }, 'settings');
-    }
+    this._broadcastService.broadcast<string>(BroadcastEvent.OpenTab, SiteTabIds.applicationSettings);
   }
 
   private _updateContainerVersion(appSettings: ArmObj<any>) {

--- a/AzureFunctions.AngularClient/src/app/site/site-enabled-features/site-enabled-features.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-enabled-features/site-enabled-features.component.ts
@@ -2,7 +2,6 @@ import { ElementRef } from '@angular/core';
 import { Dom } from './../../shared/Utilities/dom';
 import { SiteDashboardComponent } from './../site-dashboard/site-dashboard.component';
 import { SiteTabIds, KeyCodes } from './../../shared/models/constants';
-import { Url } from './../../shared/Utilities/url';
 import { Component, ViewChild } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -210,26 +209,12 @@ export class SiteEnabledFeaturesComponent {
                 };
 
             case Feature.AppSettings:
-                if (Url.getParameterByName(window.location.href, 'appsvc.feature.appsettingstab') === 'true') { // DEBUG: conditionally showing application settings tab
-                    return <EnabledFeatureItem>{
-                        title: this._translateService.instant(PortalResources.feature_applicationSettingsName),
-                        feature: feature,
-                        iconUrl: 'images/application-settings.svg',
-                        featureId: SiteTabIds.applicationSettings
-                    };
-                } else {
-                    return <EnabledFeatureItem>{
-                        title: this._translateService.instant(PortalResources.feature_applicationSettingsName),
-                        feature: feature,
-                        bladeInfo: {
-                            detailBlade: 'WebsiteConfigSiteSettings',
-                            detailBladeInputs: {
-                                resourceUri: this._descriptor.resourceId,
-                            }
-                        },
-                        iconUrl: 'images/application-settings.svg'
-                    };
-                }
+                return <EnabledFeatureItem>{
+                    title: this._translateService.instant(PortalResources.feature_applicationSettingsName),
+                    feature: feature,
+                    iconUrl: 'images/application-settings.svg',
+                    featureId: SiteTabIds.applicationSettings
+                };
 
             case Feature.AppInsight:
                 return <EnabledFeatureItem>{

--- a/AzureFunctions.AngularClient/src/app/site/site-manage/site-manage.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-manage/site-manage.component.ts
@@ -21,7 +21,6 @@ import { PortalService } from '../../shared/services/portal.service';
 import { Site } from '../../shared/models/arm/site';
 import { ArmObj } from '../../shared/models/arm/arm-obj';
 import { SiteDescriptor } from '../../shared/resourceDescriptors';
-import { Url } from "app/shared/Utilities/url";
 
 @Component({
     selector: 'site-manage',
@@ -239,6 +238,14 @@ export class SiteManageComponent implements OnDestroy {
                 SiteTabIds.functionRuntime,
                 this._broadcastService),
 
+            new TabFeature(
+                this._translateService.instant(PortalResources.tab_applicationSettings),
+                this._translateService.instant(PortalResources.tab_applicationSettings),
+                this._translateService.instant(PortalResources.feature_applicationSettingsInfo),
+                'images/application-settings.svg',
+                SiteTabIds.applicationSettings,
+                this._broadcastService),
+
             new BladeFeature(
                 this._translateService.instant(PortalResources.feature_propertiesName),
                 this._translateService.instant(PortalResources.feature_propertiesName),
@@ -282,35 +289,6 @@ export class SiteManageComponent implements OnDestroy {
                 },
                 this._portalService)
         ];
-
-        if (Url.getParameterByName(window.location.href, 'appsvc.feature.appsettingstab') === 'true') { // DEBUG: conditionally showing application settings tab
-                generalFeatures.splice(1, 0,
-                    new TabFeature(
-                        this._translateService.instant(PortalResources.tab_applicationSettings),
-                        this._translateService.instant(PortalResources.tab_applicationSettings),
-                        this._translateService.instant(PortalResources.feature_applicationSettingsInfo),
-                        'images/application-settings.svg',
-                        SiteTabIds.applicationSettings,
-                        this._broadcastService)
-                );
-            } else {
-                generalFeatures.splice(1, 0,
-                    new BladeFeature(
-                        this._translateService.instant(PortalResources.feature_applicationSettingsName),
-                        this._translateService.instant(PortalResources.feature_applicationSettingsName) +
-                        ' ' + this._translateService.instant(PortalResources.connectionStrings) +
-                        ' java php .net',
-                        this._translateService.instant(PortalResources.feature_applicationSettingsInfo),
-                        'images/application-settings.svg',
-                        {
-                            detailBlade: 'WebsiteConfigSiteSettings',
-                            detailBladeInputs: {
-                                resourceUri: site.id,
-                            }
-                        },
-                        this._portalService),
-            );
-        }
 
         this.groups1 = [
             new FeatureGroup(this._translateService.instant(PortalResources.feature_generalSettings), generalFeatures),


### PR DESCRIPTION
Whenever you click on "application settings" anywhere in the Functions UI, it will now open the app settings tab instead of opening a new blade.

![image](https://user-images.githubusercontent.com/5695405/29193922-33b87506-7ddc-11e7-961a-8f96c0155996.png)
