### PR TITLE
Fixes #1598 - Add a utility to make it easier to handle different environments (like on-prem) in code

### DIFF
--- a/AzureFunctions.AngularClient/src/app/app.module.ts
+++ b/AzureFunctions.AngularClient/src/app/app.module.ts
@@ -1,3 +1,5 @@
+import { CheckScenarioDirective } from './shared/directives/check-scenario.directive';
+import { ScenarioService } from './shared/services/scenario/scenario.service';
 import { SiteTabComponent } from './site/site-dashboard/site-tab/site-tab.component';
 import { DynamicLoaderDirective } from './shared/directives/dynamic-loader.directive';
 import { DownloadFunctionAppContentComponent } from './download-function-app-content/download-function-app-content.component';
@@ -16,7 +18,7 @@ import { HttpModule, Http } from '@angular/http';
 
 import { TranslateModule } from '@ngx-translate/core';
 import { FileUploadModule } from 'ng2-file-upload';
-import { PopoverModule } from "ng2-popover";
+import { PopoverModule } from 'ng2-popover';
 
 import { ConfigService } from './shared/services/config.service';
 import { FunctionsService } from './shared/services/functions.service';
@@ -219,6 +221,7 @@ export class AppModule {
       TblComponent,
       TblThComponent,
       FnWriteAccessDirective,
+      CheckScenarioDirective,
       DynamicLoaderDirective,
       EditModeWarningComponent,
       TextboxComponent,
@@ -268,6 +271,7 @@ export class AppModule {
         ]
       },
       CacheService,
+      ScenarioService,
       SlotsService,
       AuthzService,
       LocalStorageService,

--- a/AzureFunctions.AngularClient/src/app/shared/Utilities/logger.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/Utilities/logger.ts
@@ -1,10 +1,10 @@
-import { Url } from "app/shared/Utilities/url";
+import { Url } from 'app/shared/Utilities/url';
 
 export class Logger {
-    static debugging: any; boolean = (Url.getParameterByName(null, "appsvc.log") === 'debug');
+    static debugging: boolean = (Url.getParameterByName(null, 'appsvc.log') === 'debug');
 
     public static debug(obj: any) {
-        if (this.debugging) {
+        if (Logger.debugging) {
             console.log(obj);
         }
     }

--- a/AzureFunctions.AngularClient/src/app/shared/directives/check-scenario.directive.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/directives/check-scenario.directive.ts
@@ -1,0 +1,72 @@
+import { ScenarioService } from './../services/scenario/scenario.service';
+import { ScenarioCheckInput } from './../services/scenario/scenario.models';
+import { Directive, Input, ElementRef, SimpleChange, OnChanges } from '@angular/core';
+import { Subject } from 'rxjs/Subject';
+import 'rxjs/add/operator/debounceTime';
+import 'rxjs/add/operator/switchMap';
+
+
+@Directive({
+    selector: '[check-scenario]',
+})
+export class CheckScenarioDirective implements OnChanges {
+
+
+    @Input('check-scenario') id: string;
+    @Input('cs-input') input: ScenarioCheckInput;
+    @Input('cs-showByDefault') enabledByDefault = false;
+    @Input('cs-enabledClass') enabledClass = '';
+    @Input('cs-disabledClass') disabledClass = 'invisible';
+
+    private _idStream = new Subject<string>();
+
+    constructor(
+        scenarioCheckService: ScenarioService,
+        private _elementRef: ElementRef) {
+
+        this._idStream
+            .debounceTime(100)
+            .switchMap(id => {
+                return scenarioCheckService.checkScenarioAsync(this.id, this.input);
+            })
+            .subscribe(result => {
+                this._updateClass(result.status);
+            });
+    }
+
+    ngOnChanges(changes: { [key: string]: SimpleChange }) {
+        if (this.enabledByDefault) {
+            this._updateClass('enabled');
+        } else {
+            this._updateClass('disabled');
+        }
+
+        if (this.id && this.input) {
+            this._idStream.next(this.id);
+        }
+    }
+
+    private _updateClass(status: 'enabled' | 'disabled') {
+        const nativeElement = <HTMLElement>this._elementRef.nativeElement;
+        if (status === 'disabled') {
+
+            if (this.enabledClass) {
+                nativeElement.classList.remove(this.enabledClass);
+            }
+
+            if (this.disabledClass) {
+                nativeElement.classList.add(this.disabledClass);
+            }
+
+        } else {
+
+            if (this.disabledClass) {
+                nativeElement.classList.remove(this.disabledClass);
+            }
+
+            if (this.enabledClass) {
+                nativeElement.classList.add(this.enabledClass);
+            }
+        }
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -140,6 +140,33 @@ export class Order {
     ]
 }
 
+export class ScenarioIds {
+    public static readonly addSiteConfigTab = 'AddSiteConfigTab';
+    public static readonly addSiteFeaturesTab = 'AddSiteFeaturesTab';
+    public static readonly getSiteSlotLimits = 'GetSiteSlotLimits';
+    public static readonly showSiteAvailability = 'ShowSiteAvailability';
+    public static readonly addResourceExplorer = 'AddResourceExplorer';
+    public static readonly addPushNotifications = 'AddPushNotifications';
+    public static readonly addTinfoil = 'AddTinfoil';
+}
+
+export class ServerFarmSku {
+    public static readonly free = 'Free';
+    public static readonly shared = 'Shared';
+    public static readonly basic = 'Basic';
+    public static readonly standard = 'Standard';
+    public static readonly premium = 'Premium';
+    public static readonly premiumV2 = 'PremiumV2';
+    public static readonly isolated = 'Isolated';
+    public static readonly dynamic = 'Dynamic';
+}
+
+export class NationalCloudArmUris {
+    public static readonly fairfax = 'https://management.usgovcloudapi.net';
+    public static readonly blackforest = 'https://management.microsoftazure.de';
+    public static readonly mooncake = 'https://management.chinacloudapi.cn';
+}
+
 export class KeyCodes {
     public static readonly tab = 9;
     public static readonly enter = 13;
@@ -152,7 +179,7 @@ export class KeyCodes {
     public static readonly arrowDown = 40;
 }
 
-export class DomEvents{
+export class DomEvents {
     public static readonly keydown = 'keydown';
     public static readonly click = 'click';
 }

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -150,6 +150,8 @@ export class ScenarioIds {
     public static readonly addResourceExplorer = 'AddResourceExplorer';
     public static readonly addPushNotifications = 'AddPushNotifications';
     public static readonly addTinfoil = 'AddTinfoil';
+    public static readonly showSiteQuotas = 'ShowSiteQuotas';
+    public static readonly showSiteFileStorage = 'ShowSiteFileStorage';
     public static readonly showSitePin = 'ShowSitePin';
 }
 

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -140,6 +140,8 @@ export class Order {
     ]
 }
 
+// NOTE: If you change any string values here, make sure you search for references to the values
+// in any HTML templates first!
 export class ScenarioIds {
     public static readonly addSiteConfigTab = 'AddSiteConfigTab';
     public static readonly addSiteFeaturesTab = 'AddSiteFeaturesTab';
@@ -148,6 +150,7 @@ export class ScenarioIds {
     public static readonly addResourceExplorer = 'AddResourceExplorer';
     public static readonly addPushNotifications = 'AddPushNotifications';
     public static readonly addTinfoil = 'AddTinfoil';
+    public static readonly showSitePin = 'ShowSitePin';
 }
 
 export class ServerFarmSku {

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/azure.environment.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/azure.environment.ts
@@ -1,0 +1,63 @@
+import { Observable } from 'rxjs/Observable';
+import { ScenarioCheckInput, ScenarioResult } from './scenario.models';
+import { ScenarioIds, ServerFarmSku } from './../../models/constants';
+import { Environment } from 'app/shared/services/scenario/scenario.models';
+
+export class AzureEnvironment extends Environment {
+    name = 'Azure';
+
+    constructor() {
+        super();
+        this.scenarioChecks[ScenarioIds.addSiteFeaturesTab] = {
+            id: ScenarioIds.addSiteFeaturesTab,
+            runCheck: () => {
+                return { status: 'enabled' };
+            }
+        };
+
+        this.scenarioChecks[ScenarioIds.getSiteSlotLimits] = {
+            id: ScenarioIds.getSiteSlotLimits,
+            runCheckAsync: (input: ScenarioCheckInput) => {
+                return Observable.of(this._getSlotLimit(input));
+            }
+        };
+    }
+
+    public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {
+        return window.appsvc.env.runtimeType === 'Azure';
+    }
+
+    private _getSlotLimit(input: ScenarioCheckInput) {
+        const site = input && input.site;
+        if (!site) {
+            throw Error('No site input specified');
+        }
+
+        let limit: number;
+
+        switch (site.properties.sku) {
+            case ServerFarmSku.free:
+            case ServerFarmSku.basic:
+                limit = 0;
+                break;
+            case ServerFarmSku.dynamic:
+                limit = 1;
+                break;
+            case ServerFarmSku.standard:
+                limit = 5;
+                break;
+            case ServerFarmSku.premium:
+            case ServerFarmSku.premiumV2:
+            case ServerFarmSku.isolated:
+                limit = 20;
+                break;
+            default:
+                limit = 0;
+        }
+
+        return <ScenarioResult>{
+            status: 'enabled',
+            data: limit
+        };
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/azure.environment.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/azure.environment.ts
@@ -15,6 +15,20 @@ export class AzureEnvironment extends Environment {
             }
         };
 
+        this.scenarioChecks[ScenarioIds.showSiteQuotas] = {
+            id: ScenarioIds.showSiteQuotas,
+            runCheck: (input: ScenarioCheckInput) => {
+                return this._showSiteQuotas(input);
+            }
+        };
+
+        this.scenarioChecks[ScenarioIds.showSiteFileStorage] = {
+            id: ScenarioIds.showSiteFileStorage,
+            runCheck: (input: ScenarioCheckInput) => {
+                return this._showSiteFileStorage(input);
+            }
+        };
+
         this.scenarioChecks[ScenarioIds.getSiteSlotLimits] = {
             id: ScenarioIds.getSiteSlotLimits,
             runCheckAsync: (input: ScenarioCheckInput) => {
@@ -25,6 +39,38 @@ export class AzureEnvironment extends Environment {
 
     public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {
         return window.appsvc.env.runtimeType === 'Azure';
+    }
+
+    private _showSiteQuotas(input: ScenarioCheckInput) {
+        const site = input && input.site;
+
+        if (!site) {
+            throw Error('No site input specified');
+        }
+
+        const showQuotas = input.site.properties.sku === ServerFarmSku.free
+            || input.site.properties.sku === ServerFarmSku.shared;
+
+        return <ScenarioResult>{
+            status: showQuotas ? 'enabled' : 'disabled',
+            data: null
+        };
+    }
+
+    private _showSiteFileStorage(input: ScenarioCheckInput) {
+        const site = input && input.site;
+
+        if (!site) {
+            throw Error('No site input specified');
+        }
+
+        const showFileStorage = input.site.properties.sku !== ServerFarmSku.free
+            && input.site.properties.sku !== ServerFarmSku.shared;
+
+        return <ScenarioResult>{
+            status: showFileStorage ? 'enabled' : 'disabled',
+            data: null
+        };
     }
 
     private _getSlotLimit(input: ScenarioCheckInput) {

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/dynamic-site.environment.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/dynamic-site.environment.ts
@@ -1,0 +1,25 @@
+import { ScenarioCheckInput } from './scenario.models';
+import { ScenarioIds } from './../../models/constants';
+import { Environment } from './scenario.models';
+
+export class DynamicSiteEnvironment extends Environment {
+    name = 'DynamicSite';
+
+    constructor() {
+        super();
+        this.scenarioChecks[ScenarioIds.showSiteAvailability] = {
+            id: ScenarioIds.showSiteAvailability,
+            runCheck: () => {
+                return { status: 'disabled' };
+            }
+        };
+    }
+
+    public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {
+        if (input && input.site) {
+            return input.site.properties.sku.toLowerCase() === 'dynamic';
+        }
+
+        return false;
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/national-cloud.environment.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/national-cloud.environment.ts
@@ -1,0 +1,42 @@
+import { AzureEnvironment } from './azure.environment';
+import { ScenarioCheckInput } from './scenario.models';
+import { ScenarioIds, NationalCloudArmUris } from './../../models/constants';
+
+export class NationalCloudEnvironment extends AzureEnvironment {
+    name = 'NationalCloud';
+
+    public static isNationalCloud() {
+        return window.appsvc.env.azureResourceManagerEndpoint.toLowerCase() === NationalCloudArmUris.mooncake.toLowerCase()
+        || window.appsvc.env.azureResourceManagerEndpoint.toLowerCase() === NationalCloudArmUris.fairfax.toLowerCase()
+        || window.appsvc.env.azureResourceManagerEndpoint.toLowerCase() === NationalCloudArmUris.blackforest.toLowerCase();
+    }
+
+    constructor() {
+        super();
+        this.scenarioChecks[ScenarioIds.addResourceExplorer] = {
+            id: ScenarioIds.addResourceExplorer,
+            runCheck: () => {
+                return { status: 'disabled' };
+            }
+        };
+
+        this.scenarioChecks[ScenarioIds.addPushNotifications] = {
+            id: ScenarioIds.addPushNotifications,
+            runCheck: () => {
+                return { status: 'disabled' };
+            }
+        };
+
+        this.scenarioChecks[ScenarioIds.addTinfoil] = {
+            id: ScenarioIds.addTinfoil,
+            runCheck: () => {
+                return { status: 'disabled' };
+            }
+        };
+
+    }
+
+    public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {
+        return NationalCloudEnvironment.isNationalCloud();
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/scenario.models.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/scenario.models.ts
@@ -1,0 +1,35 @@
+import { Observable } from 'rxjs/Observable';
+import { Site } from './../../models/arm/site';
+import { ArmObj } from './../../models/arm/arm-obj';
+
+export interface ScenarioCheckInput {
+    site?: ArmObj<Site>;
+}
+
+export type ScenarioStatus = 'enabled' | 'disabled' | null;
+
+export interface ScenarioResult {
+    // status: ScenarioStatus;
+    status: ScenarioStatus;
+    data?: any;
+}
+
+export interface ScenarioCheckResult extends ScenarioResult {
+    id: string;
+    environmentName: string;
+}
+
+interface ScenarioCheck {
+    id: string;
+    runCheck?: (input?: ScenarioCheckInput) => ScenarioResult;
+    runCheckAsync?: (input?: ScenarioCheckInput) => Observable<ScenarioResult>;
+}
+
+// TODO: should this be an interface instead?
+export abstract class Environment {
+    scenarioChecks: { [key: string]: ScenarioCheck } = {};
+
+    abstract name: string;
+    abstract isCurrentEnvironment(input?: ScenarioCheckInput): boolean;
+
+}

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/scenario.models.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/scenario.models.ts
@@ -9,7 +9,6 @@ export interface ScenarioCheckInput {
 export type ScenarioStatus = 'enabled' | 'disabled' | null;
 
 export interface ScenarioResult {
-    // status: ScenarioStatus;
     status: ScenarioStatus;
     data?: any;
 }
@@ -25,7 +24,6 @@ interface ScenarioCheck {
     runCheckAsync?: (input?: ScenarioCheckInput) => Observable<ScenarioResult>;
 }
 
-// TODO: should this be an interface instead?
 export abstract class Environment {
     scenarioChecks: { [key: string]: ScenarioCheck } = {};
 

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/scenario.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/scenario.service.ts
@@ -1,0 +1,142 @@
+import { NationalCloudEnvironment } from './national-cloud.environment';
+import { Logger } from './../../Utilities/logger';
+import { DynamicSiteEnvironment } from './dynamic-site.environment';
+import { SiteSlotEnvironment } from './site-slot.environment';
+import { Observable } from 'rxjs/Observable';
+import { AzureEnvironment } from './azure.environment';
+import { ScenarioCheckResult, ScenarioResult } from './scenario.models';
+import { ScenarioCheckInput } from './scenario.models';
+import { StandaloneEnvironment } from './stand-alone.environment';
+import { Environment } from './scenario.models';
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class ScenarioService {
+
+    private _environments: Environment[] = [
+        new StandaloneEnvironment(),
+        new SiteSlotEnvironment(),
+        new DynamicSiteEnvironment()
+    ];
+
+    constructor() {
+
+        // National cloud environments inherit from AzureEnvironment so we ensure there
+        // aren't duplicates to reduce the chance of conflicts in behavior.
+        if (NationalCloudEnvironment.isNationalCloud()) {
+            this._environments.splice(0, 0, new NationalCloudEnvironment());
+        } else {
+            this._environments.splice(0, 0, new AzureEnvironment());
+        }
+    }
+
+    // Does a synchronous check against all possible environments to see whether a
+    // scenario should be either enabled (whitelisted) or disabled (blacklisted).  Things to note:
+    // 1. Blacklisting takes priority, so if there are several environments which say that a scenario is
+    //    enabled, but there is one environment that says a scenario is disabled, then the disable will
+    //    take precedence.
+    // 2. If any matching environment has only implemented an async check, it will throw an error since
+    //    this is a synchronous function.
+    public checkScenario(id: string, input?: ScenarioCheckInput): ScenarioCheckResult {
+        const results = this._environments
+            .filter(env => env.isCurrentEnvironment(input) && env.scenarioChecks[id]) // TODO: add in env.scenarioChecks[id] here
+            .map(env => {
+
+                const check = env.scenarioChecks[id];
+                if (check.runCheckAsync) {
+                    throw Error(`An async check was defined for Environment: "${env.name}", Scenario: "${check.id}".  You must run checkScenarioAsync instead.`);
+                }
+
+                if (check.runCheck) {
+                    const result = check.runCheck(input);
+                    return <ScenarioCheckResult>{
+                        status: result.status,
+                        data: result.data,
+                        environmentName: env.name,
+                        id: id
+                    };
+                } else {
+                    throw Error('No runCheck method implemented for Environment: "${env.name}", Scenario: "${check.id}"');
+                }
+            });
+
+        return this._getFinalResult(id, results);
+    }
+
+    // Similar to checkScenario, checkScenarioAsync will do checks for scenario's that require
+    // async behaviors.  If a matching scenario implemented "runCheckAsync", then it will used in this check.
+    // If however it has only implemented a the synchronous "runCheck" method, then it will treat
+    // it as an asynchronous function and include its result in the final status calculation.
+    public checkScenarioAsync(id: string, input?: ScenarioCheckInput): Observable<ScenarioCheckResult> {
+        const checks = this._environments
+            .filter(env => env.isCurrentEnvironment(input) && env.scenarioChecks[id])
+            .map(env => {
+
+                const check = env.scenarioChecks[id];
+                let runCheckObs: Observable<ScenarioResult>;
+
+                if (check.runCheckAsync) {
+                    runCheckObs = check.runCheckAsync(input);
+                } else if (check.runCheck) {
+                    runCheckObs = Observable.of(check.runCheck());
+                } else {
+                    throw Error('No runCheckAsync or runCheck method implemented for Environment: "${env.name}", Scenario: "${check.id}"');
+                }
+
+                return runCheckObs
+                    .map(r => {
+                        return <ScenarioCheckResult>{
+                            status: r.status,
+                            data: r.data,
+                            environmentName: env.name,
+                            id: id
+                        };
+                    });
+            });
+
+        if (checks.length === 0) {
+            return Observable.of(<ScenarioCheckResult>{
+                id: id,
+                status: null,
+                environmentName: null
+            });
+        }
+
+        return Observable.zip.apply(this, checks)
+            .map(results => {
+                return this._getFinalResult(id, results);
+            });
+    }
+
+    private _getFinalResult(id: string, results: ScenarioCheckResult[]) {
+        let enabledResult: ScenarioCheckResult;
+        let result: ScenarioCheckResult;
+
+        const disabledResult = results.find(r => {
+            if (r && r.status === 'disabled') {
+                return true;
+            } else if (r && r.status === 'enabled' && !enabledResult) {
+                enabledResult = r;
+            }
+
+            return false;
+        });
+
+        // A single disabled check takes precedence to disable the entire scenario
+        if (disabledResult) {
+            result = disabledResult;
+        } else if (enabledResult) {
+            result = enabledResult;
+        } else {
+            result = <ScenarioCheckResult>{
+                id: id,
+                status: null,
+                environmentName: null
+            };
+        }
+
+        Logger.debug(`[ScenarioService] final result: id = ${result.id}, environment = ${result.environmentName}, status = ${result.status}`);
+
+        return result;
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/site-slot.environment.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/site-slot.environment.ts
@@ -1,0 +1,27 @@
+import { SiteDescriptor } from 'app/shared/resourceDescriptors';
+import { ScenarioCheckInput } from './scenario.models';
+import { ScenarioIds } from './../../models/constants';
+import { Environment } from 'app/shared/services/scenario/scenario.models';
+
+export class SiteSlotEnvironment extends Environment {
+    name = 'SiteSlot';
+
+    constructor() {
+        super();
+        this.scenarioChecks[ScenarioIds.showSiteAvailability] = {
+            id: ScenarioIds.showSiteAvailability,
+            runCheck: () => {
+                return { status: 'disabled' };
+            }
+        };
+    }
+
+    public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {
+        if (input && input.site) {
+            const descriptor = SiteDescriptor.getSiteDescriptor(input.site.id);
+            return !!descriptor.slot;
+        }
+
+        return false;
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/stand-alone.environment.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/stand-alone.environment.ts
@@ -13,6 +13,21 @@ export class StandaloneEnvironment extends Environment {
                 return { status: 'enabled' };
             }
         };
+
+        this.scenarioChecks[ScenarioIds.addSiteFeaturesTab] = {
+            id: ScenarioIds.addSiteFeaturesTab,
+            runCheck: () => {
+                return { status: 'disabled' };
+            }
+        };
+
+        this.scenarioChecks[ScenarioIds.showSitePin] = {
+            id: ScenarioIds.showSitePin,
+            runCheck: () => {
+                return { status: 'disabled' };
+            }
+        };
+
     }
 
     public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/stand-alone.environment.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/stand-alone.environment.ts
@@ -1,0 +1,21 @@
+import { ScenarioCheckInput } from './scenario.models';
+import { ScenarioIds } from './../../models/constants';
+import { Environment } from 'app/shared/services/scenario/scenario.models';
+
+export class StandaloneEnvironment extends Environment {
+    name = 'Standalone';
+
+    constructor() {
+        super();
+        this.scenarioChecks[ScenarioIds.addSiteConfigTab] = {
+            id: ScenarioIds.addSiteConfigTab,
+            runCheck: () => {
+                return { status: 'enabled' };
+            }
+        };
+    }
+
+    public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {
+        return window.appsvc.env.runtimeType === 'Standalone';
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-dashboard.component.html
+++ b/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-dashboard.component.html
@@ -1,6 +1,11 @@
 <div id="site-dashboard-container">
 
-    <img *ngIf="!isStandalone" id="site-dashboard-pin" class="link" src="images/pin.svg" (click)="pinPart()" />
+    <img check-scenario="ShowSitePin"
+         [cs-input]="{site: site}"
+         id="site-dashboard-pin"
+         class="link"
+         src="images/pin.svg"
+         (click)="pinPart()" />
 
     <nav id="site-tabs">
         <div *ngFor="let info of tabInfos"

--- a/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-dashboard.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-dashboard.component.ts
@@ -20,7 +20,6 @@ import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/zip';
 
-import { ConfigService } from './../../shared/services/config.service';
 import { PortalService } from './../../shared/services/portal.service';
 import { PortalResources } from './../../shared/models/portal-resources';
 import { AiService } from './../../shared/services/ai.service';
@@ -55,7 +54,6 @@ export class SiteDashboardComponent implements OnChanges, OnDestroy {
     public viewInfoStream: Subject<TreeViewInfo<SiteData>>;
     public TabIds = SiteTabIds;
     public Resources = PortalResources;
-    public isStandalone = false;
 
     private _currentTabId: string;
     private _prevTabId: string;
@@ -70,11 +68,9 @@ export class SiteDashboardComponent implements OnChanges, OnDestroy {
         private _aiService: AiService,
         private _portalService: PortalService,
         private _translateService: TranslateService,
-        private _configService: ConfigService,
         private _broadcastService: BroadcastService,
         private _scenarioService: ScenarioService) {
 
-        this.isStandalone = this._configService.isStandalone();
 
         this._openTabSubscription = this._broadcastService.subscribe<string>(BroadcastEvent.OpenTab, tabId => {
             this.openFeature(tabId);

--- a/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-dashboard.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-dashboard.component.ts
@@ -1,3 +1,4 @@
+import { ScenarioService } from './../../shared/services/scenario/scenario.service';
 import { SiteConfigComponent } from './../site-config/site-config.component';
 import { DirtyStateEvent } from './../../shared/models/broadcast-event';
 import { SiteConfigStandaloneComponent } from './../site-config-standalone/site-config-standalone.component';
@@ -23,7 +24,7 @@ import { ConfigService } from './../../shared/services/config.service';
 import { PortalService } from './../../shared/services/portal.service';
 import { PortalResources } from './../../shared/models/portal-resources';
 import { AiService } from './../../shared/services/ai.service';
-import { SiteTabIds } from './../../shared/models/constants';
+import { SiteTabIds, ScenarioIds } from './../../shared/models/constants';
 import { AppNode } from './../../tree-view/app-node';
 import { CacheService } from '../../shared/services/cache.service';
 import { GlobalStateService } from '../../shared/services/global-state.service';
@@ -70,7 +71,8 @@ export class SiteDashboardComponent implements OnChanges, OnDestroy {
         private _portalService: PortalService,
         private _translateService: TranslateService,
         private _configService: ConfigService,
-        private _broadcastService: BroadcastService) {
+        private _broadcastService: BroadcastService,
+        private _scenarioService: ScenarioService) {
 
         this.isStandalone = this._configService.isStandalone();
 
@@ -94,9 +96,11 @@ export class SiteDashboardComponent implements OnChanges, OnDestroy {
             // Setup initial tabs without inputs immediate so that they load right away
             this.tabInfos = [this._getTabInfo(SiteTabIds.overview, true /* active */, null)];
 
-            if (this.isStandalone) {
+            if (this._scenarioService.checkScenario(ScenarioIds.addSiteConfigTab).status === 'enabled') {
                 this.tabInfos.push(this._getTabInfo(SiteTabIds.config, false /* active */, null));
-            } else {
+            }
+
+            if (this._scenarioService.checkScenario(ScenarioIds.addSiteFeaturesTab).status === 'enabled') {
                 this.tabInfos.push(this._getTabInfo(SiteTabIds.features, false /* active */, null));
             }
         }

--- a/AzureFunctions.AngularClient/src/app/site/site-manage/site-manage.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-manage/site-manage.component.ts
@@ -475,20 +475,37 @@ export class SiteManageComponent implements OnDestroy {
                 this._portalService,
                 this._hasPlanReadPermissionStream),
 
-            new DisableableBladeFeature(
-                this._translateService.instant(PortalResources.feature_quotasName),
-                this._translateService.instant(PortalResources.feature_quotasName),
-                this._translateService.instant(PortalResources.feature_quotasInfo),
-                'images/quotas.svg',
-                {
-                    detailBlade: 'QuotasBlade',
-                    detailBladeInputs: {
-                        resourceUri: site.id
-                    }
-                },
-                this._portalService,
-                null,
-                this._dynamicDisableInfo),
+            this._scenarioService.checkScenario(ScenarioIds.showSiteQuotas, { site: site }).status !== 'disabled'
+                ? new DisableableBladeFeature(
+                    this._translateService.instant(PortalResources.feature_quotasName),
+                    this._translateService.instant(PortalResources.feature_quotasName),
+                    this._translateService.instant(PortalResources.feature_quotasInfo),
+                    'images/quotas.svg',
+                    {
+                        detailBlade: 'QuotasBlade',
+                        detailBladeInputs: {
+                            resourceUri: site.id
+                        }
+                    },
+                    this._portalService,
+                    this._hasPlanReadPermissionStream)
+                : null,
+
+            this._scenarioService.checkScenario(ScenarioIds.showSiteFileStorage, { site: site }).status !== 'disabled'
+                ? new DisableableBladeFeature(
+                    this._translateService.instant(PortalResources.feature_quotasName),
+                    this._translateService.instant(PortalResources.feature_quotasName),
+                    this._translateService.instant(PortalResources.feature_quotasInfo),
+                    'images/quotas.svg',
+                    {
+                        detailBlade: 'FileSystemStorage',
+                        detailBladeInputs: {
+                            resourceUri: site.properties.serverFarmId
+                        }
+                    },
+                    this._portalService,
+                    this._hasPlanReadPermissionStream)
+                : null
         ];
 
         const resourceManagementFeatures = [
@@ -585,7 +602,9 @@ export class SiteManageComponent implements OnDestroy {
 
         this.groups3 = [
             new FeatureGroup(this._translateService.instant(PortalResources.feature_api), apiManagementFeatures),
-            new FeatureGroup(this._translateService.instant(PortalResources.appServicePlan), appServicePlanFeatures),
+            new FeatureGroup(
+                this._translateService.instant(PortalResources.appServicePlan),
+                appServicePlanFeatures.filter(f => !!f)),
             new FeatureGroup(this._translateService.instant(PortalResources.feature_resourceManagement), resourceManagementFeatures)];
     }
 }

--- a/AzureFunctions.AngularClient/src/app/site/site-summary/site-summary.component.html
+++ b/AzureFunctions.AngularClient/src/app/site/site-summary/site-summary.component.html
@@ -35,10 +35,6 @@
       </div>
     </div>
 
-    <!-- Keeping this around for now as an example of how to use the check-scenario directive.  I was originally
-         using it but realized that it doesn't really make sense here since we want to also prevent HTTP
-         requests to the slow availability API if we're going to hide this -->
-    <!-- <div check-scenario="ShowSiteAvailability" [cs-input]="{ site: site }"> -->
     <div [class.invisible]="hideAvailability">
       <label id="siteAvailabilityLabel">{{'availability' | translate}}</label>
       <div [class.site-faded-text]="availabilityState === 'unknown'" 

--- a/AzureFunctions.AngularClient/src/app/site/site-summary/site-summary.component.html
+++ b/AzureFunctions.AngularClient/src/app/site/site-summary/site-summary.component.html
@@ -35,6 +35,10 @@
       </div>
     </div>
 
+    <!-- Keeping this around for now as an example of how to use the check-scenario directive.  I was originally
+         using it but realized that it doesn't really make sense here since we want to also prevent HTTP
+         requests to the slow availability API if we're going to hide this -->
+    <!-- <div check-scenario="ShowSiteAvailability" [cs-input]="{ site: site }"> -->
     <div [class.invisible]="hideAvailability">
       <label id="siteAvailabilityLabel">{{'availability' | translate}}</label>
       <div [class.site-faded-text]="availabilityState === 'unknown'" 

--- a/AzureFunctions.AngularClient/src/app/site/site-summary/site-summary.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-summary/site-summary.component.ts
@@ -1,3 +1,4 @@
+import { ScenarioService } from './../../shared/services/scenario/scenario.service';
 import { SiteTabComponent } from './../site-dashboard/site-tab/site-tab.component';
 import { BusyStateComponent } from './../../busy-state/busy-state.component';
 import { UserService } from './../../shared/services/user.service';
@@ -20,7 +21,7 @@ import { FunctionApp } from './../../shared/function-app';
 import { PortalResources } from './../../shared/models/portal-resources';
 import { PortalService } from './../../shared/services/portal.service';
 import { Subscription } from './../../shared/models/subscription';
-import { AvailabilityStates, KeyCodes } from './../../shared/models/constants';
+import { AvailabilityStates, KeyCodes, ScenarioIds } from './../../shared/models/constants';
 import { Availability } from './../site-notifications/notifications';
 import { AiService } from './../../shared/services/ai.service';
 import { ArmObj } from './../../shared/models/arm/arm-obj';
@@ -91,7 +92,8 @@ export class SiteSummaryComponent implements OnDestroy {
         private _configService: ConfigService,
         private _slotService: SlotsService,
         userService: UserService,
-        siteTabComponent: SiteTabComponent) {
+        siteTabComponent: SiteTabComponent,
+        scenarioService: ScenarioService) {
 
         this.isStandalone = _configService.isStandalone();
         this._busyState = siteTabComponent.busyState;
@@ -142,20 +144,16 @@ export class SiteSummaryComponent implements OnDestroy {
                 this.availabilityMesg = this.ts.instant(PortalResources.functionMonitor_loading);
                 this.availabilityIcon = null;
 
-
                 this.publishProfileLink = null;
-
 
                 const serverFarm = site.properties.serverFarmId.split('/')[8];
                 this.plan = `${serverFarm} (${site.properties.sku.replace('Dynamic', 'Consumption')})`;
                 this._isSlot = SlotsService.isSlot(site.id);
 
-
-
                 this._busyState.clearBusyState();
                 this._aiService.stopTrace('/timings/site/tab/overview/revealed', this._viewInfo.data.siteTabRevealedTraceKey);
 
-                this.hideAvailability = this._isSlot || site.properties.sku === 'Dynamic';
+                this.hideAvailability = scenarioService.checkScenario(ScenarioIds.showSiteAvailability, {site: site}).status === 'disabled';
 
                 // Go ahead and assume write access at this point to unveal everything. This allows things to work when the RBAC API fails and speeds up reveal. In
                 // cases where this causes a false positive, the backend will take care of giving a graceful failure.

--- a/AzureFunctions.AngularClient/src/polyfills/window.ts
+++ b/AzureFunctions.AngularClient/src/polyfills/window.ts
@@ -1,17 +1,17 @@
 import 'core-js/es6/symbol';
 
-interface Environment{
-  hostName : string;
-  runtimeType : string;
-  azureResourceManagerEndpoint : string;
+interface Environment {
+  hostName: string;
+  runtimeType: 'OnPrem' | 'Azure' | 'Standalone';
+  azureResourceManagerEndpoint: string;
 }
 
-interface AppSvc{
-  env : Environment;
+interface AppSvc {
+  env: Environment;
 }
 
 declare global {
-  interface Window{
-    appsvc : AppSvc;
+  interface Window {
+    appsvc: AppSvc;
   }
 }


### PR DESCRIPTION
The Functions portal will soon have to be able to run in many different environment types that have different capabilities and constraints.  To help keep our view logic clean, I'm adding a new ScenarioService which will allow us to define view logic behaviors that are specific to every environment type.

**Examples of Usage**
*Checking if a scenario is enabled/disabled* – In this example, we only show the “Platform features” tab for a site if we’re running in Azure and disable for Standalone (aka Functions runtime).  Adding a simple check around the tab creation will handle this.  Notice that the call to “checkScenario” is synchronous:

      if (this._scenarioService.checkScenario(ScenarioIds.addSiteFeaturesTab).status === 'enabled') {
          this.tabInfos.push(this._getTabInfo(SiteTabIds.features, false /* active */, null));
      }

*Checking if a scenario is enabled/disabled due to an asynchronous condition, or has a data result like when checking for a feature quota* – In this example, we can find out what the current limit of slots I can create for a given site.  This is a hard-coded value in Azure based on the SKU, but in on-prem this can vary depending on how an administrator sets this up.  Notice that the call to “checkScenarioAsync” is asynchronous:

      this._scenarioService.checkScenarioAsync(ScenarioIds.getSiteSlotLimits, { site: this.site })
      .subscribe(result =>{
          this.maxNumSlots = result.data;
      });

*Enabling/disabling a feature strictly from HTML* – If the scenario is simple enough, it may be easier to just handle everything in HTML.  The yellow “check-scenario” directive allows you to pass in the id of the scenario you’d like to check for, and the blue “cs-input” allows us to pass in any input that may be necessary to resolve whether that environment applies to you or not.  There’s also other directive inputs that you can specify which allows you to control the styling for how enable/disable looks for a given element:

    <div check-scenario="ShowSiteAvailability" [cs-input]="{ site: site }">
      <label id="siteAvailabilityLabel">{{'availability' | translate}}</label>
      <div>{{availabilityMesg}}</div>
    </div>

**Defining Environments**
Defining separate environments with different conditions and behavior allows us to keep our application code clean.  When adding a new environment, you just need to implement the “isCurrentEnvironment” function to tell the service that you apply, and a scenarioCheck, which has the logic to decide whether a scenario is enabled/disabled for that environment

Base class

    export abstract class Environment {
        scenarioChecks: { [key: string]: ScenarioCheck } = {};

        abstract name: string;
        abstract isCurrentEnvironment(input?: ScenarioCheckInput): boolean;
    }

