### PR TITLE
Adding a logging service

### DIFF
--- a/AzureFunctions.AngularClient/src/app/app.module.ts
+++ b/AzureFunctions.AngularClient/src/app/app.module.ts
@@ -1,3 +1,4 @@
+import { LogService } from './shared/services/log.service';
 import { CheckScenarioDirective } from './shared/directives/check-scenario.directive';
 import { ScenarioService } from './shared/services/scenario/scenario.service';
 import { SiteTabComponent } from './site/site-dashboard/site-tab/site-tab.component';
@@ -263,6 +264,7 @@ export class AppModule {
       PortalService,
       BroadcastService,
       FunctionMonitorService,
+      LogService,
       {
         provide: ArmService, useFactory: ArmServiceFactory, deps: [
           Http,

--- a/AzureFunctions.AngularClient/src/app/shared/Utilities/url.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/Utilities/url.ts
@@ -18,4 +18,13 @@ export class Url {
 
         return decodeURIComponent(results[2].replace(/\+/g, ' '));
     }
+
+    public static getParameterArrayByName(url, name) {
+        const value = Url.getParameterByName(url, name);
+        if (value) {
+            return value.split(',');
+        } else {
+            return [];
+        }
+    }
 }

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -172,6 +172,11 @@ export class NationalCloudArmUris {
     public static readonly mooncake = 'https://management.chinacloudapi.cn';
 }
 
+export class LogCategories{
+    public static readonly siteDashboard = 'SiteDashboard';
+    public static readonly scenarioService = 'ScenarioService';
+}
+
 export class KeyCodes {
     public static readonly tab = 9;
     public static readonly enter = 13;

--- a/AzureFunctions.AngularClient/src/app/shared/services/log.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/log.service.ts
@@ -1,0 +1,101 @@
+import { AiService } from 'app/shared/services/ai.service';
+import { Injectable } from '@angular/core';
+import { Url } from 'app/shared/Utilities/url';
+
+enum LogLevel {
+    error,
+    warning,
+    debug,
+    verbose
+}
+
+@Injectable()
+export class LogService {
+
+    // static debugging: any; boolean = (Url.getParameterByName(null, "appsvc.log") === 'debug');
+    private _logLevel: LogLevel;
+    private _categories: string[];
+
+    constructor(private _aiService: AiService) {
+        const levelStr = Url.getParameterByName(null, 'appsvc.log.level');
+
+        if (levelStr) {
+            try {
+                this._logLevel = LogLevel[levelStr];
+            } catch (e) {
+                this._logLevel = LogLevel.warning;
+            }
+        } else {
+            this._logLevel = LogLevel.warning;
+        }
+
+        this._categories = Url.getParameterArrayByName(null, 'appsvc.log.category');
+    }
+
+    // TODO: Should we enforce that data is a standard generic object type?  It would make simple
+    // logging more complicated, but may help to promote better data being logged.
+    public error(category: string, id: string, data: any) {
+        if (!category || !id || !data) {
+            throw Error('You must provide a category, id, and data');
+        }
+
+        const errorId = `/errors${id}`;
+
+        // Always log errors to App Insights
+        this._aiService.trackEvent(errorId, data);
+
+        if (this._shouldLog(category, LogLevel.error)) {
+            console.error(`[${category}] - ${data}`);
+        }
+    }
+
+    public warn(category: string, id: string, data: any) {
+        if (!category || !id || !data) {
+            throw Error('You must provide a category, id, and data');
+        }
+
+        const warningId = `/warnings${id}`;
+
+        // Always log warnings to App Insights
+        this._aiService.trackEvent(warningId, data);
+
+        if (this._shouldLog(category, LogLevel.warning)) {
+            console.log(`%c[${category}] - ${data}`, 'color: #ff8c00');
+        }
+    }
+
+    public debug(category: string, data: any) {
+        if (!category || !data) {
+            throw Error('You must provide a category and data');
+        }
+
+        if (this._shouldLog(category, LogLevel.debug)) {
+            console.log(`%c[${category}] - ${data}`, 'color: #0058ad');
+        }
+    }
+
+    public verbose(category: string, data: any) {
+        if (!category || !data) {
+            throw Error('You must provide a category and data');
+        }
+
+        if (this._shouldLog(category, LogLevel.verbose)) {
+            console.log(`[${category}] - ${data}`);
+        }
+    }
+
+    private _shouldLog(category: string, logLevel: LogLevel) {
+
+        if (logLevel <= this._logLevel) {
+            if (this._categories.length > 0 && this._categories.find(c => c.toLowerCase() === category.toLowerCase())) {
+                return true;
+            } else if (this._categories.length === 0) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/shared/services/log.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/log.service.ts
@@ -12,7 +12,6 @@ enum LogLevel {
 @Injectable()
 export class LogService {
 
-    // static debugging: any; boolean = (Url.getParameterByName(null, "appsvc.log") === 'debug');
     private _logLevel: LogLevel;
     private _categories: string[];
 
@@ -32,8 +31,6 @@ export class LogService {
         this._categories = Url.getParameterArrayByName(null, 'appsvc.log.category');
     }
 
-    // TODO: Should we enforce that data is a standard generic object type?  It would make simple
-    // logging more complicated, but may help to promote better data being logged.
     public error(category: string, id: string, data: any) {
         if (!category || !id || !data) {
             throw Error('You must provide a category, id, and data');

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/scenario.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/scenario.service.ts
@@ -1,5 +1,5 @@
+import { LogService } from './../log.service';
 import { NationalCloudEnvironment } from './national-cloud.environment';
-import { Logger } from './../../Utilities/logger';
 import { DynamicSiteEnvironment } from './dynamic-site.environment';
 import { SiteSlotEnvironment } from './site-slot.environment';
 import { Observable } from 'rxjs/Observable';
@@ -9,6 +9,7 @@ import { ScenarioCheckInput } from './scenario.models';
 import { StandaloneEnvironment } from './stand-alone.environment';
 import { Environment } from './scenario.models';
 import { Injectable } from '@angular/core';
+import { LogCategories } from 'app/shared/models/constants';
 
 @Injectable()
 export class ScenarioService {
@@ -19,7 +20,7 @@ export class ScenarioService {
         new DynamicSiteEnvironment()
     ];
 
-    constructor() {
+    constructor(private _logService: LogService) {
 
         // National cloud environments inherit from AzureEnvironment so we ensure there
         // aren't duplicates to reduce the chance of conflicts in behavior.
@@ -135,7 +136,7 @@ export class ScenarioService {
             };
         }
 
-        Logger.debug(`[ScenarioService] final result: id = ${result.id}, environment = ${result.environmentName}, status = ${result.status}`);
+        this._logService.debug(LogCategories.scenarioService, `Final result: id = ${result.id}, environment = ${result.environmentName}, status = ${result.status}`);
 
         return result;
     }


### PR DESCRIPTION
I'm adding a general purpose logging service which will hopefully help to standardize how we do logging and help with troubleshooting.

There's 4 log levels: Error, Warning (default), debug, and verbose, which can be controlled with a query string like so: "?appsvc.log.level=debug".  Error and Warning messages will always get logged to App Insights, while debug and verbose will only get logged to the browser console.

In addition to controlling log levels, you can also specify which categories you'd like to log.  For instance, if I specify the query string: "?appsvc.log.category=cat1,cat2", then only log messages that match cat1 and cat2 will be logged.

![image](https://user-images.githubusercontent.com/5695405/29437393-1f81bbea-8365-11e7-9b9e-87d8aa00fa54.png)
