### PR TITLE
Fixes #1697 - Function apps list should have a refresh button

### DIFF
--- a/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.html
+++ b/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.html
@@ -56,12 +56,13 @@
     </ng-container>
   </tr>
 
-  <tr *ngIf="isLoading">
-    <td *ngIf="isLoading" colspan="4">{{'functionMonitor_loading' | translate}}</td>
-    <td *ngIf="isLoading" colspan="4"></td>
+  <tr *ngIf="appsNode?.isLoading">
+    <td colspan="4">{{'functionMonitor_loading' | translate}}</td>
+    <td colspan="4"></td>
   </tr>
 </tbl>
-<div *ngIf="!isLoading && table.items.length === 0" class="empty-browse">
+
+<div *ngIf="!appsNode?.isLoading && initialized && table.items.length === 0" class="empty-browse">
   <img src="images/emptybrowse-functions.svg" />
   <h4>{{'emptyBrowse_title' | translate}}</h4>
   <span>{{'emptyBrowse' | translate}}</span>

--- a/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.ts
+++ b/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.ts
@@ -32,7 +32,7 @@ export class AppsListComponent implements OnInit, OnDestroy {
   public appsNode: AppsNode;
   public Resources = PortalResources;
 
-  public isLoading = true;
+  public initialized = false;
 
   public allLocations = this.translateService.instant(PortalResources.allLocations);
   public numberLocations = this.translateService.instant(PortalResources.locationCount);
@@ -64,11 +64,12 @@ export class AppsListComponent implements OnInit, OnDestroy {
       .distinctUntilChanged()
       .switchMap(viewInfo => {
         this.appsNode = (<AppsNode>viewInfo.node);
-        this.isLoading = true;
+        this.initialized = false;
         return (<AppsNode>viewInfo.node).childrenStream;
       })
       .subscribe(children => {
         this.apps = children;
+        this.initialized = true;
         this.tableItems = this.apps.map(app => (<AppTableItem>{
           title: app.title,
           subscription: app.subscription,
@@ -88,7 +89,6 @@ export class AppsListComponent implements OnInit, OnDestroy {
             displayLabel: resourceGroup,
             value: resourceGroup
           }));
-        this.isLoading = false;
       });
   }
 

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
@@ -64,7 +64,7 @@ export class SideNavComponent implements AfterViewInit {
 
     private _savedSubsKey = '/subscriptions/selectedIds';
     private _subscriptionsStream = new ReplaySubject<Subscription[]>(1);
-    private _searchTermStream = new Subject<string>();
+    private _searchTermStream = new ReplaySubject<string>(1);
 
     private _initialized = false;
 

--- a/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
@@ -47,7 +47,6 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
         super(sideNav, null, rootNode);
 
         this.newDashboardType = sideNav.configService.isStandalone() ? DashboardType.createApp : null;
-        // this.inSelectedTree = !!this.newDashboardType;
 
         this.iconClass = 'tree-node-collection-icon';
         this.iconUrl = 'images/BulletList.svg';
@@ -58,7 +57,6 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
 
         this._getSearchStream()
             .subscribe((result: { term: string, children: TreeNode[] }) => {
-                this._searchObs = null;
 
                 if (!result) {
                     this.isLoading = false;


### PR DESCRIPTION
Added a refresh button to the "Function apps" node in the tree.  For now the button will only show up if you've selected the Function apps node in the tree.  This is mainly because we need to do more work in order to make sure that you can properly restore the selection state if you're currently selected on something deep in the tree, like the Function Dev component.

![image](https://user-images.githubusercontent.com/5695405/29541275-d990a7ec-8687-11e7-8208-6a698697b9f7.png)
