### PR TITLE
Accessibility fixes for delete icons in FunctionsListComponent 

### DIFF
--- a/AzureFunctions.AngularClient/src/app/functions-list/functions-list.component.html
+++ b/AzureFunctions.AngularClient/src/app/functions-list/functions-list.component.html
@@ -43,8 +43,12 @@
                     {{ 'enabled' | translate }}
                 </span>
             </td>
-            <td class="icon">
-                <img src="images/delete.svg" (click)="clickDelete(item)" />
+            <td class="command-icon">
+                <a role="button"
+                   [attr.aria-label]="'functionManage_delete' | translate:{name: item.functionName}"
+                   style="background-image: url('images/delete.svg')"
+                   (click)="clickDelete(item)">
+                </a>
             </td>
         </tr>
 

--- a/AzureFunctions.AngularClient/src/app/shared/models/portal-resources.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/portal-resources.ts
@@ -125,6 +125,7 @@ export class PortalResources
     public static functionIntegrate_changesLost2: string = "functionIntegrate_changesLost2";
     public static functionIntegrate_settingName: string = "functionIntegrate_settingName";
     public static functionIntegrate_standardEditor: string = "functionIntegrate_standardEditor";
+    public static functionManage_delete: string = "functionManage_delete";
     public static functionManage_areYouSure: string = "functionManage_areYouSure";
     public static functionMonitor_loading: string = "functionMonitor_loading";
     public static functionMonitor_successAggregate: string = "functionMonitor_successAggregate";

--- a/AzureFunctions.AngularClient/src/sass/controls/_tbl.scss
+++ b/AzureFunctions.AngularClient/src/sass/controls/_tbl.scss
@@ -40,7 +40,7 @@
         }
     }
 
-    td.icon{
+    td.icon, td.command-icon{
         width: 32px;
         height: 32px;
         cursor: pointer;
@@ -48,10 +48,25 @@
         &:hover{
             background-color: $command-color-hover;
         }
+    }
 
+    td.icon{
         img{
             margin: 0px !important;
             height: 15px !important;
+        }
+    }
+
+
+    td.command-icon{
+        a{
+            display: block;
+            margin: auto;
+            height: 25px;
+            width: 25px;
+            background-size: 15px 15px;
+            background-repeat: no-repeat;
+            background-position: 5px 5px;
         }
     }
 

--- a/AzureFunctions/ResourcesPortal/Resources.Designer.cs
+++ b/AzureFunctions/ResourcesPortal/Resources.Designer.cs
@@ -3238,6 +3238,15 @@ namespace AzureFunctions.ResourcesPortal {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delete Function {{name}}?.
+        /// </summary>
+        internal static string functionManage_delete {
+            get {
+                return ResourceManager.GetString("functionManage_delete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to delete Function {{name}}?.
         /// </summary>
         internal static string functionManage_areYouSure {

--- a/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/Resources.resx
@@ -487,6 +487,9 @@
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>Standard editor</value>
   </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>Delete Function {{name}}</value>
+  </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>Are you sure you want to delete Function {{name}}?</value>
   </data>


### PR DESCRIPTION
- Updating the delete icons to use anchor elements instead of img elements, so they are detected as tabbable elements. (When using img elements, the the TblComponent was not detecting the icons as tabable elements. Therefore they would not receive focus or have "enter" keypress events applied to them.)

- Setting the aria-label attribute for the delete icons.
- Setting the role attribute as "button" for the delete icons.