### PR TITLE
HOTFIX - Cannot save in Application Settings tab if site has MSI enabled

### DIFF
--- a/AzureFunctions.AngularClient/src/app/shared/models/arm/arm-obj.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/arm/arm-obj.ts
@@ -4,10 +4,17 @@ export interface ArmObj<T> {
     type: string;
     kind: string;
     location: string;
-    properties: T
+    properties: T;
+    identity?: Identity;
 }
 
 export interface ArmArrayResult<T> {
     value : ArmObj<T>[];
     nextLink : string;
+}
+
+export interface Identity{
+    principalId: string;
+    tenantId: string;
+    type: string;
 }

--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
@@ -527,7 +527,7 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
       group.addControl('javaVersion', javaVersionControl);
       group.addControl('javaMinorVersion', javaMinorVersionControl);
       group.addControl('javaWebContainer', javaWebContainerControl);
- 
+
       versionOptionsMap["javaVersion"] = javaVersionOptions;
       versionOptionsMap["javaMinorVersion"] = javaMinorVersionOptions;
       versionOptionsMap["javaWebContainer"] = javaWebContainerOptions;
@@ -789,6 +789,11 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
       if (this.clientAffinitySupported) {
         const clientAffinityEnabled = <boolean>(generalSettingsControls['clientAffinityEnabled'].value);
         siteConfigArm.properties.clientAffinityEnabled = clientAffinityEnabled;
+      }
+
+      // BUGBUG: Workaround.  Eventually the back-end should allow us to send same identity value from GET
+      if (siteConfigArm.identity) {
+        delete siteConfigArm.identity;
       }
 
       // level: site/config/web


### PR DESCRIPTION
If a user has MSI enabled for their app and they try to save their changes in the "Application Settings" tab, it will fail.  The reason is because the site API returns a new "identity" property in the ARM envelope, but if you try to send it back on your PUT request, it will fail because it thinks that you're trying to update it.  My fix is to make sure that we never send the identity property back in our PUT request.