### PR TITLE
Bug fix: create button disable

### DIFF
--- a/AzureFunctions.AngularClient/src/app/function-new/function-new.component.ts
+++ b/AzureFunctions.AngularClient/src/app/function-new/function-new.component.ts
@@ -249,7 +249,7 @@ export class FunctionNewComponent {
             });
             if (nameMatch) {
                 this.functionNameError = this._translateService.instant(PortalResources.functionNew_functionExsists, { name: this.functionName });
-                this.areInputsValid = true;
+                this.areInputsValid = false;
             }
         }
 


### PR DESCRIPTION
Currently you can create a function even if a function of that name already exists.

![image](https://user-images.githubusercontent.com/8560637/30937405-7b3d0f52-a38b-11e7-8e59-ce29b9c9b683.png)

This change disables the create button in that case.