### PR TITLE
Removing hard-dependencies between site tab features and BusyStateComponent

### DIFF
--- a/AzureFunctions.AngularClient/src/app/app.component.html
+++ b/AzureFunctions.AngularClient/src/app/app.component.html
@@ -1,5 +1,5 @@
 <div id="app-root" [attr.theme]="theme">
-    <busy-state name='global'></busy-state>
+    <busy-state name='global' cssClass="global"></busy-state>
     <disabled-dashboard></disabled-dashboard>
     <error-list></error-list>
 

--- a/AzureFunctions.AngularClient/src/app/busy-state/busy-state-scope-manager.ts
+++ b/AzureFunctions.AngularClient/src/app/busy-state/busy-state-scope-manager.ts
@@ -1,31 +1,32 @@
-import { BusyStateComponent } from './busy-state.component';
-import { Subscription as RxSubscription } from 'rxjs/Subscription';
+import { BroadcastEvent } from 'app/shared/models/broadcast-event';
+import { BusyStateEvent } from './../shared/models/broadcast-event';
+import { BroadcastService } from 'app/shared/services/broadcast.service';
+import { Guid } from './../shared/Utilities/Guid';
+import { BusyStateName } from './busy-state.component';
 
 export class BusyStateScopeManager {
 
-  private _busyState: BusyStateComponent;
   private _busyStateKey: string | undefined;
-  private _busyStateSubscription: RxSubscription;
 
-  constructor(busyState: BusyStateComponent) {
-    this._busyState = busyState;
-    this._busyStateSubscription = this._busyState.clear.subscribe(() => this._busyStateKey = null);
+  constructor(
+    private _broadcastService: BroadcastService,
+    private _name: BusyStateName) {
+    this._busyStateKey = Guid.newGuid();
   }
 
   public setBusy() {
-    this._busyStateKey = this._busyState.setScopedBusyState(this._busyStateKey);
+    this._broadcastService.broadcastEvent<BusyStateEvent>(BroadcastEvent.UpdateBusyState, {
+      busyComponentName: this._name,
+      action: 'setBusyState',
+      busyStateKey: this._busyStateKey
+    });
   }
 
   public clearBusy() {
-    this._busyState.clearBusyState(this._busyStateKey);
-    this._busyStateKey = null;
-  }
-
-  public dispose() {
-    this.clearBusy();
-    if (this._busyStateSubscription) {
-      this._busyStateSubscription.unsubscribe();
-      this._busyStateSubscription = null;
-    }
+    this._broadcastService.broadcastEvent<BusyStateEvent>(BroadcastEvent.UpdateBusyState, {
+      busyComponentName: this._name,
+      action: 'clearBusyState',
+      busyStateKey: this._busyStateKey
+    });
   }
 }

--- a/AzureFunctions.AngularClient/src/app/busy-state/busy-state.component.html
+++ b/AzureFunctions.AngularClient/src/app/busy-state/busy-state.component.html
@@ -1,10 +1,4 @@
-<!-- TODO: Should probably come up with a better way to control styling for the container -->
-<div class="container"
-    [class.try-functions-busy]="name === 'try-functions'"
-    [class.global]="isGlobal"
-    [class.busy-dashboard]="name === 'dashboard'"
-    [class.busy-site-tabs]="name === 'site-tabs'"
-    *ngIf="busy">
+<div [class]="cssClass" *ngIf="busy">
 
     <div class="fxs-progress" *ngIf="name !== 'try-functions'">
         <div class="fxs-progress-dots">

--- a/AzureFunctions.AngularClient/src/app/busy-state/busy-state.component.scss
+++ b/AzureFunctions.AngularClient/src/app/busy-state/busy-state.component.scss
@@ -9,21 +9,25 @@
 }
 
 .try-functions-busy {
+    @extend .container;
     background-color: #337ab7;
     color: white;
     font-family: "Segoe UI Light", "Segoe UI", "Segoe", Tahoma, Helvetica, Arial, sans-serif;
 }
 
 .global {
+    @extend .container;
     position: fixed;
 }
 
 .busy-dashboard{
+  @extend .container;
   width: calc(100% - #{$sidenav-width});
   margin-left: $sidenav-width;
 }
 
 .busy-site-tabs{
+  @extend .container;
   width: calc(100% - #{$sidenav-width});  
   height: calc(100% - #{$top-bar-height} - 1px);
 }

--- a/AzureFunctions.AngularClient/src/app/busy-state/busy-state.component.ts
+++ b/AzureFunctions.AngularClient/src/app/busy-state/busy-state.component.ts
@@ -1,59 +1,104 @@
-import { Component, Input, Output, OnInit } from '@angular/core';
+import { LogCategories } from 'app/shared/models/constants';
+import { LogService } from './../shared/services/log.service';
+import { BusyStateEvent } from './../shared/models/broadcast-event';
+import { BroadcastEvent } from 'app/shared/models/broadcast-event';
+import { BroadcastService } from './../shared/services/broadcast.service';
+import { Component, Input, Output, OnInit, OnDestroy } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import { Guid } from './../shared/Utilities/Guid';
-import { BusyStateScopeManager } from './busy-state-scope-manager';
+
+export type BusyStateName =
+    'global'
+    | 'dashboard'
+    | 'site-tabs'
+    | 'try-functions'
+    | 'function-keys';
 
 @Component({
     selector: 'busy-state',
     templateUrl: './busy-state.component.html',
     styleUrls: ['./busy-state.component.scss']
 })
-export class BusyStateComponent implements OnInit {
+export class BusyStateComponent implements OnInit, OnDestroy {
 
     public busy = false;
-    @Input() name: string;
-    isGlobal = false;
+    @Input() name: BusyStateName;
     @Input() message: string;
     @Output() clear = new Subject<any>();
+    @Input() cssClass: string;
 
-    private busyStateMap: { [key: string]: boolean } = {};
-    private reservedKey = '-';
+    private _ngUnsubscribe = new Subject();
+
+    private _busyStateMap: { [key: string]: boolean } = {};
+    private _busyStateDebounceMap: { [key: string]: Subject<BusyStateEvent> } = {};
+    private _reservedKey = '-';
+
+    constructor(
+        private _broadcastService: BroadcastService,
+        private _logService: LogService) {
+    }
 
     ngOnInit() {
-        this.isGlobal = this.name === 'global';
+
+        this._broadcastService.getEvents<BusyStateEvent>(BroadcastEvent.UpdateBusyState)
+            .takeUntil(this._ngUnsubscribe)
+            .filter(event => event.busyComponentName === this.name)
+            .subscribe(event => {
+
+                if (event.action === 'setBusyState') {
+                    this._logService.verbose(LogCategories.busyState, `[${this.name}] Called set with key '${event.busyStateKey}'`)
+                } else if (event.action === 'clearBusyState') {
+                    this._logService.verbose(LogCategories.busyState, `[${this.name}] Called clear with key '${event.busyStateKey}'`)
+                } else {
+                    this._logService.verbose(LogCategories.busyState, `[${this.name}] Called clearOverall with key '${event.busyStateKey}'`)
+                }
+
+                this._debounceEventsBasedOnKey(event);
+            });
+    }
+
+    ngOnDestroy() {
+        this._ngUnsubscribe.next();
     }
 
     setBusyState() {
-        this.setScopedBusyState(this.reservedKey);
+        this.setScopedBusyState(this._reservedKey);
     }
 
     setScopedBusyState(key: string): string {
         key = key || Guid.newGuid();
-        this.busyStateMap[key] = true;
+        this._busyStateMap[key] = true;
         this.busy = true;
+
+        this._logService.debug(LogCategories.busyState, `[${this.name}][set] - Final state for key '${key}' is 'busy'`);
         return key;
     }
 
     clearBusyState(key?: string) {
-        key = key || this.reservedKey;
-        if (this.busyStateMap[key]) {
-            delete this.busyStateMap[key];
+        key = key || this._reservedKey;
+        if (this._busyStateMap[key]) {
+            delete this._busyStateMap[key];
         }
-        this.busy = !this.isEmptyMap(this.busyStateMap);
+        this.busy = !this.isEmptyMap(this._busyStateMap);
+        this._logService.debug(
+            LogCategories.busyState,
+            `[${this.name}][clear] - Final state for key '${key}' is '${this.busy ? 'busy' : 'not busy'}'`);
     }
 
     clearOverallBusyState() {
-        this.busyStateMap = {};
+        this._busyStateMap = {};
         this.clear.next(1);
         this.busy = false;
+
+        this._logService.debug(LogCategories.busyState, `[${this.name}][clearOverall]`);
     }
 
     getBusyState(): boolean {
-        return this.getScopedBusyState(this.reservedKey);
+        return this.getScopedBusyState(this._reservedKey);
     }
 
     getScopedBusyState(key: string): boolean {
-        return !!key && !!this.busyStateMap[key];
+        return !!key && !!this._busyStateMap[key];
     }
 
     get isBusy(): boolean {
@@ -70,8 +115,31 @@ export class BusyStateComponent implements OnInit {
         return true;
     }
 
-    getScopeManager(): BusyStateScopeManager {
-        return new BusyStateScopeManager(this);
-    }
+    // Debounce events based on key
+    private _debounceEventsBasedOnKey(event: BusyStateEvent) {
+        if (!this._busyStateDebounceMap[event.busyStateKey]) {
 
+            const keySubject = new Subject<BusyStateEvent>();
+            this._busyStateDebounceMap[event.busyStateKey] = keySubject;
+
+            keySubject
+                .takeUntil(this._ngUnsubscribe)
+                .debounceTime(50)
+                .subscribe(e => {
+                    if (e.action === 'setBusyState') {
+                        this.setScopedBusyState(e.busyStateKey);
+                    } else if (e.action === 'clearBusyState') {
+                        delete this._busyStateDebounceMap[e.busyStateKey];
+                        this.clearBusyState(e.busyStateKey);
+                    } else {
+                        this.clearOverallBusyState();
+                        this._busyStateDebounceMap = {};
+                    }
+                });
+
+            keySubject.next(event);
+        } else {
+            this._busyStateDebounceMap[event.busyStateKey].next(event);
+        }
+    }
 }

--- a/AzureFunctions.AngularClient/src/app/function-keys/function-keys.component.html
+++ b/AzureFunctions.AngularClient/src/app/function-keys/function-keys.component.html
@@ -1,5 +1,5 @@
 <div class="wrapper" *ngIf="!disabled" role="region" aria-labelledby="keys1 keys2">
-    <busy-state></busy-state>
+    <busy-state name="function-keys"></busy-state>
     <label *ngIf="functionInfo" id="keys1" class="title"> {{'functionKeys_title' | translate}} </label>
     <label *ngIf="!functionInfo" id="keys2" class="title"> {{'adminKeys_title' | translate}} </label>
     <table class="table-function">

--- a/AzureFunctions.AngularClient/src/app/ibiza-feature/app-settings-shell/app-settings-shell.component.html
+++ b/AzureFunctions.AngularClient/src/app/ibiza-feature/app-settings-shell/app-settings-shell.component.html
@@ -1,8 +1,2 @@
-<site-tab
-[title]="title"
-[id]="id"
-[active]="active"
-[closeable]="closeable"
-[iconUrl]="iconUrl"
-[componentFactory]="componentFactory"
-[componentInput]="componentInput"></site-tab> 
+<busy-state name="site-tabs" cssClass="ibiza-feature"></busy-state>
+<site-config *ngIf="viewInfo" [viewInfoInput]='viewInfo'></site-config>

--- a/AzureFunctions.AngularClient/src/app/ibiza-feature/app-settings-shell/app-settings-shell.component.ts
+++ b/AzureFunctions.AngularClient/src/app/ibiza-feature/app-settings-shell/app-settings-shell.component.ts
@@ -1,8 +1,8 @@
-import { Component, Type, OnDestroy } from '@angular/core';
+import { DashboardType } from 'app/tree-view/models/dashboard-type';
+import { TreeViewInfo, SiteData } from './../../tree-view/models/tree-view-info';
+import { Component, OnDestroy } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { PortalResources } from 'app/shared/models/portal-resources';
 import { ActivatedRoute } from '@angular/router';
-import { SiteConfigComponent } from 'app/site/site-config/site-config.component';
 import { Subscription } from 'rxjs/Subscription';
 
 @Component({
@@ -11,37 +11,19 @@ import { Subscription } from 'rxjs/Subscription';
     styleUrls: ['./app-settings-shell.component.scss']
 })
 export class AppSettingsShellComponent implements OnDestroy {
-    title: string;
-
-    id: string;
-
-    active: boolean;
-
-    closeable: boolean;
-
-    componentFactory: Type<any>;
-
-    componentInput: { [key: string]: any };
-
-    iconUrl = '';
+    viewInfo: TreeViewInfo<SiteData>;
 
     private routeParamsSubscription: Subscription;
     constructor(translateService: TranslateService, route: ActivatedRoute) {
-        this.title = translateService.instant(PortalResources.tab_configuration);
-        this.componentFactory = SiteConfigComponent;
-        this.closeable = false;
-        this.active = true;
-        this.componentInput = {
-            resourceId: null
-        };
 
         this.routeParamsSubscription = route.params.subscribe(x => {
-            this.componentInput = {
-                viewInfoInput: {
-                    resourceId: `/subscriptions/${x['subscriptionId']}/resourceGroups/${x[
-                        'resourceGroup'
-                    ]}/providers/Microsoft.Web/sites/${x['site']}`
-                }
+            this.viewInfo = {
+                resourceId: `/subscriptions/${x['subscriptionId']}/resourceGroups/${x[
+                    'resourceGroup'
+                ]}/providers/Microsoft.Web/sites/${x['site']}`,
+                dashboardType: DashboardType.none,
+                node: null,
+                data: null
             };
         });
     }

--- a/AzureFunctions.AngularClient/src/app/ibiza-feature/ibiza-feature.component.ts
+++ b/AzureFunctions.AngularClient/src/app/ibiza-feature/ibiza-feature.component.ts
@@ -25,7 +25,7 @@ export class IbizaFeatureComponent implements AfterViewInit, OnDestroy {
     @ViewChild(BusyStateComponent) busyStateComponent: BusyStateComponent;
 
     private _ngUnsubscribe = new Subject();
-    private _busyStateScopeManager: BusyStateScopeManager;
+    private _busyManager: BusyStateScopeManager;
 
     constructor(
         private _userService: UserService
@@ -43,6 +43,6 @@ export class IbizaFeatureComponent implements AfterViewInit, OnDestroy {
 
     ngOnDestroy() {
         this._ngUnsubscribe.next();
-        this._busyStateScopeManager.dispose();
+        this._busyManager.clearBusy();
     }
 }

--- a/AzureFunctions.AngularClient/src/app/main/main.component.html
+++ b/AzureFunctions.AngularClient/src/app/main/main.component.html
@@ -1,5 +1,5 @@
 <top-bar *ngIf="ready"></top-bar>
-<busy-state name='dashboard'></busy-state>
+<busy-state name='dashboard' cssClass="busy-dashboard"></busy-state>
 
 <div id="content">
 

--- a/AzureFunctions.AngularClient/src/app/main/main.component.ts
+++ b/AzureFunctions.AngularClient/src/app/main/main.component.ts
@@ -44,15 +44,15 @@ export class MainComponent implements AfterViewInit, OnDestroy {
     @ViewChild(BusyStateComponent) busyStateComponent: BusyStateComponent;
 
     private _ngUnsubscribe = new Subject();
-    private _busyStateScopeManager: BusyStateScopeManager;
+    private _busyManager: BusyStateScopeManager;
 
     constructor(private _userService: UserService,
         private _globalStateService: GlobalStateService,
         private _cacheService: CacheService,
         private _portalService: PortalService,
+        private _broadcastService: BroadcastService,
         _ngHttp: Http,
         _translateService: TranslateService,
-        _broadcastService: BroadcastService,
         _armService: ArmService,
         _languageService: LanguageService,
         _authZService: AuthzService,
@@ -89,7 +89,7 @@ export class MainComponent implements AfterViewInit, OnDestroy {
 
     ngAfterViewInit() {
         this._globalStateService.GlobalBusyStateComponent = this.busyStateComponent;
-        this._busyStateScopeManager = this.busyStateComponent.getScopeManager();
+        this._busyManager = new BusyStateScopeManager(this._broadcastService, 'dashboard');
 
         this._userService.getStartupInfo()
             .first()
@@ -105,7 +105,7 @@ export class MainComponent implements AfterViewInit, OnDestroy {
 
     ngOnDestroy() {
         this._ngUnsubscribe.next();
-        this._busyStateScopeManager.dispose();
+        this._busyManager.clearBusy();
     }
 
     private initializeChildWindow(_userService: UserService,
@@ -182,13 +182,13 @@ export class MainComponent implements AfterViewInit, OnDestroy {
 
     private _navigationInterceptor(event: RouterEvent): void {
         if (event instanceof NavigationStart) {
-            this._busyStateScopeManager.setBusy();
+            this._busyManager.setBusy();
         } else if (event instanceof NavigationEnd) {
-            this._busyStateScopeManager.clearBusy();
+            this._busyManager.clearBusy();
         } else if (event instanceof NavigationCancel) {
-            this._busyStateScopeManager.clearBusy();
+            this._busyManager.clearBusy();
         } else if (event instanceof NavigationError) {
-            this._busyStateScopeManager.clearBusy();
+            this._busyManager.clearBusy();
         }
     }
 }

--- a/AzureFunctions.AngularClient/src/app/shared/models/broadcast-event.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/broadcast-event.ts
@@ -4,7 +4,7 @@ export enum BroadcastEvent {
     FunctionSelected,
     FunctionUpdated,
     // FunctionNew,
-    BusyState,
+    UpdateBusyState,
     TutorialStep,
     IntegrateChanged,
     Error,
@@ -35,4 +35,10 @@ export enum BroadcastEvent {
 export interface DirtyStateEvent {
     dirty: boolean;
     reason: string | null;
+}
+
+export interface BusyStateEvent{
+    busyComponentName: string;
+    action: 'setBusyState' | 'clearBusyState' | 'clearOverallBusyState';
+    busyStateKey: string;
 }

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -180,6 +180,7 @@ export class LogCategories {
     public static readonly apiDetails = 'ApiDetails';
     public static readonly newSlot = 'NewSlot';
     public static readonly svgLoader = 'SvgLoader';
+    public static readonly busyState = 'BusyState';
 }
 
 export class KeyCodes {

--- a/AzureFunctions.AngularClient/src/app/shared/shared.module.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/shared.module.ts
@@ -47,7 +47,6 @@ import { NgModule, ModuleWithProviders, ErrorHandler } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { ArmService } from 'app/shared/services/arm.service';
 import { Url } from 'app/shared/Utilities/url';
-import { SiteTabComponent } from 'app/site/site-dashboard/site-tab/site-tab.component';
 import { EmptyDashboardComponent } from 'app/main/empty-dashboard.component';
 
 export function ArmServiceFactory(
@@ -90,7 +89,6 @@ export function AiServiceFactory() {
         TooltipDirective,
         SlideToggleComponent,
         LoadImageDirective,
-        SiteTabComponent,
         EmptyDashboardComponent
     ],
     exports: [
@@ -119,7 +117,6 @@ export function AiServiceFactory() {
         TooltipDirective,
         SlideToggleComponent,
         LoadImageDirective,
-        SiteTabComponent,
         EmptyDashboardComponent
     ],
     imports: [

--- a/AzureFunctions.AngularClient/src/app/site/function-runtime/function-runtime.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/function-runtime/function-runtime.component.ts
@@ -1,6 +1,5 @@
+import { BusyStateScopeManager } from './../../busy-state/busy-state-scope-manager';
 import { ConfigService } from './../../shared/services/config.service';
-import { SiteTabComponent } from './../site-dashboard/site-tab/site-tab.component';
-import { BusyStateComponent } from './../../busy-state/busy-state.component';
 import { EditModeHelper } from './../../shared/Utilities/edit-mode.helper';
 import { Component, Input, OnDestroy } from '@angular/core';
 import { Response } from '@angular/http';
@@ -13,7 +12,6 @@ import 'rxjs/add/operator/retry';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/observable/zip';
 import { TranslateService } from '@ngx-translate/core';
-
 import { ErrorIds } from './../../shared/models/error-ids';
 import { ErrorEvent, ErrorType } from './../../shared/models/error-event';
 import { NotificationIds, Constants, SiteTabIds } from './../../shared/models/constants';
@@ -78,7 +76,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
   public slotsAppSetting: string;
   public slotsEnabled: boolean;
   private slotsValueChange: Subject<boolean>;
-  private _busyState: BusyStateComponent;
+  private _busyManager: BusyStateScopeManager;
 
   constructor(
     private _armService: ArmService,
@@ -89,15 +87,14 @@ export class FunctionRuntimeComponent implements OnDestroy {
     private _translateService: TranslateService,
     private _slotsService: SiteService,
     private _configService: ConfigService,
-    siteTabsComponent: SiteTabComponent
   ) {
 
-    this._busyState = siteTabsComponent.busyState;
+    this._busyManager = new BusyStateScopeManager(_broadcastService, 'site-tabs');
 
     this._viewInfoSub = this._viewInfoStream
       .switchMap(viewInfo => {
         this._viewInfo = viewInfo;
-        this._busyState.setBusyState();
+        this._busyManager.setBusy();
 
         this._appNode = (<AppNode>viewInfo.node);
 
@@ -169,7 +166,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
         } else {
           this.functionAppEditMode = true;
         }
-        this._busyState.clearBusyState();
+        this._busyManager.clearBusy();
         this._aiService.stopTrace('/timings/site/tab/function-runtime/revealed', this._viewInfo.data.siteTabRevealedTraceKey);
 
         // settings for enabling slots, display if there are no slots && appSetting property for slot is set
@@ -221,7 +218,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
     this.proxySettingValueStream
       .subscribe((value: boolean) => {
         if (this.apiProxiesEnabled !== value) {
-          this._busyState.setBusyState();
+          this._busyManager.setBusy();
           const appSettingValue: string = value ? this._configService.FunctionsVersionInfo.proxyDefault : Constants.disabled;
 
           this._cacheService.postArm(`${this.site.id}/config/appsettings/list`, true)
@@ -233,7 +230,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
               this.apiProxiesEnabled = value;
               this.needUpdateRoutingExtensionVersion = false;
               this.routingExtensionVersion = this._configService.FunctionsVersionInfo.proxyDefault;
-              this._busyState.clearBusyState();
+              this._busyManager.clearBusy();
               this._cacheService.clearArmIdCachePrefix(this.site.id);
             });
         }
@@ -243,7 +240,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
     this.functionEditModeValueStream
       .switchMap(state => {
         const originalState = this.functionAppEditMode;
-        this._busyState.setBusyState();
+        this._busyManager.setBusy();
         this.functionAppEditMode = state;
         const appSetting = this.functionAppEditMode ? Constants.ReadWriteMode : Constants.ReadOnlyMode;
         return this._cacheService.postArm(`${this.site.id}/config/appsettings/list`, true)
@@ -256,7 +253,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
       })
       .do(null, originalState => {
         this.functionAppEditMode = originalState;
-        this._busyState.clearBusyState();
+        this._busyManager.clearBusy();
         this._broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
           message: this._translateService.instant(PortalResources.error_unableToUpdateFunctionAppEditMode),
           errorType: ErrorType.ApiError,
@@ -273,26 +270,26 @@ export class FunctionRuntimeComponent implements OnDestroy {
         this._aiService.stopTrace('/timings/site/tab/function-runtime/full-ready',
           this._viewInfo.data.siteTabFullReadyTraceKey);
 
-        this._busyState.clearBusyState();
+        this._busyManager.clearBusy();
       });
 
     this.slotsValueChange = new Subject<boolean>();
     this.slotsValueChange.subscribe((value: boolean) => {
-      this._busyState.setBusyState();
+      this._busyManager.setBusy();
       const slotsSettingsValue: string = value ? Constants.slotsSecretStorageSettingsValue : Constants.disabled;
       this._cacheService.postArm(`${this.site.id}/config/appsettings/list`, true)
         .mergeMap(r => {
           return this._slotsService.setStatusOfSlotOptIn(r.json(), slotsSettingsValue);
         })
         .do(null, e => {
-          this._busyState.clearBusyState();
+          this._busyManager.clearBusy();
           this._aiService.trackException(e, 'function-runtime');
         })
         .retry()
         .subscribe(() => {
           this.functionApp.fireSyncTrigger();
           this.slotsEnabled = value;
-          this._busyState.clearBusyState();
+          this._busyManager.clearBusy();
           this._cacheService.clearArmIdCachePrefix(this.site.id);
         });
     });
@@ -323,9 +320,9 @@ export class FunctionRuntimeComponent implements OnDestroy {
   }
 
   saveMemorySize(value: string | number) {
-    this._busyState.setBusyState();
+    this._busyManager.setBusy();
     this._updateMemorySize(this.site, value)
-      .subscribe(r => { this._busyState.clearBusyState(); Object.assign(this.site, r); this.dirty = false; });
+      .subscribe(r => { this._busyManager.clearBusy(); Object.assign(this.site, r); this.dirty = false; });
   }
 
   isIE(): boolean {
@@ -342,7 +339,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
       version = this.getLatestVersion(this.extensionVersion);
     };
     this._aiService.trackEvent('/actions/app_settings/update_version');
-    this._busyState.setBusyState();
+    this._busyManager.setBusy();
     this._cacheService.postArm(`${this.site.id}/config/appsettings/list`, true)
       .mergeMap(r => {
         return this._updateContainerVersion(r.json(), version);
@@ -366,7 +363,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
         });
       })
       .do(null, e => {
-        this._busyState.clearBusyState();
+        this._busyManager.clearBusy();
         this._aiService.trackException(e, '/errors/rutime-update');
         console.error(e);
       })
@@ -375,7 +372,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
         this.exactExtensionVersion = hostStatus ? hostStatus.version : '';
         this.extensionVersion = version;
         this.setNeedUpdateExtensionVersion();
-        this._busyState.clearBusyState();
+        this._busyManager.clearBusy();
         this._cacheService.clearArmIdCachePrefix(this.site.id);
         this._appNode.clearNotification(NotificationIds.newRuntimeVersion);
       });
@@ -383,7 +380,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
 
   updateRoutingExtensionVersion() {
     this._aiService.trackEvent('/actions/app_settings/update_routing_version');
-    this._busyState.setBusyState();
+    this._busyManager.setBusy();
 
     this._cacheService.postArm(`${this.site.id}/config/appsettings/list`, true)
       .mergeMap(r => {
@@ -391,7 +388,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
       })
       .subscribe(() => {
         this.needUpdateRoutingExtensionVersion = false;
-        this._busyState.clearBusyState();
+        this._busyManager.clearBusy();
         this._cacheService.clearArmIdCachePrefix(this.site.id);
       });
   }
@@ -402,28 +399,28 @@ export class FunctionRuntimeComponent implements OnDestroy {
       const dailyMemoryTimeQuota = +this.dailyMemoryTimeQuota;
 
       if (dailyMemoryTimeQuota > 0) {
-        this._busyState.setBusyState();
+        this._busyManager.setBusy();
         this._updateDailyMemory(this.site, dailyMemoryTimeQuota).subscribe((r) => {
           const site = r.json();
           this.showDailyMemoryWarning = (!site.properties.enabled && site.properties.siteDisabledReason === 1);
           this.showDailyMemoryInfo = true;
           this.site.properties.dailyMemoryTimeQuota = dailyMemoryTimeQuota;
           this.dailyMemoryTimeQuotaOriginal = this.dailyMemoryTimeQuota;
-          this._busyState.clearBusyState();
+          this._busyManager.clearBusy();
         });
       }
     }
   }
 
   removeQuota() {
-    this._busyState.setBusyState();
+    this._busyManager.setBusy();
     this._updateDailyMemory(this.site, 0).subscribe(() => {
       this.showDailyMemoryInfo = false;
       this.showDailyMemoryWarning = false;
       this.dailyMemoryTimeQuota = '';
       this.dailyMemoryTimeQuotaOriginal = this.dailyMemoryTimeQuota;
       this.site.properties.dailyMemoryTimeQuota = 0;
-      this._busyState.clearBusyState();
+      this._busyManager.clearBusy();
     });
   }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-tab/site-tab.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-tab/site-tab.component.ts
@@ -6,7 +6,7 @@ import { Component, OnChanges, Input, Type, ViewChild, ComponentFactoryResolver,
   selector: 'site-tab',
   template: `
       <div *ngIf="initialized">
-        <busy-state name="site-tabs"></busy-state>
+        <busy-state name="site-tabs" cssClass="busy-site-tabs"></busy-state>
         <div [hidden]="!active" [attr.aria-label]="title">
             <ng-template *ngIf="componentFactory" dynamic-loader></ng-template>
         </div>

--- a/AzureFunctions.AngularClient/src/app/site/site.module.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site.module.ts
@@ -1,3 +1,4 @@
+import { SiteTabComponent } from 'app/site/site-dashboard/site-tab/site-tab.component';
 import { SharedFunctionsModule } from './../shared/shared-functions.module';
 import { FeatureGroupComponent } from './../feature-group/feature-group.component';
 import { DownloadFunctionAppContentComponent } from './../download-function-app-content/download-function-app-content.component';
@@ -45,7 +46,8 @@ const routing: ModuleWithProviders = RouterModule.forChild([
         SwaggerFrameDirective,
         DownloadFunctionAppContentComponent,
         SiteEnabledFeaturesComponent,
-        HostEditorComponent
+        HostEditorComponent,
+        SiteTabComponent
     ],
     providers: []
 })

--- a/AzureFunctions.AngularClient/src/app/try-landing/try-landing.component.html
+++ b/AzureFunctions.AngularClient/src/app/try-landing/try-landing.component.html
@@ -1,4 +1,4 @@
-<busy-state name="try-functions"></busy-state>
+<busy-state name="try-functions" cssClass="try-functions"></busy-state>
 <top-bar gettingStarted="true" isTry="true"></top-bar>
 <div class="trylanding-container">
     <div [ngClass]="busyState?.busy? 'trylanding-body-disabled' : 'trylanding-body'">


### PR DESCRIPTION
**3 main changes being made to how busy state works**
1. BusyStateScopedManager will now use the broadcast service to communicate with a given BusyStateComponent based on the name of the BusyStateComponent.
2. The BusyStateComponent will also debounce state changes which should help reduce flickering and asserts being thrown which say that your state is changing too fast.
3. I updated the BusyStateComponent so that you can pass in the class you want it to use, instead of hardcoding style logic inside of the component itself.

Ideally all of our code should now be using the BusyStateScopedManager but that's a larger change and we can make those changes going forward..