### PR TITLE
Fixes #1704 - The or text when creating a new Function may not fit if localized

### DIFF
--- a/AzureFunctions.AngularClient/src/app/function-quickstart/function-quickstart.component.html
+++ b/AzureFunctions.AngularClient/src/app/function-quickstart/function-quickstart.component.html
@@ -68,7 +68,12 @@
 </div>  <!-- /intro-header -->
 
 <div id="quickstart-footer">
-    <h2 class="circle">{{ 'intro_or' | translate}}</h2>
+    <h2 class="circle-container">
+        <!-- Need to split the "circle" into 3 parts to allow it to expand if the text is long -->
+        <span class="circle-left"></span>
+        <span class="circle-middle">{{ 'intro_or' | translate}}</span>
+        <span class="circle-right"></span>
+    </h2>
 
     <h1>{{ 'intro_getStartedOn' | translate }}</h1>
     <div>

--- a/AzureFunctions.AngularClient/src/app/function-quickstart/function-quickstart.component.scss
+++ b/AzureFunctions.AngularClient/src/app/function-quickstart/function-quickstart.component.scss
@@ -102,15 +102,34 @@
     margin-bottom: 25px;
 }
 
-.circle {
-    background-color: $qs-header-bg-color;
-	border-radius: 50%;
-	width: 35px;
-	height: 35px;
+.circle-container{
+    height: 35px;
     margin: auto;
     padding-top: 3px;
     position: relative;
     top: -33px;
+}
+
+.circle-left, .circle-middle, .circle-right{
+    background-color: $qs-header-bg-color;
+    height: 35px;
+    display: inline-block;
+}
+
+.circle-left{
+    border-bottom-left-radius: 50%;
+    width: 22px;
+    margin-right: -5px;
+}
+
+.circle-middle{
+    vertical-align: top;
+}
+
+.circle-right{
+    border-bottom-right-radius: 50%;
+    width: 22px;
+    margin-left: -5px;
 }
 
 #quickstart-footer{
@@ -140,7 +159,7 @@
         background-color: lighten($body-bg-color-dark, 10%);
     }
 
-    #quickstart-header, h2.circle{
+    #quickstart-header, .circle-left, .circle-middle, .circle-right{
         background-color: $body-bg-color-dark;
     }
 


### PR DESCRIPTION
The default English doesn't look quite as nice because it's no longer a perfect circle, but at least now it can expand if the content is long.  The only way to make it a perfect circle for English and be expandable would be if I made the circle taller which I don't want to do.

Also verified in dark theme.

**Short text**
![image](https://user-images.githubusercontent.com/5695405/31025213-97c009ba-a4f6-11e7-8c80-f97610e80af8.png)


**Long text**
![image](https://user-images.githubusercontent.com/5695405/31025139-3dec42be-a4f6-11e7-9b74-97124f7c1452.png)

