### PR TITLE
Resource strings sometimes don't load properly for apps list component

### DIFF
--- a/AzureFunctions.AngularClient/src/app/app.component.ts
+++ b/AzureFunctions.AngularClient/src/app/app.component.ts
@@ -34,6 +34,8 @@ export class AppComponent implements OnInit, AfterViewInit {
         this._userService.getStartupInfo()
             .subscribe(info => {
                 if (this.theme) {
+                    // Need to make sure we continue to set the theme even if we don't want to
+                    // rerun the routing logic below.
                     this.theme = info.theme;
                     return;
                 }

--- a/AzureFunctions.AngularClient/src/app/app.component.ts
+++ b/AzureFunctions.AngularClient/src/app/app.component.ts
@@ -30,30 +30,37 @@ export class AppComponent implements OnInit, AfterViewInit {
     ) {
         const devGuide = Url.getParameterByName(null, 'appsvc.devguide');
 
-        // TODO: for now we don't honor any deep links.  We'll need to make a bunch of updates to our
-        // tree logic in order to get it working properly
-        if (_globalStateService.showTryView) {
-            this._router.navigate(['/try'], { queryParams: Url.getQueryStringObj() });
-        } else if (devGuide) {
-            this._router.navigate(['/devguide'], { queryParams: Url.getQueryStringObj() });
-        } else if (
-            !this._userService.inIFrame &&
-            window.location.protocol !== 'http:' &&
-            !this._userService.inTab &&
-            !configService.isStandalone() &&
-            !this._userService.deeplinkAllowed
-        ) {
-            this._router.navigate(['/landing'], { queryParams: Url.getQueryStringObj() });
-        } else if (!this._userService.deeplinkAllowed) {
-            this._router.navigate(['/resources/apps'], { queryParams: Url.getQueryStringObj() });
-        }
 
-        this._userService.getStartupInfo().subscribe(info => {
-            this.theme = info.theme;
-        });
+        this._userService.getStartupInfo()
+            .subscribe(info => {
+                if (this.theme) {
+                    this.theme = info.theme;
+                    return;
+                }
+
+                this.theme = info.theme;
+
+                // TODO: for now we don't honor any deep links.  We'll need to make a bunch of updates to our
+                // tree logic in order to get it working properly
+                if (_globalStateService.showTryView) {
+                    this._router.navigate(['/try'], { queryParams: Url.getQueryStringObj() });
+                } else if (devGuide) {
+                    this._router.navigate(['/devguide'], { queryParams: Url.getQueryStringObj() });
+                } else if (
+                    !this._userService.inIFrame &&
+                    window.location.protocol !== 'http:' &&
+                    !this._userService.inTab &&
+                    !configService.isStandalone() &&
+                    !this._userService.deeplinkAllowed
+                ) {
+                    this._router.navigate(['/landing'], { queryParams: Url.getQueryStringObj() });
+                } else if (!this._userService.deeplinkAllowed) {
+                    this._router.navigate(['/resources/apps'], { queryParams: Url.getQueryStringObj() });
+                }
+            });
     }
 
-    ngOnInit() {}
+    ngOnInit() { }
 
     ngAfterViewInit() {
         this._globalStateService.GlobalBusyStateComponent = this.busyStateComponent;

--- a/AzureFunctions.AngularClient/src/app/main/main.component.html
+++ b/AzureFunctions.AngularClient/src/app/main/main.component.html
@@ -1,12 +1,12 @@
-<top-bar *ngIf="ready"></top-bar>
+<top-bar></top-bar>
 <busy-state name='dashboard' cssClass="busy-dashboard"></busy-state>
 
 <div id="content">
 
-    <side-nav *ngIf="ready" [tryFunctionAppInput]="tryFunctionApp"></side-nav>
+    <side-nav  [tryFunctionAppInput]="tryFunctionApp"></side-nav>
     <top-warning></top-warning>
 
-    <div id="dashboard" [hidden]="!ready">
+    <div id="dashboard">
         <router-outlet></router-outlet>
     </div>
 </div>

--- a/AzureFunctions.AngularClient/src/app/main/main.component.ts
+++ b/AzureFunctions.AngularClient/src/app/main/main.component.ts
@@ -32,7 +32,6 @@ import { NavigationStart, Event as RouterEvent, NavigationEnd, NavigationCancel,
     styleUrls: ['./main.component.scss']
 })
 export class MainComponent implements AfterViewInit, OnDestroy {
-    public ready = false;
     public resourceId: string;
     public viewInfo: TreeViewInfo<any>;
     public dashboardType: string;
@@ -94,7 +93,6 @@ export class MainComponent implements AfterViewInit, OnDestroy {
         this._userService.getStartupInfo()
             .first()
             .subscribe(info => {
-                this.ready = true;
 
                 this._portalService.sendTimerEvent({
                     timerId: 'PortalReady',


### PR DESCRIPTION
There's a race condition between lazy loading the apps list component and initializing the resource strings. This means that you'll sometime wind up with strings that look like the image below.  For now, I'm changing the lazy load initialization logic so that we don't download any of the child modules until we've completed init.  This isn't great for performance but it's a simple fix.  Long-term, I'd like to think of a way where we could do both at the same time.

![image](https://user-images.githubusercontent.com/5695405/31783141-110aca56-b4b2-11e7-99cb-2c0169cac57a.png)
