### PR TITLE
Fixing issue where site config component no longer load for Ibiza scenario's

### DIFF
--- a/AzureFunctions.AngularClient/src/app/app.component.ts
+++ b/AzureFunctions.AngularClient/src/app/app.component.ts
@@ -30,39 +30,30 @@ export class AppComponent implements OnInit, AfterViewInit {
     ) {
         const devGuide = Url.getParameterByName(null, 'appsvc.devguide');
 
+        // TODO: for now we don't honor any deep links.  We'll need to make a bunch of updates to our
+        // tree logic in order to get it working properly
+        if (_globalStateService.showTryView) {
+            this._router.navigate(['/try'], { queryParams: Url.getQueryStringObj() });
+        } else if (devGuide) {
+            this._router.navigate(['/devguide'], { queryParams: Url.getQueryStringObj() });
+        } else if (
+            !this._userService.inIFrame &&
+            window.location.protocol !== 'http:' &&
+            !this._userService.inTab &&
+            !configService.isStandalone() &&
+            !this._userService.deeplinkAllowed
+        ) {
+            this._router.navigate(['/landing'], { queryParams: Url.getQueryStringObj() });
+        } else if (!this._userService.deeplinkAllowed) {
+            this._router.navigate(['/resources/apps'], { queryParams: Url.getQueryStringObj() });
+        }
 
-        this._userService.getStartupInfo()
-            .subscribe(info => {
-                if (this.theme) {
-                    // Need to make sure we continue to set the theme even if we don't want to
-                    // rerun the routing logic below.
-                    this.theme = info.theme;
-                    return;
-                }
-
-                this.theme = info.theme;
-
-                // TODO: for now we don't honor any deep links.  We'll need to make a bunch of updates to our
-                // tree logic in order to get it working properly
-                if (_globalStateService.showTryView) {
-                    this._router.navigate(['/try'], { queryParams: Url.getQueryStringObj() });
-                } else if (devGuide) {
-                    this._router.navigate(['/devguide'], { queryParams: Url.getQueryStringObj() });
-                } else if (
-                    !this._userService.inIFrame &&
-                    window.location.protocol !== 'http:' &&
-                    !this._userService.inTab &&
-                    !configService.isStandalone() &&
-                    !this._userService.deeplinkAllowed
-                ) {
-                    this._router.navigate(['/landing'], { queryParams: Url.getQueryStringObj() });
-                } else if (!this._userService.deeplinkAllowed) {
-                    this._router.navigate(['/resources/apps'], { queryParams: Url.getQueryStringObj() });
-                }
-            });
+        this._userService.getStartupInfo().subscribe(info => {
+            this.theme = info.theme;
+        });
     }
 
-    ngOnInit() { }
+    ngOnInit() {}
 
     ngAfterViewInit() {
         this._globalStateService.GlobalBusyStateComponent = this.busyStateComponent;

--- a/AzureFunctions.AngularClient/src/app/app.module.ts
+++ b/AzureFunctions.AngularClient/src/app/app.module.ts
@@ -1,7 +1,9 @@
-import { RouterModule } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
+import { UserService } from './shared/services/user.service';
+import { RouterModule, Resolve, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { SharedModule } from './shared/shared.module';
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
+import { NgModule, Injectable } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 import { TranslateModule } from '@ngx-translate/core';
@@ -26,21 +28,53 @@ import 'rxjs/add/observable/timer';
 import 'rxjs/add/observable/throw';
 import 'rxjs/add/observable/zip';
 
+// Prevents a route from loading until the observable has been resolved
+@Injectable()
+class InitResolver implements Resolve<any>{
+    constructor(private _userService: UserService) { }
+
+    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<any> {
+        return this._userService
+            .getStartupInfo()
+            .first();
+    }
+}
+
 const routes = RouterModule.forRoot([
     // "/resources" will load the main component which has the tree view for all resources
-    { path: 'resources', loadChildren: 'app/main/main.module#MainModule' },
+    {
+        path: 'resources',
+        loadChildren: 'app/main/main.module#MainModule',
+        resolve: { info: InitResolver }
+    },
 
     // "/landing" will load the getting started page for functions.azure.com
-    { path: 'landing', loadChildren: 'app/getting-started/getting-started.module#GettingStartedModule' },
+    {
+        path: 'landing',
+        loadChildren: 'app/getting-started/getting-started.module#GettingStartedModule',
+        resolve: { info: InitResolver }
+    },
 
     // "/try" will load the try functions start page for https://functions.azure.com?trial=true
-    { path: 'try', loadChildren: 'app/try-landing/try-landing.module#TryLandingModule' },
+    {
+        path: 'try',
+        loadChildren: 'app/try-landing/try-landing.module#TryLandingModule',
+        resolve: { info: InitResolver }
+    },
 
     // "/feature" will load a window to show a specific feature(i.e. app settings) with nothing else, defined by query string
-    { path: 'feature', loadChildren: 'app/ibiza-feature/ibiza-feature.module#IbizaFeatureModule' },
+    {
+        path: 'feature',
+        loadChildren: 'app/ibiza-feature/ibiza-feature.module#IbizaFeatureModule',
+        resolve: { info: InitResolver }
+    },
 
     // /devguide
-    { path: 'devguide', loadChildren: 'app/dev-guide/dev-guide.module#DevGuideModule' }
+    {
+        path: 'devguide',
+        loadChildren: 'app/dev-guide/dev-guide.module#DevGuideModule',
+        resolve: { info: InitResolver }
+    }
 
 ]);
 
@@ -61,6 +95,7 @@ export class AppModule {
             PopoverModule,
             routes
         ],
+        providers: [InitResolver],
         bootstrap: [AppComponent]
     };
 }

--- a/AzureFunctions.AngularClient/src/app/app.module.ts
+++ b/AzureFunctions.AngularClient/src/app/app.module.ts
@@ -30,7 +30,7 @@ import 'rxjs/add/observable/zip';
 
 // Prevents a route from loading until the observable has been resolved
 @Injectable()
-class InitResolver implements Resolve<any>{
+export class InitResolver implements Resolve<any>{
     constructor(private _userService: UserService) { }
 
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<any> {
@@ -40,7 +40,7 @@ class InitResolver implements Resolve<any>{
     }
 }
 
-const routes = RouterModule.forRoot([
+export const routes = RouterModule.forRoot([
     // "/resources" will load the main component which has the tree view for all resources
     {
         path: 'resources',

--- a/AzureFunctions.AngularClient/src/app/main/main.component.html
+++ b/AzureFunctions.AngularClient/src/app/main/main.component.html
@@ -1,12 +1,12 @@
-<top-bar></top-bar>
+<top-bar *ngIf="ready"></top-bar>
 <busy-state name='dashboard' cssClass="busy-dashboard"></busy-state>
 
 <div id="content">
 
-    <side-nav  [tryFunctionAppInput]="tryFunctionApp"></side-nav>
+    <side-nav *ngIf="ready" [tryFunctionAppInput]="tryFunctionApp"></side-nav>
     <top-warning></top-warning>
 
-    <div id="dashboard">
+    <div id="dashboard" [hidden]="!ready">
         <router-outlet></router-outlet>
     </div>
 </div>

--- a/AzureFunctions.AngularClient/src/app/main/main.component.ts
+++ b/AzureFunctions.AngularClient/src/app/main/main.component.ts
@@ -32,6 +32,7 @@ import { NavigationStart, Event as RouterEvent, NavigationEnd, NavigationCancel,
     styleUrls: ['./main.component.scss']
 })
 export class MainComponent implements AfterViewInit, OnDestroy {
+    public ready = false;
     public resourceId: string;
     public viewInfo: TreeViewInfo<any>;
     public dashboardType: string;
@@ -93,6 +94,7 @@ export class MainComponent implements AfterViewInit, OnDestroy {
         this._userService.getStartupInfo()
             .first()
             .subscribe(info => {
+                this.ready = true;
 
                 this._portalService.sendTimerEvent({
                     timerId: 'PortalReady',


### PR DESCRIPTION
Apparently the change that I made earlier to fix the resource string loading caused a regression when loading the site config component for Ibiza scenario's.  I'm still not 100% sure why, but apparently my previous change caused the SiteConfig component to load before the authentication token was initialized for Ibiza scenario's.  This caused the component to fail horribly with a ton of 401's.

While I still don't understand what was wrong, I found a cleaner way to handle route loading when waiting for something to load.  So I created a new Resolve class which allows you to prevent a route from loading until an async operation has completed, which is a much cleaner approach to route loading.