### PR TITLE
Fixes #1914 - Function monitor dashboard may not load if there are no AI resources in subscription

### DIFF
--- a/AzureFunctions.AngularClient/src/app/shared/services/slots.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/slots.service.ts
@@ -25,12 +25,18 @@ export class SiteService {
             const ikey = r.appSettings.json().properties[Constants.instrumentationKeySettingName];
             let result = null;
             if (ikey) {
-                r.appInsights.json().value.forEach((ai) => {
-                    if (ai.properties.InstrumentationKey === ikey) {
-                        result = ai.id;
-                    }
-                });
+                const aiResources = r.appInsights.json();
+
+                // AI RP has an issue where they return an array instead of a JSON response if empty
+                if (aiResources && !Array.isArray(aiResources)) {
+                    aiResources.value.forEach((ai) => {
+                        if (ai.properties.InstrumentationKey === ikey) {
+                            result = ai.id;
+                        }
+                    });
+                }
             }
+
             return result;
         });
     }

--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.html
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.html
@@ -6,8 +6,8 @@
   <div class="settings-wrapper">
 
     <div *ngIf="netFrameworkSupported" class="setting-wrapper">
-      <label class="setting-label">{{ 'netFrameworkVersionLabel' | translate }}
-        <pop-over [message]="('netFrameworkVersionLabelHelp' | translate)">
+      <label class="setting-label">{{ 'netFrameWorkVersionLabel' | translate }}
+        <pop-over [message]="('netFrameWorkVersionLabelHelp' | translate)">
             <span class="glyphicon glyphicon-info-sign button-title"></span>
         </pop-over>
       </label>


### PR DESCRIPTION
AI has an issue where they return a "[]" instead of a proper JSON response if there are no AI resources in your subscription.  Since we're expecting JSON, we fail to parse the response properly and crash the monitor blade.

Another scenario that could trigger this is if the user has the AI key setup but it points to an AI resource in a different subscription.  In that case, it's possible that they'll run into this problem again.  That one is a bit less likely, so I've logged a separate issue for it #1915. 