### PR TITLE
Fixing tree navigation issues by adding separate event streams for each event type for the new broadcast apis

### DIFF
--- a/AzureFunctions.AngularClient/src/app/api/api-details/api-details.component.ts
+++ b/AzureFunctions.AngularClient/src/app/api/api-details/api-details.component.ts
@@ -1,3 +1,4 @@
+import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { LogCategories } from 'app/shared/models/constants';
 import { LogService } from './../../shared/services/log.service';
 import { CacheService } from 'app/shared/services/cache.service';
@@ -50,7 +51,8 @@ export class ApiDetailsComponent implements OnDestroy {
 
         this.initComplexFrom();
 
-        this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.ProxyDashboard)
+        this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.TreeNavigation)
+            .filter(info => info.dashboardType === DashboardType.ProxyDashboard)
             .takeUntil(this._ngUnsubscribe)
             .switchMap(viewInfo => {
                 this._globalStateService.setBusyState();

--- a/AzureFunctions.AngularClient/src/app/api/api-new/api-new.component.ts
+++ b/AzureFunctions.AngularClient/src/app/api/api-new/api-new.component.ts
@@ -1,3 +1,4 @@
+import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { Component, ViewChild, OnDestroy } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -67,7 +68,8 @@ export class ApiNewComponent implements OnDestroy {
             this.isMethodsVisible = !(value === 'All');
         });
 
-        this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.CreateProxyDashboard)
+        this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.TreeNavigation)
+            .filter(info => info.dashboardType === DashboardType.CreateProxyDashboard)
             .takeUntil(this._ngUnsubscribe)
             .switchMap(viewInfo => {
                 this._globalStateService.setBusyState();

--- a/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.ts
+++ b/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.ts
@@ -1,3 +1,4 @@
+import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { ActivatedRoute } from '@angular/router';
 import { BroadcastEvent } from 'app/shared/models/broadcast-event';
 import { BroadcastService } from 'app/shared/services/broadcast.service';
@@ -62,7 +63,8 @@ export class AppsListComponent implements OnDestroy {
     public broadcastService: BroadcastService,
     public route: ActivatedRoute) {
 
-    this.broadcastService.getEvents<TreeViewInfo<SiteData>>(BroadcastEvent.AppsDashboard)
+    this.broadcastService.getEvents<TreeViewInfo<SiteData>>(BroadcastEvent.TreeNavigation)
+      .filter(viewInfo => viewInfo.dashboardType === DashboardType.AppsDashboard)
       .takeUntil(this._ngUnsubscribe)
       .distinctUntilChanged()
       .switchMap(viewInfo => {

--- a/AzureFunctions.AngularClient/src/app/create-function-wrapper/create-function-wrapper.component.ts
+++ b/AzureFunctions.AngularClient/src/app/create-function-wrapper/create-function-wrapper.component.ts
@@ -1,3 +1,4 @@
+import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { BroadcastEvent } from 'app/shared/models/broadcast-event';
 import { BroadcastService } from './../shared/services/broadcast.service';
 import { ConfigService } from './../shared/services/config.service';
@@ -8,7 +9,6 @@ import { FunctionInfo } from './../shared/models/function-info';
 import { AppNode } from './../tree-view/app-node';
 import { AiService } from './../shared/services/ai.service';
 import { TreeViewInfo } from './../tree-view/models/tree-view-info';
-import { DashboardType } from '../tree-view/models/dashboard-type';
 
 @Component({
   selector: 'create-function-wrapper',
@@ -72,24 +72,16 @@ export class CreateFunctionWrapperComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this._broadCastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.CreateFunctionDashboard)
-    .takeUntil(this._ngUnsubscribe)
-    .subscribe(info => {
-      this._viewInfoStream.next(info);
-    });
-
-    this._broadCastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.CreateFunctionAutoDetectDashboard)
-    .takeUntil(this._ngUnsubscribe)
-    .subscribe(info => {
-      this._viewInfoStream.next(info);
-    });
-
-    this._broadCastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.CreateFunctionQuickstartDashboard)
-    .takeUntil(this._ngUnsubscribe)
-    .subscribe(info => {
-      this._viewInfoStream.next(info);
-    });
-
+    this._broadCastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.TreeNavigation)
+      .filter(info => {
+        return info.dashboardType === DashboardType.CreateFunctionAutoDetectDashboard
+          || info.dashboardType === DashboardType.CreateFunctionDashboard
+          || info.dashboardType === DashboardType.CreateFunctionQuickstartDashboard;
+      })
+      .takeUntil(this._ngUnsubscribe)
+      .subscribe(info => {
+        this._viewInfoStream.next(info);
+      });
   }
 
   ngOnDestroy() {

--- a/AzureFunctions.AngularClient/src/app/function-edit/function-edit.component.ts
+++ b/AzureFunctions.AngularClient/src/app/function-edit/function-edit.component.ts
@@ -1,3 +1,4 @@
+import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { BroadcastEvent } from 'app/shared/models/broadcast-event';
 import { AppNode } from './../tree-view/app-node';
 import { Component, ViewChild, OnDestroy } from '@angular/core';
@@ -69,25 +70,13 @@ export class FunctionEditComponent implements OnDestroy {
                 }
             });
 
-        this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.FunctionDashboard)
-            .takeUntil(this._ngUnsubscribe)
-            .subscribe(info => {
-                this._viewInfoStream.next(info);
-            });
-
-        this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.FunctionIntegrateDashboard)
-            .takeUntil(this._ngUnsubscribe)
-            .subscribe(info => {
-                this._viewInfoStream.next(info);
-            });
-
-        this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.FunctionManageDashboard)
-            .takeUntil(this._ngUnsubscribe)
-            .subscribe(info => {
-                this._viewInfoStream.next(info);
-            });
-
-        this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.FunctionMonitorDashboard)
+        this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.TreeNavigation)
+            .filter(info => {
+                return info.dashboardType === DashboardType.FunctionDashboard
+                    || info.dashboardType === DashboardType.FunctionIntegrateDashboard
+                    || info.dashboardType === DashboardType.FunctionManageDashboard
+                    || info.dashboardType === DashboardType.FunctionMonitorDashboard;
+            })
             .takeUntil(this._ngUnsubscribe)
             .subscribe(info => {
                 this._viewInfoStream.next(info);

--- a/AzureFunctions.AngularClient/src/app/functions-list/functions-list.component.ts
+++ b/AzureFunctions.AngularClient/src/app/functions-list/functions-list.component.ts
@@ -1,3 +1,4 @@
+import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { ErrorIds } from './../shared/models/error-ids';
 import { BroadcastEvent } from 'app/shared/models/broadcast-event';
 import { BroadcastService } from './../shared/services/broadcast.service';
@@ -12,7 +13,6 @@ import { GlobalStateService } from '../shared/services/global-state.service';
 import { TranslateService } from '@ngx-translate/core';
 import { PortalResources } from '../shared/models/portal-resources';
 import { PortalService } from '../shared/services/portal.service';
-import { DashboardType } from '../tree-view/models/dashboard-type';
 import { ErrorType, ErrorEvent } from 'app/shared/models/error-event';
 
 @Component({
@@ -34,8 +34,8 @@ export class FunctionsListComponent implements OnDestroy {
         private _translateService: TranslateService,
         private _broadcastService: BroadcastService
     ) {
-        this._broadcastService.getEvents<TreeViewInfo<void>>(BroadcastEvent.FunctionsDashboard)
-        .takeUntil(this._ngUnsubscribe)
+        this._broadcastService.getEvents<TreeViewInfo<void>>(BroadcastEvent.TreeNavigation)
+            .filter(viewInfo => viewInfo.dashboardType === DashboardType.FunctionsDashboard)
             .takeUntil(this._ngUnsubscribe)
             .distinctUntilChanged()
             .switchMap(viewInfo => {

--- a/AzureFunctions.AngularClient/src/app/proxies-list/proxies-list.component.ts
+++ b/AzureFunctions.AngularClient/src/app/proxies-list/proxies-list.component.ts
@@ -1,3 +1,4 @@
+import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { BroadcastEvent } from 'app/shared/models/broadcast-event';
 import { BroadcastService } from 'app/shared/services/broadcast.service';
 import { Component, OnDestroy } from '@angular/core';
@@ -29,7 +30,8 @@ export class ProxiesListComponent implements OnDestroy {
   constructor(private _broadcastService: BroadcastService) {
     this.viewInfoStream = new Subject<TreeViewInfo<any>>();
 
-    this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.ProxiesDashboard)
+    this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.TreeNavigation)
+      .filter(info => info.dashboardType === DashboardType.ProxiesDashboard)
       .takeUntil(this._ngUnsubscribe)
       .distinctUntilChanged()
       .switchMap(viewInfo => {

--- a/AzureFunctions.AngularClient/src/app/shared/models/broadcast-event.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/broadcast-event.ts
@@ -1,4 +1,5 @@
 export enum BroadcastEvent {
+    TreeNavigation,
     FunctionDeleted,
     FunctionAdded,
     FunctionSelected,
@@ -14,22 +15,7 @@ export enum BroadcastEvent {
     RefreshPortal,
     ClearError,
     OpenTab,
-    DirtyStateChange,
-    AppsDashboard,
-    AppDashboard,
-    FunctionsDashboard,
-    FunctionDashboard,
-    FunctionIntegrateDashboard,
-    FunctionManageDashboard,
-    FunctionMonitorDashboard,
-    CreateFunctionAutoDetectDashboard,
-    CreateFunctionDashboard,
-    CreateFunctionQuickstartDashboard,
-    CreateProxyDashboard,
-    ProxiesDashboard,
-    ProxyDashboard,
-    CreateSlotDashboard,
-    SlotsDashboard,
+    DirtyStateChange
 }
 
 export interface DirtyStateEvent {

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -196,6 +196,7 @@ export class LogCategories {
     public static readonly siteDashboard = 'SiteDashboard';
     public static readonly scenarioService = 'ScenarioService';
     public static readonly apiDetails = 'ApiDetails';
+    public static readonly broadcastService = 'BroadcastService';
     public static readonly newSlot = 'NewSlot';
     public static readonly svgLoader = 'SvgLoader';
     public static readonly busyState = 'BusyState';

--- a/AzureFunctions.AngularClient/src/app/shared/services/log.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/log.service.ts
@@ -77,7 +77,7 @@ export class LogService {
         }
 
         if (this._shouldLog(category, LogLevel.verbose)) {
-            console.log(`[${category}] - ${data}`);
+            console.log(`${this._getTime()} [${category}] - ${data}`);
         }
     }
 
@@ -94,5 +94,10 @@ export class LogService {
         }
 
         return false;
+    }
+
+    private _getTime(){
+        const now = new Date();
+        return now.toISOString();
     }
 }

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
@@ -266,8 +266,9 @@ export class SideNavComponent implements AfterViewInit {
         this.logService.debug(LogCategories.SideNav, `Navigating to ${navId}`);
         this.router.navigate([navId], { relativeTo: this.route, queryParams: Url.getQueryStringObj() });
 
-        const dashboardString = DashboardType[newDashboardType];
-        setTimeout(() => this.broadcastService.broadcastEvent(BroadcastEvent[dashboardString], viewInfo), 100);
+        // const dashboardString = DashboardType[newDashboardType];
+        // setTimeout(() => this.broadcastService.broadcastEvent(BroadcastEvent[dashboardString], viewInfo), 100);
+        this.broadcastService.broadcastEvent(BroadcastEvent.TreeNavigation, viewInfo);
 
         this._updateTitle(newSelectedNode);
         this.portalService.closeBlades();

--- a/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-dashboard.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-dashboard.component.ts
@@ -1,3 +1,4 @@
+import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { LogicAppsComponent } from './../../logic-apps/logic-apps.component';
 import { Dom } from './../../shared/Utilities/dom';
 import { LogService } from './../../shared/services/log.service';
@@ -69,23 +70,23 @@ export class SiteDashboardComponent implements OnDestroy, OnInit {
         private _logService: LogService) {
 
         this._broadcastService.getEvents<string>(BroadcastEvent.OpenTab)
-        .takeUntil(this._ngUnsubscribe)
-        .subscribe(tabId =>{
-            this.openFeature(tabId);
-        });
+            .takeUntil(this._ngUnsubscribe)
+            .subscribe(tabId => {
+                this.openFeature(tabId);
+            });
 
         this._broadcastService.getEvents<DirtyStateEvent>(BroadcastEvent.DirtyStateChange)
-        .takeUntil(this._ngUnsubscribe)
-        .subscribe(event =>{
-            if (!event.dirty && !event.reason) {
-                this.tabInfos.forEach(t => (t.dirty = false));
-            } else {
-                const info = this.tabInfos.find(t => t.id === event.reason);
-                if (info) {
-                    info.dirty = event.dirty;
+            .takeUntil(this._ngUnsubscribe)
+            .subscribe(event => {
+                if (!event.dirty && !event.reason) {
+                    this.tabInfos.forEach(t => (t.dirty = false));
+                } else {
+                    const info = this.tabInfos.find(t => t.id === event.reason);
+                    if (info) {
+                        info.dirty = event.dirty;
+                    }
                 }
-            }
-        });
+            });
 
         if (this.tabInfos.length === 0) {
             // Setup initial tabs without inputs immediate so that they load right away
@@ -184,7 +185,8 @@ export class SiteDashboardComponent implements OnDestroy, OnInit {
     }
 
     ngOnInit() {
-        this._broadcastService.getEvents<TreeViewInfo<SiteData>>(BroadcastEvent.AppDashboard)
+        this._broadcastService.getEvents<TreeViewInfo<SiteData>>(BroadcastEvent.TreeNavigation)
+            .filter(viewInfo => viewInfo.dashboardType === DashboardType.AppDashboard)
             .takeUntil(this._ngUnsubscribe)
             .subscribe(viewInfo => {
                 this.viewInfo = viewInfo;

--- a/AzureFunctions.AngularClient/src/app/slot-new/slot-new.component.ts
+++ b/AzureFunctions.AngularClient/src/app/slot-new/slot-new.component.ts
@@ -1,3 +1,4 @@
+import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { LogCategories } from 'app/shared/models/constants';
 import { LogService } from './../shared/services/log.service';
 import { Component, Injector, OnDestroy } from '@angular/core';
@@ -69,12 +70,14 @@ export class SlotNewComponent implements OnDestroy {
         injector: Injector) {
         const validator = new RequiredValidator(this._translateService);
 
-        this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.CreateSlotDashboard)
+        this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.TreeNavigation)
+            .filter(info => info.dashboardType === DashboardType.CreateSlotDashboard)
             .takeUntil(this._ngUnsubscribe)
             .switchMap(viewInfo => {
                 this._globalStateService.setBusyState();
                 this._slotsNode = <SlotsNode>viewInfo.node;
                 this._viewInfo = viewInfo;
+
                 // parse the site resourceId from slot's
                 this._siteId = viewInfo.resourceId.substring(0, viewInfo.resourceId.indexOf('/slots'));
                 const slotNameValidator = new SlotNameValidator(injector, this._siteId);

--- a/AzureFunctions.AngularClient/src/app/slots-list/slots-list.component.ts
+++ b/AzureFunctions.AngularClient/src/app/slots-list/slots-list.component.ts
@@ -1,3 +1,4 @@
+import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { Component, OnDestroy } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import { TranslateService } from '@ngx-translate/core';
@@ -35,14 +36,15 @@ export class SlotsListComponent implements OnDestroy {
         private _translateService: TranslateService
     ) {
 
-        this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.SlotsDashboard)
+        this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.TreeNavigation)
+            .filter(info => info.dashboardType === DashboardType.SlotsDashboard)
             .takeUntil(this._ngUnsubscribe)
             .switchMap(viewInfo => {
                 this.isLoading = true;
                 this._slotsNode = (<SlotsNode>viewInfo.node);
                 return this._slotsNode.loadChildren();
             })
-            .do(null, e =>{
+            .do(null, e => {
                 this.isLoading = false;
                 this._broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
                     message: this._translateService.instant(PortalResources.error_unableToLoadSlotsList),


### PR DESCRIPTION
Originally I was trying to cut down on the number of streams that we had to keep track of for the new broadcastEvent and getEvent API's.  But it turns out to be more complicated because some streams want you to keep track of many events (like busy state events from different managers), while other really only want the latest.  I couldn't find a way to do this using filtering, so I just went back to having multiple streams.