### PR TITLE
Fix issue where tab crashes and function dev throws exception on tree navigation

### DIFF
--- a/AzureFunctions.AngularClient/src/app/function-dev/function-dev.component.ts
+++ b/AzureFunctions.AngularClient/src/app/function-dev/function-dev.component.ts
@@ -141,7 +141,7 @@ export class FunctionDevComponent implements OnChanges, OnDestroy {
                 this.checkErrors(fi);
 
                 this.functionApp.getEventGridKey().subscribe(eventGridKey => {
-                    this.eventGridSubscribeUrl = `${this.functionApp.getMainSiteUrl().toLowerCase()}/admin/extensions/EventGridExtensionConfig?functionName=${this.functionInfo.name}&code=${eventGridKey}`;;
+                    this.eventGridSubscribeUrl = `${this.functionApp.getMainSiteUrl().toLowerCase()}/admin/extensions/EventGridExtensionConfig?functionName=${fi.name}&code=${eventGridKey}`;;
                 });
 
                 return Observable.zip(

--- a/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-dashboard.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-dashboard.component.ts
@@ -1,3 +1,4 @@
+import { Subscription } from 'rxjs/Subscription';
 import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { LogicAppsComponent } from './../../logic-apps/logic-apps.component';
 import { Dom } from './../../shared/Utilities/dom';
@@ -58,6 +59,7 @@ export class SiteDashboardComponent implements OnDestroy, OnInit {
 
     private _tabsLoaded = false;
     private _ngUnsubscribe: Subject<void> = new Subject<void>();
+    private _openTabSubscription: Subscription;
 
     constructor(
         private _cacheService: CacheService,
@@ -68,12 +70,6 @@ export class SiteDashboardComponent implements OnDestroy, OnInit {
         private _broadcastService: BroadcastService,
         private _scenarioService: ScenarioService,
         private _logService: LogService) {
-
-        this._broadcastService.getEvents<string>(BroadcastEvent.OpenTab)
-            .takeUntil(this._ngUnsubscribe)
-            .subscribe(tabId => {
-                this.openFeature(tabId);
-            });
 
         this._broadcastService.getEvents<DirtyStateEvent>(BroadcastEvent.DirtyStateChange)
             .takeUntil(this._ngUnsubscribe)
@@ -120,6 +116,14 @@ export class SiteDashboardComponent implements OnDestroy, OnInit {
                 viewInfo.data.siteTabFullReadyTraceKey = this._aiService.startTrace();
 
                 this._globalStateService.setBusyState();
+
+                if (!this._openTabSubscription) {
+                    this._openTabSubscription = this._broadcastService.getEvents<string>(BroadcastEvent.OpenTab)
+                        .takeUntil(this._ngUnsubscribe)
+                        .subscribe(tabId => {
+                            this.openFeature(tabId);
+                        });
+                }
 
                 return this._cacheService.getArm(viewInfo.resourceId);
             })


### PR DESCRIPTION
My broadcast changes modified the timing of when things are loaded and a few components appear to be affected by this.  

1. The site dashboard was trying to read some properties on viewinfo before they were ready.  This only gets exposed if you have tabs open, you navigate away, then come back to the app node which tries to reopen the tabs.
2. The function dev component may throw a null ref if you navigate to it too quickly.  It seems like this should have always been an issue but I wasn't able to reproduce in prod. Anyway I did a simple fix here, though the code itself is precarious and I think it needs a deeper rewrite.