### PR TITLE
Fixes and updates to site config save operation

### DIFF
--- a/AzureFunctions.AngularClient/src/app/site/site-config/default-documents/default-documents.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/default-documents/default-documents.component.ts
@@ -229,9 +229,16 @@ export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
   }
 
   save(): Observable<SaveOrValidationResult> {
-    let defaultDocGroups = this.groupArray.controls;
+    // Don't make unnecessary PATCH call if these settings haven't been changed
+    if (this.groupArray.pristine) {
+      return Observable.of({
+        success: true,
+        error: null
+      });
+    }
+    else if (this.mainForm.contains("defaultDocs") && this.mainForm.controls["defaultDocs"].valid) {
+      let defaultDocGroups = this.groupArray.controls;
 
-    if (this.mainForm.contains("defaultDocs") && this.mainForm.controls["defaultDocs"].valid) {
       let webConfigArm: ArmObj<any> = JSON.parse(JSON.stringify(this._webConfigArm));
       webConfigArm.properties = {};
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
@@ -316,7 +316,7 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
       }
 
       if (ArmUtil.isFunctionApp(siteConfigArm)) {
-        phpSupported = false;
+        netFrameworkSupported = false;
         pythonSupported = false;
         javaSupported = false;
         classicPipelineModeSupported = false;

--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
@@ -1028,9 +1028,16 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
   }
 
   save(): Observable<SaveOrValidationResult> {
-    const generalSettingsControls = this.group.controls;
+    // Don't make unnecessary PATCH call if these settings haven't been changed
+    if (this.group.pristine) {
+      return Observable.of({
+        success: true,
+        error: null
+      });
+    }
+    else if (this.mainForm.contains("generalSettings") && this.mainForm.controls["generalSettings"].valid) {
+      const generalSettingsControls = this.group.controls;
 
-    if (this.mainForm.contains("generalSettings") && this.mainForm.controls["generalSettings"].valid) {
       // level: site
       const siteConfigArm: ArmObj<Site> = JSON.parse(JSON.stringify(this.siteArm));
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/handler-mappings/handler-mappings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/handler-mappings/handler-mappings.component.ts
@@ -221,9 +221,16 @@ export class HandlerMappingsComponent implements OnChanges, OnDestroy {
   }
 
   save(): Observable<SaveOrValidationResult> {
-    let handlerMappingGroups = this.groupArray.controls;
+    // Don't make unnecessary PATCH call if these settings haven't been changed
+    if (this.groupArray.pristine) {
+      return Observable.of({
+        success: true,
+        error: null
+      });
+    }
+    else if (this.mainForm.contains("handlerMappings") && this.mainForm.controls["handlerMappings"].valid) {
+      let handlerMappingGroups = this.groupArray.controls;
 
-    if (this.mainForm.contains("handlerMappings") && this.mainForm.controls["handlerMappings"].valid) {
       let webConfigArm: ArmObj<any> = JSON.parse(JSON.stringify(this._webConfigArm));
       webConfigArm.properties = {};
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/virtual-directories/virtual-directories.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/virtual-directories/virtual-directories.component.ts
@@ -271,9 +271,16 @@ export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
   }
 
   save(): Observable<SaveOrValidationResult> {
-    let virtualDirGroups = this.groupArray.controls;
+    // Don't make unnecessary PATCH call if these settings haven't been changed
+    if (this.groupArray.pristine) {
+      return Observable.of({
+        success: true,
+        error: null
+      });
+    }
+    else if (this.mainForm.contains("virtualDirectories") && this.mainForm.controls["virtualDirectories"].valid) {
+      let virtualDirGroups = this.groupArray.controls;
 
-    if (this.mainForm.contains("virtualDirectories") && this.mainForm.controls["virtualDirectories"].valid) {
       let webConfigArm: ArmObj<any> = JSON.parse(JSON.stringify(this._webConfigArm));
       webConfigArm.properties = {};
 


### PR DESCRIPTION
- Fixes #1958 by no longer hiding the PHP version dropdown in the General Settings section for function apps.
- Avoids unnecessary PUT/PATCH calls for config sections that haven't been updated.

(Note: This is a temporary solution to fix issue #1958. There is already a issue open for a proper solution that will solve both of the issues addressed by this change.)