### PR TITLE
UI bug fixes and updates for Application Settings tab/blade

### DIFF
--- a/AzureFunctions.AngularClient/AzureFunctions.AngularClient.csproj
+++ b/AzureFunctions.AngularClient/AzureFunctions.AngularClient.csproj
@@ -104,6 +104,7 @@
     <None Include="src\app\copy-pre\copy-pre.component.scss" />
     <Content Include="src\app\controls\click-to-edit\click-to-edit.component.html" />
     <Content Include="src\app\controls\command-bar\command\command.component.html" />
+    <Content Include="src\app\controls\info-box\info-box.component.html" />
     <Content Include="src\app\controls\textbox\textbox.component.html" />
     <Content Include="src\app\controls\slide-toggle\slide-toggle.component.html" />
     <Content Include="src\app\copy-pre\copy-pre.component.css" />
@@ -125,6 +126,7 @@
     <Content Include="src\app\create-function-wrapper\create-function-wrapper.component.scss" />
     <Content Include="src\app\controls\click-to-edit\click-to-edit.component.scss" />
     <Content Include="src\app\controls\command-bar\command\command.component.scss" />
+    <Content Include="src\app\controls\info-box\info-box.component.scss" />
     <Content Include="src\app\controls\slide-toggle\slide-toggle.component.scss" />
     <Content Include="src\app\controls\textbox\textbox.component.scss" />
     <Content Include="src\app\edit-mode-warning\edit-mode-warning.component.scss" />
@@ -401,6 +403,7 @@
     <TypeScriptCompile Include="src\app\controls\command-bar\command-bar.component.ts" />
     <TypeScriptCompile Include="src\app\controls\command-bar\command\command.component.spec.ts" />
     <TypeScriptCompile Include="src\app\controls\command-bar\command\command.component.ts" />
+    <TypeScriptCompile Include="src\app\controls\info-box\info-box.component.ts" />
     <TypeScriptCompile Include="src\app\controls\pair-list\pair-list.component.spec.ts" />
     <TypeScriptCompile Include="src\app\controls\pair-list\pair-list.component.ts" />
     <TypeScriptCompile Include="src\app\controls\slide-toggle\slide-toggle.component.spec.ts" />

--- a/AzureFunctions.AngularClient/src/app/controls/info-box/info-box.component.html
+++ b/AzureFunctions.AngularClient/src/app/controls/info-box/info-box.component.html
@@ -1,0 +1,18 @@
+<div
+    class="info-box"
+    [class.clickable]="!!infoLink"
+    (click)="onClick($event)"
+    [tabIndex]="!!infoLink ? 0 : -1"
+    (keydown)="onKeyPress($event)">
+
+    <div class="info-icon-container">
+        <div class="glyphicon glyphicon-info-sign info-icon"></div>
+    </div>
+    <div class="info-text-container">
+        <div>{{ infoText }}</div>
+    </div>
+    <div *ngIf="!!infoLink" class="info-link-container">
+        <span load-image="image/learn-more.svg" class="icon-small"></span>
+    </div>
+
+</div>

--- a/AzureFunctions.AngularClient/src/app/controls/info-box/info-box.component.scss
+++ b/AzureFunctions.AngularClient/src/app/controls/info-box/info-box.component.scss
@@ -1,0 +1,36 @@
+@import '../../../sass/common/variables';
+
+.info-box{
+    margin-bottom: 10px;
+    background-color: $info-box-color;
+
+    .info-icon-container{
+        display: table-cell;
+        vertical-align: middle;
+
+        .info-icon{
+            font-size: 30px;
+            padding: 5px;
+            color: $primary-color;
+        }
+    }
+
+    .info-text-container{
+        display: table-cell;
+        width: 100%;
+        vertical-align: middle;
+        padding: 5px;
+        color: $body-bg-color-dark;
+    }
+
+    .info-link-container{
+        display: table-cell;
+        vertical-align: top;
+        padding-top: 5px;
+        padding-right: 5px;
+    }
+}
+
+.info-box.clickable:hover{
+    background-color: $info-box-color-hover;
+}

--- a/AzureFunctions.AngularClient/src/app/controls/info-box/info-box.component.ts
+++ b/AzureFunctions.AngularClient/src/app/controls/info-box/info-box.component.ts
@@ -1,0 +1,28 @@
+import { KeyCodes } from './../../shared/models/constants';
+import { Component, Input } from '@angular/core';
+
+@Component({
+    selector: 'info-box',
+    templateUrl: './info-box.component.html',
+    styleUrls: ['./info-box.component.scss']
+})
+export class InfoBoxComponent {
+
+    @Input() infoText: string = null;
+    @Input() infoLink: string = null;
+
+    constructor() { }
+
+    onClick(event: any) {
+        if (!!this.infoLink) {
+            window.open(this.infoLink, '_blank');
+        }
+    }
+
+    onKeyPress(event: KeyboardEvent) {
+        if (!!this.infoLink && event.keyCode === KeyCodes.enter) {
+            window.open(this.infoLink, '_blank');
+        }
+    }
+
+}

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -104,6 +104,8 @@ export class Regex {
 
 export class Links {
     public static standaloneCreateLearnMore = "https://go.microsoft.com/fwlink/?linkid=848756";
+    public static pythonLearnMore = "https://go.microsoft.com/fwlink/?linkid=852196";
+    public static clientAffinityLearnMore = "https://go.microsoft.com/fwlink/?linkid=798249";
 }
 
 export class LocalStorageKeys {

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -176,6 +176,7 @@ export class ScenarioIds {
     public static readonly enablePlatform64 = 'EnablePlatform64';
     public static readonly enableAlwaysOn = 'EnableAlwaysOn';
     public static readonly deleteAppDirectly = 'deleteAppDirectly';
+    public static readonly enableAutoSwap = 'EnableAutoSwap';
 }
 
 export class ServerFarmSku {

--- a/AzureFunctions.AngularClient/src/app/shared/models/portal-resources.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/portal-resources.ts
@@ -417,6 +417,7 @@
     public static phpVersionLabelHelp: string = "phpVersionLabelHelp";
     public static pythonVersionLabel: string = "pythonVersionLabel";
     public static pythonVersionLabelHelp: string = "pythonVersionLabelHelp";
+    public static pythonInfoText: string = "pythonInfoText";
     public static javaVersionLabel: string = "javaVersionLabel";
     public static javaVersionLabelHelp: string = "javaVersionLabelHelp";
     public static javaMinorVersionLabel: string = "javaMinorVersionLabel";
@@ -436,6 +437,7 @@
     public static autoSwapEnabledLabel: string = "autoSwapEnabledLabel";
     public static autoSwapSlotNameLabel: string = "autoSwapSlotNameLabel";
     public static clientAffinityEnabledLabel: string = "clientAffinityEnabledLabel";
+    public static clientAffinityInfoText: string = "clientAffinityInfoText";
     public static remoteDebuggingEnabledLabel: string = "remoteDebuggingEnabledLabel";
     public static remoteDebuggingVersionLabel: string = "remoteDebuggingVersionLabel";
     public static linuxFxVersionLabel: string = "linuxFxVersionLabel";

--- a/AzureFunctions.AngularClient/src/app/shared/models/portal-resources.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/portal-resources.ts
@@ -439,7 +439,9 @@
     public static remoteDebuggingEnabledLabel: string = "remoteDebuggingEnabledLabel";
     public static remoteDebuggingVersionLabel: string = "remoteDebuggingVersionLabel";
     public static linuxFxVersionLabel: string = "linuxFxVersionLabel";
+    public static linuxFxVersionLabelHelp: string = "linuxFxVersionLabelHelp";
     public static appCommandLineLabel: string = "appCommandLineLabel";
+    public static appCommandLineLabelHelp: string = "appCommandLineLabelHelp";
     public static newest: string = "newest";
     public static architecture32: string = "architecture32";
     public static architecture64: string = "architecture64";

--- a/AzureFunctions.AngularClient/src/app/shared/models/portal-resources.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/portal-resources.ts
@@ -434,6 +434,7 @@
     public static alwaysOnUpsell: string = "alwaysOnUpsell";
     public static managedPipelineModeLabel: string = "managedPipelineModeLabel";
     public static autoSwapNotSupportedFromProd: string = "autoSwapNotSupportedFromProd";
+    public static autoSwapUpsell: string = "autoSwapUpsell";
     public static autoSwapEnabledLabel: string = "autoSwapEnabledLabel";
     public static autoSwapSlotNameLabel: string = "autoSwapSlotNameLabel";
     public static clientAffinityEnabledLabel: string = "clientAffinityEnabledLabel";

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/azure.environment.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/azure.environment.ts
@@ -49,6 +49,13 @@ export class AzureEnvironment extends Environment {
                 return this._enableIfBasicOrHigher(input);
             }
         };
+
+        this.scenarioChecks[ScenarioIds.enableAutoSwap] = {
+            id: ScenarioIds.enableAutoSwap,
+            runCheck: (input: ScenarioCheckInput) => {
+                return this._enableIfStandardOrHigher(input);
+            }
+        };
     }
 
     public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {
@@ -60,6 +67,19 @@ export class AzureEnvironment extends Environment {
             && input.site
             && (input.site.properties.sku === ServerFarmSku.free
                 || input.site.properties.sku === ServerFarmSku.shared);
+
+        return <ScenarioResult>{
+            status: disabled ? 'disabled' : 'enabled',
+            data: null
+        };
+    }
+
+    private _enableIfStandardOrHigher(input: ScenarioCheckInput) {
+        const disabled = input
+            && input.site
+            && (input.site.properties.sku === ServerFarmSku.free
+                || input.site.properties.sku === ServerFarmSku.shared
+                || input.site.properties.sku === ServerFarmSku.basic);
 
         return <ScenarioResult>{
             status: disabled ? 'disabled' : 'enabled',

--- a/AzureFunctions.AngularClient/src/app/shared/shared.module.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/shared.module.ts
@@ -49,6 +49,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { ArmService } from 'app/shared/services/arm.service';
 import { Url } from 'app/shared/Utilities/url';
 import { EmptyDashboardComponent } from 'app/main/empty-dashboard.component';
+import { InfoBoxComponent } from './../controls/info-box/info-box.component';
 
 export function ArmServiceFactory(
     http: Http,
@@ -91,7 +92,8 @@ export function AiServiceFactory() {
         TooltipDirective,
         SlideToggleComponent,
         LoadImageDirective,
-        EmptyDashboardComponent
+        EmptyDashboardComponent,
+        InfoBoxComponent
     ],
     exports: [
         CommonModule,
@@ -120,7 +122,8 @@ export function AiServiceFactory() {
         TooltipDirective,
         SlideToggleComponent,
         LoadImageDirective,
-        EmptyDashboardComponent
+        EmptyDashboardComponent,
+        InfoBoxComponent
     ],
     imports: [
         FormsModule,

--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.html
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.html
@@ -184,20 +184,29 @@
     </div>
 
     <ng-container *ngIf="autoSwapSupported">
-      <div class="setting-wrapper">
-        <info-box [infoText]="('autoSwapNotSupportedFromProd' | translate)"></info-box>
+      <div class="setting-wrapper" check-scenario="EnableAutoSwap" [cs-input]="{site: siteArm}" cs-enabledClass="" cs-disabledClass="last">
+        <info-box [infoText]="('autoSwapNotSupportedFromProd' | translate)" check-scenario="EnableAutoSwap" [cs-input]="{site: siteArm}"></info-box>
         <label class="setting-label">{{ 'autoSwapEnabledLabel' | translate }}</label>
         <div class="setting-control-container">
           <radio-selector
             [control]="!!group ? group.controls['autoSwapEnabled'] : null"
             [options]="autoSwapEnabledOptions"
             [highlightDirty]="true"
-            (value)="updateAutoSwapSlotNameOptions($event)">
+            (value)="updateAutoSwapSlotNameOptions($event)"
+            check-scenario="EnableAutoSwap"
+            [cs-input]="{site: siteArm}">
           </radio-selector>
+
+          <span check-scenario="EnableAutoSwap" [cs-input]="{site: siteArm}" cs-enabledClass="hidden" cs-disabledClass="">
+            <a tabindex="0" (click)="scaleUp()">{{'upgradeToEnable' | translate}}</a>
+            <pop-over [message]="'autoSwapUpsell' | translate">
+              <span load-image="image/upsell.svg" class="icon-small"></span>
+            </pop-over>
+          </span>
         </div>
       </div>
       
-      <div class="setting-wrapper last">
+      <div class="setting-wrapper last" check-scenario="EnableAutoSwap" [cs-input]="{site: siteArm}">
         <label class="setting-label">{{ 'autoSwapSlotNameLabel' | translate }}</label>
         <div class="setting-control-container">
           <drop-down

--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.html
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.html
@@ -182,9 +182,8 @@
     </div>
 
     <ng-container *ngIf="autoSwapSupported">
-      <div class="auto-swap-warning" >{{ 'autoSwapNotSupportedFromProd' | translate }}</div>
-
       <div class="setting-wrapper">
+        <info-box [infoText]="('autoSwapNotSupportedFromProd' | translate)"></info-box>
         <label class="setting-label">{{ 'autoSwapEnabledLabel' | translate }}</label>
         <div class="setting-control-container">
           <radio-selector

--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.html
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.html
@@ -261,7 +261,11 @@
     <div class="settings-wrapper">
 
       <div class="setting-wrapper">
-        <label class="setting-label">{{ 'linuxFxVersionLabel' | translate }}</label>
+        <label class="setting-label">{{ 'linuxFxVersionLabel' | translate }}
+          <pop-over [message]="('linuxFxVersionLabelHelp' | translate)">
+              <span class="glyphicon glyphicon-info-sign button-title"></span>
+          </pop-over>
+        </label>
         <div class="setting-control-container">
           <drop-down
             [control]="!!group ? group.controls['linuxFxVersion'] : null"
@@ -272,7 +276,11 @@
       </div>
 
       <div class="setting-wrapper last">
-        <label class="setting-label">{{ 'appCommandLineLabel' | translate }}</label>
+        <label class="setting-label">{{ 'appCommandLineLabel' | translate }}
+          <pop-over [message]="('appCommandLineLabelHelp' | translate)">
+              <span class="glyphicon glyphicon-info-sign button-title"></span>
+          </pop-over>
+        </label>
         <div class="setting-control-container">
           <textbox
             [control]="!!group ? group.controls['appCommandLine'] : null"

--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.html
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.html
@@ -36,6 +36,7 @@
     </div>
 
     <div *ngIf="pythonSupported" class="setting-wrapper">
+      <info-box [infoText]="('pythonInfoText' | translate)" [infoLink]="FwLinks.pythonLearnMore"></info-box>
       <label class="setting-label">{{ 'pythonVersionLabel' | translate }}
         <pop-over [message]="('pythonVersionLabelHelp' | translate)">
             <span class="glyphicon glyphicon-info-sign button-title"></span>
@@ -171,6 +172,7 @@
     </div>
 
     <div *ngIf="clientAffinitySupported" class="setting-wrapper" [class.last]="!autoSwapSupported">
+      <info-box [infoText]="('clientAffinityInfoText' | translate)" [infoLink]="FwLinks.clientAffinityLearnMore"></info-box>
       <label class="setting-label">{{ 'clientAffinityEnabledLabel' | translate }}</label>
       <div class="setting-control-container">
         <radio-selector

--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
@@ -177,7 +177,7 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
         if (!this._linuxFxVersionOptionsClean) {
           this._parseLinuxBuiltInStacks(LinuxConstants.builtInStacks);
         }
-        this._processSupportedControls(this.siteArm, this._webConfigArm, this._slotsConfigArm);
+        this._processSupportedControls(this.siteArm, this._webConfigArm);
         this._setupForm(this._webConfigArm, this.siteArm, this._slotsConfigArm);
         this.loadingMessage = null;
         this.showPermissionsMessage = true;
@@ -208,7 +208,7 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
     const inputs = {
       aspResourceId: this.siteArm.properties.serverFarmId,
       aseResourceId: this.siteArm.properties.hostingEnvironmentProfile
-        && this.siteArm.properties.hostingEnvironmentProfile.id
+      && this.siteArm.properties.hostingEnvironmentProfile.id
     };
 
     const openScaleUpBlade = this._portalService.openCollectorBladeWithInputs(
@@ -278,7 +278,7 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
     this.linuxRuntimeSupported = false;
   }
 
-  private _processSupportedControls(siteConfigArm: ArmObj<Site>, webConfigArm: ArmObj<SiteConfig>, slotsConfigArm: ArmArrayResult<Site>) {
+  private _processSupportedControls(siteConfigArm: ArmObj<Site>, webConfigArm: ArmObj<SiteConfig>) {
     if (!!siteConfigArm) {
       let netFrameworkSupported = true;
       let phpSupported = true;
@@ -290,17 +290,13 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
       let classicPipelineModeSupported = true;
       let remoteDebuggingSupported = true;
       let clientAffinitySupported = true;
-      let autoSwapSupported = false;
+      let autoSwapSupported = true;
       let linuxRuntimeSupported = false;
 
       this._sku = siteConfigArm.properties.sku;
       this._kind = siteConfigArm.kind;
 
-      if (slotsConfigArm && slotsConfigArm.value && slotsConfigArm.value.length > 0) {
-        autoSwapSupported = true;
-      }
-
-      if (this._kind.indexOf('linux') >= 0) {
+      if (ArmUtil.isLinuxApp(siteConfigArm)) {
         netFrameworkSupported = false;
         phpSupported = false;
         pythonSupported = false;
@@ -329,6 +325,7 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
           clientAffinitySupported = false;
         }
       }
+
       // if (this._sku === 'Free' || this._sku === 'Shared') {
       //   platform64BitSupported = false;
       //   alwaysOnSupported = false;
@@ -512,10 +509,12 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
       }
       else {
         const slotNames: string[] = ['production'];
-        slotsConfigArm.value
-          .map(s => s.name)
-          .filter(r => r !== siteConfigArm.name)
-          .forEach(n => slotNames.push(n.split("/").slice(-1)[0]))
+        if (slotsConfigArm && slotsConfigArm.value) {
+          slotsConfigArm.value
+            .map(s => s.name)
+            .filter(r => r !== siteConfigArm.name)
+            .forEach(n => slotNames.push(n.split("/").slice(-1)[0]))
+        }
 
         slotNames.forEach(name => {
           autoSwapSlotNameOptions.push({

--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
@@ -13,7 +13,7 @@ import { AvailableStackNames, AvailableStack, Framework, MajorVersion, LinuxCons
 import { DropDownElement, DropDownGroupElement } from './../../../shared/models/drop-down-element';
 import { SelectOption } from './../../../shared/models/select-option';
 
-import { LogCategories } from 'app/shared/models/constants';
+import { Links, LogCategories } from 'app/shared/models/constants';
 import { LogService } from './../../../shared/services/log.service';
 import { PortalResources } from './../../../shared/models/portal-resources';
 import { BusyStateScopeManager } from './../../../busy-state/busy-state-scope-manager';
@@ -53,6 +53,8 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
 
   private _sku: string;
   private _kind: string;
+
+  public FwLinks = Links;
 
   public clientAffinityEnabledOptions: SelectOption<boolean>[];
   public use32BitWorkerProcessOptions: SelectOption<boolean>[];

--- a/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.html
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.html
@@ -25,10 +25,10 @@
 
   <connection-strings [mainForm]="mainForm" [resourceId]="resourceId"></connection-strings>
 
-  <default-documents [mainForm]="mainForm" [resourceId]="resourceId"></default-documents>
+  <default-documents *ngIf="defaultDocumentsSupported" [mainForm]="mainForm" [resourceId]="resourceId"></default-documents>
 
-  <handler-mappings [mainForm]="mainForm" [resourceId]="resourceId"></handler-mappings>
+  <handler-mappings *ngIf="handlerMappingsSupported" [mainForm]="mainForm" [resourceId]="resourceId"></handler-mappings>
 
-  <virtual-directories [mainForm]="mainForm" [resourceId]="resourceId"></virtual-directories>
+  <virtual-directories *ngIf="virtualDirectoriesSupported" [mainForm]="mainForm" [resourceId]="resourceId"></virtual-directories>
 
 </div>

--- a/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.scss
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.scss
@@ -23,7 +23,7 @@ td{
     }
 }
 
-.padded-col {
+.padded-col{
     padding-left: 2px;
     padding-right: 2px;
 }
@@ -32,7 +32,7 @@ td{
     width: 33%;
 }
 
-.two-thirds-Col{
+.two-thirds-col{
     width: 66%;
 }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.scss
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.scss
@@ -142,6 +142,7 @@ h3{
     }
 
     .setting-wrapper{
+        width: 535px;
         padding-bottom: 15px;
 
         &.last{
@@ -152,13 +153,13 @@ h3{
             box-sizing: border-box;
             display: inline-block;
             min-height: 20px;
-            width: 16%;
+            width: 32%;
         }
 
         .setting-control-container{
             display: inline-block;
             vertical-align: middle;
-            width: 265px;
+            width: 66%;
         }
     }
 }

--- a/AzureFunctions.AngularClient/src/sass/common/_variables.scss
+++ b/AzureFunctions.AngularClient/src/sass/common/_variables.scss
@@ -73,3 +73,6 @@ $grey-color: #f5f5f5;
 
 $command-color-hover: #f1f1f8;
 $heading-text-color: #252525;
+
+$info-box-color: #d1e7f8;
+$info-box-color-hover: darken($info-box-color, 5%);

--- a/AzureFunctions/ResourcesPortal/Resources.Designer.cs
+++ b/AzureFunctions/ResourcesPortal/Resources.Designer.cs
@@ -1267,6 +1267,15 @@ namespace AzureFunctions.ResourcesPortal {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You can improve the performance of your stateless applications by turning off the Affinity Cookie, stateful applications should keep the Affinity Cookie turned on for increased compatibility. Click to learn more.
+        /// </summary>
+        internal static string clientAffinityInfoText {
+            get {
+                return ResourceManager.GetString("clientAffinityInfoText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Close.
         /// </summary>
         internal static string close {
@@ -5178,6 +5187,15 @@ namespace AzureFunctions.ResourcesPortal {
         internal static string pythonVersionLabelHelp {
             get {
                 return ResourceManager.GetString("pythonVersionLabelHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to App Service supports installing newer versions of Python. Click here to learn more.
+        /// </summary>
+        internal static string pythonInfoText {
+            get {
+                return ResourceManager.GetString("pythonInfoText", resourceCulture);
             }
         }
         

--- a/AzureFunctions/ResourcesPortal/Resources.Designer.cs
+++ b/AzureFunctions/ResourcesPortal/Resources.Designer.cs
@@ -448,6 +448,15 @@ namespace AzureFunctions.ResourcesPortal {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Provide an optional startup command that will be run as part of container startup. &lt;a href="https://go.microsoft.com/fwlink/?linkid=861969"&gt;Learn more&lt;/a&gt;.
+        /// </summary>
+        internal static string appCommandLineLabelHelp {
+            get {
+                return ResourceManager.GetString("appCommandLineLabelHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Proxies (preview).
         /// </summary>
         internal static string appFunctionSettings_apiProxies {
@@ -4665,6 +4674,15 @@ namespace AzureFunctions.ResourcesPortal {
         internal static string linuxFxVersionLabel {
             get {
                 return ResourceManager.GetString("linuxFxVersionLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Web Apps on Linux provide run-time options through a collection of built in containers. &lt;a href="https://go.microsoft.com/fwlink/?linkid=861969"&gt;Learn more&lt;/a&gt;.
+        /// </summary>
+        internal static string linuxFxVersionLabelHelp {
+            get {
+                return ResourceManager.GetString("linuxFxVersionLabelHelp", resourceCulture);
             }
         }
         

--- a/AzureFunctions/ResourcesPortal/Resources.Designer.cs
+++ b/AzureFunctions/ResourcesPortal/Resources.Designer.cs
@@ -4588,7 +4588,7 @@ namespace AzureFunctions.ResourcesPortal {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Web container.
+        ///   Looks up a localized string similar to Java web container.
         /// </summary>
         internal static string javaWebContainerLabel {
             get {

--- a/AzureFunctions/ResourcesPortal/Resources.Designer.cs
+++ b/AzureFunctions/ResourcesPortal/Resources.Designer.cs
@@ -772,6 +772,15 @@ namespace AzureFunctions.ResourcesPortal {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Auto Swap requires a standard or higher App Service Plan.
+        /// </summary>
+        internal static string autoSwapUpsell {
+            get {
+                return ResourceManager.GetString("autoSwapUpsell", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Auto Swap Slot.
         /// </summary>
         internal static string autoSwapSlotNameLabel {

--- a/AzureFunctions/ResourcesPortal/Resources.Designer.cs
+++ b/AzureFunctions/ResourcesPortal/Resources.Designer.cs
@@ -3076,7 +3076,7 @@ namespace AzureFunctions.ResourcesPortal {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Virtual applicataions and directories.
+        ///   Looks up a localized string similar to Virtual applications and directories.
         /// </summary>
         internal static string feature_virtualDirectoriesName {
             get {

--- a/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/Resources.resx
@@ -1366,6 +1366,9 @@
   <data name="pythonVersionLabelHelp" xml:space="preserve">
     <value>The version used to run your web app if using Python</value>
   </data>
+  <data name="pythonInfoText" xml:space="preserve">
+    <value>App Service supports installing newer versions of Python. Click here to learn more.</value>
+  </data>
   <data name="javaVersionLabel" xml:space="preserve">
     <value>Java version</value>
   </data>
@@ -1422,6 +1425,9 @@
   </data>
   <data name="clientAffinityEnabledLabel" xml:space="preserve">
     <value>ARR Affinity</value>
+  </data>
+  <data name="clientAffinityInfoText" xml:space="preserve">
+    <value>You can improve the performance of your stateless applications by turning off the Affinity Cookie, stateful applications should keep the Affinity Cookie turned on for increased compatibility. Click to learn more.</value>
   </data>
   <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
     <value>Remote debugging</value>

--- a/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/Resources.resx
@@ -1319,7 +1319,7 @@
     <value>Handler mappings</value>
   </data>
   <data name="feature_virtualDirectoriesName" xml:space="preserve">
-    <value>Virtual applicataions and directories</value>
+    <value>Virtual applications and directories</value>
   </data>
   <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
     <value>You must have write permissions on the current app in order to edit these settings.</value>

--- a/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/Resources.resx
@@ -1417,6 +1417,9 @@
   <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
     <value>Auto swap destinations cannot be configured from production slot</value>
   </data>
+  <data name="autoSwapUpsell" xml:space="preserve">
+    <value>Auto Swap requires a standard or higher App Service Plan</value>
+  </data>
   <data name="autoSwapEnabledLabel" xml:space="preserve">
     <value>Auto Swap</value>
   </data>

--- a/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/Resources.resx
@@ -1379,7 +1379,7 @@
     <value>Select the desired Java minor version. Selecting 'Newest' will keep your app using the JVM most recently added to the portal.</value>
   </data>
   <data name="javaWebContainerLabel" xml:space="preserve">
-    <value>Web container</value>
+    <value>Java web container</value>
   </data>
   <data name="javaWebContainerLabelHelp" xml:space="preserve">
     <value>The web container version used to run your web app if using Java</value>

--- a/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/Resources.resx
@@ -1432,8 +1432,14 @@
   <data name="linuxFxVersionLabel" xml:space="preserve">
     <value>Stack</value>
   </data>
+  <data name="linuxFxVersionLabelHelp" xml:space="preserve">
+    <value>Web Apps on Linux provide run-time options through a collection of built in containers. &lt;a href="https://go.microsoft.com/fwlink/?linkid=861969"&gt;Learn more&lt;/a&gt;.</value>
+  </data>
   <data name="appCommandLineLabel" xml:space="preserve">
     <value>Startup File</value>
+  </data>
+  <data name="appCommandLineLabelHelp" xml:space="preserve">
+    <value>Provide an optional startup command that will be run as part of container startup. &lt;a href="https://go.microsoft.com/fwlink/?linkid=861969"&gt;Learn more&lt;/a&gt;.</value>
   </data>
   <data name="newest" xml:space="preserve">
     <value>Newest</value>

--- a/AzureFunctions/ResourcesPortal/cs-CZ/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/cs-CZ/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>Konfigurovat</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>Pokud ji chcete povolit, upgradujte plán.</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>Vybrat vše</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>Vybraly se všechny položky.</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>Počet vybraných položek: {0}</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>Chyba při vytváření funkce: {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>Zvolte šablonu níže nebo</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>Pokud chcete vytvořit nové předplatné, zvolte plán níže.</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>Zadejte popisný název předplatného.</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>Popisný název předplatného</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>Kód pozvánky</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>Tato šablona je experimentální a ještě nemá plnou podporu. Pokud narazíte na potíže, pošlete prosím zprávu o chybě prostřednictvím našeho &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;úložiště GitHub&lt;/a&gt;.</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>Uložit</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>V tuto chvíli probíhá nějaká operace ukládání. Když přejdete jinam, může dojít ke ztrátě některých změn.</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ Přidat nové nastavení</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ Přidat nový připojovací řetězec</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ Přidat nový dokument</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ Přidat nové mapování obslužné rutiny</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ Přidat novou virtuální aplikaci nebo adresář</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>Zadejte název</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>Zadat hodnotu</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>Zadejte příponu.</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>Zadejte procesor skriptů.</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>Zadejte argumenty.</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>Zadejte virtuální cestu.</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>Zadejte fyzickou cestu.</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>Aplikace</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>Nastavení slotu</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>Skrytá hodnota. Kliknutím ji zobrazíte.</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>Hledat</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>Nastavit obor na tuto položku</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>Funkce pro hledání</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>Hledat v aplikacích Function App</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>ID předplatného</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>Povoleno</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>zakázat</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>povoleno</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>tady</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>Chyba při analýze konfigurace: {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>Nepovedlo se {{state}} funkci: {{functionName}}.</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>Funkce</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>Standardní editor</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>Odstranit funkci {{name}}</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>Opravdu chcete odstranit funkci {{name}}?</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>Proxies (Preview)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>Verze modulu runtime proxy serveru: {{extensionVersion}}. K dispozici je novější verze ({{latestExtensionVersion}}).</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>Verze modulu runtime proxy serveru: nejnovější ({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>Povolit Azure Functions Proxies (Preview)</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>Funkce Azure Functions Proxies je v tuto chvíli zakázaná. Pokud ji chcete povolit, navštivte</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>Změny provedené v proxy serveru {{name}} se ztratí. Opravdu chcete pokračovat?</value>
@@ -967,7 +1033,7 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Sloty Azure Functions (Preview) jsou v tuto chvíli zakázané. Pokud je chcete povolit, navštivte</value>
   </data>
-  <data name="discrard" xml:space="preserve">
+  <data name="discard" xml:space="preserve">
     <value>Zahodit</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
@@ -983,7 +1049,7 @@
     <value>Přihlásit se přes Google</value>
   </data>
   <data name="intro_signInWithMicrosoft" xml:space="preserve">
-    <value>Přihlásit se k Microsoftu</value>
+    <value>Přihlásit se účtem Microsoft</value>
   </data>
   <data name="apiProxy_backanrUrlStart" xml:space="preserve">
     <value>Adresa URL back-endu musí začínat na http:// nebo https://.</value>
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>Všechna předplatná</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>Předplatná</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>Počet předplatných: {0}</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>Tady se zobrazí rychlé odkazy na vaše funkce, až je nakonfigurujete na kartě Funkce platformy výše.</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>Neuložené změny aplikace {0} budou ztraceny. Opravdu chcete pokračovat?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>Při načítání informací o aplikaci {0} došlo k chybě.</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>Pro aplikace v plánu Consumption se tato funkce nepodporuje.</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>Tato funkce se pro sloty nepodporuje.</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Pro linuxové aplikace se tato funkce nepodporuje.</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>Abyste mohli tuto funkci používat, musíte mít v aktuální aplikaci oprávnění zapisovat.</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>Prozkoumání systému souborů aplikace z interaktivní webové konzoly</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>SSH poskytuje pro váš kód linuxové aplikace konzolové prostředí Web SSH.</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>Rozšíření</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>Rozšíření obohacují celou aplikaci o další funkce.</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(Nejsou k dispozici žádná nastavení, která by se dala zobrazit.)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(Nejsou k dispozici žádné připojovací řetězce, které by se daly zobrazit.)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(Nejsou k dispozici žádné výchozí dokumenty, které by se daly zobrazit.)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(Nejsou k dispozici žádná mapování obslužné rutiny, která by se dala zobrazit.)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(Nejsou k dispozici žádné virtuální aplikace ani adresáře, které by se daly zobrazit.)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>Obecná nastavení</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>Automatické prohození</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>Ladění</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>Runtime</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>Nastavení aplikace</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>Správa nastavení aplikace, připojovacích řetězců, nastavení modulu runtime a další</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>Výchozí dokumenty</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>Mapování obslužných rutin</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>Virtuální aplikace a adresáře</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>Abyste mohli upravit tato nastavení, musíte mít v aktuální aplikaci oprávnění k zápisu.</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>Tato aplikace je zamknuta jen pro čtení, což brání v úpravě nastavení nebo načtení zabezpečených dat. Odeberte prosím zámek a zkuste to znovu.</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>Zobrazit nastavení v režimu jen pro čtení</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>Nepovedlo se načíst nastavení.</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>Načítá se...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>Aktualizuje se nastavení webové aplikace.</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>Nastavení webové aplikace se úspěšně aktualizovalo</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>Nastavení webové aplikace se nepovedlo aktualizovat: </value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>Chyba při ukládání {{configGroupName}}: Byl zadán neplatný vstup.</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>Verze rozhraní .NET Framework</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>Verze, která se používá ke spouštění vaší webové aplikace, pokud se používá .NET Framework</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>Verze PHP</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>Verze, která se používá ke spouštění vaší webové aplikace, pokud se používá PHP</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Verze Pythonu</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>Verze, která se používá ke spouštění vaší webové aplikace, pokud se používá Python</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Verze Javy</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>Verze, která se používá ke spouštění vaší webové aplikace, pokud se používá Java</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Podverze Javy</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>Vyberte požadovanou podverzi Javy. Pokud zvolíte Nejnovější, bude vaše aplikace vždycky používat systém JVM, který byl na portál přidaný jako nejnovější.</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Webový kontejner</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>Verze webového kontejneru, která se používá ke spouštění vaší webové aplikace, pokud se používá Java</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>Platforma</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>Architektura platformy, na které běží vaše webová aplikace</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>64bitová konfigurace vyžaduje plán služby App Service Basic nebo vyšší.</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Webové sokety</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>Technologie WebSockets umožňuje flexibilnější propojení mezi webovými aplikacemi a moderními prohlížeči. Vaše webová aplikace by musela být vytvořená tak, aby tyto možnosti využívala.</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>Stálé připojení</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>Označuje, že vaše webová aplikace musí být vždycky načtená. Ve výchozím nastavení se webové aplikace po nějaké době nečinnosti uvolní. Tuto možnost se doporučuje povolit, pokud vám ve webové aplikaci nepřetržitě běží webové úlohy.</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>Funkce Always On vyžaduje plán služby App Service Basic nebo vyšší.</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>Spravovaná verze kanálu</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>Cíle automatického prohození se nedají konfigurovat z produkčního slotu.</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>Automatické prohození</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>Slot automatického prohození</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>Spřažení Směrování žádostí na aplikace</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>Vzdálené ladění</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>Verze vzdáleného klienta Visual Studio</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>Zásobník</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>Spouštěcí soubor</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>Od nejnovějších</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32 bitů</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64 bitů</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>Klasicky</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>Integrované</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>Vlastnosti</value>
@@ -1220,7 +1469,7 @@
     <value>Zobrazí všechna nastavení služby App Service.</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>Správa nastavení, která mají vliv na modul runtime Functions pro všechny funkce v aplikaci</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>Obecné nastavení</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>Použije ověřování/autorizaci k ochraně aplikace a pracuje s daty jednotlivých uživatelů.</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>Identita spravované služby</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>Vaše aplikace může s ostatními službami Azure komunikovat sama za sebe pomocí spravované identity Azure Active Directory.</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>Nabízená oznámení</value>
@@ -1349,10 +1604,10 @@
     <value>App Service Editor poskytuje prostředí pro úpravy kódu v prohlížeči.</value>
   </data>
   <data name="feature_resourceExplorerName" xml:space="preserve">
-    <value>Průzkumník prostředků</value>
+    <value>Resource Explorer</value>
   </data>
   <data name="feature_resourceExplorerInfo" xml:space="preserve">
-    <value>Umožňuje prozkoumávat rozhraní API pro správu pomocí Průzkumníka prostředků Azure (Preview).</value>
+    <value>Umožňuje prozkoumat toto API prostředků pomocí Azure Resource Exploreru (Preview).</value>
   </data>
   <data name="featureEnabled_cors" xml:space="preserve">
     <value>Pravidla CORS (počet definovaných: {0})</value>
@@ -1379,10 +1634,13 @@
     <value>Nastavení</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>Nastavení Function App</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>Konfigurace</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>Nastavení aplikace</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>Pro tuto zkušební verzi není správa aplikace Function App k dispozici.</value>
@@ -1574,7 +1832,7 @@
     <value>Přejít na kurz Začínáme</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>Funkce</value>
+    <value>Funkce (Preview)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>Klíč definice rozhraní API</value>
@@ -1586,7 +1844,7 @@
     <value>Vygenerovat šablonu definic rozhraní API</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>Exportovat do Power Apps a Flowu</value>
+    <value>Exportovat do PowerApps a Flowu</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
     <value>Definici rozhraní API s nesprávným formátem nejde uložit.</value>
@@ -1613,7 +1871,7 @@
     <value>Použít definici rozhraní API</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>Definice rozhraní API (Preview)</value>
+    <value>Definice rozhraní API</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>Nemůžeme vytvořit nebo aktualizovat klíč swaggerdocumentationkey pro koncový bod Swaggeru. Podívejte se prosím, jestli v protokolech modulu runtime nejsou nějaké chyby, nebo to zkuste později.</value>
@@ -1653,8 +1911,8 @@
 Před použitím vyplňte &lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;objekty operací&lt;/a&gt; a další informace o rozhraní API.</value>
   </data>
   <data name="swaggerDefinition_keyHelp" xml:space="preserve">
-    <value>Tento klíč chrání definici rozhraní API, aby k ní neměl přístup nikdo, kdo nemá daný klíč.
-Nezabezpečuje základní rozhraní API. Zabezpečení klíčem najdete v jednotlivých funkcích.</value>
+    <value>Tento klíč zabezpečuje definici rozhraní API, aby k ní neměl přístup nikdo, kdo nemá daný klíč.
+Nezabezpečuje základní rozhraní API. Zabezpečení klíčem najdete u jednotlivých funkcí.</value>
   </data>
   <data name="swaggerDefinition_sourceHelp" xml:space="preserve">
     <value>Pokud chcete povolit hostovanou definici rozhraní API a generování definic šablon, nastavte tuto možnost na Funkce.
@@ -1676,7 +1934,7 @@ Pokud chcete použít definici rozhraní API, která se hostuje někde jinde, na
     <value>Jen pro čtení</value>
   </data>
   <data name="appFunctionSettings_readWriteMode" xml:space="preserve">
-    <value>Čtení\zápis</value>
+    <value>Čtení či zápis</value>
   </data>
   <data name="validation_duplicateError" xml:space="preserve">
     <value>Duplicitní hodnoty se nepovolují.</value>
@@ -1704,6 +1962,9 @@ Pokud chcete použít definici rozhraní API, která se hostuje někde jinde, na
   </data>
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>Vaše aplikace je aktuálně v režimu čtení\zápis, protože jste tak nastavili režim úprav, přestože máte aktivovanou správu zdrojového kódu. Případné změny, které provedete, se můžou přepsat při příštím nasazení. Pokud chcete režim úprav změnit, navštivte </value>
+  </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>Vaše aplikace je v tuto chvíli v režimu jen pro čtení, protože jste publikovali vygenerovaný soubor function.json. Modul runtime Functions bude změny v souboru function.json ignorovat. </value>
   </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>Kopírovat</value>
@@ -1748,10 +2009,22 @@ Pokud chcete použít definici rozhraní API, která se hostuje někde jinde, na
     <value>Sloty (Preview)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>Povolit sloty nasazení (Preview). Toto je jednorázový výslovný souhlas v aplikaci Function App, který se nedá vzít zpět a který resetuje všechny stávající tajné kódy. Po aktualizaci se tajné kódy dají zkopírovat pod </value>
+    <value>Povolí sloty nasazení (Preview).</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>Uzel Spravovat pro jednotlivé funkce</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>Známé problémy:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>Když je povolená funkce Sloty (Preview), nefunguje integrace Logic Apps s Functions.</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>Když se přihlásíte k této funkci ve verzi Preview, dojde k resetování všech stávajících tajných kódů. Tajné kódy funkce najdete v uzlu</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>Spravovat</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>pro jednotlivé funkce.</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>Název</value>
@@ -1790,7 +2063,7 @@ Pokud chcete použít definici rozhraní API, která se hostuje někde jinde, na
     <value>Sloty (Preview)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>Abyste měli k dispozici rozmanitější možnosti monitorování, včetně živých metrik a vlastních dotazů, doporučujeme použít &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights&lt;/a&gt;.</value>
+    <value>Abyste měli k dispozici rozmanitější možnosti monitorování, včetně živých metrik a vlastních dotazů, zapněte pro svoji aplikaci Function App &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights&lt;/a&gt;.</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>Tato hodnota se připojí k adrese URL vaší hlavní webové aplikace a bude sloužit jako veřejná adresa slotu. Pokud třeba máte webovou aplikaci s názvem contoso a slot s názvem staging, bude mít nový slot adresu URL podobnou této: http://contoso-staging.azurewebsites.net.</value>
@@ -1803,6 +2076,9 @@ Pokud chcete použít definici rozhraní API, která se hostuje někde jinde, na
   </data>
   <data name="new_" xml:space="preserve">
     <value>Nový</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
+    <value>Vytvořit nový</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
     <value>Odstranit funkci</value>
@@ -1878,5 +2154,308 @@ Pokud chcete použít definici rozhraní API, která se hostuje někde jinde, na
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>Obsah a projekt sady Visual Studio</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>načíst</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>Odstranit proxy</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>Nový proxy server</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>Bez přepsání</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>Expresní registrace AAD</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>create</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>Po vytvoření funkce musíte přidat předplatné Event Gridu.</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>Adresa URL předplatného Event Gridu</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>Adresa URL předplatného Event Gridu</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>Spravovat předplatná Event Gridu</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>Přidat předplatné Event Gridu</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>Všechna místa</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>Počet míst: {0}</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>Umístění:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>Seskupit podle umístění</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>Bez seskupení</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>Seskupit podle skupiny prostředků</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>Seskupit podle předplatného</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>Střed USA – jih</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>Severní Evropa</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>Západní Evropa</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>Jihovýchodní Asie</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>Korea – střed</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>Korea – jih</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>Západní USA</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>Východní USA</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>Japonsko – západ</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>Japonsko – východ</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>Východní Asie</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>Východní USA 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>Střed USA – sever</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>Střed USA</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>Brazílie – jih</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>Austrálie – východ</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>Indie – západ</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>Indie – střed</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>Jižní Indie</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>Střední Kanada</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>Východní Kanada</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>Západní USA – střed</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>Spojené království – západ</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>Spojené království – jih</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>Západní USA 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>Všechny skupiny prostředků</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>Skupina prostředků:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>Počet skupin prostředků: {0}</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>Text</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>Stavový kód</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>Stavová zpráva</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>Přepsání žádosti</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>Přepsání odpovědi</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>Volitelné</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>Používáte předběžnou verzi Azure Functions. Děkujeme za vyzkoušení!</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>Kliknutím skryjete položky.</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>Aplikace logiky umožňují snadno využít funkce na různých platformách.</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>Přidružené aplikace logiky</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>Orchestrace s aplikacemi logiky</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>Vytvořit aplikace logiky</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>Nejsou k dispozici žádné aplikace logiky, které by se daly zobrazit</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>Služba Logic Apps umožňuje rychle vytvářet integrace s aplikacemi SaaS a podnikovými aplikacemi, ale i vizuálně navrhovat procesy a pracovní postupy.</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>Rozbalit nebo sbalit</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>Ověřování nebo autorizace služby App Service:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>Nakonfigurovat AAD</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>Přidat oprávnění</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>nakonfigurováno</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>Požadavky na identitu (nejsou splněny)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>není nakonfigurováno</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>Požadovaná oprávnění</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>Šablona potřebuje následující oprávnění:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>Tato integrace pro danou aplikaci funkcí vyžaduje konfiguraci AAD.</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>Tato šablona pro danou aplikaci funkcí vyžaduje konfiguraci AAD.</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>Možná bude nutné nakonfigurovat další oprávnění, která vaše funkce vyžaduje. Přečtěte si prosím dokumentaci k této vazbě.</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>Spravovat ověřování nebo autorizaci služby App Service</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>Musí se nakonfigurovat ověřování.</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>Požadavky na identitu</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>Spravovat</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>Nepovedlo se nám získat seznam nainstalovaných rozšíření modulu runtime.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Nepovedlo se nám nainstalovat rozšíření modulu runtime {{extensionId}}.</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Nepovedlo se nám odinstalovat rozšíření modulu runtime {{extensionId}}.</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>Instalace rozšíření modulu runtime trvá déle, než se očekávalo.</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>Rozšíření {{extensionId}} už je nainstalované v jiné verzi.</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>Otevřít Application Insights</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>Služba App Insights je pro vaši funkci zapnutá.</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>Neexistují žádná data monitorování, která by se dala zobrazit.</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>Instalovat</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>Rozšíření se úspěšně nainstalovalo.</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>Rozšíření nejsou nainstalovaná.</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>Tato integrace vyžaduje následující rozšíření.</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>Tato šablona vyžaduje následující rozšíření.</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>Instalují se potřebná rozšíření. Tato operace může trvat až 10 minut.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>Nepovedlo se nám nainstalovat rozšíření modulu runtime. ID instalace: {{installationId}}</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>Zadejte hodnotu v GB/s.</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>Připojení</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>Notification Hub</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>Funkce Java je možné sestavovat, testovat a nasazovat místně z vašeho počítače. Nevyžaduje se žádný portál!</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>Kliknutím níže si otevřete dokumentaci, jak sestavit první funkci Java v Azure.</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>Proxy jsou povolené. Pokud je chcete znovu zakázat, odstraňte nebo zakažte všechny jednotlivé proxy.</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Rychlý start s funkcemi Java v Azure</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/de-DE/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/de-DE/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>Konfigurieren</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>Upgrade zum Aktivieren von:</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>Alle auswählen</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>Alle Elemente ausgewählt</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>{0} Elemente ausgewählt</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>Fehler beim Erstellen der Funktion: {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>Wählen Sie unten eine Vorlage aus, oder</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>Choose a plan below to create new subscription</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>Provide a friendly subscription name</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>Friendly subscription name</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>Invitation code</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>Diese Vorlage ist experimentell und wird noch nicht vollständig unterstützt. Wenn Probleme auftreten, posten Sie einen Fehlerbericht in unserem &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;GitHub-Repository.&lt;/a&gt;</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>Speichern</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>Ein Speichervorgang wird gerade ausgeführt. Wenn Sie zu einer anderen Seite wechseln, gehen möglicherweise einige Änderungen verloren.</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ Neue Einstellung hinzufügen</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ Neue Verbindungszeichenfolge hinzufügen</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ Neues Dokument hinzufügen</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ Neue Handlerzuordnung hinzufügen</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ Neue virtuelle Anwendung oder Verzeichnis hinzufügen</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>Geben Sie einen Namen ein</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>Wert eingeben</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>Erweiterung eingeben</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>Skriptprozessor eingeben</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>Argumente eingeben</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>Virtuellen Pfad eingeben</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>Physischen Pfad eingeben</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>Anwendung</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>Sloteinstellung</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>Ausgeblendeter Wert. Klicken Sie, um den Wert anzuzeigen.</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>Suchen</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>Bereich auf dieses Element festlegen</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>Features durchsuchen</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>Funktions-Apps suchen</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>Abonnement-ID</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>Aktiviert</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>deaktivieren</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>aktiviert</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>hier</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>Fehler beim Analysieren der Konfiguration: {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>Fehler beim {{state}} von Funktion: {{functionName}}</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>Features</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>Standard-Editor</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>Funktion "{{name}}" löschen</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>Möchten Sie die Funktion {{name}} löschen?</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>Proxys (Vorschau)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>Proxylaufzeitversion: {{extensionVersion}}. Es ist eine neuere Version verfügbar ({{latestExtensionVersion}}).</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>Proxylaufzeitversion: aktuell ({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>Azure Functions-Proxys aktivieren (Vorschau)</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>Azure Functions-Proxys sind zurzeit deaktiviert. Wechseln Sie zum Aktivieren hierher:</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>Änderungen, die am Proxy "{{name}}" vorgenommen wurden, gehen verloren. Möchten Sie den Vorgang fortsetzen?</value>
@@ -967,7 +1033,7 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Azure Functions-Slots (Vorschau) sind zurzeit deaktiviert. Wechseln Sie zur Aktivierung hierhin:</value>
   </data>
-  <data name="discrard" xml:space="preserve">
+  <data name="discard" xml:space="preserve">
     <value>Verwerfen</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
@@ -983,7 +1049,7 @@
     <value>Mit Google anmelden</value>
   </data>
   <data name="intro_signInWithMicrosoft" xml:space="preserve">
-    <value>Mit Microsoft anmelden</value>
+    <value>Bei Microsoft anmelden</value>
   </data>
   <data name="apiProxy_backanrUrlStart" xml:space="preserve">
     <value>Die Back-End-URL muss mit "http://" oder "https://" beginnen.</value>
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>Alle Abonnements</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>Abonnements</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>{0} Abonnements</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>Hier werden Quicklinks zu Ihren Features angezeigt, nachdem Sie sie über die obige Registerkarte "Plattformfeatures" konfiguriert haben.</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>Nicht gespeicherte Änderungen an der App "{0}" gehen verloren. Möchten Sie fortfahren?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>Fehler beim Abrufen von Informationen zur App "{0}".</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>Dieses Feature wird für Apps in einem Verbrauchstarif nicht unterstützt.</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>Dieses Feature wird für Slots noch nicht unterstützt.</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Dieses Feature wird für Linux-Apps nicht unterstützt.</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>Sie benötigen Schreibberechtigungen für die aktuelle App, um dieses Feature zu verwenden.</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>Erkunden Sie das Dateisystem Ihrer App über eine interaktive, webbasierte Konsole.</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>SSH bietet eine Web-SSH-Konsolenoberfläche für Ihren Linux-App-Code.</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>Erweiterungen</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>Durch Erweiterungen werden Ihrer gesamten App weitere Funktionen hinzugefügt.</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(Keine Anwendungseinstellungen zur Anzeige vorhanden.)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(Keine Verbindungszeichenfolgen zur Anzeige vorhanden.)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(Keine Standarddokumente zur Anzeige vorhanden.)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(Keine Handlerzuordnungen zur Anzeige vorhanden.)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(Keine virtuellen Anwendungen oder Verzeichnisse zur Anzeige vorhanden.)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>Allgemeine Einstellungen</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>Automatisch tauschen</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>Debuggen</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>Laufzeit</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>Anwendungseinstellungen</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>Verwalten Sie App-Einstellungen, Verbindungszeichenfolgen, Laufzeiteinstellungen und vieles mehr.</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>Standarddokumente</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>Handlerzuordnungen</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>Virtuelle Anwendungen und Verzeichnisse</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>Sie benötigen Schreibberechtigungen für die aktuelle App, um diese Einstellungen zu bearbeiten.</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>Diese App weist eine Schreibschutzsperre auf, die das Bearbeiten von Einstellungen und das Empfangen sicherer Daten verhindert. Entfernen Sie die Sperre, und versuchen Sie es noch mal.</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>Hiermit werden Einstellungen im schreibgeschützten Modus angezeigt.</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>Fehler beim Laden der Einstellungen.</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>Wird geladen...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>Die Web-App-Einstellungen werden aktualisiert.</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>Die Web-App-Einstellungen wurden erfolgreich aktualisiert.</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>Fehler beim Aktualisieren der Web-App-Einstellungen: </value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>Fehler beim Speichern von "{{configGroupName}}": ungültige Eingabe.</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>.NET Framework-Version</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>Die für Ihre Web-App verwendete Version, wenn Sie .NET Framework verwenden.</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>PHP-Version</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>Die für Ihre Web-App verwendete Version, wenn Sie PHP verwenden.</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Python-Version</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>Die für Ihre Web-App verwendete Version, wenn Sie Python verwenden.</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Java-Version</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>Die für Ihre Web-App verwendete Version, wenn Sie Java verwenden.</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Java-Nebenversion</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>Wählen Sie die gewünschte Java-Nebenversion aus. Wenn Sie "Aktuellste" auswählen, verwendet Ihre App die JVM, die dem Portal zuletzt hinzugefügt wurde.</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Webcontainer</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>Die Version des Webcontainers für Ihre Web-App, wenn Sie Java verwenden.</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>Plattform</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>Die Plattformarchitektur, die Ihre Web-App ausführt.</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>64-Bit-Konfiguration erfordert App Service-Plan "Basic" oder höher</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Websockets</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>WebSockets ermöglicht flexiblere Verbindungen zwischen Web-Apps und modernen Browsern. Damit diese Funktionen genutzt werden können, muss Ihre Web-App entsprechend ausgelegt sein.</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>Immer aktiv</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>Zeigt an, dass die Web-App zu jeder Zeit geladen sein muss. Standardmäßig werden Web-Apps entladen, nachdem sie sich im Leerlauf befanden. Es wird empfohlen, diese Option zu aktivieren, wenn für die Web-App fortlaufende Webaufträge ausgeführt werden.</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>Always On erfordert App Service-Plan "Basic" oder höher</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>Verwaltete Pipelineversion</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>Ziele für automatischen Tausch können nicht über den Produktionsslot konfiguriert werden.</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>Automatisch tauschen</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>Slot für automatischen Tausch</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>ARR-Affinität</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>Remotedebuggen</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>Remote Visual Studio-Version</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>Stapel</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>Startdatei</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>Neueste</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32 Bit</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64 Bit</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>Klassisch</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>Integriert</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>Eigenschaften</value>
@@ -1220,7 +1469,7 @@
     <value>Zeigen Sie alle App Service-Einstellungen an.</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>Verwalten Sie Einstellungen, die sich auf die Functions-Laufzeit für alle Funktionen innerhalb Ihrer App auswirken.</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>Allgemeine Einstellungen</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>Mit der Authentifizierung/Autorisierung können Sie Ihre Anwendung schützen und mit benutzerbasierten Daten arbeiten.</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>Verwaltete Dienstidentität</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>Ihre Anwendung kann unter Verwendung einer verwalteten Azure Active Directory-Identität als sie selbst mit anderen Azure-Diensten kommunizieren.</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>Pushbenachrichtigungen</value>
@@ -1379,10 +1634,13 @@
     <value>Einstellungen</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>Funktionen-App-Einstellungen</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>Konfiguration</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>Anwendungseinstellungen</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>Die Verwaltung Ihrer Funktionen-App ist für diese Testversion nicht verfügbar.</value>
@@ -1574,7 +1832,7 @@
     <value>Tutorial für erste Schritte ansehen</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>Funktion</value>
+    <value>Funktion (Vorschau)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>Schlüssel für API-Definition</value>
@@ -1586,7 +1844,7 @@
     <value>API-Definitionsvorlage generieren</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>In Power Apps + Flow exportieren</value>
+    <value>Nach PowerApps + Flow exportieren</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
     <value>Falsch formatierte API-Definition kann nicht gespeichert werden.</value>
@@ -1613,7 +1871,7 @@
     <value>Eigene API-Definition verwenden</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>API-Definition (Vorschau)</value>
+    <value>API-Definition</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>Wir können den Schlüssel "swaggerdocumentationkey" für den Swagger-Endpunkt nicht erstellen oder aktualisieren. Prüfen Sie die Laufzeitprotokolle auf Fehler, oder versuchen Sie es später noch mal.</value>
@@ -1653,7 +1911,7 @@
 Füllen Sie vor der Verwendung die &lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;Vorgangsobjekte&lt;/a&gt; sowie weitere Informationen zu Ihrer API aus.</value>
   </data>
   <data name="swaggerDefinition_keyHelp" xml:space="preserve">
-    <value>Dieser Schlüssel schützt Ihre API-Definition vor einem Zugriff durch Personen ohne den Schlüssel.
+    <value>Dieser Schlüssel schützt Ihre API-Definition vor einem Zugriff durch Personen ohne Schlüssel.
 Die zugrunde liegende API wird hierdurch nicht geschützt. Informationen zum jeweiligen Schlüsselschutz finden Sie unter jeder Funktion.</value>
   </data>
   <data name="swaggerDefinition_sourceHelp" xml:space="preserve">
@@ -1705,6 +1963,9 @@ Legen Sie die Einstellung auf "Externe URL" fest, um eine API-Definition zu verw
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>Ihre App befindet sich zurzeit im Lese-/Schreibmodus, weil Sie den Bearbeitungsmodus auf "Lesen/Schreiben" festgelegt haben, obwohl die Quellcodeverwaltung aktiviert ist. Alle durchgeführten Änderungen werden bei der nächsten Bereitstellung möglicherweise überschrieben. Sie können den Bearbeitungsmodus hier ändern: </value>
   </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>Ihre App befindet sich zurzeit im schreibgeschützten Modus, weil Sie eine generierte Datei "function.json" veröffentlicht haben. Änderungen an "function.json" werden von der Functions-Laufzeit nicht berücksichtigt. </value>
+  </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>Kopieren</value>
   </data>
@@ -1748,10 +2009,22 @@ Legen Sie die Einstellung auf "Externe URL" fest, um eine API-Definition zu verw
     <value>Slots (Vorschau)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>Hiermit werden Bereitstellungsslots (Vorschau) aktiviert. Es handelt sich um eine einmalige Aktivierung auf Ebene der Funktionen-App, mit der alle vorhandenen Geheimnisse zurückgesetzt werden. Nach dem Update können die Geheimnisse von hier kopiert werden: </value>
+    <value>Hiermit werden Bereitstellungsslots aktiviert (Vorschau).</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>Knoten "Verwalten" für jede Funktion.</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>Bekannte Probleme:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>Die Logic Apps-Integration mit Functions funktioniert nicht, wenn Slots (Vorschau) aktiviert sind.</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>Durch das Aktivieren dieses Vorschaufeatures werden alle vorhandenen Geheimnisse zurückgesetzt. Funktionsgeheimnisse finden Sie hier:</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>Der Knoten "Verwalten"</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>für jede Funktion.</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>Name</value>
@@ -1790,7 +2063,7 @@ Legen Sie die Einstellung auf "Externe URL" fest, um eine API-Definition zu verw
     <value>Slots (Vorschau)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>Für eine leistungsstärkere Überwachungsoberfläche einschließlich von Livemetriken und benutzerdefinierten Abfragen empfehlen wir die Verwendung von &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights&lt;/a&gt;.</value>
+    <value>Für eine leistungsstärkere Überwachungsoberfläche einschließlich von Livemetriken und benutzerdefinierten Abfragen empfehlen wir die Aktivierung von &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Application Insights für Ihre Funktions-App&lt;/a&gt;.</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>Dieser Wert wird an die Haupt-URL Ihrer Web-App angefügt und dient als öffentliche Adresse des Slots. Lautet der Name Ihrer Web-App z. B. "contoso" und der Ihres Slots "staging", dann lautet die URL des neuen Slots "http://contoso-staging.azurewebsites.net".</value>
@@ -1803,6 +2076,9 @@ Legen Sie die Einstellung auf "Externe URL" fest, um eine API-Definition zu verw
   </data>
   <data name="new_" xml:space="preserve">
     <value>Neu</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
+    <value>Neu erstellen</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
     <value>Funktion löschen</value>
@@ -1878,5 +2154,308 @@ Legen Sie die Einstellung auf "Externe URL" fest, um eine API-Definition zu verw
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>Inhalt und Visual Studio-Projekt</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>Abrufen</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>Proxy löschen</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>Neuer Proxy</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>Keine Außerkraftsetzung</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>Express-AAD-Registrierung</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>Erstellen</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>Sie müssen nach dem Erstellen der Funktion ein Event Grid-Abonnement hinzufügen.</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>Event Grid-Abonnement-URL</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>Event Grid-Abonnement-URL</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>Event Grid-Abonnements verwalten</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>Event Grid-Abonnement hinzufügen</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>Alle Standorte</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>{0} Standorte</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>Speicherort:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>Nach Standort gruppieren</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>Keine Gruppierung</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>Nach Ressourcengruppe gruppieren</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>Nach Abonnement gruppieren</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>USA, Süden-Mitte</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>Europa, Norden</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>Westeuropa</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>Südostasien</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>Korea, Mitte</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>Korea, Süden</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>USA, Westen</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>USA, Osten</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>Japan, Westen</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>Japan, Osten</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>Ostasien</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>USA, Osten 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>USA, Norden-Mitte</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>USA, Mitte</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>Brasilien, Süden</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>Australien, Osten</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>Indien, Westen</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>Indien, Mitte</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>Indien, Süden</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>Kanada, Mitte</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>Kanada, Osten</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>USA, Westen-Mitte</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>Vereinigtes Königreich, Westen</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>Vereinigtes Königreich, Süden</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>USA, Westen 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>Alle Ressourcengruppen</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>Ressourcengruppe:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>{0} Ressourcengruppen</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>Text</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>Statuscode</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>Statusmeldung</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>Außerkraftsetzung von Anforderung</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>Außerkraftsetzung von Antwort</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>Optional</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>Sie verwenden eine Vorabversion von Azure Functions. Vielen Dank, dass Sie diese Version ausprobieren!</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>Zum Ausblenden klicken</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>Mit Logik-Apps können Sie Ihre Funktion problemlos plattformübergreifend verwenden.</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>Zugehörige Logik-Apps</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>Mit Logic Apps orchestrieren</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>Logik-Apps erstellen</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>Es liegen keine Logik-Apps für die Anzeige vor.</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>Logik-Apps</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>Logic Apps ermöglicht Ihnen die schnelle Integration von SaaS- und Unternehmens-Apps sowie den visuellen Entwurf von Prozessen und Workflows.</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>Erweitern oder reduzieren</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>App Service-Authentifizierung/-Autorisierung:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>AAD jetzt konfigurieren</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>Jetzt Berechtigungen hinzufügen</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>Konfiguriert</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>Identitätsanforderungen (nicht erfüllt)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>Nicht konfiguriert</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>Erforderliche Berechtigungen</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>Die Vorlage benötigt die folgende Berechtigung:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>Diese Integration erfordert eine AAD-Konfiguration für die Funktions-App.</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>Diese Vorlage erfordert eine AAD-Konfiguration für die Funktions-App.</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>Sie müssen möglicherweise zusätzliche Berechtigungen konfigurieren, die für Ihre Funktion erforderlich sind. Informationen zu dieser Bindung finden Sie in der Dokumentation.</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>App Service-Authentifizierung/-Autorisierung verwalten</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>Authentifizierungskonfiguration erforderlich</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>Identitätsanforderungen</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>Verwalten</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>Die Liste der installierten Laufzeiterweiterungen kann nicht abgerufen werden.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Die Laufzeiterweiterung "{{extensionId}}" kann nicht installiert werden.</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Die Laufzeiterweiterung "{{extensionId}}" kann nicht deinstalliert werden.</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>Die Installation der Laufzeiterweiterungen dauert länger als erwartet.</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>Die Erweiterung "{{extensionId}}" ist bereits in einer anderen Version installiert.</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>Application Insights öffnen</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>App Insights ist für Ihre Funktion aktiviert.</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>Keine anzuzeigenden Überwachungsdaten.</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>Installieren</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>Erweiterungsinstallation erfolgreich</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>Erweiterungen nicht installiert</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>Diese Integration erfordert die folgenden Erweiterungen.</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>Diese Vorlage erfordert die folgenden Erweiterungen.</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>Die erforderlichen Erweiterungen werden installiert. Dieser Vorgang kann bis zu 10 Minuten in Anspruch nehmen.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>Die Laufzeiterweiterung kann nicht installiert werden. Installations-ID: {{installationId}}</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>Wert in GB pro Sekunde eingeben</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>Verbindung</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>Notification Hub</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>Java-Funktionen können lokal von Ihrem Computer aus erstellt, getestet und bereitgestellt werden. Kein Portal erforderlich!</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>Klicken Sie unten, um die Dokumentation zum Erstellen Ihrer ersten Azure-Funktion mit Java zu öffnen.</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>Proxys wurden aktiviert. Um sie wieder zu deaktivieren, löschen oder deaktivieren Sie alle einzelnen Proxys.</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Schnellstart zu Java in Azure Functions</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/es-ES/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/es-ES/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>Configurar</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>Actualizar para habilitar</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>Seleccionar todo</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>Todos los elementos seleccionados</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>{0} elementos seleccionados</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>Error al crear la función: {{error}}.</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>Elegir una plantilla a continuación o</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>Elegir un plan a continuación para crear una suscripción</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>Proporcionar un nombre descriptivo de la suscripción</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>Nombre descriptivo de la suscripción</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>Código de invitación</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>Esta plantilla es experimental y aún no es totalmente compatible. Si encuentra problemas, registre un error en el &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;repositorio de GitHub&lt;/a&gt;.</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>Guardar</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>Hay una operación de guardar en curso. Al salir, puede que se pierdan algunos cambios.</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ Agregar nuevo valor</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ Agregar nueva cadena de conexión</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ Agregar un nuevo documento</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ Agregar una nueva asignación de controlador</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ Agregar una nueva aplicación o directorio virtual</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>Escribir un nombre</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>Escribir un valor</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>Escribir extensión</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>Escribir el procesador de script</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>Escribir argumentos</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>Escribir la ruta de acceso virtual</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>Escribir la ruta de acceso física</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>Aplicación</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>Configuración de espacios</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>Valor oculto. Haga clic para mostrarlo.</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>Buscar</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>Ámbito a este elemento</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>Buscar en características</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>Buscar en aplicaciones de función</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>Id. de suscripción</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>Habilitado</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>deshabilitar</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>habilitado</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>aquí</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>Error al analizar la configuración: {{error}}.</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>No se pudo {{state}} la función: {{functionName}}</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>Características</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>Editor estándar</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>Eliminar función {{name}}</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>¿Seguro que quiere eliminar la función {{name}}?</value>
@@ -560,7 +635,7 @@
     <value>Elegir un desencadenador</value>
   </data>
   <data name="templatePicker_language" xml:space="preserve">
-    <value>Idioma:</value>
+    <value>Lenguaje:</value>
   </data>
   <data name="templatePicker_scenario" xml:space="preserve">
     <value>Escenario:</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>Servidores proxy (versión preliminar)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>Entorno en tiempo de ejecución del proxy: {{extensionVersion}}. Hay disponible una versión más reciente ({{latestExtensionVersion}}).</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>Versión del proxy en entorno de ejecución: más reciente ({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>Habilitar servidores proxy de Azure Functions (versión preliminar)</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>Los servidores proxy de Azure Functions están actualmente deshabilitados. Para habilitarlos, visite</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>Los cambios realizados en el servidor proxy {{name}} se perderán. ¿Está seguro de que desea continuar?</value>
@@ -967,7 +1033,7 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Los espacios de Azure Functions (vista previa) están actualmente deshabilitados. Para habilitarlos, visite</value>
   </data>
-  <data name="discrard" xml:space="preserve">
+  <data name="discard" xml:space="preserve">
     <value>Descartar</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>Todas las suscripciones</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>Suscripciones</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>{0} suscripciones</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>Los vínculos rápidos a las características aparecerán aquí una vez que los configure en la pestaña "Características" anterior.</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>Los cambios no guardados para la aplicación "{0}" se perderán. ¿Seguro que quiere continuar?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>Error al recuperar información sobre la aplicación "{0}"</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>Esta característica no es compatible con aplicaciones en un plan de consumo</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>Esta característica no se admite para los espacios.</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Esta característica no es compatible con las aplicaciones Linux</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>Debe tener permisos de escritura sobre la aplicación actual para poder usar esta característica</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>Explore el sistema de archivos de la aplicación desde una consola web interactiva.</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>SSH proporciona una experiencia de consola SSH web para el código de aplicación de Linux.</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>Extensiones</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>Las extensiones amplían la funcionalidad a toda la aplicación.</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(no hay ninguna configuración de aplicación para mostrar)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(no hay ninguna cadena de conexión para mostrar)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(no hay ningún documento predeterminado para mostrar)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(no hay ninguna asignación de controlador para mostrar)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(no hay ninguna aplicación o directorio virtual para mostrar)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>Configuración general</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>Intercambio automático</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>Depuración</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>Tiempo de ejecución</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>Configuración de la aplicación</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>Administre la configuración de aplicación, las cadenas de conexión, la configuración del entorno de tiempo de ejecución, y más.</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>Documentos predeterminados</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>Asignaciones de controlador</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>Aplicaciones y directorios virtuales</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>Debe tener permisos de escritura en la aplicación actual para poder editar esta configuración.</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>Esta aplicación tiene un bloqueo de solo lectura que impide editar la configuración o recuperar datos seguros. Quite el bloqueo y vuelva a intentarlo.</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>Vea la configuración en modo de solo lectura.</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>No se pudo cargar la configuración.</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>Cargando...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>Actualizando la configuración de la aplicación web</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>La configuración de la aplicación web se actualizó correctamente</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>No se pudo actualizar la configuración de la aplicación web: </value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>Error al guardar {{configGroupName}}: se proporcionó una entrada no válida.</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>Versión de .NET Framework</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>La versión que se usa para ejecutar la aplicación web si se usa .NET Framework</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>Versión de PHP</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>La versión que se usa para ejecutar la aplicación web si se usa PHP</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Versión de Python</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>La versión que se usa para ejecutar la aplicación web si se usa Python</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Versión de Java</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>La versión que se usa para ejecutar la aplicación web si se usa Java</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Versión secundaria de Java</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>Seleccione la versión secundaria de Java que desee. Si selecciona "Más reciente", la aplicación seguirá usando la versión JVM que se haya agregado al portal más recientemente.</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Contenedor web</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>La versión del contenedor web que se usa para ejecutar la aplicación web si se usa Java</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>Plataforma</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>La arquitectura de plataforma que ejecuta la aplicación web</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>La configuración de 64 bits requiere un plan de App Service básico o superior</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Web sockets</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>WebSockets permite una conectividad más flexible entre las aplicaciones web y los navegadores modernos. La aplicación web deberá crearse para sacar provecho de estas capacidades.</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>Siempre disponible</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>Indica que la aplicación web se debe cargar en todo momento. De forma predeterminada, las aplicaciones web se descargan después de quedar inactivos. Se recomienda habilitar esta opción cuando tenga trabajos web continuos ejecutándose en la aplicación web.</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>La opción Siempre activado requiere un plan de App Service básico o superior</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>Versión de canalización administrada</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>Los destinos de intercambio automático no se pueden configurar desde las ranuras de producción</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>Intercambio automático</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>Ranura de intercambio automático</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>Afinidad ARR</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>Depuración remota</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>Versión remota de Visual Studio</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>Pila</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>Archivo de inicio</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>Más reciente</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32 bits</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64 bits</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>Clásica</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>Integrada</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>Propiedades</value>
@@ -1220,7 +1469,7 @@
     <value>Consulte toda la configuración de App Service.</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>Administre la configuración que afecta al entorno de ejecución de Functions para todas las funciones de su aplicación.</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>Configuración general</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>Use Autenticación o autorización para proteger la aplicación y trabajar con datos por usuario.</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>Identidad de servicio administrada</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>La aplicación puede comunicarse con otros servicios de Azure como ella misma con una identidad de Azure Active Directory administrada.</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>Notificaciones de inserción</value>
@@ -1379,10 +1634,13 @@
     <value>Configuración</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>Configuración de Function App</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>Configuración</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>Configuración de la aplicación</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>La administración de Function App no está disponible para esta evaluación.</value>
@@ -1574,7 +1832,7 @@
     <value>Consulte nuestro tutorial de introducción</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>Función</value>
+    <value>Functions (versión preliminar)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>Clave de definición de API</value>
@@ -1586,7 +1844,7 @@
     <value>Generar plantilla de definición de API</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>Exportar a Power Apps + Flow</value>
+    <value>Exportar a PowerApps + Flow</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
     <value>No se puede guardar una definición de API con un formato incorrecto.</value>
@@ -1613,7 +1871,7 @@
     <value>Use su definición de API</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>Definición de API (vista previa)</value>
+    <value>Definición de la API</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>No se ha podido crear o actualizar la clave swaggerdocumentationkey del punto de conexión de Swagger. Compruebe los errores en los registros de tiempo de ejecución o inténtelo de nuevo más tarde.</value>
@@ -1650,14 +1908,14 @@
   </data>
   <data name="swaggerDefinition_generateHelp" xml:space="preserve">
     <value>Cree una definición dispersa con los metadatos de las funciones desencadenadas por HTTP.
-Complete los &lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;objetos de la operación&lt;/a&gt; y otra información sobre la API antes del uso.</value>
+Complete los &lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;objetos de la operación&lt;/a&gt; y otra información sobre la API antes de usarla.</value>
   </data>
   <data name="swaggerDefinition_keyHelp" xml:space="preserve">
-    <value>Esta clave protege la definición de API frente al acceso de todo aquel que no tenga clave. 
+    <value>Esta clave protege la definición de API frente al acceso de todo aquel que no tenga clave.
 No protege la API subyacente. Vea cada función para consultar su seguridad de claves.</value>
   </data>
   <data name="swaggerDefinition_sourceHelp" xml:space="preserve">
-    <value>Seleccione el valor "Función" para habilitar una definición de API hospedada y la generación de la definición de plantillas. 
+    <value>Seleccione el valor "Función" para habilitar una definición de API hospedada y la generación de la definición de plantillas.
 Elija "URL externa" para usar una definición de API hospedada en otro lugar.</value>
   </data>
   <data name="swaggerDefinition_urlHelp" xml:space="preserve">
@@ -1705,6 +1963,9 @@ Elija "URL externa" para usar una definición de API hospedada en otro lugar.</v
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>La aplicación está actualmente en modo de lectura y escritura porque ha establecido el modo de edición en lectura y escritura a pesar de tener el control de código fuente habilitado. Los cambios que haga pueden sobrescribirse con su próxima implementación. Para cambiar el modo de edición, visite </value>
   </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>La aplicación se encuentra actualmente en modo de solo lectura porque se ha publicado un archivo function.json generado. El entorno en tiempo de ejecución de Functions no respetará los cambios realizados en function.json. </value>
+  </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>Copiar</value>
   </data>
@@ -1748,10 +2009,22 @@ Elija "URL externa" para usar una definición de API hospedada en otro lugar.</v
     <value>Espacios (vista previa)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>Habilitar espacios de implementación (versión preliminar). Esta es una característica de suscripción puntual de Function App que no se puede deshabilitar y restablecerá cualquier secreto preexistente. Después de la implementación, los secretos se pueden copiar desde el </value>
+    <value>Habilita los espacios de implementación (versión preliminar).</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>nodo "Administrar" de cada función.</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>Problemas conocidos:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>La integración de Logic Apps con Functions no funciona cuando están habilitados los espacios (versión preliminar).</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>Al participar en esta característica en versión preliminar, se restablecerán los secretos ya existentes. Los secretos de la función se encuentran en</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>Nodo "Administrar"</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>de cada función.</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>Nombre</value>
@@ -1790,7 +2063,7 @@ Elija "URL externa" para usar una definición de API hospedada en otro lugar.</v
     <value>Espacios (vista previa)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>Para una mejor experiencia de supervisión, incluidas métricas en directo y consultas personalizadas, se recomienda usar &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights.&lt;/a&gt;</value>
+    <value>Para una mejor experiencia de supervisión, incluidas métricas en directo y consultas personalizadas, &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;habilite Application Insights para su aplicación de función&lt;/a&gt;</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>Este valor se anexará a la dirección URL de la aplicación web principal y actuará como la dirección pública de la ranura. Por ejemplo, si tiene una aplicación web con el nombre "contoso" y una ranura denominada "staging", la dirección URL de la nueva ranura será similar a "http://contoso-staging.azurewebsites.net".</value>
@@ -1803,6 +2076,9 @@ Elija "URL externa" para usar una definición de API hospedada en otro lugar.</v
   </data>
   <data name="new_" xml:space="preserve">
     <value>Nuevo</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
+    <value>Crear nueva</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
     <value>Eliminar función</value>
@@ -1878,5 +2154,308 @@ Elija "URL externa" para usar una definición de API hospedada en otro lugar.</v
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>Contenido y proyecto de Visual Studio</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>recuperar</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>Eliminar proxy</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>Nuevo servidor proxy</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>Sin invalidación</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>Registro rápido de AAD</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>crear</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>Debe agregar una suscripción a Event Grid después de crear las funciones.</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>Dirección URL de la suscripción a Event Grid</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>Dirección URL de la suscripción a Event Grid</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>Administrar suscripciones a Event Grid</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>Agregar suscripción a Event Grid</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>Todas las ubicaciones</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>{0} ubicaciones</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>Ubicación:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>Agrupar por ubicación</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>Sin agrupar</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>Agrupar por grupo de recursos</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>Agrupar por suscripción</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>Centro-sur de EE. UU.</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>Europa del Norte</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>Europa Occidental</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>Sudeste Asiático</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>Centro de Corea</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>Sur de Corea</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>Oeste de EE. UU.</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>Este de EE. UU.</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>Oeste de Japón</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>Este de Japón</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>Asia Oriental</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>Este de EE. UU. 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>Centro y norte de EE. UU.</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>Centro de EE. UU.</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>Sur de Brasil</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>Este de Australia</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>Oeste de la India</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>Centro de la India</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>India del Sur</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>Canadá central</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>Canadá oriental</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>Oeste del centro de EE. UU.</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>Oeste de Reino Unido</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>Sur de Reino Unido</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>Oeste de EE. UU. 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>Todos los grupos de recursos</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>Grupo de recursos:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>{0} grupos de recursos</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>Cuerpo</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>Código de estado</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>Mensaje de estado</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>Invalidación de solicitud</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>Invalidación de respuesta</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>Opcional</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>Está usando una versión preliminar de Azure Functions. Gracias por probar esta solución.</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>Haga clic aquí para ocultar</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>Logic Apps le permite usar su función con toda facilidad en múltiples plataformas.</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>Instancias de Logic Apps asociadas</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>Organizar con Logic Apps</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>Crear instancias de Logic Apps</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>No hay instancias de Logic Apps para mostrar</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>Aplicaciones lógicas</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>Con Logic Apps, puede compilar integraciones con aplicaciones empresariales y SaaS rápidamente, además de diseñar visualmente los procesos y los flujos de trabajo.</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>Expandir o contraer</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>Autenticación o autorización de App Service:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>Configurar AAD ahora</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>Agregar permisos ahora</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>configurado</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>Requisitos de identidad (no cumplidos)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>no configurado</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>Permisos necesarios</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>La plantilla necesita el permiso siguiente:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>Esta integración requiere una configuración de AAD para la aplicación de función.</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>Esta plantilla requiere una configuración de AAD para la aplicación de función.</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>Puede que sea necesario configurar permisos adicionales requeridos para la función. Consulte la documentación del enlace.</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>Administrar la autenticación o autorización de App Service</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>Configuración de autenticación requerida</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>Requisitos de identidad</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>Administrar</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>No se puede obtener la lista de extensiones en tiempo de ejecución instaladas.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>No se puede instalar la extensión en tiempo de ejecución {{extensionId}}.</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>No se puede desinstalar la extensión en tiempo de ejecución {{extensionId}}.</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>La instalación de las extensiones en tiempo de ejecución está tardando más de lo esperado.</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>La extensión {{extensionId}} ya está instalada con otra versión distinta.</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>Abrir Application Insights</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>App Insights está habilitado para su función.</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>No hay datos de supervisión para mostrar</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>Instalar</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>Instalación de la extensión realizada correctamente</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>Extensiones no instaladas</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>Esta integración requiere las extensiones siguientes.</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>Esta plantilla requiere las extensiones siguientes.</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>Se instalarán las extensiones necesarias. Esta operación puede tardar hasta 10 minutos.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>No se puede instalar la extensión en tiempo de ejecución. Identificador de instalación {{installationId}}</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>Escribir un valor en GB/seg.</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>Conexión</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>Centro de notificaciones</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>Las funciones de Java se pueden crear, probar e implementar localmente desde la máquina. No se necesita el portal.</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>Haga clic a continuación para empezar a trabajar con la documentación sobre cómo crear la primera función de Azure con Java.</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>Los servidores proxy se han habilitado. Para volver a deshabilitarlos, elimine o deshabilite todos los servidores proxy individuales.</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Java en la guía de inicio rápido de Azure Functions</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/fr-FR/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/fr-FR/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>Configurer</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>Mettre à niveau pour activer</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>Sélectionner tout</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>Tous les éléments sélectionnés</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>{0} éléments sélectionnés</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>Erreur de création de la fonction : {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>Choisissez un modèle ci-dessous ou</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>Choisir un plan ci-dessous pour créer un abonnement</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>Fournir un nom convivial d'abonnement</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>Nom convivial d'abonnement</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>Code d'invitation</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>Ce modèle est expérimental et ne bénéficie pas encore d'une prise en charge complète. Si vous rencontrez des problèmes, ouvrez un bogue sur notre &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;dépôt GitHub&lt;/a&gt;.</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>Enregistrer</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>Une opération d'enregistrement est en cours. Si vous poursuivez votre navigation ailleurs, vous pouvez perdre des modifications.</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ Ajouter un nouveau paramètre</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ Ajouter une nouvelle chaîne de connexion</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ Ajouter un nouveau document</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ Ajouter un nouveau mappage de gestionnaire</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ Ajouter une nouvelle application/un nouvel annuaire virtuel</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>Entrer un nom</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>Entrer une valeur</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>Entrer une extension</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>Entrer un processeur de script</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>Entrer des arguments</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>Entrer un chemin virtuel</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>Entrer un chemin physique</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>Application</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>Paramètre d'emplacement</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>Valeur masquée. Cliquez pour l'afficher.</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>Rechercher</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>Définir l'étendue à cet élément</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>Fonctionnalités de recherche</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>Rechercher dans les applications de fonction</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>ID d'abonnement</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>Activé</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>désactiver</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>activé</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>ici</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>Erreur d'analyse de la configuration : {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>Échec de {{state}} de la fonction : {{functionName}}</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>Fonctionnalités</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>Éditeur standard</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>Supprimer la fonction {{name}}</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>Voulez-vous vraiment supprimer la fonction {{name}} ?</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>Proxys (préversion)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>Version du runtime du proxy : {{extensionVersion}}. Une version plus récente est disponible ({{latestExtensionVersion}}).</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>Version du runtime du proxy : la plus récente ({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>Activer les proxys Azure Functions (préversion)</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>Les proxys Azure Functions sont actuellement désactivés. Pour les activer, visitez</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>Les modifications apportées au proxy {{name}} seront perdues. Voulez-vous vraiment continuer ?</value>
@@ -967,8 +1033,8 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Les emplacements Azure Functions (préversion) sont actuellement désactivés. Pour les activer, visitez</value>
   </data>
-  <data name="discrard" xml:space="preserve">
-    <value>Ignorer</value>
+  <data name="discard" xml:space="preserve">
+    <value>Abandonner</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
     <value>Fonctions</value>
@@ -983,7 +1049,7 @@
     <value>Se connecter avec Google</value>
   </data>
   <data name="intro_signInWithMicrosoft" xml:space="preserve">
-    <value>Connectez-vous avec Microsoft</value>
+    <value>Se connecter avec Microsoft</value>
   </data>
   <data name="apiProxy_backanrUrlStart" xml:space="preserve">
     <value>Une URL de serveur principal doit commencer par « http:// » ou « https:// »</value>
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>Tous les abonnements</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>Abonnements</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>{0} abonnements</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>Les liens rapides vers vos fonctionnalités s'affichent ici une fois que vous avez configuré celles-ci sous l'onglet « Fonctionnalités de la plateforme » ci-dessus.</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>Tout changement non enregistré apporté à l'application « {0} » sera perdu. Voulez-vous vraiment continuer ?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>Une erreur s'est produite durant la récupération des informations de l'application '{0}'</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>Cette fonctionnalité n'est pas prise en charge pour les applications d'un plan Consommation</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>Cette fonctionnalité n'est pas prise en charge pour les emplacements</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Cette fonctionnalité n'est pas prise en charge pour les applications Linux</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>Vous devez disposer d'autorisations d'accès en écriture sur l'application actuelle pour pouvoir utiliser cette fonctionnalité</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>Explorez le système de fichiers de votre application à partir d'une console web interactive.</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>SSH offre une expérience de console web SSH pour le code de votre application Linux</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>Extensions</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>Les extensions ajoutent des fonctionnalités à l'ensemble de votre application.</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(aucun paramètre d'application à afficher)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(aucune chaîne de connexion à afficher)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(aucun document par défaut à afficher)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(aucun mappage de gestionnaire à afficher)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(aucune application/aucun annuaire virtuel à afficher)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>Paramètres généraux</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>Échange automatique</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>Débogage</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>Runtime</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>Paramètres de l'application</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>Gérez les paramètres de l'application, les chaînes de connexion, les paramètres d'exécution et bien plus encore.</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>Documents par défaut</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>Mappages de gestionnaires</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>Applications et annuaires virtuels</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>Vous devez disposer d'autorisations d'accès en écriture sur l'application active pour modifier ces paramètres.</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>Cette application a un verrou en lecture seule qui empêche la modification de paramètres ou la récupération de données sécurisées. Supprimez le verrou et réessayez.</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>Affichez les paramètres en mode lecture seule.</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>Échec du chargement des paramètres.</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>Chargement...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>Mise à jour des paramètres de l'application web</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>Les paramètres de l'application web ont été mis à jour</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>Échec de la mise à jour des paramètres de l'application web : </value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>Erreur d'enregistrement de {{configGroupName}} : entrée non valide fournie.</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>Version du .NET Framework</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>Version utilisée pour exécuter votre application web si vous utilisez le .NET Framework</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>Version PHP</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>Version utilisée pour exécuter votre application web si vous utilisez PHP</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Version de Python</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>Version utilisée pour exécuter votre application web si vous utilisez Python</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Version de Java</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>Version utilisée pour exécuter votre application web si vous utilisez Java</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Version mineure de Java</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>Sélectionnez la version mineure de Java souhaitée. Si vous sélectionnez « La plus récente », votre application continuera d'utiliser la machine virtuelle Java la plus récemment ajoutée au portail.</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Conteneur web</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>Version du conteneur web utilisée pour exécuter votre application web si vous utilisez Java</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>Plateforme</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>Architecture de la plateforme sur laquelle votre application web s'exécute</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>La configuration 64 bits nécessite un plan App Service de base ou supérieur</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Web sockets</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>Les WebSockets permettent des connexions plus flexibles entre les applications web et les navigateurs récents. Votre application web doit être conçue pour tirer parti de ces fonctionnalités.</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>Toujours actif</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>Indique que votre application web doit toujours être chargée. Par défaut, les applications web sont déchargées quand elles deviennent inactives. Il est recommandé d'activer cette option quand des tâches web s'exécutent en continu sur l'application web.</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>Always On nécessite un plan App Service de base ou supérieur</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>Version de pipeline gérée</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>Impossible de configurer les destinations d'échange automatique depuis l'emplacement de production</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>Échange automatique</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>Emplacement d'échange automatique</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>Affinité ARR</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>Débogage distant</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>Version distante de Visual Studio</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>Pile</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>Fichier de démarrage</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>Les plus récents</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32 bits</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64 bits</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>Classique</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>Intégré</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>Propriétés</value>
@@ -1220,7 +1469,7 @@
     <value>Affichez tous les paramètres App Service.</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>Gérez les paramètres qui affectent l'exécution de Functions pour toutes les fonctions de votre application.</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>Paramètres généraux</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>Utilisez Authentification/autorisation pour protéger votre application et utiliser les données par utilisateur.</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>Managed Service Identity</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>Votre application peut communiquer en son nom avec d'autres services Azure à l'aide d'une identité Azure Active Directory managée.</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>Notifications Push</value>
@@ -1379,10 +1634,13 @@
     <value>Paramètres</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>Paramètres de l'application de fonctions</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>Configuration</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>Paramètres de l'application</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>La gestion de votre application de fonction n'est pas disponible pour cet essai.</value>
@@ -1574,7 +1832,7 @@
     <value>Consulter notre didacticiel de prise en main</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>Fonction</value>
+    <value>Fonction (préversion)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>Clé de définition d'API</value>
@@ -1586,7 +1844,7 @@
     <value>Générer le modèle de définition d'API</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>Exporter vers Power Apps + Flow</value>
+    <value>Exporter vers PowerApps + Flow</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
     <value>Impossible d'enregistrer une définition d'API incorrecte.</value>
@@ -1613,7 +1871,7 @@
     <value>Utiliser votre définition d'API</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>Définition d'API (préversion)</value>
+    <value>Définition de l'API</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>Nous ne pouvons pas créer ou mettre à jour la clé swaggerdocumentationkey pour le point de terminaison Swagger. Recherchez les éventuelles erreurs dans les journaux du runtime ou réessayez plus tard.</value>
@@ -1650,10 +1908,10 @@
   </data>
   <data name="swaggerDefinition_generateHelp" xml:space="preserve">
     <value>Créez une définition minime avec les métadonnées de vos fonctions déclenchées par HTTP.
-Remplissez les &lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;objets d'opération&lt;/a&gt; et d'autres informations sur votre API avant de l'utiliser.</value>
+Fournissez les &lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;objets d'opération&lt;/a&gt; et d'autres informations sur votre API avant de l'utiliser.</value>
   </data>
   <data name="swaggerDefinition_keyHelp" xml:space="preserve">
-    <value>Cette clé sécurise votre définition d'API en empêchant les personnes qui n'ont pas cette clé d'y accéder.
+    <value>Cette clé sécurise votre définition d'API en bloquant l'accès aux personnes qui n'ont pas la clé.
 Elle ne sécurise pas l'API sous-jacente. Consultez chaque fonction pour voir sa clé de sécurité.</value>
   </data>
   <data name="swaggerDefinition_sourceHelp" xml:space="preserve">
@@ -1676,7 +1934,7 @@ Choisissez « URL externe » pour utiliser une définition d'API hébergée ai
     <value>Lecture seule</value>
   </data>
   <data name="appFunctionSettings_readWriteMode" xml:space="preserve">
-    <value>Lecture\écriture</value>
+    <value>Lecture/écriture</value>
   </data>
   <data name="validation_duplicateError" xml:space="preserve">
     <value>Les valeurs en double ne sont pas autorisées</value>
@@ -1704,6 +1962,9 @@ Choisissez « URL externe » pour utiliser une définition d'API hébergée ai
   </data>
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>Votre application est actuellement en mode lecture\écriture, car vous avez défini le mode d'édition en lecture\écriture (bien que la gestion de code source soit activée). Tout changement risque d'être remplacé par votre prochain déploiement. Pour changer le mode d'édition, visitez </value>
+  </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>Votre application est actuellement en lecture seule, car vous avez publié du code function.json généré. Les modifications apportées à function.json ne sont pas honorées par le runtime Functions. </value>
   </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>Copier</value>
@@ -1748,10 +2009,22 @@ Choisissez « URL externe » pour utiliser une définition d'API hébergée ai
     <value>Emplacements (préversion)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>Activer les emplacements de déploiement (préversion). Cette fonctionnalité d'adhésion (opt-in) à usage unique sur l'application de fonction ne peut pas être désactivée et réinitialise tous les secrets préexistants. Une fois la mise à jour effectuée, vous pouvez copier les secrets à partir de </value>
+    <value>Activer les emplacements de déploiement (préversion).</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>l'onglet « Gérer » pour chaque fonction.</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>Problèmes connus :</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>L'intégration de Logic Apps avec Functions ne fonctionne pas quand Emplacements (préversion) est activé.</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>La participation à cette fonctionnalité en préversion entraîne la réinitialisation de tous les secrets préexistants. Les secrets de fonction se trouvent sous le</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>nœud « Gérer »</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>pour chaque fonction.</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>Nom</value>
@@ -1790,7 +2063,7 @@ Choisissez « URL externe » pour utiliser une définition d'API hébergée ai
     <value>Emplacements (préversion)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>Pour bénéficier de fonctionnalités de surveillance plus riches, notamment des métriques en temps réel et des requêtes personnalisées, nous vous recommandons d'utiliser &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights&lt;/a&gt;.</value>
+    <value>Pour obtenir une expérience de surveillance plus complète, notamment des métriques en temps réel et des requêtes personnalisées, &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;activez Application Insights pour votre application de fonction&lt;/a&gt;</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>Cette valeur sera ajoutée à l'URL de votre application web principale et servira d'adresse publique de l'emplacement. Par exemple, si votre application web s'appelle « contoso » et que votre emplacement s'appelle « staging », le nouvel emplacement aura une URL similaire à « http://contoso-staging.azurewebsites.net ».</value>
@@ -1803,6 +2076,9 @@ Choisissez « URL externe » pour utiliser une définition d'API hébergée ai
   </data>
   <data name="new_" xml:space="preserve">
     <value>Nouveau</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
+    <value>Créer</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
     <value>Supprimer la fonction</value>
@@ -1878,5 +2154,308 @@ Choisissez « URL externe » pour utiliser une définition d'API hébergée ai
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>Contenu et projet Visual Studio</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>récupérer</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>Supprimer le proxy</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>Nouveau proxy</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>Aucun remplacement</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>Enregistrement express auprès d'AAD</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>créer</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>Vous devez ajouter l'abonnement Event Grid après la création de la fonction.</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>URL de l'abonnement Event Grid</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>URL de l'abonnement Event Grid</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>Gérer les abonnements Event Grid</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>Ajouter un abonnement Event Grid</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>Tous les emplacements</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>{0} emplacements</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>Emplacement :</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>Grouper par emplacement</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>Aucun regroupement</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>Grouper par groupe de ressources</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>Grouper par abonnement</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>Sud du centre des États-Unis</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>Europe du Nord</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>Europe de l'Ouest</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>Asie du Sud-Est</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>Corée - Centre</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>Corée - Sud</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>Ouest des États-Unis</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>Est des États-Unis</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>Ouest du Japon</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>Est du Japon</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>Asie de l'Est</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>Est des États-Unis 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>Centre-Nord des États-Unis</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>Centre des États-Unis</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>Sud du Brésil</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>Est de l'Australie</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>Inde de l'Ouest</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>Centre de l'Inde</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>Inde du Sud</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>Centre du Canada</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>Est du Canada</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>Ouest du centre des États-Unis</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>Ouest du Royaume-Uni</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>Sud du Royaume-Uni</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>Ouest des États-Unis 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>Tous les groupes de ressources</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>Groupe de ressources :</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>{0} groupes de ressources</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>Corps</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>Code d'état</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>Message d'état</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>Remplacement de la demande</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>Remplacement de la réponse</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>Facultatif</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>Vous utilisez une préversion d'Azure Functions. Merci de l'avoir essayée !</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>Cliquer pour masquer</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>Logic Apps vous permet d'utiliser facilement votre fonction sur plusieurs plateformes</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>Applications logiques associées</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>Orchestrer avec Logic Apps</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>Créer des applications logiques</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>Aucune application logique à afficher</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>Logic Apps vous permet de générer rapidement des intégrations aux applications SaaS et d'entreprise, ainsi que de concevoir visuellement les processus et les workflows.</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>Développer ou réduire</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>Authentification et autorisations App Service :</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>Configurer AAD maintenant</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>Ajouter des autorisations maintenant</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>configuré</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>Exigences en matière d'identité (non satisfaites)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>non configuré</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>Autorisations requises</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>Le modèle a besoin des autorisations suivantes :</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>Cette intégration nécessite une configuration AAD pour l'application de fonction.</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>Ce modèle nécessite une configuration AAD pour l'application de fonction.</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>Vous pouvez avoir besoin de configurer des autorisations supplémentaires que nécessite votre fonction. Consultez la documentation sur cette liaison.</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>Gérer l'authentification et les autorisations App Service</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>Configuration d'authentification obligatoire</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>Exigences en matière d'identité</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>Gérer</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>Nous ne pouvons pas obtenir la liste des extensions de Runtime installées</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Nous ne pouvons pas installer l'extension de Runtime {{extensionId}}</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Nous ne pouvons pas désinstaller l'extension de Runtime {{extensionId}}</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>L'installation des extensions de Runtime est plus longue que prévu</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>L'extension {{extensionId}} est déjà installée avec une version différente</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>Ouvrir Application Insights</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>Application Insights est activé pour votre fonction.</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>Aucune donnée de surveillance à afficher</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>Installer</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>Extension installée</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>Extensions non installées</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>Cette intégration nécessite les extensions suivantes.</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>Ce modèle nécessite les extensions suivantes.</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>L'installation nécessite des extensions. Cette opération peut prendre jusqu'à 10 minutes.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>Impossible d'installer l'extension de runtime. ID d'installation {{installationId}}</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>Entrer une valeur en Go-sec</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>Connexion</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>Notification Hubs</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>Les fonctions Java peuvent être créées, testées et déployées localement à partir de votre ordinateur. Aucun portail n'est nécessaire !</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>Cliquez ci-dessous pour consulter la documentation permettant de créer votre première fonction Azure avec Java.</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>La fonctionnalité Proxies a été activée. Pour la désactiver à nouveau, supprimez ou désactivez tous les proxys individuels.</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Guide de démarrage rapide de Java sur Azure Functions</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/hu-HU/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/hu-HU/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>Konfigurálás</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>Frissítés az engedélyezéshez</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>Az összes kijelölése</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>Minden elem ki van jelölve</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>{0} elem van kijelölve</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>Hiba történt a függvény létrehozásakor: {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>Válasszon ki egy sablont az alábbiak közül, vagy</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>Előfizetés létrehozásához válasszon az alábbi csomagok közül</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>Adja meg az előfizetés rövid nevét</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>Előfizetés rövid neve</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>Meghívókód</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>Ez egy kísérleti sablon, amely még nem rendelkezik teljes körű támogatással. Ha problémákat tapasztal, jelentse a hibát a &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;GitHub-adattárunkban&lt;/a&gt;.</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>Mentés</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>Jelenleg folyamatban van egy mentési művelet.  Ha ellép a lapról, néhány módosítás elveszhet.</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ Új beállítás hozzáadása</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ Új kapcsolati karakterlánc hozzáadása</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ Új dokumentum hozzáadása</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ Új kezelőtársítás hozzáadása</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ Új virtuális alkalmazás vagy könyvtár hozzáadása</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>Írjon be egy nevet.</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>Adjon meg egy értéket.</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>Adja meg a kiterjesztést</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>Adja meg a parancsprogram-feldolgozót</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>Adja meg az argumentumokat</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>Adja meg a virtuális elérési utat</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>Adja meg a fizikai elérési utat</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>Alkalmazás</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>Tárhelybeállítás</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>Rejtett érték.  A megjelenítéshez kattintson ide.</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>Keresés</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>Az elem hatóköre</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>Szolgáltatások keresése</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>Keresés a függvényalkalmazások között</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>Előfizetés azonosítója</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>Engedélyezve</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>letiltása</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>engedélyezve</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>itt</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>Hiba történt a konfiguráció elemzésekor: {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>A(z) {{functionName}} függvényt nem sikerült a(z) {{state}} állapotba helyezni</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>Szolgáltatások</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>Normál szerkesztő</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>A(z) {{name}} függvény törlése</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>Biztosan törli a függvényt ({{name}})?</value>
@@ -806,7 +881,7 @@
     <value>Lekérdezés</value>
   </data>
   <data name="topBar_alwaysOn" xml:space="preserve">
-    <value>A Mindig bekapcsolva beállítás nincs engedélyezve. Előfordulhat, hogy az alkalmazás nem működik megfelelően</value>
+    <value>Az AlwaysOn beállítás nincs engedélyezve. Előfordulhat, hogy az alkalmazás nem működik megfelelően</value>
   </data>
   <data name="topBar_slotsHostId" xml:space="preserve">
     <value>Az azonosító értéke explicit módon be van állítva a host.json fájlban, ami üzembe helyezési pontok használata esetén nem várt működést okozhat</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>Proxyk (előzetes verzió)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>Proxy futásidejű verziója: {{extensionVersion}}. Újabb verzió érhető el ({{latestExtensionVersion}}).</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>Proxy futásidejű verziója: legújabb ({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>Azure Functions-proxyk engedélyezése (előzetes verzió)</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>Az Azure Functions-proxyk jelenleg le vannak tiltva. Az engedélyezéshez látogasson el a következő helyre:</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>A(z) {{name}} proxyn végzett módosítások elvesznek. Biztosan folytatja?</value>
@@ -967,7 +1033,7 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Az Azure Functions-tárolóhelyek (előzetes verzió) jelenleg le vannak tiltva. Az engedélyezéshez látogasson el a következő helyre:</value>
   </data>
-  <data name="discrard" xml:space="preserve">
+  <data name="discard" xml:space="preserve">
     <value>Elvetés</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>Minden előfizetés</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>Előfizetések</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>{0} előfizetés</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>A szolgáltatásokra mutató gyorshivatkozások itt jelennek meg, miután beállította azokat a fenti A platform szolgáltatásai lapon.</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>A(z) {0} alkalmazás nem mentett módosításai el fognak veszni.  Biztosan folytatja?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>Hiba történt a(z) {0} alkalmazással kapcsolatos adatok beolvasásakor</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>A használatalapú csomag alkalmazásai nem támogatják ezt a funkciót</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>Ez a funkció még nem támogatott tárolóhelyek esetén</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>A Linux-alkalmazások nem támogatják ezt a funkciót</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>A funkció használatához írási engedélyekkel kell rendelkeznie a jelenlegi alkalmazásban</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>Interaktív webes konzolon böngészhet az alkalmazás fájlrendszerében.</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>Az SSH webes SSH-konzolfelületet biztosít a Linux-alkalmazás kódjához</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>Kiterjesztések</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>A bővítményekkel a alkalmazás funkcióit bővítheti.</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(nincsenek megjeleníthető alkalmazásbeállítások)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(nincsenek megjeleníthető kapcsolati karakterláncok)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(nincsenek megjeleníthető alapértelmezett dokumentumok)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(nincsenek megjeleníthető kezelőtársítások)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(nincsenek megjeleníthető virtuális alkalmazások vagy könyvtárak)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>Általános beállítások</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>Automatikus felcserélés</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>Hibakeresés</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>Futtatókörnyezet</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>Alkalmazásbeállítások</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>Kezelheti az alkalmazásbeállításokat, a kapcsolati karakterláncokat, a futásidejű beállításokat és sok más funkciót.</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>Alapértelmezett dokumentumok</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>Leírók leképezése</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>Virtuális alkalmazások és könyvtárak</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>E beállítások módosításához írási hozzáféréssel kell rendelkeznie a jelenlegi alkalmazáshoz.</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>Az alkalmazás írásvédettségi zárolása megakadályozza a beállítások módosítását és a védett adatok beolvasását. Oldja fel a zárolást, majd próbálkozzon újra.</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>Beállítások megtekintése írásvédett üzemmódban.</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>Nem sikerült betölteni a beállításokat.</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>Betöltés...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>Folyamatban van a webalkalmazás-beállítások frissítése.</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>A webalkalmazás-beállítások sikeresen frissítve</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>A webalkalmazás-beállítások frissítése sikertelen: </value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>{{configGroupName}} Mentési hiba: a megadott adat érvénytelen.</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>.NET-keretrendszer verziója</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>A webalkalmazás üzemeltetéséhez használt verzió .NET-es környezetekben</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>PHP-verzió</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>A webalkalmazás üzemeltetéséhez használt verzió PHP-s környezetekben</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Python-verzió</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>A webalkalmazás üzemeltetéséhez használt verzió pythonos környezetekben</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Java-verzió</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>A webalkalmazás üzemeltetéséhez használt verzió javás környezetekben</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Java-alverzió</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>Válassza ki a használni kívánt Java-alverziót. Ha a „Legújabb” lehetőséget választja, az alkalmazás mindig a portálhoz legutóbb hozzáadott JVM-et fogja használni.</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Webes tároló</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>A webes tárolónak a webalkalmazás üzemeltetéséhez használt verziója javás környezetekben</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>Platform</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>A webalkalmazás platformarchitektúrája</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>A 64 bites konfigurációhoz alap- vagy magasabb szintű App Service-csomag szükséges</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Webes szoftvercsatornák</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>Webes szoftvercsatornák használatával a modern böngészők rugalmasabb módon csatlakozhatnak a webalkalmazásokhoz. Érdemes a webalkalmazást úgy kialakítani, hogy ki tudja használni ezen képességek előnyeit.</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>Mindig bekapcsolva</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>Ezzel a beállítással adható meg, hogy a webalkalmazásnak mindig betöltve kell lennie. A tétlen állapotot követően a rendszer alapértelmezés szerint eltávolítja a memóriából a webalkalmazásokat. Akkor ajánlott engedélyezni ezt a beállítást, ha a webalkalmazásban folyamatosan futó webes feladatok is működnek.</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>Az AlwaysOn megoldáshoz alap- vagy magasabb szintű App Service-csomag szükséges</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>Kezelt folyamatverzió</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>Az automatikus felcserélés célja nem konfigurálható éles környezetbeli tárolóhelyről</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>Automatikus felcserélés</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>Automatikus felcserélési tárolóhely</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>ARR-affinitás</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>Távoli hibakeresés</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>Távoli Visual Studio verziója</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>Verem</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>Indítási fájl</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>Legújabb</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32 bites</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64 bites</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>Klasszikus</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>Integrált</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>Tulajdonságok</value>
@@ -1220,7 +1469,7 @@
     <value>Megtekintheti az összes App Service-beállítást.</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>Kezelheti azokat a beállításokat, melyek az alkalmazásban lévő összes függvény Functions-futtatókörnyezetére kihatnak.</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>Általános beállítások</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>Hitelesítéssel és engedélyezéssel biztosíthatja az alkalmazás védelmét, és használat felhasználónkénti adatokat.</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>Felügyeltszolgáltatás-identitás</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>Az alkalmazás egy Azure Active Directory-identitás használatával képes saját magaként kommunikálni más Azure-szolgáltatásokkal.</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>Leküldéses értesítések</value>
@@ -1379,10 +1634,13 @@
     <value>Beállítások</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>Függvényalkalmazás beállításai</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>Konfiguráció</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>Alkalmazásbeállítások</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>A függvényalkalmazás kezelése nem érhető el a próbaverzióban.</value>
@@ -1574,7 +1832,7 @@
     <value>Tekintse meg az első lépéseket megkönnyítő oktatóanyagunkat</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>Függvény</value>
+    <value>Funkció (előzetes verzió)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>API-definíciós kulcs</value>
@@ -1586,7 +1844,7 @@
     <value>API-definíció-sablon létrehozása</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>Exportálás a Power Appsbe és a Flow-ba</value>
+    <value>Exportálás a PowerAppsba és a Flow-ba</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
     <value>Nem sikerült menteni az API-definíciót, mert helytelenül formázott.</value>
@@ -1613,7 +1871,7 @@
     <value>Az API-definíció használata</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>API-definíció (előzetes verzió)</value>
+    <value>API-definíció</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>Nem sikerült létrehozni vagy frissíteni a Swagger-végpont swaggerdocumentationkey kulcsát. Tekintse meg a futtatókörnyezet naplóiban található hibaüzeneteket, vagy később próbálkozzon újra.</value>
@@ -1676,7 +1934,7 @@ Máshol tárolt API-definíció használatához a „Külső URL-cím” érték
     <value>Csak olvasható</value>
   </data>
   <data name="appFunctionSettings_readWriteMode" xml:space="preserve">
-    <value>Olvasás\írás</value>
+    <value>Olvasás/Írás</value>
   </data>
   <data name="validation_duplicateError" xml:space="preserve">
     <value>Az ismétlődő értékek használata nem engedélyezett</value>
@@ -1704,6 +1962,9 @@ Máshol tárolt API-definíció használatához a „Külső URL-cím” érték
   </data>
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>Az alkalmazás jelenleg olvasási\írási módban van, mivel olvasási\írásira állította a szerkesztési módot annak ellenére, hogy engedélyezve van a verziókövetés. Az Ön által végrehajtott módosítások bármelyikét felülírhatja a következő üzemelő példány. A szerkesztési módot itt változtathatja meg: </value>
+  </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>Az alkalmazás jelenleg írásvédett üzemmódban van, mert generált function.json fájlt tett közzé. A function.json fájlban végrehajtott módosítások a Functions-futtatókörnyezetben nem lesznek figyelembe véve. </value>
   </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>Másolás</value>
@@ -1748,10 +2009,22 @@ Máshol tárolt API-definíció használatához a „Külső URL-cím” érték
     <value>Tárolóhelyek (előzetes verzió)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>Üzembe helyezési pontok (előzetes verzió) engedélyezése. Ez egy olyan egyszeri jóváhagyás a függvényalkalmazás szintjén, amely nem tiltható le, és alaphelyzetbe állítja a meglévő titkos kulcsokat. A frissítés után lehetőség van a titkos kulcsok másolására az </value>
+    <value>Az üzembe helyezési pontok engedélyezése (előzetes verzió).</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>egyes függvények Kezelés csomópontjáról.</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>Ismert problémák:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>A Logic Apps és a Functions integrációja nem működik, ha a Slots (előzetes verzió) engedélyezve van.</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>Ha ezt az előzetes funkciót választja, alaphelyzetbe állítja az összes meglévő titkos kódot. A titkos függvénykódok az egyes függvények</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>Kezelés</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>csomópontjában találhatók.</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>Név</value>
@@ -1790,7 +2063,7 @@ Máshol tárolt API-definíció használatához a „Külső URL-cím” érték
     <value>Tárolóhelyek (előzetes verzió)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>A jobb figyelési élményért – beleértve az élő metrikákat és az egyéni lekérdezéseket – ajánlott &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;az Azure-beli Application Insights szolgáltatást&lt;/a&gt; használni.</value>
+    <value>A jobb figyelési élményért – beleértve az élő metrikákat és az egyéni lekérdezéseket – &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;engedélyezze az Application Insights szolgáltatást a függvényalkalmazáshoz&lt;/a&gt;</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>Ez az érték hozzáíródik az elsődleges webes alkalmazás URL-címéhez, és a tárolóhely nyilvános címe lesz. Ha a webes alkalmazás neve például contoso, a tárhelyé pedig marketing, akkor az új tárhely URL-címe http://contoso-staging.azurewebsites.net lesz.</value>
@@ -1802,6 +2075,9 @@ Máshol tárolt API-definíció használatához a „Külső URL-cím” érték
     <value>Függvények keresése</value>
   </data>
   <data name="new_" xml:space="preserve">
+    <value>Új</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
     <value>Új</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
@@ -1878,5 +2154,308 @@ Máshol tárolt API-definíció használatához a „Külső URL-cím” érték
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>Tartalom és Visual Studio-projekt</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>beolvasás</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>Proxy törlése</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>Új proxy</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>Nincs felülbírálás</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>Expressz AAD-regisztráció</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>létrehozás</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>A függvény létrehozása után kell felvennie az Even Grid-előfizetést.</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>Event Grid-előfizetés URL-címe</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>Event Grid-előfizetés URL-címe</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>Event Grid-előfizetések kezelése</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>Event Grid-előfizetés hozzáadása</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>Összes hely</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>{0} hely</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>Hely:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>Csoportosítás hely szerint</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>Nincs csoportosítás</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>Csoportosítás erőforráscsoport szerint</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>Csoportosítás előfizetés szerint</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>Dél-USA</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>Észak-Európa</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>Nyugat-Európa</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>Délkelet-Ázsia</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>Korea középső régiója</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>Korea déli régiója</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>Nyugat-USA</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>USA keleti régiója</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>Nyugat-Japán</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>Kelet-Japán</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>Kelet-Ázsia</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>USA 2. keleti régiója</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>USA északi középső régiója</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>USA középső régiója</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>Dél-Brazília</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>Kelet-Ausztrália</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>Nyugat-India</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>Közép-India</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>Dél-India</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>Közép-Kanada</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>Kelet-Kanada</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>Egyesült Államok nyugati középső régiója</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>Egyesült Királyság nyugati régiója</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>Egyesült Királyság déli régiója</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>Egyesült Államok 2. nyugati régiója</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>Minden erőforráscsoport</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>Erőforráscsoport:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>{0} erőforráscsoport</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>Törzs</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>Állapotkód</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>Állapotüzenet</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>Kérés felülbírálása</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>Válasz felülbírálása</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>Nem kötelező</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>Az Azure Functions előzetes verzióját használja. Köszönjük, hogy kipróbálja!</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>Kattintson ide az elrejtéséhez</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>A Logic Apps szolgáltatással könnyedén használhat funkciókat több platformon</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>Társított logikai alkalmazások</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>Összehangolás a Logic Apps szolgáltatással</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>Logika alkalmazások létrehozása</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>Nincsenek megjelenítendő logikai alkalmazások</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>A Logic Apps szolgáltatással gyorsan hozhat létre integrációkat SaaS- és vállalati alkalmazásokkal, valamint vizuálisan is megtervezhet folyamatokat és munkafolyamatokat.</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>Kibontás vagy összecsukás</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>App Service-hitelesítés és -engedélyezés:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>Az AAD konfigurálása</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>Engedélyek hozzáadása</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>konfigurálva</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>Identitással kapcsolatos követelmények (nem teljesített)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>nincs konfigurálva</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>Szükséges engedélyek</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>A sablonhoz a következő engedély szükséges:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>Az integrációhoz a függvényalkalmazás AAD-konfigurációja szükséges.</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>A sablonhoz a függvényalkalmazás AAD-konfigurációja szükséges.</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>Előfordulhat, hogy a függvényhez szükséges további engedélyeket is konfigurálnia kell. A kötéssel kapcsolatban a dokumentációban találhat további információkat.</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>App Service-hitelesítés és -engedélyezés kezelése</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>A hitelesítés konfigurálása szükséges</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>Identitással kapcsolatos követelmények</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>Kezelés</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>Nem sikerült beolvasni a telepített futtatókörnyezeti bővítmények listáját</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Nem sikerült telepíteni a(z) {{extensionId}} futtatókörnyezeti bővítményt</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Nem sikerült eltávolítani a(z) {{extensionId}} futtatókörnyezeti bővítményt</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>A futtatókörnyezeti bővítmények telepítése a vártnál több időt vesz igénybe</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>A(z) {{extensionId}} bővítmény egy másik verziója már telepítve van</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>Az Application Insights megnyitása</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>Az App Insights engedélyezve van a függvényhez.</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>Nincsenek megjeleníthető figyelési adatok</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>Telepítés</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>A bővítmény telepítése sikerült</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>Nincsenek telepítve a bővítmények</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>Az integrációhoz a következő bővítmények szükségesek.</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>A sablonhoz a következő bővítmények szükségesek.</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>A szükséges bővítmények telepítése folyamatban van. A művelet végrehajtása akár 10 percig is eltarthat.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>Nem sikerült telepíteni a(z) {{installationId}} telepítési azonosítójú futtatókörnyezeti bővítményt</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>Adjon meg egy GB/s-értéket</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>Kapcsolat</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>Notification Hub</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>A Java-függvényeket helyileg létrehozhatja, tesztelheti és üzembe helyezheti a számítógépen. A portálra nincs szükség!</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>A lenti gombra kattintva megkezdheti az első Azure-függvény a Javával való létrehozására vonatkozó dokumentáció olvasását.</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>A proxyk használata engedélyezve van. Az újbóli letiltáshoz törölje vagy tiltsa le az összes egyedi proxyt.</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Java az Azure Functions szolgáltatásban – első lépések</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/it-IT/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/it-IT/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>Configura</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>Per abilitarla, aggiornare il piano</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>Seleziona tutto</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>Tutti gli elementi selezionati</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>{0} elementi selezionati</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>Errore durante la creazione della funzione: {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>Scegliere un modello sotto oppure</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>Per creare una nuova sottoscrizione, scegliere un piano sotto</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>Specificare un nome descrittivo per la sottoscrizione</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>Nome descrittivo sottoscrizione</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>Codice di invito</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>Questo modello è sperimentale e quindi il supporto completo non è ancora disponibile. Se si verificano problemi, pubblicare un bug nel &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;repository di GitHub.&lt;/a&gt;</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>Salva</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>È in corso un'operazione di salvataggio. Se si esce adesso alcune modifiche potrebbero andare perse.</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ Aggiungi nuova impostazione</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ Aggiungi nuova stringa di connessione</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ Aggiungi nuovo documento</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ Aggiungi nuovo mapping del gestore</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ Aggiungi nuova directory o applicazione virtuale</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>Immettere un nome</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>Immettere un valore</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>Immettere l'estensione</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>Immettere il processore script</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>Immettere gli argomenti</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>Immettere il percorso virtuale</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>Immettere il percorso fisico</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>Applicazione</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>Impostazione slot</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>Valore nascosto. Fare clic per visualizzarlo.</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>Cerca</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>Imposta questo elemento come ambito</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>Cerca funzionalità</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>Cerca app per le funzioni</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>ID sottoscrizione</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>Abilitato</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>disabilita</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>abilitato</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>qui</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>Errore durante l'analisi della configurazione: {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>Non è stato possibile {{state}} la funzione: {{functionName}}</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>Funzionalità</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>Editor standard</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>Elimina funzione {{name}}</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>Eliminare la funzione {{name}}?</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>Proxy (anteprima)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>Versione runtime del proxy: {{extensionVersion}}. È disponibile una versione più recente ({{latestExtensionVersion}}).</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>Versione runtime proxy: più recente ({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>Abilita Proxy di Funzioni di Azure (anteprima)</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>I proxy di Funzioni di Azure sono attualmente disabilitati. Per abilitarli, visitare</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>Le modifiche apportate al proxy {{name}} andranno perse. Continuare?</value>
@@ -967,8 +1033,8 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Gli slot di Funzioni di Azure (anteprima) sono attualmente disabilitati. Per abilitarli, visitare</value>
   </data>
-  <data name="discrard" xml:space="preserve">
-    <value>Rimuovi</value>
+  <data name="discard" xml:space="preserve">
+    <value>Ignora</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
     <value>Funzioni</value>
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>Tutte le sottoscrizioni</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>Sottoscrizioni</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>Sottoscrizioni: {0}</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>Dopo aver configurato i collegamenti rapidi alle funzionalità nella scheda "Funzionalità della piattaforma" disponibile sopra, i collegamenti saranno visualizzati qui.</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>Le modifiche non salvate per l'app '{0}' andranno perse. Continuare?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>Si è verificato un errore durante il recupero delle informazioni per l'app '{0}'</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>Questa funzionalità non è supportata per le app con un piano a consumo</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>Questa funzionalità non è supportata per gli slot</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Questa funzionalità non è supportata per le app Linux</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>Per usare questa funzionalità, è necessario disporre delle autorizzazioni di scrittura per l'app corrente</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>Consente di esplorare il file system dell'app da una console interattiva basata sul Web.</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>SSH offre un'esperienza console SSH Web per il codice dell'app Linux</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>Estensioni</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>Le estensioni aggiungono funzionalità all'intera app.</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(nessuna impostazione dell'applicazione da visualizzare)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(nessuna stringa di connessione da visualizzare)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(nessun documento predefinito da visualizzare)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(nessun mapping del gestore da visualizzare)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(nessuna directory o applicazione virtuale da visualizzare)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>Impostazioni generali</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>Scambio automatico</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>Debug</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>Runtime</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>Impostazioni dell'applicazione</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>Consente di gestire le impostazioni dell'app, le stringhe di connessione, le impostazioni di runtime e altro ancora.</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>Documenti predefiniti</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>Mapping del gestore</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>Directory e applicazioni virtuali</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>Per modificare queste impostazioni, è necessario disporre delle autorizzazioni di scrittura per l'app corrente.</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>Questa app include un blocco di sola lettura che impedisce la modifica delle impostazioni o il recupero dei dati protetti. Rimuovere il blocco e riprovare.</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>Visualizza le impostazioni è in modalità di sola lettura.</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>Non è stato possibile caricare le impostazioni.</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>Caricamento...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>Aggiornamento delle impostazioni dell'app Web</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>Le impostazioni dell'app Web sono state aggiornate</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>Non è stato possibile aggiornare le impostazioni dell'app Web: </value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>Errore di salvataggio per {{configGroupName}}: è stato specificato un input non valido.</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>Versione di .NET Framework</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>Versione usata per eseguire l'app Web, se si usa .NET Framework</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>Versione PHP</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>Versione usata per eseguire l'app Web, se si usa PHP</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Versione Python</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>Versione usata per eseguire l'app Web, se si usa Python</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Versione Java</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>Versione usata per eseguire l'app Web, se si usa Java</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Versione secondaria Java</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>Selezionare la versione secondaria Java desiderata. Se si seleziona "Più recente", l'app continuerà a usare la JVM aggiunta più di recente al portale.</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Contenitore Web</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>Versione del contenitore Web usata per eseguire l'app Web, se si usa Java</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>Piattaforma</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>Architettura della piattaforma eseguita dall'app Web</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>La configurazione a 64 bit richiede un piano di servizio app Basic o superiore</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Web Socket</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>I WebSocket offrono connettività flessibile tra le app Web e i browser moderni. L'app Web deve essere creata in modo da poter usufruire di queste funzionalità.</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>Sempre online</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>Indica che l'app Web deve essere sempre caricata. Per impostazione predefinita, se le app Web diventano inattive vengono scaricati. È consigliabile abilitare questa opzione quando nell'app Web sono in esecuzione processi Web continui.</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>La modalità Always On richiede un piano di servizio app Basic o superiore</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>Versione pipeline gestita</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>Non è possibile configurare le destinazioni di scambio automatico dallo slot di produzione</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>Scambio automatico</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>Scambia automaticamente slot</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>Affinità ARR</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>Debug remoto</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>Debug remoto: versione di Visual Studio</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>Stack</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>File di avvio</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>Più recenti</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32 bit</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64 bit</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>Classica</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>Integrata</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>Proprietà</value>
@@ -1220,7 +1469,7 @@
     <value>Consente di visualizzare tutte le impostazioni del servizio app.</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>Consente di gestire le impostazioni che interessano il runtime delle funzioni per tutte le funzioni all'interno dell'app.</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>Impostazioni generali</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>Consente di usare la modalità Autenticazione/Autorizzazione per proteggere l'applicazione e di lavorare con i dati per utente.</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>Identità del servizio gestito</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>L'applicazione può comunicare con altri servizi di Azure come se stessa usando un'identità di Azure Active Directory gestita.</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>Notifiche push</value>
@@ -1379,10 +1634,13 @@
     <value>Impostazioni</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>Impostazioni dell'app per le funzioni</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>Configurazione</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>Impostazioni dell'applicazione</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>Con questa versione di valutazione, non è possibile gestire l'app per le funzioni.</value>
@@ -1574,7 +1832,7 @@
     <value>Vedere l'esercitazione introduttiva</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>Funzione</value>
+    <value>Funzione (anteprima)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>Chiave di definizione dell'API</value>
@@ -1613,7 +1871,7 @@
     <value>Usare una definizione dell'API personalizzata</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>Definizione API (anteprima)</value>
+    <value>Definizione API</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>Non è possibile creare o aggiornare la chiave swaggerdocumentationkey per l'endpoint Swagger. Esaminare i log di runtime per individuare eventuali errori o riprovare più tardi.</value>
@@ -1646,7 +1904,7 @@
     <value>Sovrascrivere la definizione dell'API nell'editor?</value>
   </data>
   <data name="swaggerDefinition_exporthelp" xml:space="preserve">
-    <value>Usare la definizione dell'API per accedere alle funzioni da &lt;a href="https://powerapps.microsoft.com/it-it/" target="_blank"&gt;PowerApps&lt;/a&gt; e &lt;a href="https://ms.flow.microsoft.com/en-us/" target="_blank"&gt;Microsoft Flow&lt;/a&gt;. </value>
+    <value>Usare la definizione dell'API per accedere alle funzioni da &lt;a href="https://powerapps.microsoft.com/it-it/" target="_blank"&gt;PowerApps&lt;/a&gt; e &lt;a href="https://ms.flow.microsoft.com/it-it/" target="_blank"&gt;Microsoft Flow&lt;/a&gt;. </value>
   </data>
   <data name="swaggerDefinition_generateHelp" xml:space="preserve">
     <value>Creare una definizione di tipo sparse con i metadati delle funzioni attivate tramite HTTP.
@@ -1676,7 +1934,7 @@ Impostare il valore su "URL esterno" per usare una definizione dell'API ospitata
     <value>Sola lettura</value>
   </data>
   <data name="appFunctionSettings_readWriteMode" xml:space="preserve">
-    <value>Lettura\Scrittura</value>
+    <value>Lettura/Scrittura</value>
   </data>
   <data name="validation_duplicateError" xml:space="preserve">
     <value>I valori duplicati non sono consentiti</value>
@@ -1704,6 +1962,9 @@ Impostare il valore su "URL esterno" per usare una definizione dell'API ospitata
   </data>
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>L'app è attualmente in modalità di lettura\scrittura perché la modalità di modifica è stata impostata su lettura\scrittura anche se è abilitato il controllo del codice sorgente. È possibile che le modifiche effettuate vengano sovrascritte alla distribuzione successiva. Per cambiare la modalità di modifica, visitare </value>
+  </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>L'app è attualmente in modalità di sola lettura perché è stato pubblicato un file function.json generato. Le modifiche apportate al file function.json non saranno considerate dal runtime di Funzioni di Azure. </value>
   </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>Copia</value>
@@ -1748,10 +2009,22 @@ Impostare il valore su "URL esterno" per usare una definizione dell'API ospitata
     <value>Slot (anteprima)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>Abilita slot di distribuzione (anteprima). Questa funzionalità prevede un consenso esplicito da fornire una sola volta per l'app per le funzioni, non può essere disabilitata successivamente e reimposta tutti i segreti preesistenti. Dopo l'aggiornamento, è possibile copiare i segreti dal </value>
+    <value>Abilita slot di distribuzione (anteprima)</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>nodo 'Gestisci' per ogni funzione.</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>Problemi noti:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>l'integrazione delle app per la logica con Funzioni di Azure non funziona quando è abilitata la funzionalità Slot (anteprima).</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>L'uso di questa funzionalità in anteprima reimposterà i segreti preesistenti. I segreti della funzione sono disponibili nel nodo</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>'Gestisci'</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>di ogni funzione.</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>Nome</value>
@@ -1790,7 +2063,7 @@ Impostare il valore su "URL esterno" per usare una definizione dell'API ospitata
     <value>Slot (anteprima)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>Per un'esperienza di monitoraggio avanzata, con metriche in tempo reale e query personalizzate, è consigliabile usare &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights.&lt;/a&gt;</value>
+    <value>Per un'esperienza di monitoraggio avanzata, con metriche in tempo reale e query personalizzate, &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;abilitare Application Insights per l'app per le funzioni&lt;/a&gt;</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>Questo valore verrà aggiunto all'URL dell'app Web principale e verrà usato come indirizzo pubblico dello slot. Ad esempio, per un'app Web denominata 'contoso' e uno slot denominato 'staging', l'URL del nuovo slot sarà il seguente 'http://contoso-staging.azurewebsites.net'.</value>
@@ -1803,6 +2076,9 @@ Impostare il valore su "URL esterno" per usare una definizione dell'API ospitata
   </data>
   <data name="new_" xml:space="preserve">
     <value>Nuovo</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
+    <value>Crea nuovo</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
     <value>Elimina funzione</value>
@@ -1878,5 +2154,308 @@ Impostare il valore su "URL esterno" per usare una definizione dell'API ospitata
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>Contenuto e progetto di Visual Studio</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>recupera</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>Elimina proxy</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>Nuovo proxy</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>Nessun override</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>Registrazione rapida per AAD</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>crea</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>È necessario aggiungere la sottoscrizione di Griglia di eventi dopo la creazione della funzione.</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>URL sottoscrizione di Griglia di eventi</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>URL sottoscrizione di Griglia di eventi</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>Gestisci sottoscrizioni di Griglia di eventi</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>Aggiungi sottoscrizione di Griglia di eventi</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>Tutte le località</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>{0} località</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>Località:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>Raggruppa per località</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>Nessun raggruppamento</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>Raggruppa per gruppo di risorse</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>Raggruppa per sottoscrizione</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>Stati Uniti centro-meridionali</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>Europa settentrionale</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>Europa occidentale</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>Asia sudorientale</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>Corea centrale</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>Corea meridionale</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>Stati Uniti occidentali</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>Stati Uniti orientali</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>Giappone occidentale</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>Giappone orientale</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>Asia orientale</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>Stati Uniti orientali 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>Stati Uniti centro-settentrionali</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>Stati Uniti centrali</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>Brasile meridionale</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>Australia orientale</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>India occidentale</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>India centrale</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>India meridionale</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>Canada centrale</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>Canada orientale</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>Stati Uniti centro-occidentali</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>Regno Unito occidentale</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>Regno Unito meridionale</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>Stati Uniti occidentali 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>Tutti i gruppi di risorse</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>Gruppo di risorse:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>{0} gruppi di risorse</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>Corpo</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>Codice di stato</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>Messaggio di stato</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>Override della richiesta</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>Override della risposta</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>Facoltativo</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>È in uso una versione non definitiva di Funzioni di Azure. Grazie per aver scelto di provare il servizio.</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>Fare clic per nascondere</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>Le app per la logica consentono di usare facilmente le funzioni in più piattaforme</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>App per la logica</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>App per la logica associate</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>Orchestrare con le app per la logica</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>Crea app per la logica</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>Nessuna app per la logica da visualizzare</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>App per la logica</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>Le app per la logica consentono di creare rapidamente integrazioni con app SaaS e aziendali, nonché con processi di progettazione visivi e flussi di lavoro.</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>Espandi/Comprimi</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>Autenticazione/Autorizzazione del servizio app:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>Configura AAD adesso</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>Aggiungi autorizzazioni adesso</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>configurato</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>Requisiti di identità (non soddisfatti)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>non configurato</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>Autorizzazioni necessarie</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>Per il modello è necessaria l'autorizzazione seguente:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>Questa integrazione richiede una configurazione di AAD per l'app per le funzioni.</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>Questo modello richiede una configurazione di AAD per l'app per le funzioni.</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>Potrebbe essere necessario configurare le eventuali autorizzazioni aggiuntive richieste dalla funzione. Vedere la documentazione per questa associazione.</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>Gestisci autenticazione/autorizzazione del servizio app</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>Configurazione autenticazione/autorizzazione obbligatoria</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>Requisiti di identità</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>Gestisci</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>Non è possibile recuperare l'elenco delle estensioni di runtime installate</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Non è possibile installare l'estensione di runtime {{extensionId}}</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Non è possibile disinstallare l'estensione di runtime {{extensionId}}</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>L'installazione delle estensioni di runtime richiede più tempo del previsto</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>È già installata un'estensione {{extensionId}} ma con una versione diversa</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>Apri Application Insights</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>Application Insights non è abilitato per la funzione corrente.</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>Nessun dato di monitoraggio da visualizzare</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>Installa</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>L'installazione dell'estensione è riuscita</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>Estensioni non installate</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>Questa integrazione richiede le estensioni seguenti.</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>Questo modello richiede le estensioni seguenti.</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>Installazione delle estensioni necessarie. L'operazione potrebbe richiedere fino a 10 minuti.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>Non è possibile installare l'estensione di runtime. ID installazione: {{installationId}}</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>Specificare il valore in GB/sec</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>Connessione</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>Hub di notifica</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>È possibile creare, testare e distribuire funzioni Java in locale dal computer in uso. Non è richiesto l'uso del portale.</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>Fare clic sotto per la documentazione che illustra come creare la prima funzione di Azure con Java.</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>I proxy sono stati abilitati. Per disabilitarli, eliminare o disabilitare i singoli proxy.</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Guida introduttiva a Java in Funzioni di Azure</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/ja-JP/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/ja-JP/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>構成</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>アップグレードして有効にする</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>すべて選択</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>選択済みの項目すべて</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>{0} 個のアイテムが選択されています</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>関数の作成エラー: {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>以下からテンプレートを選択するか、</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>新しいサブスクリプションを作成するには、下のプランを選択します</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>サブスクリプションのフレンドリ名を指定します</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>サブスクリプションのフレンドリ名</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>招待コード</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>このテンプレートは試験段階であり、まだ完全にはサポートされていません。問題が発生した場合には、&lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;GitHub リポジトリ&lt;/a&gt;でバグを報告してください。</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>保存</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>保存操作が現在進行中です。移動すると、変更内容の一部が失われる可能性があります。</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ 新しい文字列の追加</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ 新しい接続文字列の追加</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ 新しいドキュメントを追加します</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ 新しいハンドラー マッピングを追加します</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ 新しい仮想アプリケーションまたはディレクトリを追加します</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>名前の入力</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>値を入力してください</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>拡張機能を入力してください</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>スクリプト プロセッサを入力してください</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>引数を入力してください</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>仮想パスを入力してください</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>物理パスを入力してください</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>アプリケーション</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>スロットの設定</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>非表示の値です。表示するには、クリックしてください。</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>検索する</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>この項目にスコープを合わせる</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>機能の検索</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>関数アプリの検索</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>サブスクリプション ID</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>有効</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>無効にする</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>有効</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>ここ</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>構成の解析エラー: {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>関数 {{functionName}} を {{state}} できませんでした</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>機能</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>標準エディター</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>関数 {{name}} の削除</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>関数 {{name}} を削除してもよろしいですか?</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>プロキシ (プレビュー)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>プロキシのランタイム バージョン: {{extensionVersion}}。新しいバージョン ({{latestExtensionVersion}}) が利用可能です。</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>プロキシのランタイム バージョン: 最新 ({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>Azure Functions プロキシの有効化 (プレビュー)</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>現在、Azure Functions プロキシが無効になっています。有効にするには、</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>プロキシ {{name}} に対して行った変更が失われます。続行してもよろしいですか?</value>
@@ -967,7 +1033,7 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Azure Functions スロット (プレビュー) は現在無効になっています。有効にするには、</value>
   </data>
-  <data name="discrard" xml:space="preserve">
+  <data name="discard" xml:space="preserve">
     <value>破棄</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>すべてのサブスクリプション</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>サブスクリプション</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>{0} 個のサブスクリプション</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>上の [Platform features] タブで機能を構成すると、その機能へのクイック リンクがここに表示されます。</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>アプリ '{0}' に未保存の変更がある場合には、変更内容が失われます。続行してもよろしいですか?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>アプリ '{0}' に関する情報を取得している間にエラーが発生しました</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>従量課金プランのアプリでは、この機能がサポートされていません</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>スロットではこの機能がサポートされていません。</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Linux アプリでは、この機能はサポートされていません</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>この機能を使用するには、現在のアプリに対する書き込みアクセス許可が必要です</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>Web ベースの対話型コンソールでアプリのファイル システムを調査します。</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>SSH は、Linux アプリのコードに Web SSH コンソールのエクスペリエンスを提供します</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>拡張機能</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>拡張機能では、アプリ全体に機能を追加できます。</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(表示するアプリケーション設定がありません)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(表示する接続文字列がありません)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(表示する既定ドキュメントはありません)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(表示するハンドラー マッピングがありません)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(表示する仮想アプリケーションまたはディレクトリはありません)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>全般設定</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>自動スワップ</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>デバッグ</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>ランタイム</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>アプリケーション設定</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>アプリの設定、接続文字列、ランタイム設定などを管理します。</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>既定のドキュメント</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>ハンドラー マッピング</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>仮想アプリケーションとディレクトリ</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>この設定を編集するには、現在のアプリに対する書き込みアクセス許可が必要です。</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>このアプリには読み取り専用ロックが設定されているため、設定の編集や保護されたデータの取得ができません。ロックを解除してからもう一度やり直してください。</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>読み取り専用モードで設定を表示します。</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>設定の読み込みに失敗しました。</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>読み込んでいます...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>Web アプリ設定を更新しています</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>Web アプリ設定が正常に更新されました</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>Web アプリ設定を更新できませんでした:</value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>{{configGroupName}} 保存エラー: 入力内容が無効です。</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>.NET Framework のバージョン</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>.NET Framework を使用している場合に、Web アプリを実行するために使用されるバージョン</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>PHP のバージョン</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>PHP を使用している場合に、Web アプリを実行するために使用されるバージョン</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Python バージョン</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>Python を使用している場合に、Web アプリを実行するために使用されるバージョン</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Java バージョン</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>Java を使用している場合に、Web アプリを実行するために使用されるバージョン</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Java マイナー バージョン</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>希望する Java マイナー バージョンを選択してください。"最新" を選択すると、ポータルに追加された日時が最も新しい JVM が常にアプリで使用されます。</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Web コンテナー</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>Java を使用している場合に、Web アプリを実行するために使用される Web コンテナー バージョン</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>プラットフォーム</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>Web アプリが実行されているプラットフォーム アーキテクチャ</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>64 ビット構成には、Basic 以上の App Service プランが必要です</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Web ソケット</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>WebSocket では、Web アプリと最新ブラウザーをより柔軟に接続できます。Web アプリは、これらの機能を活用するように構築する必要があります。</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>常時接続</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>Web アプリを毎回読み込む必要があることを示します。既定では、Web アプリはアイドルになった後でアンロードされます。この Web アプリで実行されている継続的な Web ジョブがある場合は、このオプションを有効にすることをお勧めします。</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>常にオンにするには、Basic 以上の App Service プランが必要です</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>マネージ パイプライン バージョン</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>自動スワップの送信先を実稼働スロットから構成することはできません</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>自動スワップ</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>自動スワップ スロット</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>ARR アフィニティ</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>リモート デバッグ</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>リモート Visual Studio のバージョン</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>スタック</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>スタートアップ ファイル</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>新しい順</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32 ビット</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64 ビット</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>クラシック</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>統合</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>プロパティ</value>
@@ -1220,7 +1469,7 @@
     <value>App Service の設定をすべて表示します。</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>アプリ内の関数すべてに使用する Functions ランタイムに影響を及ぼす設定を管理します。</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>全般設定</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>アプリケーションを保護してユーザーごとのデータを取り扱うには、認証/承認を使用します。</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>管理対象サービス ID</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>アプリケーションが、管理されている Azure Active Directory ID を使って自ら他の Azure サービスと通信できます。</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>プッシュ通知</value>
@@ -1379,10 +1634,13 @@
     <value>設定</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>Function App の設定</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>構成</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>アプリケーション設定</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>この試用版では、Function App の管理機能は利用できません。</value>
@@ -1574,7 +1832,7 @@
     <value>入門用チュートリアルを確認する</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>関数</value>
+    <value>関数 (プレビュー)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>API 定義キー</value>
@@ -1586,7 +1844,7 @@
     <value>API 定義テンプレートを生成する</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>PowerApps + Flow にエクスポートする</value>
+    <value>PowerApps + Flow にエクスポート</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
     <value>API 定義の形式が正しくないため、保存できません。</value>
@@ -1613,7 +1871,7 @@
     <value>自分の API 定義を使用する</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>API 定義 (プレビュー)</value>
+    <value>API 定義</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>Swagger エンドポイント用のキー swaggerdocumentationkey を作成または更新できません。ランタイム ログでエラーの有無を確認するか、後でもう一度やり直してください。</value>
@@ -1676,7 +1934,7 @@
     <value>読み取り専用</value>
   </data>
   <data name="appFunctionSettings_readWriteMode" xml:space="preserve">
-    <value>読み取り\書き込み</value>
+    <value>読み取り/書き込み</value>
   </data>
   <data name="validation_duplicateError" xml:space="preserve">
     <value>値の重複は許可されていません</value>
@@ -1704,6 +1962,9 @@
   </data>
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>ソース管理が有効になっているにもかかわらず編集モードが [読み取り\書き込み] に設定されたため、アプリが現在 [読み取り\書き込み] モードになっています。今回の変更はいずれも、次回のデプロイで上書きされる可能性があります。編集モードを変更するには、</value>
+  </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>生成された function.json を公開しているため、アプリは現在読み取り専用モードになっています。function.json に加えられた変更は、Functions ランタイムでは受け入れられません。</value>
   </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>コピー</value>
@@ -1748,10 +2009,22 @@
     <value>スロット (プレビュー)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>展開スロット (プレビュー) を有効にします。これは、Function App に対する 1 回限りのオプトインであり、後から無効にはできません。シークレットが既に存在する場合には、リセットされます。更新後の新しいシークレットは、次の場所にコピーされます</value>
+    <value>デプロイ スロット (プレビュー) を有効にします。</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>各関数の [管理] ノード。</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>既知の問題:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>Logic Apps の Functions との統合は、スロット (プレビュー) が有効になっている場合は機能しません。</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>このプレビュー機能の利用を選択すると、既存のシークレットがすべてリセットされます。関数のシークレットは、各関数の </value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>'管理'</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>ノードの下にあります。</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>名前</value>
@@ -1790,7 +2063,7 @@
     <value>スロット (プレビュー)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>ライブ メトリックやカスタム クエリなど、これまで以上に充実した監視エクスペリエンスを実現するために、&lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights&lt;/a&gt; の使用をお勧めします。</value>
+    <value>ライブ メトリックやカスタム クエリなど、これまで以上に充実した監視エクスペリエンスを実現するために、&lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Function App で Application Insights を有効にしてください&lt;/a&gt;</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>この値は、メイン Web アプリの URL に追加され、スロットのパブリック アドレスとして機能します。たとえば、'contoso' という名前の Web アプリで、スロットの名前が 'staging' である場合、新しいスロットの URL は 'http://contoso-staging.azurewebsites.net' のようになります。</value>
@@ -1803,6 +2076,9 @@
   </data>
   <data name="new_" xml:space="preserve">
     <value>新規</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
+    <value>新規作成</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
     <value>関数の削除</value>
@@ -1878,5 +2154,308 @@
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>コンテンツと Visual Studio プロジェクト</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>取得</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>プロキシの削除</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>新しいプロキシ</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>上書きなし</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>簡易 AAD の登録</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>作成</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>関数の作成後に Event Grid のサブスクリプションを追加する必要があります。</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>Event Grid のサブスクリプション URL</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>Event Grid のサブスクリプション URL</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>Event Grid サブスクリプションの管理</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>Event Grid サブスクリプションの追加</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>すべての場所</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>{0} 箇所</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>場所:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>場所でグループ化</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>グループ化なし</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>リソース グループでグループ化</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>サブスクリプションでグループ化</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>米国中南部</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>北ヨーロッパ</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>西ヨーロッパ</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>東南アジア</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>韓国中部</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>韓国南部</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>米国西部</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>米国東部</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>西日本</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>東日本</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>東アジア</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>米国東部 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>米国中北部</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>米国中央部</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>ブラジル南部</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>オーストラリア東部</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>西インド</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>中央インド</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>南インド</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>カナダ中部</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>カナダ東部</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>西中央アメリカ</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>英国西部</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>英国南部</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>西アメリカ 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>すべてのリソース グループ</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>リソース グループ:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>{0} のリソース グループ</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>ボディ</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>状態コード</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>状態メッセージ</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>要求の上書き</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>応答の上書き</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>省略可能</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>プレリリース版の Azure Functions を使用しています。ご利用ありがとうございます。</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>非表示にするにはクリック</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>Logic Apps を使用すると、関数を複数のプラットフォーム間で簡単に利用することができます</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>関連する Logic Apps</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>Logic Apps を使用した調整</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>Logic Apps の作成</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>表示する Logic Apps はありません</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>Logic Apps により、SaaS と Enterprise アプリの統合を、視覚的な設計プロセスおよびワークフローと共に迅速に構築できるようになります。</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>展開または折りたたみ</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>App Service の認証と承認:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>AAD を今すぐ構成</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>アクセス許可を今すぐ追加</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>構成済み</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>ID 要件 (満たしていないもの)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>未構成</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>必要なアクセス許可</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>テンプレートに次のアクセス許可が必要です:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>この統合には、関数アプリ用の AAD 構成が必要です。</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>このテンプレートには、関数アプリ用の AAD 構成が必要です。</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>関数で必要とされるアクセス許可を追加で構成することが必要になる場合があります。このバインディングに関するドキュメントをご覧ください。</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>App Service の認証と承認の管理</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>認証の構成が必要です</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>ID 要件</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>管理</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>インストールされているランタイム拡張機能の一覧を取得できません</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>ランタイム拡張機能 {{extensionId}} をインストールできません</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>ランタイム拡張機能 {{extensionId}} をアンインストールできません</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>ランタイム拡張機能のインストールに想定よりも長く時間がかかっています</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>拡張機能 {{extensionId}} は、別のバージョンが既にインストールされています</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>Application Insights を開く</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>関数で App Insights が有効になっています。</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>表示する監視データはありません</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>インストール</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>拡張機能のインストールに成功しました</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>拡張機能がインストールされていません</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>この統合には次の拡張機能が必要です。</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>このテンプレートには次の拡張機能が必要です。</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>必要な拡張機能をインストールします。この操作には最大 10 分かかる場合があります。</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>ランタイム拡張機能をインストールできません。インストール ID: {{installationId}}</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>GB-秒単位で値を入力してください</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>接続</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>通知ハブ</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>お使いのコンピューターで Java 関数のビルド、テスト、ローカルへのデプロイが可能です。ポータルは必要ありません。</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>Java で、最初の Azure 関数を構築する方法についてのドキュメントを開始するには下をクリックします。</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>プロキシが有効になっています。もう一度無効にするには、個々のプロキシをすべて削除するか、無効にします。</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Azure Functions 上の Java のクイック スタート</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/ko-KR/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/ko-KR/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>구성</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>사용하도록 설정하려면 업그레이드하세요.</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>모두 선택</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>모든 항목이 선택됨</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>{0}개 항목이 선택됨</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>함수 만들기 오류: {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>아래 템플릿을 선택하거나</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>아래 계획을 선택하여 새 구독을 만드세요.</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>친숙한 구독 이름 제공</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>친숙한 구독 이름</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>초대 코드</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>이 템플릿은 실험적이며 아직 완벽히 지원되지 않습니다. 문제가 발생하는 경우 &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;GitHub 리포지토리&lt;/a&gt;에서 버그를 보고하세요.</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>저장</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>저장 작업이 현재 진행 중입니다. 다른 곳으로 나가면 일부 변경 내용이 손실될 수 있습니다.</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ 새 설정 추가</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ 새 연결 문자열 추가</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ 새 문서 추가</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ 새 핸들러 매핑 추가</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ 새 가상 응용 프로그램 또는 디렉터리 추가</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>이름 입력</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>값 입력</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>확장명 입력</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>스크립트 처리기 입력</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>인수 입력</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>가상 경로 입력</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>물리적 경로 입력</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>응용 프로그램</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>슬롯 설정</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>숨겨진 값. 표시하려면 클릭하세요.</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>검색</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>이 항목까지 범위 지정</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>기능 검색</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>함수 앱 검색</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>구독 ID</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>사용</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>사용 안 함</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>사용</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>여기</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>구성 구문 분석 오류: {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>{{state}} 함수: {{functionName}}에 실패했습니다.</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>기능</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>표준 편집기</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>{{name}} 함수 삭제</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>{{name}} 함수를 삭제하시겠습니까?</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>프록시(미리 보기)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>프록시 런타임 버전: {{extensionVersion}}. 최신 버전을 사용할 수 있습니다({{latestExtensionVersion}}).</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>프록시 런타임 버전: 최신({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>Azure Functions 프록시(미리 보기) 사용</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>Azure Functions 프록시를 현재 사용할 수 없습니다. 이 프록시를 사용하려면 다음을 방문하세요.</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>{{name}} 프록시에 대한 변경 내용이 손실됩니다. 계속할까요?</value>
@@ -967,8 +1033,8 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Azure 함수 슬롯(미리 보기)이 현재 사용하지 않도록 설정되어 있습니다. 사용하도록 설정하려면 다음을 방문하세요.</value>
   </data>
-  <data name="discrard" xml:space="preserve">
-    <value>삭제</value>
+  <data name="discard" xml:space="preserve">
+    <value>취소</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
     <value>함수</value>
@@ -983,7 +1049,7 @@
     <value>Google로 로그인</value>
   </data>
   <data name="intro_signInWithMicrosoft" xml:space="preserve">
-    <value>Microsoft로 로그인</value>
+    <value>Microsoft에 로그인</value>
   </data>
   <data name="apiProxy_backanrUrlStart" xml:space="preserve">
     <value>백 엔드 URL은 'http://' 또는 'https://'로 시작해야 합니다.</value>
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>모든 구독</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>구독</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>{0}개 구독</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>위의 "플랫폼 기능" 탭에서 구성한 후 여기에 기능에 대한 빠른 링크가 표시됩니다.</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>앱 '{0}'의 저장되지 않은 변경 내용이 손실됩니다. 계속하시겠습니까?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>앱 '{0}'에 대한 정보를 검색하는 중 오류가 발생했습니다.</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>사용 계획의 앱에 대해 이 기능은 지원되지 않습니다.</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>이 기능은 슬롯에 대해 지원되지 않습니다.</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Linux 앱에 대해 이 기능은 지원되지 않습니다.</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>이 기능을 사용하려면 현재 앱에 대한 쓰기 권한이 있어야 합니다.</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>대화형 웹 기반 콘솔에서 앱의 파일 시스템을 탐색합니다.</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>SSH는 Linux 앱 코드에 대해 웹 SSH 콘솔 환경을 제공합니다.</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>확장</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>확장 프로그램은 전체 앱에 기능을 추가합니다.</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(표시할 응용 프로그램 설정 없음)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(표시할 연결 문자열 없음)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(표시할 기본 문서 없음)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(표시할 핸들러 매핑 없음)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(표시할 가상 응용 프로그램 또는 디렉터리 없음)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>일반 설정</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>자동 전환</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>디버깅</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>런타임</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>응용 프로그램 설정</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>앱 설정, 연결 문자열, 런타임 설정 등을 관리합니다.</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>기본 문서</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>처리기 매핑</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>가상 응용 프로그램 및 디렉터리</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>이러한 설정을 편집하려면 현재 앱에 대한 쓰기 권한이 있어야 합니다.</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>이 앱에는 설정 편집이나 보안 데이터 검색을 방지하는 읽기 전용 잠금이 있습니다. 잠금을 제거하고 다시 시도하세요.</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>읽기 전용 모드로 설정을 확인합니다.</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>설정을 로드하지 못했습니다.</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>로드 중...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>웹앱 설정을 업데이트하는 중</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>웹앱 설정을 업데이트함</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>웹앱 설정 업데이트 실패: </value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>{{configGroupName}} 저장 오류: 잘못된 입력이 제공되었습니다.</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>.NET Framework 버전</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>.NET Framework를 사용하는 경우 웹앱을 실행하는 데 사용되는 버전</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>PHP 버전</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>PHP를 사용하는 경우 웹앱을 실행하는 데 사용되는 버전</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Python 버전</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>Python을 사용하는 경우 웹앱을 실행하는 데 사용되는 버전</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Java 버전</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>Java를 사용하는 경우 웹앱을 실행하는 데 사용되는 버전</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Java 부 버전</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>원하는 Java 부 버전을 선택합니다. '가장 최근 항목'을 선택하면 가장 최근에 포털에 추가된 JVM을 사용하는 앱을 유지합니다.</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>웹 컨테이너</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>Java를 사용하는 경우 웹앱을 실행하는 데 사용되는 웹 컨테이너 버전</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>플랫폼</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>웹앱에서 실행되는 플랫폼 아키텍처</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>64비트 구성에서는 기본 이상의 App Service 계획이 필요합니다.</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>웹 소켓</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>WebSocket을 사용하면 웹앱과 최신 브라우저 간을 더욱 유연하게 연결할 수 있습니다. 이러한 기능을 활용하려면 웹앱을 빌드해야 합니다.</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>항상</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>웹앱을 항상 로드해야 함을 나타냅니다. 기본적으로 웹앱은 유휴 상태가 되면 언로드됩니다. 웹앱에서 연속 웹 작업이 실행되고 있는 경우 이 옵션을 사용하도록 설정하는 것이 좋습니다.</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>항상 켜려면 기본 이상의 App Service 계획이 필요합니다.</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>관리되는 파이프라인 버전</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>자동 전환 대상은 제품 슬롯에서 구성할 수 없습니다.</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>자동 전환</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>슬롯 자동 전환</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>ARR 선호도</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>원격 디버깅</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>원격 Visual Studio 버전</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>스택</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>시작 파일</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>최신</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32비트</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64비트</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>클래식</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>통합됨</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>속성</value>
@@ -1220,7 +1469,7 @@
     <value>모든 App Service 설정을 봅니다.</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>앱 내에서 모든 함수의 Functions 런타임에 영향을 주는 설정을 관리합니다.</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>일반 설정</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>인증/권한 부여를 사용하여 응용 프로그램을 보호하고 사용자 단위 데이터로 작업합니다.</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>관리 서비스 ID</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>응용 프로그램은 관리되는 Azure Active Directory ID를 사용하여 다른 Azure 서비스와 통신할 수 있습니다.</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>푸시 알림</value>
@@ -1379,10 +1634,13 @@
     <value>설정</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>함수 앱 설정</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>구성</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>응용 프로그램 설정</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>이 평가판에서는 함수 앱 관리를 사용할 수 없습니다.</value>
@@ -1394,7 +1652,7 @@
     <value>이벤트</value>
   </data>
   <data name="appServicePlan" xml:space="preserve">
-    <value>앱 서비스 계획</value>
+    <value>App Service 계획</value>
   </data>
   <data name="appServicePlanPricingTier" xml:space="preserve">
     <value>App Service 요금제 / 가격 책정 계층</value>
@@ -1574,7 +1832,7 @@
     <value>시작 자습서 확인</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>함수</value>
+    <value>함수(미리 보기)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>API 정의 키</value>
@@ -1586,7 +1844,7 @@
     <value>API 정의 템플릿 생성</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>Power Apps + Flow로 내보내기</value>
+    <value>PowerApps + Flow로 내보내기</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
     <value>형식이 잘못된 API 정의를 저장할 수 없습니다.</value>
@@ -1613,7 +1871,7 @@
     <value>API 정의 사용</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>API 정의(미리 보기)</value>
+    <value>API 정의</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>Swagger 끝점에 대해 swaggerdocumentationkey 키를 만들거나 업데이트할 수 없습니다. 오류에 대해서 런타임 로그를 확인하거나 나중에 다시 시도하세요.</value>
@@ -1676,7 +1934,7 @@
     <value>읽기 전용</value>
   </data>
   <data name="appFunctionSettings_readWriteMode" xml:space="preserve">
-    <value>읽기\쓰기</value>
+    <value>읽기/쓰기</value>
   </data>
   <data name="validation_duplicateError" xml:space="preserve">
     <value>중복 값은 사용할 수 없습니다.</value>
@@ -1704,6 +1962,9 @@
   </data>
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>소스 제어를 사용하도록 설정했지만 편집 모드를 읽기\쓰기로 설정했으므로 현재 앱은 읽기\쓰기 모드입니다. 변경한 내용을 다음 배포 시 덮어쓸 수 있습니다. 편집 모드를 변경하려면 다음을 방문하세요. </value>
+  </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>생성된 function.json을 게시했기 때문에 현재 앱이 읽기 전용 모드입니다. function.json의 변경 내용이 함수 런타임에 적용되지 않습니다. </value>
   </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>복사</value>
@@ -1748,10 +2009,22 @@
     <value>슬롯(미리 보기)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>배포 슬롯(미리 보기)을 사용하도록 설정합니다. 이는 사용하지 않도록 설정할 수 없는 함수 앱에 대한 일회성 옵트인이며 기존 암호를 다시 설정합니다. 업데이트 후 암호를 </value>
+    <value>배포 슬롯을 사용합니다(미리 보기).</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>각 함수의 '관리' 노드 아래에서 복사할 수 있습니다.</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>알려진 문제:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>슬롯(미리 보기)을 사용하도록 설정하면 논리 앱과 함수의 통합이 작동하지 않습니다.</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>이 미리 보기 기능을 선택하면 기존의 암호가 모두 재설정됩니다. 함수 암호는 각 함수에 대한</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>'관리'</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>노드 아래에서 확인할 수 있습니다.</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>이름</value>
@@ -1790,7 +2063,7 @@
     <value>슬롯(미리 보기)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>더 풍부한 모니터링 환경(라이브 메트릭 및 사용자 지정 쿼리 포함)을 위해 &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights&lt;/a&gt;를 사용하는 것이 좋습니다.</value>
+    <value>더 풍부한 모니터링 환경(라이브 메트릭 및 사용자 지정 쿼리 포함)을 위해 &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Function 앱용 Application Insights를 사용하도록 설정&lt;/a&gt;하는 것이 좋습니다.</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>이 값은 기본 웹 앱의 URL에 추가되며 슬롯의 공용 주소로 사용됩니다. 예를 들어 'contoso'라는 웹 앱과 'staging'이라는 슬롯이 있는 경우 새 슬롯은 'http://contoso-staging.azurewebsites.net'과 같은 URL을 갖게 됩니다.</value>
@@ -1802,6 +2075,9 @@
     <value>검색 함수</value>
   </data>
   <data name="new_" xml:space="preserve">
+    <value>새로 만들기</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
     <value>새로 만들기</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
@@ -1878,5 +2154,308 @@
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>콘텐츠 및 Visual Studio 프로젝트</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>검색</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>프록시 삭제</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>새 프록시</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>재정의 없음</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>Express AAD 등록</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>만들기</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>함수를 만든 후에는 Event Grid 구독을 추가해야 합니다.</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>Event Grid 구독 URL</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>Event Grid 구독 URL</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>Event Grid 구독 관리</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>Event Grid 구독 추가</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>모든 위치</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>위치 {0}개</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>위치:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>위치별 그룹화</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>그룹화 안 함</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>리소스 그룹별 그룹화</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>구독별 그룹화</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>미국 중남부</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>북유럽</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>서유럽</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>동남아시아</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>대한민국 중부</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>대한민국 남부</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>미국 서부</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>미국 동부</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>일본 서부</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>일본 동부</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>동아시아</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>미국 동부 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>미국 중북부</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>미국 중부</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>브라질 남부</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>호주 동부</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>서인도</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>중앙 인도</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>남인도</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>캐나다 중부</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>캐나다 동부</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>미국 중서부</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>영국 서부</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>영국 남부</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>미국 서부 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>모든 리소스 그룹</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>리소스 그룹:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>{0}개 리소스 그룹</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>본문</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>상태 코드</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>상태 메시지</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>요청 재정의</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>응답 재정의</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>옵션</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>Azure Functions의 시험판 버전을 사용하고 있습니다. 사용해 주셔서 감사합니다!</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>숨기려면 클릭</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>Logic Apps를 사용하면 여러 플랫폼에서 함수를 쉽게 활용할 수 있습니다.</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>논리 앱</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>연결된 Logic Apps</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>Logic Apps로 오케스트레이션</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>Logic Apps 만들기</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>표시할 Logic Apps 없음</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>논리 앱</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>Logic Apps를 사용하면 프로세스 및 워크플로를 시각적으로 설계할 수 있을 뿐 아니라 SaaS 및 엔터프라이즈 앱과의 통합을 신속하게 구축할 수 있습니다.</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>확장 또는 축소</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>App Service 인증/권한 부여:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>지금 AAD 구성</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>지금 권한 추가</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>구성됨</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>ID 요구 사항(충족되지 않음)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>구성되어 있지 않음</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>필수 권한</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>템플릿에 다음 권한이 필요함:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>이 통합에는 함수 앱에 대한 AAD 구성이 필요합니다.</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>이 템플릿에는 함수 앱에 대한 AAD 구성이 필요합니다.</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>함수에 필요한 추가 권한을 구성해야 할 수 있습니다. 이 바인딩에 대한 설명서를 참조하세요.</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>App Service 인증/권한 부여 관리</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>인증 구성 필요</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>ID 요구 사항</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>관리</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>설치된 런타임 확장의 목록을 가져올 수 없습니다.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>런타임 확장 {{extensionId}}을(를) 설치할 수 없습니다.</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>런타임 확장 {{extensionId}}을(를) 제거할 수 없습니다.</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>런타임 확장을 설치하는 시간이 예상보다 길어지고 있습니다.</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>다른 버전의 확장 {{extensionId}}이(가) 이미 설치되어 있습니다.</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>Application Insights 열기</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>기능에 대해 App Insights를 사용하도록 설정했습니다.</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>표시할 모니터링 데이터 없음</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>설치</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>확장을 설치했습니다.</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>확장이 설치되지 않았습니다.</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>이 통합에는 다음의 확장이 필요합니다.</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>이 템플릿에는 다음의 확장이 필요합니다.</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>필수 확장을 설치하는 중입니다. 이 작업은 최대 10분 정도 소요될 수 있습니다.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>런타임 확장을 설치할 수 없습니다. 설치 ID: {{installationId}}</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>GB-초 단위의 값을 입력하세요.</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>연결</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>알림 허브</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>Java 함수는 컴퓨터에서 로컬로 빌드, 테스트 및 배포할 수 있습니다. 포털이 필요하지 않습니다!</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>Java를 사용하여 첫 번째 Azure Functions를 빌드하는 방법에 대한 문서를 시작하려면 아래를 클릭하세요.</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>프록시를 사용하도록 설정했습니다. 다시 사용하지 않도록 설정하려면 모든 개별 프록시를 삭제하거나 사용하지 않도록 설정합니다.</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Azure Functions 빠른 시작의 Java</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/nl-NL/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/nl-NL/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>Configureren</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>Voer een upgrade uit om dit in te schakelen</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>Alles selecteren</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>Alle items geselecteerd</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>{0} items geselecteerd</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>Fout bij het maken van de functie: {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>Kies hieronder een sjabloon of</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>Kies hieronder een plan om een nieuw abonnement maken</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>Een beschrijvende abonnementsnaam opgeven</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>Beschrijvende abonnementsnaam</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>Uitnodigingscode</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>Deze sjabloon is experimenteel en wordt nog niet volledig ondersteund. Als u problemen tegenkomt, kunt u een fout rapporteren in de &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;GitHub-opslagplaats.&lt;/a&gt;</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>Opslaan</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>Er wordt een bewerking voor opslaan uitgevoerd. Als u deze pagina verlaat, kunnen sommige wijzigingen verloren gaan.</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ Nieuwe instelling toevoegen</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ Nieuwe verbindingsreeks toevoegen</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ Nieuw document toevoegen</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ Nieuwe handlertoewijzing toevoegen</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ Nieuwe virtuele toepassing of map toevoegen</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>Een naam invoeren</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>Typ een waarde</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>Extensie invoeren</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>Scriptprocessor invoeren</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>Argumenten invoeren</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>Virtueel pad invoeren</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>Fysiek pad invoeren</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>Toepassing</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>Site-instelling</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>Verborgen waarde. Klik om de waarde weer te geven.</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>Zoeken</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>Bereik instellen tot dit item</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>Zoeken naar functies</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>Functie-apps zoeken</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>Abonnements-id</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>Ingeschakeld</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>uitschakelen</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>ingeschakeld</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>hier</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>Fout bij het parseren van Config: {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>Kan {{state}} niet instellen voor de functie: {{functionName}}</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>Functies</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>Standaardeditor</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>Functie {{name}} verwijderen</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>Weet u zeker dat u functie {{name}} wilt verwijderen?</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>Proxy's (preview)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>Runtime-versie van proxy: {{extensionVersion}}. Er is een nieuwere versie beschikbaar ({{latestExtensionVersion}}).</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>Runtime-versie van proxy: meest recente ({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>Azure Functions-proxy's inschakelen (preview)</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>Azure Functions-proxy's zijn momenteel uitgeschakeld. Als u Azure Functions-proxy's wilt inschakelen, gaat u naar</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>De wijzigingen voor de proxy {{name}} gaan verloren. Weet u zeker dat u wilt doorgaan?</value>
@@ -967,7 +1033,7 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Sites (preview-versie) voor Azure Functions is uitgeschakeld. Als u deze functie wilt inschakelen, gaat u naar</value>
   </data>
-  <data name="discrard" xml:space="preserve">
+  <data name="discard" xml:space="preserve">
     <value>Negeren</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>Alle abonnementen</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>Abonnementen</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>{0} abonnementen</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>Snelkoppelingen naar uw functies worden hier weergegeven nadat u de functies hebt geconfigureerd op het tabblad Platformfuncties hierboven.</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>Niet-opgeslagen wijzigingen voor de app {0} gaan verloren. Weet u zeker dat u wilt doorgaan?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>Er is een fout opgetreden bij het ophalen van de informatie over de app {0}</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>Deze functie wordt niet ondersteund voor apps in een verbruiksabonnement</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>Deze functie wordt niet ondersteund voor sleuven</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Deze functie wordt niet ondersteund voor Linux-apps</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>U moet schrijfbevoegdheden voor de huidige app hebben als u functie wilt gebruiken</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>Verken het bestandssysteem van uw app via een interactieve webconsole.</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>SSH voorziet in een online SSH-console-ervaring voor de code van uw Linux-apps</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>Uitbreidingen</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>Met extensies voegt u functionaliteit toe aan uw app.</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(geen toepassingsinstellingen om weer te geven)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(geen verbindingsreeksen om weer te geven)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(geen standaarddocumenten om weer te geven)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(geen handlertoewijzingen om weer te geven)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(geen virtuele toepassingen of mappen om weer te geven)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>Algemene instellingen</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>Automatische wisselen</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>Foutopsporing</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>Runtime</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>Toepassingsinstellingen</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>Beheer app-instellingen, verbindingsreeksen, runtime-instellingen en meer.</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>Standaarddocumenten</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>Handlertoewijzingen</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>Virtuele toepassingen en mappen</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>U moet schrijfbevoegdheden voor de huidige app hebben als u deze instellingen wilt bewerken.</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>Deze app heeft een alleen-lezenvergrendeling waardoor het bewerken van instellingen of het ophalen van beveiligde gegevens wordt voorkomen. Verwijder de vergrendeling en probeer het opnieuw.</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>Instellingen weergeven in de alleen-lezenmodus.</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>Kan de instellingen niet laden.</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>Laden...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>Web-appinstellingen bijwerken</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>Web-appinstellingen zijn bijgewerkt</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>Kan de web-appinstellingen niet bijwerken: </value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>Kan {{configGroupName}} niet opslaan: ongeldige invoer opgegeven.</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>.NET Framework-versie</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>De versie die wordt gebruikt voor het uitvoeren van uw web-app als u .NET Framework gebruikt</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>PHP-versie</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>De versie die wordt gebruikt voor het uitvoeren van uw web-app als u PHP gebruikt</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Python-versie</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>De versie die wordt gebruikt voor het uitvoeren van uw web-app als u Python gebruikt</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Java-versie</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>De versie die wordt gebruikt voor het uitvoeren van uw web-app als u Java gebruikt</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Java Minor-versie</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>Selecteer de gewenste Java Minor-versie. Als u Nieuwste selecteert, blijft uw app de meest recentelijk aan de portal toegevoegde JVM gebruiken.</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Webcontainer</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>De webcontainerversie die wordt gebruikt voor het uitvoeren van uw web-app als u Java gebruikt</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>Platform</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>De platformarchitectuur die uw web-app gebruikt</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>Er is een standaard of hoger App Service-plan vereist voor de 64-bits configuratie</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Websockets</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>WebSockets maken een flexibelere verbinding mogelijk tussen Web Apps en moderne browsers. Uw Web App moet zijn aangepast om van deze mogelijkheden gebruik te kunnen maken.</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>Altijd aan</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>Dit geeft aan dat uw Web App steeds geladen moet zijn. Standaard worden Web Apps uit het geheugen verwijderd als ze inactief zijn geweest. Aanbevolen wordt deze optie in te schakelen wanneer u doorlopende webtaken uitvoert op de Web Apps.</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>Er is een standaard of hoger App Service-plan vereist voor AlwaysOn</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>Beheerde pipeline-versie</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>Doelen voor automatisch wisselen kunnen niet worden geconfigureerd uit productiesleuf</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>Automatische wisselen</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>Sleuf voor automatisch wisselen</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>ARR-affiniteit</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>Foutopsporing op afstand</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>Versie van Visual Studio op afstand</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>Stack</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>Opstartbestand</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>Nieuwste</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32-bits</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64-bits</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>Klassiek</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>Geïntegreerd</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>Eigenschappen</value>
@@ -1220,7 +1469,7 @@
     <value>Bekijk alle App Service-instellingen.</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>Instellingen beheren die van invloed zijn op de Functions-runtime voor alle functies in uw app.</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>Algemene instellingen</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>Gebruik Verificatie/autorisatie om uw toepassing te beschermen en met individuele gebruikersgegevens te werken.</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>Beheerde service-identiteit</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>Uw toepassing kan met een beheerde Azure Active Directory-id als zichzelf met andere Azure-services communiceren.</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>Pushmeldingen</value>
@@ -1379,10 +1634,13 @@
     <value>Instellingen</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>Instellingen voor functie-apps</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>Configuratie</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>Toepassingsinstellingen</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>U kunt uw functie-app niet beheren met deze proefversie.</value>
@@ -1574,7 +1832,7 @@
     <value>Bekijk de zelfstudie Aan de slag</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>Functie</value>
+    <value>Functie (preview-versie)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>Sleutel van API-definitie</value>
@@ -1613,7 +1871,7 @@
     <value>Uw API-definitie gebruiken</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>API-definitie (preview-versie)</value>
+    <value>API-definitie</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>De sleutel swaggerdocumentationkey voor het Swagger-eindpunt kan niet worden gemaakt of bijgewerkt. Controleer de runtimelogboeken voor informatie over mogelijke fouten of probeer het later opnieuw.</value>
@@ -1676,7 +1934,7 @@ Geef de waarde Externe URL op om een API-definitie te gebruiken die ergens ander
     <value>Alleen-lezen</value>
   </data>
   <data name="appFunctionSettings_readWriteMode" xml:space="preserve">
-    <value>Lezen\Schrijven</value>
+    <value>Lezen/Schrijven</value>
   </data>
   <data name="validation_duplicateError" xml:space="preserve">
     <value>Dubbele waarden zijn niet toegestaan</value>
@@ -1704,6 +1962,9 @@ Geef de waarde Externe URL op om een API-definitie te gebruiken die ergens ander
   </data>
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>Uw app bevindt zich momenteel in de modus lezen\schrijven omdat u de bewerkingsmodus hebt ingesteld op lezen\schrijven ondanks dat bronbeheer is ingeschakeld. Wijzigingen die u hebt aangebracht kunnen worden overschreven bij de volgende implementatie. Voor het wijzigen van de bewerkingsmodus, gaat u naar </value>
+  </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>De app is momenteel in de modus alleen-lezen omdat u hebt gegenereerde function.json hebt gepubliceerd. Wijzigingen in de function.json worden niet verwerkt in de Functions-runtime. </value>
   </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>Kopiëren</value>
@@ -1748,10 +2009,22 @@ Geef de waarde Externe URL op om een API-definitie te gebruiken die ergens ander
     <value>Sites (preview-versies)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>Implementatiesites inschakelen (preview-versie). Dit is een eenmalige opt-in in de functie-app die niet kan worden uitgeschakeld. Eerder ingestelde geheimen worden opnieuw ingesteld. Na het bijwerken, kunnen de geheimen worden gekopieerd via het </value>
+    <value>Implementatiesites (preview-versie) inschakelen.</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>knooppunt Beheren voor elke functie.</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>Bekende problemen:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>Integratie van Logica Apps met Functions werkt niet als Sites (preview-versie) is ingeschakeld.</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>Als u zich aanmeldt voor deze preview-functie, worden bestaande geheimen opnieuw ingesteld. Functiegeheimen kunt u vinden onder het knooppunt</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>Beheren</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>voor elke functie.</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>Naam</value>
@@ -1790,7 +2063,7 @@ Geef de waarde Externe URL op om een API-definitie te gebruiken die ergens ander
     <value>Sites (preview-versies)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>Voor een uitgebreidere controle, waaronder live metrische gegevens en aangepaste query's, kunt u het beste &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights&lt;/a&gt; gebruiken.</value>
+    <value>Schakel voor een uitgebreidere controle, waaronder live metrische gegevens en aangepaste query's &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt; Application Insights&lt;/a&gt; in voor uw functie-app</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>Deze waarde wordt aan het eind van de URL van uw hoofdweb-app toegevoegd en dient als het publieke adres van de site. Als u bijvoorbeeld een web-app hebt met de naam 'contoso' en een site met de naam 'staging', krijgt de nieuwe site de URL 'http://contoso-staging.azurewebsites.net'.</value>
@@ -1802,6 +2075,9 @@ Geef de waarde Externe URL op om een API-definitie te gebruiken die ergens ander
     <value>Functies zoeken</value>
   </data>
   <data name="new_" xml:space="preserve">
+    <value>Nieuw</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
     <value>Nieuw</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
@@ -1878,5 +2154,309 @@ Geef de waarde Externe URL op om een API-definitie te gebruiken die ergens ander
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>Inhoud en Visual Studio-project</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>ophalen</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>Proxy verwijderen</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>Nieuwe proxy</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>Niet negeren</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>Snelregistratie bij AAD</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>maken</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>U moet een Event Grid-abonnement toevoegen na het maken van de functie.</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>URL van Event Grid-abonnement</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>URL van Event Grid-abonnement</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>Event Grid-abonnementen beheren</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>Event Grid-abonnement toevoegen</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>Alle locaties</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>{0} locaties</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>Locatie:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>Groeperen op locatie</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>Geen groepering</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>Groeperen op resourcegroep</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>Groeperen op abonnement</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>Zuid-centraal VS</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>Noord-Europa</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>West-Europa</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>Zuidoost-Azië</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>Korea - centraal</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>Korea - zuid</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>VS - west</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>VS - Oost</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>Japan - west</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>Japan - oost</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>Oost-Azië</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>Verenigde Staten - oost 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>Noord-centraal VS</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>VS - Midden</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>Brazilië - zuid</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>Australië - oost</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>West-India</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>Centraal-India</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>Zuid-India</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>Canada Centraal</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>Canada Oost</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>West-centraal VS</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>VK West</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>VK Zuid</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>VS - west 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>Alle resourcegroepen</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>Resourcegroep:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>{0} resourcegroepen</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>Hoofdtekst</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>Statuscode</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>Statusbericht</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>Aanvraag negeren</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>Antwoord negeren</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>Optioneel</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>U gebruikt een voorlopige versie van Azure Functions. Bedankt dat u het uitprobeert.</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>Klik om te verbergen</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>Met logische apps kunt u eenvoudig uw functie gebruiken op meerdere platformen</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>Gekoppelde logische apps</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>Organiseren met logische apps</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>Logische apps maken</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>Er zijn geen logische apps om weer te geven</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>Met logische apps kunt u snel integraties maken met SaaS- en bedrijfs-apps. Ook kunt u visueel processen en werkstromen ontwerpen.</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>Uitvouwen of samenvouwen</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>App Service-verificatie/-autorisatie:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>AAD nu configureren</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>Machtigingen nu toevoegen</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>geconfigureerd</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>Vereisten voor de identiteit (onvoldoende)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>niet geconfigureerd</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>Vereiste machtigingen</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>De volgende machtiging is vereist voor de sjabloon:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>Voor deze integratie is een AAD-configuratie vereist voor de functie-app.</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>Voor deze sjabloon is een AAD-configuratie vereist voor de functie-app.</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>U moet mogelijk extra machtigingen configureren die vereist zijn voor de functie. Raadpleeg de documentatie voor deze binding.</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>App Service-verificatie/-autorisatie beheren</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>Configuratie van de verificatie is vereist</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>Vereisten voor de identiteit</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>Beheren</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>Kan de lijst met geïnstalleerde runtime-extensies niet ophalen</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>De runtime-extensie {{extensionId}} kan niet worden geïnstalleerd</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>De installatie van de runtime-extensie {{extensionId}} kan niet ongedaan worden gemaakt</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>Het installeren van de runtime-extensies duurt langer dan verwacht</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>De extensie {{extensionId}} met een andere versie is al geïnstalleerd</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>Application Insights openen</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>App Insights is ingeschakeld voor uw functie.</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>Geen bewakingsgegevens om weer te geven</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>Installeren</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>Installatie van extensie is voltooid</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>De extensies zijn niet geïnstalleerd</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>Voor deze integratie zijn de volgende extensies vereist.</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>Voor dit sjabloon zijn de volgende extensies vereist.</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>De vereiste extensies worden geïnstalleerd. Het kan tot tien minuten duren voordat deze bewerking is voltooid.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>De runtime-extensie kan niet worden geïnstalleerd. Installatie-id {{installationId}}
+</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>Voer de waarde in GB-sec in</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>Verbinding</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>Notification Hub</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>Java-functies kunt u gewoon vanaf uw lokale computer maken, testen en implementeren. U hebt geen portal nodig.</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>Klik hieronder om aan de slag te gaan met de documentatie over het maken van uw eerste Azure Function met Java.</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>Proxy's zijn ingeschakeld. Als u deze wilt uitschakelen, moet u alle afzonderlijke proxy's verwijderen of uitschakelen.</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Quick Start voor Java in Azure Functions</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/pl-PL/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/pl-PL/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>Konfiguruj</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>Podnieś poziom planu, aby włączyć</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>Zaznacz wszystko</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>Zaznaczono wszystkie elementy</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>Zaznaczone elementy: {0}</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>Błąd tworzenia funkcji: {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>Wybierz szablon poniżej lub</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>Wybierz plan poniżej, aby utworzyć nową subskrypcję</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>Podaj przyjazną nazwę subskrypcji</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>Przyjazna nazwa subskrypcji</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>Kod zaproszenia</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>To jest szablon eksperymentalny, który nie jest jeszcze w pełni obsługiwany. Jeśli napotkasz problemy, zgłoś usterkę w naszym &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;repozytorium GitHub&lt;/a&gt;.</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>Zapisz</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>Operacja zapisywania jest obecnie w toku.  Zamknięcie tego okna może spowodować utratę niektórych zmian.</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ Dodaj nowe ustawienie</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ Dodaj nowe parametry połączenia</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ Dodaj nowy dokument.</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ Dodaj nowe mapowanie procedury obsługi</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ Dodaj nową wirtualną aplikację lub katalog</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>Wprowadź nazwę</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>Wprowadź wartość</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>Wprowadź rozszerzenie</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>Wprowadź procesor skryptów</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>Wprowadź argumenty</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>Wprowadź ścieżkę wirtualną</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>Wprowadź ścieżkę fizyczną</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>Aplikacja</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>Ustawienie miejsca</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>Wartość ukryta. Kliknij, aby pokazać.</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>Wyszukaj</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>Ustaw zakres na ten element</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>Wyszukaj funkcje</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>Wyszukaj aplikacje funkcji</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>Identyfikator subskrypcji</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>Włączono</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>wyłącz</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>włączone</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>tutaj</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>Błąd analizowania konfiguracji: {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>Nie można przełączyć stanu {{state}} funkcji: {{functionName}}</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>Funkcje</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>Edytor standardowy</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>Usuń funkcję {{name}}</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>Czy na pewno chcesz usunąć funkcję {{name}}?</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>Serwery proxy (wersja zapoznawcza)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>Wersja środowiska uruchomieniowego serwera proxy: {{extensionVersion}}. Dostępna jest nowsza wersja ({{latestExtensionVersion}}).</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>Wersja środowiska uruchomieniowego serwera proxy: najnowsza ({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>Włącz serwery proxy usługi Azure Functions (wersja zapoznawcza)</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>Serwery proxy usługi Azure Functions są obecnie wyłączone. Aby je włączyć, odwiedź</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>Wprowadzone zmiany serwera proxy {{name}} zostaną utracone. Czy na pewno chcesz kontynuować?</value>
@@ -967,7 +1033,7 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Miejsca usługi Azure Functions (wersja zapoznawcza) są obecnie wyłączone. Aby je włączyć, odwiedź</value>
   </data>
-  <data name="discrard" xml:space="preserve">
+  <data name="discard" xml:space="preserve">
     <value>Odrzuć</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>Wszystkie subskrypcje</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>Subskrypcje</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>Subskrypcje: {0}</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>Szybkie linki do Twoich funkcji będą wyświetlane w tym miejscu po ich skonfigurowaniu na karcie „Funkcje platformy” powyżej.</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>Niezapisane zmiany dla aplikacji „{0}” zostaną utracone. Czy na pewno chcesz kontynuować?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>Wystąpił błąd podczas pobierania informacji na temat aplikacji „{0}”</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>Ta funkcja nie jest obsługiwana w przypadku aplikacji w ramach planu Zużycie</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>Ta funkcja nie jest jeszcze obsługiwana dla miejsc</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Ta funkcja nie jest obsługiwana w przypadku aplikacji systemu Linux</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>Aby korzystać z tej funkcji, musisz mieć uprawnienia do zapisu dla bieżącej aplikacji</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>Eksploruj system plików aplikacji z poziomu interaktywnej konsoli sieci Web.</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>Protokół SSH udostępnia internetowe środowisko konsoli SSH na potrzeby kodu aplikacji systemu Linux</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>Rozszerzenia</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>Rozszerzenia dodają funkcje do całej aplikacji.</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(brak ustawień aplikacji do wyświetlenia)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(brak parametrów połączenia do wyświetlenia)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(brak dokumentów domyślnych do wyświetlenia)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(brak mapowań procedur obsługi do wyświetlenia)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(brak wirtualnych aplikacji lub katalogów do wyświetlenia)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>Ustawienia ogólne</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>Automatyczna wymiana</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>Debugowanie</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>Środowisko uruchomieniowe</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>Ustawienia aplikacji</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>Zarządzaj ustawieniami aplikacji, parametrami połączeń, ustawieniami środowiska uruchomieniowego itd.</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>Domyślne dokumenty</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>Mapowania procedur obsługi</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>Wirtualne aplikacje i katalogi</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>Aby edytować te ustawienia, należy mieć uprawnienia do zapisu dla bieżącej aplikacji.</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>Ta aplikacja ma blokadę tylko do odczytu, która uniemożliwia edycję ustawień i pobieranie zabezpieczonych danych. Usuń blokadę, a następnie spróbuj ponownie.</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>Wyświetl ustawienia w trybie tylko do odczytu.</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>Nie można załadować ustawień.</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>Trwa ładowanie...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>Aktualizowanie ustawień aplikacji internetowej</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>Pomyślnie zaktualizowano ustawienia aplikacji sieci Web</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>Nie można zaktualizować ustawień aplikacji internetowej:</value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>{{configGroupName}} Błąd zapisywania: podano nieprawidłowe dane wejściowe.</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>Wersja platformy .NET Framework</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>Wersja użyta do uruchomienia aplikacji sieci Web, jeśli jest używana platforma .NET Framework</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>Wersja języka PHP</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>Wersja użyta do uruchomienia aplikacji sieci Web, jeśli jest używany język PHP</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Wersja języka Python</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>Wersja użyta do uruchomienia aplikacji sieci Web, jeśli jest używany język Python</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Wersja języka Java</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>Wersja użyta do uruchomienia aplikacji sieci Web, jeśli jest używany język Java</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Wersja pomocnicza środowiska Java</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>Wybierz żądaną wersję pomocniczą środowiska Java. Wybranie pozycji „Najnowsza” spowoduje, że aplikacja będzie używała maszyny JVM dodanej do portalu jako ostatnia.</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Kontener sieci Web</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>Wersja kontenera sieci Web użyta do uruchomienia aplikacji sieci Web, jeśli jest używany język Java</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>Platforma</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>Architektura platformy, na której działa aplikacja sieci Web</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>Konfiguracja 64-bitowa wymaga planu usługi App Service w warstwie Podstawowa lub wyższej</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Gniazda sieci Web</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>Gniazda WebSocket umożliwiają nawiązywanie bardziej elastycznych połączeń między aplikacjami sieci Web a nowoczesnymi przeglądarkami. Aplikacja sieci Web musi być utworzona pod kątem tej funkcji, aby można było ją wykorzystać.</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>Zawsze włączone</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>Wskazuje, że aplikacja sieci Web powinna być załadowana przez cały czas. Domyślnie aplikacje sieci Web są usuwane z pamięci po okresie bezczynności. Zalecamy włączenie tej opcji, jeśli w aplikacji sieci Web istnieją zadania Web Job działające w sposób ciągły.</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>Opcja Zawsze włączone wymaga planu usługi App Service w warstwie Podstawowa lub wyższej</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>Wersja potoku zarządzanego</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>Nie można konfigurować miejsc docelowych automatycznej wymiany z poziomu gniazda produkcyjnego</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>Automatyczna wymiana</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>Automatyczna wymiana gniazda</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>Koligacja ARR</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>Zdalne debugowanie</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>Wersja zdalnego programu Visual Studio</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>Stos</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>Plik startowy</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>Najnowsze</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32-bitowa</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64-bitowa</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>Klasyczny</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>Zintegrowany</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>Właściwości</value>
@@ -1220,7 +1469,7 @@
     <value>Wyświetlaj wszystkie ustawienia usługi App Service.</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>Zarządzaj ustawieniami, które wpływają na środowisko uruchomieniowe usługi Functions dla wszystkich funkcji w ramach Twojej aplikacji.</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>Ustawienia ogólne</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>Chroń aplikację i pracuj z danymi pojedynczych użytkowników dzięki uwierzytelnianiu/autoryzacji.</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>Tożsamość usługi zarządzanej</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>Twoja aplikacja może komunikować się z innymi usługami platformy Azure w swoim imieniu, używając zarządzanej tożsamości usługi Azure Active Directory.</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>Powiadomienia wypychane</value>
@@ -1379,10 +1634,13 @@
     <value>Ustawienia</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>Ustawienia aplikacji funkcji</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>Konfiguracja</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>Ustawienia aplikacji</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>Zarządzanie aplikacją funkcji nie jest dostępne w tej wersji próbnej.</value>
@@ -1574,7 +1832,7 @@
     <value>Zapoznaj się z samouczkiem ułatwiającym rozpoczęcie pracy</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>Funkcja</value>
+    <value>Funkcja (wersja zapoznawcza)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>Klucz definicji interfejsu API</value>
@@ -1586,7 +1844,7 @@
     <value>Generuj szablon definicji interfejsu API</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>Eksportuj do usług PowerApps i Flow</value>
+    <value>Eksportowanie do usług PowerApps i Flow</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
     <value>Nie można zapisać źle sformułowanej definicji interfejsu API.</value>
@@ -1613,7 +1871,7 @@
     <value>Użyj definicji interfejsu API</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>Definicja interfejsu API (wersja zapoznawcza)</value>
+    <value>Definicja interfejsu API</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>Nie można utworzyć lub zaktualizować klucza swaggerdocumentationkey punktu końcowego struktury Swagger. Przeszukaj dzienniki środowiska uruchomieniowego pod kątem błędów lub spróbuj ponownie później.</value>
@@ -1649,16 +1907,16 @@
     <value>Używaj swojej definicji interfejsu API, aby uzyskiwać dostęp do swoich funkcji z usług &lt;a href="https://powerapps.microsoft.com/en-us/" target="_blank"&gt;PowerApps&lt;/a&gt; i &lt;a href="https://ms.flow.microsoft.com/en-us/" target="_blank"&gt;Flow&lt;/a&gt;. </value>
   </data>
   <data name="swaggerDefinition_generateHelp" xml:space="preserve">
-    <value>Utwórz rozrzedzoną definicję przy użyciu metadanych z funkcji wyzwalanych przez HTTP.
-Przed użyciem wypełnij &lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;obiekty operacji&lt;/a&gt; i inne informacje na temat Twojego interfejsu API.</value>
+    <value>Utwórz rozrzedzoną definicję przy użyciu metadanych z funkcji wyzwalanych przez protokół HTTP.
+Przed użyciem wypełnij &lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;obiekty operacji&lt;/a&gt; i inne informacje na temat interfejsu API.</value>
   </data>
   <data name="swaggerDefinition_keyHelp" xml:space="preserve">
-    <value>Ten klucz zabezpiecza Twoją definicję interfejsu API przed dostępem osób, które go nie mają. 
-Nie zabezpiecza bazowego interfejsu API. Przyjrzyj się każdej funkcji, aby zobaczyć jej zabezpieczenia za pomocą klucza.</value>
+    <value>Ten klucz zabezpiecza definicję interfejsu API przed dostępem osób, które go nie posiadają.
+Nie zabezpiecza on bazowego interfejsu API. Przyjrzyj się każdej funkcji, aby sprawdzić jej zabezpieczenia za pomocą klucza.</value>
   </data>
   <data name="swaggerDefinition_sourceHelp" xml:space="preserve">
-    <value>Ustaw wartość „Funkcja”, aby włączyć hostowaną definicję interfejsu API i generowanie definicji szablonu. 
-Ustaw wartość „Zewnętrzny adres URL”, aby użyć definicji interfejsu API hostowanej gdzie indziej.</value>
+    <value>Ustaw wartość „Funkcja”, aby włączyć hostowaną definicję interfejsu API i generowanie definicji szablonu.
+Ustaw wartość „Zewnętrzny adres URL”, aby użyć definicji interfejsu API hostowanej w innej lokalizacji.</value>
   </data>
   <data name="swaggerDefinition_urlHelp" xml:space="preserve">
     <value>Użyj tego adresu URL, aby bezpośrednio uzyskiwać dostęp do swojej definicji interfejsu API i importować ją do narzędzi innych firm </value>
@@ -1676,7 +1934,7 @@ Ustaw wartość „Zewnętrzny adres URL”, aby użyć definicji interfejsu API
     <value>Tylko do odczytu</value>
   </data>
   <data name="appFunctionSettings_readWriteMode" xml:space="preserve">
-    <value>Odczyt\zapis</value>
+    <value>Odczyt/zapis</value>
   </data>
   <data name="validation_duplicateError" xml:space="preserve">
     <value>Zduplikowane wartości są niedozwolone</value>
@@ -1704,6 +1962,9 @@ Ustaw wartość „Zewnętrzny adres URL”, aby użyć definicji interfejsu API
   </data>
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>Twoja aplikacja jest obecnie w trybie Odczyt\zapis, ponieważ masz ustawiony tryb edycji Odczyt\zapis mimo włączonej kontroli źródła. Wszelkie wprowadzone zmiany mogą zostać zastąpione kolejnym wdrożeniem. Aby zmienić tryb edycji, odwiedź </value>
+  </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>Twoja aplikacja jest obecnie w trybie tylko do odczytu, ponieważ opublikowano wygenerowany plik function.json. Zmiany wprowadzone w pliku function.json nie będą uznawane przez środowisko uruchomieniowe usługi Functions.</value>
   </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>Kopiuj</value>
@@ -1748,10 +2009,22 @@ Ustaw wartość „Zewnętrzny adres URL”, aby użyć definicji interfejsu API
     <value>Miejsca (wersja zapoznawcza)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>Włącz miejsca wdrożenia (wersja zapoznawcza). Jest to jednorazowa zgoda na uczestnictwo na poziomie aplikacji funkcji, której nie można wyłączyć i która powoduje zresetowanie wszystkich już istniejących kluczy tajnych. Po aktualizacji klucze tajne można skopiować w obszarze </value>
+    <value>Włącz miejsca wdrożenia (wersja zapoznawcza).</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>Węzeł „Zarządzanie” dla poszczególnych funkcji.</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>Znane problemy:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>Integracja aplikacji logiki z usługą Functions nie działa, gdy miejsca wdrożenia (wersja zapoznawcza) są włączone.</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>Włączenie tej funkcji w wersji zapoznawczej spowoduje zresetowanie wszystkich już istniejących kluczy tajnych. Klucze tajne usługi Functions można znaleźć w węźle</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>„Zarządzanie”</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>dla poszczególnych funkcji.</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>Nazwa</value>
@@ -1790,7 +2063,7 @@ Ustaw wartość „Zewnętrzny adres URL”, aby użyć definicji interfejsu API
     <value>Miejsca (wersja zapoznawcza)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>Aby skorzystać z bogatszego środowiska monitorowania, w tym metryk na żywo i zapytań niestandardowych, zalecamy użycie usługi &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights&lt;/a&gt;.</value>
+    <value>Aby skorzystać z bogatszego środowiska monitorowania, w tym metryk na żywo i zapytań niestandardowych, &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;włącz usługę Application Insights dla swojej aplikacji funkcji&lt;/a&gt;</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>Ta wartość zostanie dołączona do głównego adresu URL aplikacji sieci Web i będzie służyć jako publiczny adres miejsca. Jeśli na przykład aplikacja sieci Web nazywa się „contoso”, a nazwa miejsca to „staging”, adres URL nowego miejsca będzie mieć postać „http://contoso-staging.azurewebsites.net”.</value>
@@ -1803,6 +2076,9 @@ Ustaw wartość „Zewnętrzny adres URL”, aby użyć definicji interfejsu API
   </data>
   <data name="new_" xml:space="preserve">
     <value>Nowy</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
+    <value>Utwórz nowy</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
     <value>Usuwanie funkcji</value>
@@ -1878,5 +2154,308 @@ Ustaw wartość „Zewnętrzny adres URL”, aby użyć definicji interfejsu API
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>Zawartość i projekt programu Visual Studio</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>pobierz</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>Usuń serwer proxy</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>Nowy serwer proxy</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>Bez przesłaniania</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>Ekspresowa rejestracja w usłudze AAD</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>create</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>Po utworzeniu funkcji należy dodać subskrypcję siatki zdarzeń.</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>Adres URL subskrypcji siatki zdarzeń</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>Adres URL subskrypcji siatki zdarzeń</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>Zarządzaj subskrypcjami siatki zdarzeń</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>Dodaj subskrypcję siatki zdarzeń</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>Wszystkie lokalizacje</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>Lokalizacje: {0}</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>Lokalizacja:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>Grupuj według lokalizacji</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>Brak grupowania</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>Grupuj według grupy zasobów</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>Grupuj według subskrypcji</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>Południowo-środkowe stany USA</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>Europa Północna</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>Europa Zachodnia</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>Azja Południowo-Wschodnia</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>Korea Środkowa</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>Korea Południowa</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>Zachodnie stany USA</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>Wschodnie stany USA</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>Japonia Zachodnia</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>Japonia Wschodnia</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>Azja Wschodnia</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>Wschodnie stany USA 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>Północno-środkowe stany USA</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>Środkowe stany USA</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>Brazylia Południowa</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>Australia Wschodnia</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>Indie Zachodnie</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>Indie Środkowe</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>Indie Południowe</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>Kanada Środkowa</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>Kanada Wschodnia</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>Zachodnio-środkowe stany USA</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>Zjednoczone Królestwo (zachód)</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>Zjednoczone Królestwo (południe)</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>Zachodnie stany USA 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>Wszystkie grupy zasobów</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>Grupa zasobów:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>Grupy zasobów: {0}</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>Treść</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>Kod stanu</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>Komunikat o stanie</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>Przesłonięcie żądania</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>Przesłonięcie odpowiedzi</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>Opcjonalnie</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>Korzystasz z wersji wstępnej usługi Azure Functions. Dziękujemy za wypróbowanie jej!</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>Kliknij, aby ukryć</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>Dzięki aplikacjom Logic Apps możesz łatwo korzystać ze swojej funkcji na różnych platformach</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>Aplikacje logiki</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>Skojarzone aplikacje Logic Apps</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>Organizuj przy użyciu aplikacji Logic Apps</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>Utwórz aplikacje Logic Apps</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>Brak aplikacji Logic Apps do wyświetlenia</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>Aplikacje logiki</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>Dzięki aplikacjom Logic Apps możesz szybko tworzyć integracje z aplikacjami SaaS i aplikacjami przedsiębiorstwa oraz wizualnie projektować procesy i przepływy pracy.</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>Rozwiń lub zwiń</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>Uwierzytelnianie/autoryzacja usługi App Service:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>Skonfiguruj usługę AAD teraz</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>Dodaj uprawnienia teraz</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>skonfigurowano</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>Wymagania dotyczące tożsamości (niespełnione)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>nie skonfigurowano</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>Wymagane uprawnienia</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>Szablon wymaga następującego uprawnienia:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>Ta integracja wymaga konfiguracji usługi AAD dla aplikacji funkcji.</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>Ten szablon wymaga konfiguracji usługi AAD dla aplikacji funkcji.</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>Może być konieczne skonfigurowanie dodatkowych uprawnień wymaganych przez funkcję. Zajrzyj do dokumentacji, aby uzyskać więcej informacji o tym powiązaniu.</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>Zarządzaj uwierzytelnianiem/autoryzacją usługi App Service</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>Wymagana konfiguracja uwierzytelniania</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>Wymagania dotyczące tożsamości</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>Zarządzaj</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>Nie możemy uzyskać listy zainstalowanych rozszerzeń środowiska uruchomieniowego</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Nie możemy zainstalować rozszerzenia środowiska uruchomieniowego {{extensionId}}</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Nie możemy odinstalować rozszerzenia środowiska uruchomieniowego {{extensionId}}</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>Instalowanie rozszerzeń środowiska uruchomieniowego trwa dłużej niż oczekiwano</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>Rozszerzenie {{extensionId}} o innej wersji jest już zainstalowane</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>Otwórz usługę Application Insights</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>Usługa App Insights została włączona dla Twojej funkcji.</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>Brak danych monitorowania do wyświetlenia</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>Zainstaluj</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>Instalacja rozszerzenia została pomyślnie zakończona</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>Rozszerzenia niezainstalowane</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>Ta integracja wymaga następujących rozszerzeń.</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>Ten szablon wymaga następujących rozszerzeń.</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>Instalowanie wymaganych rozszerzeń. Ta operacja może potrwać do 10 minut.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>Nie możemy zainstalować rozszerzenia środowiska uruchomieniowego. Identyfikator instalacji: {{installationId}}</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>Wprowadź wartość w GB/s</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>Połączenie</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>Centrum powiadomień</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>Funkcje języka Java można tworzyć, testować i wdrażać lokalnie z komputera. Portal nie jest potrzebny!</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>Kliknij poniżej, aby rozpocząć pracę z dokumentacją dotyczącą tworzenia pierwszej funkcji platformy Azure w języku Java.</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>Serwery proxy został włączony. Aby ponownie go wyłączyć, usuń lub wyłącz wszystkie poszczególne serwery proxy.</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Język Java w usłudze Azure Functions — Szybki start</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/pt-BR/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/pt-BR/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>Configurar</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>Upgrade to enable</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>Selecionar tudo</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>Todos os itens selecionados</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>{0} itens selecionados</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>Erro na Criação da Função: {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>Escolha um modelo abaixo ou</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>Choose a plan below to create new subscription</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>Provide a friendly subscription name</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>Friendly subscription name</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>Invitation code</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>Este modelo é experimental e ainda não tem suporte completo. Se tiver problemas, registre um bug no nosso &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;repositório GitHub.&lt;/a&gt;</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>Salvar</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>A save operation is currently in progress.  Navigating away may cause some changes to be lost.</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ Adicionar nova configuração</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ Adicionar nova cadeia de conexão</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ Adicionar novo documento</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ Adicionar novo mapeamento de manipulador</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ Adicionar novo diretório ou aplicativo virtual</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>Insira um nome</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>Digite um valor</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>Inserir extensão</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>Inserir processador de script</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>Inserir argumentos</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>Inserir caminho virtual</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>Inserir caminho físico</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>Aplicativo</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>Configuração do Slot</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>Valor oculto.  Clique para mostrar.</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>Pesquisar</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>Escopo para este item</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>Procurar recursos</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>Aplicativos de Função de pesquisa</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>ID da Assinatura</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>Habilitada</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>desabilitar</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>habilitado</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>aqui</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>Erro de configuração de análise: {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>Falha em função {{state}}: {{functionName}}</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>Recursos</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>Editor padrão</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>Excluir Função {{name}}</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>Tem certeza de que deseja excluir a Função {{name}}?</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>Proxies (visualização)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>Versão de tempo de execução do proxy: {{extensionVersion}}. Uma versão mais recente está disponível ({{latestExtensionVersion}}).</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>Versão de tempo de execução do proxy: última versão ({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>Habilitar os Proxies do Azure Functions (visualização)</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>Os Proxies do Azure Functions estão atualmente desabilitados. Para habilitar, acesse</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>As alterações feitas ao proxy {{name}} serão perdidas. Tem certeza de que deseja continuar?</value>
@@ -967,7 +1033,7 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Os slots (visualização) de funções do Azure estão desabilitados. Para habilitar, visite</value>
   </data>
-  <data name="discrard" xml:space="preserve">
+  <data name="discard" xml:space="preserve">
     <value>Descartar</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
@@ -983,7 +1049,7 @@
     <value>Entrar com o Google</value>
   </data>
   <data name="intro_signInWithMicrosoft" xml:space="preserve">
-    <value>Entre com Microsoft</value>
+    <value>Entrar com a conta da Microsoft</value>
   </data>
   <data name="apiProxy_backanrUrlStart" xml:space="preserve">
     <value>O URL do back-end deve começar com 'http://' ou 'https://'</value>
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>Todas as assinaturas</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>Assinaturas</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>{0} assinaturas</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>Links rápidos para seus recursos serão exibidos aqui depois que você os tiver configurado na guia "Recursos de plataforma" acima.</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>As alterações não salvas para o aplicativo '{0}' serão perdidas.  Tem certeza de que deseja continuar?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>Ocorreu um erro ao recuperar as informações sobre o aplicativo '{0}'</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>Este recurso não tem suporte para aplicativos em um Plano de consumo</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>Este recurso não oferece suporte para slots</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Este recurso não é compatível com aplicativos Linux</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>Você deve ter permissões de gravação no aplicativo atual para usar este recurso</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>Explore o sistema de arquivos de seu aplicativo a partir de um console interativo com base na Web.</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>O SSH fornece uma experiência de console SSH da Web para seu código de aplicativo Linux</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>Extensões</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>As extensões adicionam funcionalidade a todo o seu aplicativo.</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(não há configurações do aplicativo para exibir)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(não há cadeias de conexão para exibir)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(não há documentos padrão para exibir)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(não há mapeamentos de manipulador para exibir)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(não há aplicativos virtuais ou diretórios para exibir)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>Configurações gerais</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>Troca Automática</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>Depuração</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>Tempo de Execução</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>Configurações do aplicativo</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>Gerenciar configurações do aplicativo, cadeias de conexão, configurações de tempo de execução, e muito mais.</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>Documentos padrão</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>Mapeamentos do manipulador</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>Diretórios e aplicativos virtuais</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>Você deve ter permissões de gravação no aplicativo atual para editar essas configurações.</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>Este aplicativo possui um bloqueio somente leitura que impede a edição de configurações ou a recuperação de dados seguros. Remova o bloqueio e tente novamente.</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>Exibir configurações no modo somente leitura.</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>Falha ao carregar configurações.</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>Carregando...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>Atualizando configurações do aplicativo Web</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>Configurações do aplicativo Web atualizadas com êxito</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>Falha ao atualizar configurações do aplicativo Web: </value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>{{configGroupName}} Erro ao salvar: entrada inválida fornecida.</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>Versão do .NET Framework</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>A versão usada para executar seu aplicativo Web se for utilizado .NET Framework</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>Versão do PHP</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>A versão usada para executar seu aplicativo Web se for utilizado PHP</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Versão do Python</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>A versão usada para executar seu aplicativo Web se for utilizado Python</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Versão Java</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>A versão usada para executar seu aplicativo Web se for utilizado Java</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Versão secundária do Java</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>Selecione a versão secundária do Java desejada. Selecionar 'Mais recente' manterá o aplicativo usando o mais recente JVM adicionado ao portal.</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Contêiner da Web</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>A versão do contêiner da Web usada para executar seu aplicativo Web se for utilizado Java</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>Plataforma</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>A arquitetura da plataforma na qual seu aplicativo Web é executado</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>64-bit configuration requires a basic or higher App Service plan</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Soquetes Web</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>Os WebSockets permitem uma conectividade mais flexível entre aplicativos Web e navegadores modernos. Para aproveitar esses recursos, seu aplicativo Web precisaria ser compilado.</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>Sempre Ativo</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>Indica que seu aplicativo Web precisa ser carregado o tempo todo. Por padrão, os aplicativos Web são descarregados depois que ficam ociosos. É aconselhável habilitar essa opção quando você tiver trabalhos Web contínuos executados no aplicativo Web.</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>Always on requires a basic or higher App Service plan</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>Versão do Pipeline Gerenciada</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>Os destinos de troca automática não podem ser configurados no slot de produção</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>Troca Automática</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>Slot de Troca Automática</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>Afinidade ARR</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>Depuração remota</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>Versão do Remote Visual Studio</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>Pilha</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>Arquivo de Inicialização</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>Mais Novo</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32 bits</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64 bits</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>Clássico</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>Integrado</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>Propriedades</value>
@@ -1220,7 +1469,7 @@
     <value>Exibir todas as configurações do Serviço de Aplicativo.</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>Gerencie configurações que afetam o tempo de execução para todas as funções no seu aplicativo.</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>Configurações Gerais</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>Use a Autenticação/Autorização para proteger seu aplicativo e trabalhar com dados por usuário.</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>Identidade de serviço gerenciada</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>Seu aplicativo pode se comunicar com outros serviços do Azure usando uma identidade gerenciada do Azure Active Directory.</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>Notificações por push</value>
@@ -1379,10 +1634,13 @@
     <value>Configurações</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>Configurações do aplicativo de funções</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>Configuração</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>Configurações do aplicativo</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>O gerenciamento de seu aplicativo de Função não está disponível para esta avaliação.</value>
@@ -1574,7 +1832,7 @@
     <value>Verifique nosso tutorial de introdução</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>Função</value>
+    <value>Função (versão prévia)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>Chave de definição da API</value>
@@ -1586,7 +1844,7 @@
     <value>Gerar modelo de definição de API</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>Exportar para Power Apps + Flow</value>
+    <value>Exportar para o PowerApps + Flow</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
     <value>Não é possível salvar a definição de API mal formada.</value>
@@ -1613,7 +1871,7 @@
     <value>Use sua definição de API</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>Definição de API (visualização)</value>
+    <value>Definição de API</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>Não é possível criar ou atualizar a chave swaggerdocumentationkey para o Ponto de Extremidade do Swagger. Verifique os logs do tempo de execução para verificar se há erros ou tente novamente mais tarde.</value>
@@ -1676,7 +1934,7 @@ Defina como "URL Externa" para usar uma definição de API hospedada em outro lo
     <value>Somente Leitura</value>
   </data>
   <data name="appFunctionSettings_readWriteMode" xml:space="preserve">
-    <value>Leitura\Gravação</value>
+    <value>Leitura/Gravação</value>
   </data>
   <data name="validation_duplicateError" xml:space="preserve">
     <value>Os valores duplicados não são permitidos</value>
@@ -1704,6 +1962,9 @@ Defina como "URL Externa" para usar uma definição de API hospedada em outro lo
   </data>
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>Atualmente, seu aplicativo está no modo leitura\gravação porque você definiu o modo de edição como leitura\gravação apesar de não ter o controle do código-fonte habilitado. Quaisquer alterações feitas podem ser substituídas em sua próxima implantação. Para alterar o modo de edição, visite </value>
+  </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>Atualmente, seu aplicativo está no modo somente leitura porque você publicou um function.json gerado. As alterações feitas em function.json não serão respeitadas pelo tempo de execução das Funções. </value>
   </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>Copiar</value>
@@ -1748,10 +2009,22 @@ Defina como "URL Externa" para usar uma definição de API hospedada em outro lo
     <value>Slots (visualização)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>Habilitar slots de implantação (visualização). Esta é uma aceitação única no nível do Aplicativo de Função que não pode ser desabilitada e que habilitará os segredos pré-existentes. Após a atualização, os segredos poderão ser copiados de </value>
+    <value>Habilite os slots de implantação (visualização).</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>'Gerenciar' nó para cada função.</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>problemas conhecidos:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>A integração de aplicativos de lógica com funções não funciona quando Slots(preview) está ativado.</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>Optar por esta versão prévia do recurso redefinirá todos os segredos pré-existentes. Os segredos de função podem ser encontrados em</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>'Gerenciar'</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>nó para cada função.</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>Nome</value>
@@ -1790,7 +2063,7 @@ Defina como "URL Externa" para usar uma definição de API hospedada em outro lo
     <value>Slots (visualização)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>Para obter uma experiência de monitoramento mais rica, incluindo métricas em tempo real e consultas personalizadas, recomendamos o uso do &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights.&lt;/a&gt;</value>
+    <value>Para obter uma experiência de monitoramento mais rica, incluindo métricas em tempo real e consultas personalizadas, &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;habilite o Application Insights para seu aplicativo de Funções.&lt;/a&gt;</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>Este valor será acrescentado à URL de seu aplicativo Web principal e funcionará como o endereço público do slot. Por exemplo, se você tiver um aplicativo Web chamado 'contoso' e um slot chamado 'staging', o novo slot terá uma URL do tipo 'http://contoso-staging.azurewebsites.net'.</value>
@@ -1803,6 +2076,9 @@ Defina como "URL Externa" para usar uma definição de API hospedada em outro lo
   </data>
   <data name="new_" xml:space="preserve">
     <value>Novo</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
+    <value>Criar novo</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
     <value>Excluir função</value>
@@ -1878,5 +2154,308 @@ Defina como "URL Externa" para usar uma definição de API hospedada em outro lo
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>Conteúdo e projeto do Visual Studio</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>recuperar</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>Excluir proxy</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>Novo proxy</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>Sem substituições</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>Registro do Express AAD</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>criar</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>É necessário adicionar a assinatura da Grade de Eventos após a criação da função.</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>URL de Assinatura da Grade de Eventos</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>URL de Assinatura da Grade de Eventos</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>Gerenciar assinaturas da Grade de Eventos</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>Adicionar assinatura da Grade de Eventos</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>Todos os locais</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>{0} locais</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>Local:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>Agrupar por local</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>Nenhum agrupamento</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>Agrupar por grupo de recursos</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>Agrupar por assinatura</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>Centro-Sul dos EUA</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>Norte da Europa</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>Oeste da Europa</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>Sudeste da Ásia</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>Centro da Coreia</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>Sul da Coreia</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>Oeste dos EUA</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>Leste dos EUA</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>Oeste do Japão</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>Leste do Japão</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>Leste da Ásia</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>Leste dos EUA 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>Centro-Norte dos EUA</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>Centro dos EUA</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>Sul do Brasil</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>Leste da Austrália</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>Índia Ocidental</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>Índia Central</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>Sul da Índia</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>Central do Canadá</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>Leste do Canadá</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>Centro-oeste dos EUA</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>Oeste do Reino Unido</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>Sul do Reino Unido</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>Oeste dos EUA 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>Todos os grupos de recursos</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>Grupo de Recursos:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>{0} grupos de recursos</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>Corpo</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>Código de status</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>Mensagem de status</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>Substituição da solicitação</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>Substituição da resposta</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>Opcional</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>Você está usando um pré-lançamento do Azure Functions. Obrigado por experimentar!</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>Clique para ocultar</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>Logic Apps allow you to easily utilize your function across multiple platforms</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>Aplicativos Lógicos</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>Associated Logic Apps</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>Orchestrate with Logic Apps</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>Create Logic Apps</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>No Logic Apps to display</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>Aplicativos Lógicos</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>Logic Apps lets you quickly build integrations with SaaS and Enterprise apps, as well as visually design processes and workflows.</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>Expandir ou Recolher</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>Autenticação/Autorização do Serviço de Aplicativo:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>Configurar o AAD agora</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>Adicionar permissões agora</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>configurado</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>Requisitos de identidade (não atendidos)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>Não configurado</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>Permissões necessárias</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>O modelo precisa da seguinte permissão:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>Esta integração requer uma configuração do AAD para o aplicativo de funções.</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>Este modelo requer uma configuração do AAD para o aplicativo de funções.</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>Talvez seja necessário configurar permissões adicionais solicitadas por sua função. Confira a documentação para esta associação.</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>Gerenciar Autenticação/Autorização do Serviço de Aplicativo</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>Configuração de autenticação necessária</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>Requisitos de identidade</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>Gerenciar</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>Não foi possível obter a lista de extensões de tempo de execução instaladas</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Não foi possível instalar a extensão de tempo de execução {{extensionId}}</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Não foi possível desinstalar a extensão de tempo de execução {{extensionId}}</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>A instalação de extensões de tempo de execução está demorando mais do que o esperado</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>Já está instalada a extensão {{extensionId}} com uma versão diferente</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>Abrir Application Insights</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>O App Insights está habilitado para sua função.</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>Não há dados de Monitoramento a serem exibidos</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>Instalar</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>Instalação da Extensão Bem-Sucedida</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>Extensões não Instaladas</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>Esta integração requer as seguintes extensões.</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>Este modelo requer as seguintes extensões.</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>Instalando as extensões necessárias. Esta operação pode levar até 10 minutos.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>Não foi possível instalar a extensão de tempo de execução. Instale a ID {{installationId}}</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>Inserir valor em GB-s</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>Conexão</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>Hub de Notificação</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>As Funções do Java podem ser criadas, testadas e implantadas localmente a partir de seu computador. Nenhum portal necessário!</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>Clique abaixo para começar a ler a documentação sobre como criar sua primeira Função do Azure com Java.</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>Os proxies foram habilitados. Para desabilitá-los novamente, apague ou desabilite todos os proxies individuais.</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Java no início rápido do Azure Functions</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/pt-PT/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/pt-PT/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>Configurar</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>Upgrade to enable</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>Seleccionar tudo</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>Todos os itens selecionados</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>{0} itens selecionados</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>Erro ao Criar Função: {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>Escolha um modelo abaixo ou</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>Choose a plan below to create new subscription</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>Provide a friendly subscription name</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>Friendly subscription name</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>Invitation code</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>Este modelo é experimental e ainda não tem suporte completo. Se tiver problemas, arquive um erro no nosso &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;repositório do GitHub.&lt;/a&gt;</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>Guardar</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>A save operation is currently in progress.  Navigating away may cause some changes to be lost.</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ Adicionar nova definição</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ Adicionar nova cadeia de ligação</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ Adicionar novo documento</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ Adicionar novo mapeamento do processador</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ Adicionar nova aplicação virtual ou diretório</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>Introduzir um nome</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>Introduzir um valor</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>Introduzir extensão</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>Introduzir o processador de scripts</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>Introduzir argumentos</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>Introduzir o caminho virtual</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>Introduzir o caminho físico</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>Aplicação</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>Definição de Ranhura</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>Valor oculto.  Clique para mostrar.</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>Pesquisar</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>Âmbito para este item</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>Procurar funcionalidades</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>Procurar aplicações de Função</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>ID da Subscrição</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>Ativado</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>desativar</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>enabled</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>aqui</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>Erro ao analisar configuração: {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>Falha na função {{state}}: {{functionName}}</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>Funcionalidades</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>Editor padrão</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>Eliminar Função {{name}}</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>Tem a certeza de que quer eliminar a Função {{name}}?</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>Proxies (pré-visualização)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>Versão runtime do proxy: {{extensionVersion}}. Está disponível uma versão mais recente ({{latestExtensionVersion}}).</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>Versão runtime do proxy: mais recente ({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>Ativar Proxies das Funções do Azure (pré-visualização)</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>Os Proxies das Funções do Azure estão atualmente desativados. Para ativar, visite</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>As alterações realizadas no proxy {{name}} serão perdidas. Quer mesmo continuar?</value>
@@ -967,7 +1033,7 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>As ranhuras de funções do Azure (pré-visualização) estão atualmente desativadas. Para ativar, visite</value>
   </data>
-  <data name="discrard" xml:space="preserve">
+  <data name="discard" xml:space="preserve">
     <value>Eliminar</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>Todas as subscrições</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>Subscrições</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>{0} subscrições</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>As ligações rápidas para as suas funcionalidades vão ser apresentadas aqui depois de as configurar a partir do separador "Funcionalidades de plataforma" acima.</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>As alterações não guardadas para a aplicação "{0}" serão perdidas.  Quer mesmo continuar?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>Ocorreu um erro ao obter as informações sobre a aplicação "{0}"</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>Esta funcionalidade não é suportada para aplicações num plano de Consumo</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>Esta funcionalidade não é suportada para ranhuras</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Esta funcionalidade não é suportada para aplicações Linux</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>Tem de ter permissões de escrita na aplicação atual para utilizar esta funcionalidade</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>Explore o sistema de ficheiros de aplicações a partir de uma consola interativa baseada na Web.</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>O SSH fornece uma experiência de consola SSH Web para o código de aplicação Linux</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>Extensões</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>As extensões adicionam funcionalidade à aplicação inteira.</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(não existem definições de aplicação para apresentar)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(não existem cadeias de ligação para apresentar)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(não existem documentos predefinidos para apresentar)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(não existem mapeamentos do processador para apresentar)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(não existem aplicações virtuais ou diretórios para apresentar)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>Definições gerais</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>Troca Automática</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>A depurar</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>Runtime</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>Definições da aplicação</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>Gerir as definições, cadeias de ligação, definições de tempo de execução da aplicação e muito mais.</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>Documentos predefinidos</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>Mapeamentos de processador</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>Aplicações virtuais e diretórios</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>Tem de ter permissões de escrita na aplicação atual para editar estas definições.</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>Esta aplicação tem um bloqueio só de leitura que impede a edição das definições ou obtenção de dados protegidos. Remova o bloqueio e tente novamente.</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>Ver definições no modo só de leitura.</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>Falha ao carregar as definições.</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>A carregar...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>A atualizar as definições de aplicação Web</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>Definições de aplicação Web atualizadas com êxito</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>Falha ao atualizar as definições de aplicação Web: </value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>{{configGroupName}} Erro ao Guardar: entrada inválida fornecida.</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>Versão de .NET Framework</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>A versão utilizada para executar a aplicação Web se estiver a ser utilizado o .NET Framework</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>Versão de PHP</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>A versão utilizada para executar a aplicação Web se estiver a ser utilizada linguagem PHP</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Versão de Python</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>A versão utilizada para executar a aplicação Web se estiver a ser utilizada linguagem Python</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Versão de Java</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>A versão utilizada para executar a aplicação Web se estiver a ser utilizada linguagem Java</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Versão secundária de Java</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>Selecione a versão secundária do Java que deseja. Se selecionar "Recentes", a sua aplicação continuará a utilizar as JVM adicionadas ao portal mais recentemente.</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Contentor Web</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>A versão do contentor Web utilizada para executar a aplicação Web se estiver a ser utilizada linguagem Java</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>Plataforma</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>A arquitetura da plataforma em execução na sua aplicação Web</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>64-bit configuration requires a basic or higher App Service plan</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Sockets Web</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>Os WebSockets permitem uma conectividade mais flexível entre as aplicações Web e os browsers modernos. A aplicação Web teria de ser criada de modo a tirar partido destas capacidades.</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>Always On</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>Indica que a sua aplicação Web precisa de estar carregada de forma contínua. Por predefinição, as aplicações Web são descarregadas após terem estado inativas. Recomenda-se a ativação desta opção quando tiver WebJobs contínuos em execução na aplicação Web.</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>Always on requires a basic or higher App Service plan</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>Versão de Pipeline Gerido</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>Os destinos de troca automática não podem ser configurados a partir da ranhura de produção</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>Troca Automática</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>Ranhura de Troca Automática</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>Afinidade ARR</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>Depuração remota</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>Versão do Visual Studio Remoto</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>Pilha</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>Ficheiro de Arranque</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>Recentes</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32 bits</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64 bits</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>Clássico</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>Integrado</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>Propriedades</value>
@@ -1220,7 +1469,7 @@
     <value>Ver todas as definições do Serviço de Aplicações.</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>Gira as definições que afetam o runtime das Funções relativamente a todas as funções no âmbito da sua aplicação.</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>Definições Gerais</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>Utilize a Autenticação/Autorização para proteger a aplicação e o trabalho com dados por utilizador.</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>Identidade do serviço gerido</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>A aplicação pode comunicar com outros serviços do Azure em nome próprio utilizando uma identidade do Azure Active Directory gerida.</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>Notificações push</value>
@@ -1379,10 +1634,13 @@
     <value>Definições</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>Definições da aplicação de funções</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>Configuração</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>Definições da aplicação</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>Gerir a aplicação de Função não está disponível para esta versão de avaliação.</value>
@@ -1574,7 +1832,7 @@
     <value>Consulte o nosso tutorial de introdução</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>Função</value>
+    <value>Função (pré-visualização)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>Chave de definição de API</value>
@@ -1586,7 +1844,7 @@
     <value>Gerar modelo de definição de API</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>Exportar para o Power Apps + Flow</value>
+    <value>Exportar para PowerApps + Flow</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
     <value>Não é possível guardar definição de API danificada.</value>
@@ -1613,7 +1871,7 @@
     <value>Utilize a sua definição de API</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>Definição de API (pré-visualização)</value>
+    <value>Definição API</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>Não foi possível criar ou atualizar a chave swaggerdocumentationkey para o Ponto Final de Swagger. Verifique os registos de tempo de execução para quaisquer erros e tente novamente mais tarde.</value>
@@ -1653,11 +1911,11 @@
 Preencha nos &lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;objetos de operação&lt;/a&gt;, e outras informações sobre a API antes de utilizar.</value>
   </data>
   <data name="swaggerDefinition_keyHelp" xml:space="preserve">
-    <value>Esta chave protege a Definição de API do acesso a qualquer pessoa sem chave. 
+    <value>Esta chave protege a Definição de API do acesso a qualquer pessoa sem chave.
 Não protege a API subjacente. Veja cada Função para ver a respetiva segurança de chaves.</value>
   </data>
   <data name="swaggerDefinition_sourceHelp" xml:space="preserve">
-    <value>Defina como "Função" para ativar uma definição de API alojada e a geração da definição de modelo.
+    <value>Defina como "Função" para ativar uma definição de API alojada e a geração da definição de modelo.
 Defina para "URL Externo" para utilizar uma definição de API que está alojada noutro local.</value>
   </data>
   <data name="swaggerDefinition_urlHelp" xml:space="preserve">
@@ -1676,7 +1934,7 @@ Defina para "URL Externo" para utilizar uma definição de API que está alojada
     <value>Só de Leitura</value>
   </data>
   <data name="appFunctionSettings_readWriteMode" xml:space="preserve">
-    <value>Leitura\Escrita</value>
+    <value>Leitura/Escrita</value>
   </data>
   <data name="validation_duplicateError" xml:space="preserve">
     <value>Não são permitidos valores duplicados</value>
@@ -1704,6 +1962,9 @@ Defina para "URL Externo" para utilizar uma definição de API que está alojada
   </data>
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>A aplicação está atualmente no modo de leitura\escrita porque definiu o modo de edição para leitura\escrita mesmo tendo o controlo de origem ativado. Quaisquer alterações que efetue podem ser substituídas pela próxima implementação. Para alterar o modo de edição visite </value>
+  </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>De momento, a sua aplicação está em modo só de leitura porque publicou um function.json gerado. As alterações realizadas a function.json não serão respeitadas pelo runtime das Funções. </value>
   </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>Copiar</value>
@@ -1748,10 +2009,22 @@ Defina para "URL Externo" para utilizar uma definição de API que está alojada
     <value>Ranhuras (pré-visualização)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>Ative as ranhuras de implementação (pré-visualização). Esta é uma opção ativa de participação na aplicação de Função que não pode ser desativada e serão repostos quaisquer segredos já existentes. Após a atualização, os segredos podem ser copiados sob o</value>
+    <value>Ativar ranhuras de implementação (pré-visualização).</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>Nó de "Gerir" para cada função.</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>Problemas conhecidos:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>A integração de aplicações lógicas nas Funções não funciona quando as Ranhuras (pré-visualização) estão ativadas.</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>Optar por esta funcionalidade de pré-visualização irá repor todos os segredos já existentes. Pode encontrar os segredos da função em</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>"Gerir"</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>o nó para cada função.</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>Nome</value>
@@ -1790,7 +2063,7 @@ Defina para "URL Externo" para utilizar uma definição de API que está alojada
     <value>Ranhuras (pré-visualização)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>Para uma melhor experiência de monitorização, incluindo métricas dinâmicas e consultas personalizadas, recomendamos que utilize o &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Application Insights do Azure.&lt;/a&gt;</value>
+    <value>Para uma melhor experiência de monitorização, incluindo métricas dinâmicas e consultas personalizadas, &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt; ative o Application Insights para a Aplicação de Funções.&lt;/a&gt;</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>Este valor será anexado ao URL da principal aplicação Web e funcionará como endereço público da ranhura. Por exemplo, se tiver uma aplicação Web com o nome "contoso" e uma ranhura denominada "testes", a nova ranhura terá um URL como o que se segue: "http://contoso-staging.azurewebsites.net".</value>
@@ -1803,6 +2076,9 @@ Defina para "URL Externo" para utilizar uma definição de API que está alojada
   </data>
   <data name="new_" xml:space="preserve">
     <value>Nova</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
+    <value>Criar novo</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
     <value>Eliminar função</value>
@@ -1878,5 +2154,308 @@ Defina para "URL Externo" para utilizar uma definição de API que está alojada
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>Conteúdo e projeto do Visual Studio</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>obter</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>Eliminar proxy</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>Novo proxy</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>Sem substituição</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>Registo rápido de AAD</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>criar</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>Tem de adicionar a subscrição do Event Grid depois da criação da função.</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>URL da Subscrição de Grelha do Evento</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>URL da Subscrição de Grelha do Evento</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>Gerir subscrições do Event Grid</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>Adicionar subscrição do Event Grid</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>Todas as localizações</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>{0} localizações</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>Localização:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>Agrupar por localização</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>Sem agrupamento</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>Agrupar por grupo de recurso</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>Agrupar por subscrição</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>E.U.A. Centro-Sul</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>Europa do Norte</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>Europa Ocidental</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>Sudeste Asiático</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>Coreia Central</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>Sul da Coreia</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>E.U.A. Oeste</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>E.U.A. Leste</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>Oeste do Japão</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>Leste do Japão</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>Ásia Oriental</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>E.U.A. Leste 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>E.U.A. Centro-Norte</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>Centro dos E.U.A.</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>Sul do Brasil</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>Leste da Austrália</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>Índia Ocidental</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>Índia Central</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>Sul da Índia</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>Canadá Central</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>Leste do Canadá</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>Centro Oeste dos E.U.A </value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>Oeste do R.U.</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>Sul do R.U.</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>Oeste dos E.U.A 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>Todos os grupos de recursos</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>Grupo de Recursos:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>{0} grupos de recursos</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>Corpo</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>Código de estado</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>Mensagem de estado</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>Substituição do pedido</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>Substituição de resposta</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>Opcional</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>Está a utilizar uma versão de pré-lançamento das Funções do Azure. Obrigado por experimentar!</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>Clique para ocultar</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>Logic Apps allow you to easily utilize your function across multiple platforms</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>Associated Logic Apps</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>Orchestrate with Logic Apps</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>Create Logic Apps</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>No Logic Apps to display</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>Logic Apps lets you quickly build integrations with SaaS and Enterprise apps, as well as visually design processes and workflows.</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>Expandir ou Fechar</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>Autenticação/Autorização do serviço de aplicações:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>Configurar AAD agora</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>Adicionar permissões agora</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>configurado</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>Requisitos de identidade (não satisfeitos)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>não configurado</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>Permissões obrigatórias</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>O modelo necessita da seguinte permissão:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>Esta integração necessita uma configuração ADD para a aplicação de funções.</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>Este modelo necessita uma configuração ADD para a aplicação de funções.</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>Poderá ser necessário configurar as permissões adicionais que a função necessite. Veja a documentação para este enlace.</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>Autenticação/Autorização do Serviço de Aplicações de Gestão</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>Configuração de autenticação necessária</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>Requisitos de identidade</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>Gerir</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>Não foi possível obter a lista de extensões do runtime instaladas</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Não foi possível instalar a extensão do runtime {{extensionId}}</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Não foi possível desinstalar a extensão do runtime {{extensionId}}</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>A instalação das extensões do runtime está a demorar mais do que o esperado</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>A extensão {{extensionId}} com uma versão diferente já se encontra instalada</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>Abrir Application Insights</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>O App Insights está ativado para a função.</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>Nenhum dado de monitorização a apresentar</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>Instalar</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>Instalação da Extensão Efetuada com Êxito</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>Extensões não Instaladas</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>Esta integração precisa das seguintes extensões.</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>Este modelo necessita as seguintes extensões.</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>A instalar as extensões necessárias. Esta operação poderá demorar até 10 minutos.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>Não foi possível instalar a extensão do runtime. Instale o id {{installationId}}</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>Introduza o valor em GB/seg</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>Ligação</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>Hub de Notificação</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>Pode criar, testar e implementar Funções Java localmente a partir do seu computador. Não precisa do portal!</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>Clique abaixo para começar a trabalhar com documentação sobre como criar a sua primeira Função do Azure com Java.</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>Os proxies foram ativados. Para desativar novamente, elimine ou desative todos os proxies individuais.</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Início rápido sobre Java nas Funções do Azure</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/qps-ploc/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/qps-ploc/AzureFunctions/ResourcesPortal/Resources.resx
@@ -118,1765 +118,2344 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="azureFunctions" xml:space="preserve">
-    <value>[io2Ya][ÅÀAzure Functions !!! !!]</value>
+    <value>[io2Ya][ÊíAzure Functions !!! !!]</value>
   </data>
   <data name="azureFunctionsRuntime" xml:space="preserve">
-    <value>[P49PT][þÅAzure Functions Runtime !!! !!! !]</value>
+    <value>[P49PT][ÂñAzure Functions Runtime !!! !!! !]</value>
   </data>
   <data name="cancel" xml:space="preserve">
-    <value>[R71II][ìäCancel !!!]</value>
+    <value>[R71II][ÎÿCancel !!!]</value>
   </data>
   <data name="configure" xml:space="preserve">
-    <value>[oYutu][ÊúConfigure !!! ]</value>
+    <value>[oYutu][ÆÙConfigure !!! ]</value>
+  </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>[g957b][ÛëUpgrade to enable !!! !!!]</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>[t7Nlz][íÈSelect all !!! !]</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>[ZRG8G][ÉÜAll items selected !!! !!!]</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>[WLpTT][ªØ{0} items selected !!! !!!]</value>
   </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
-    <value>[17ym6][þìCreate Function Error: {{error}} !!! !!! !!! ]</value>
+    <value>[17ym6][õêCreate Function Error: {{error}} !!! !!! !!! ]</value>
   </data>
   <data name="functionCreateErrorMessage" xml:space="preserve">
-    <value>[S6XZZ][âøFunction creation error! Please try again. !!! !!! !!! !!! ]</value>
+    <value>[S6XZZ][ÐèFunction creation error! Please try again. !!! !!! !!! !!! ]</value>
   </data>
   <data name="functionDev_functionErrorDetails" xml:space="preserve">
-    <value>[3Qo2N][ÈÌFunction Error: {{error}} !!! !!! !!]</value>
+    <value>[3Qo2N][ÍùFunction Error: {{error}} !!! !!! !!]</value>
   </data>
   <data name="functionDev_functionErrorMessage" xml:space="preserve">
-    <value>[oR0Kt][ìþFunction (${{name}}) Error: {{error}} !!! !!! !!! !!]</value>
+    <value>[oR0Kt][äÐFunction (${{name}}) Error: {{error}} !!! !!! !!! !!]</value>
   </data>
   <data name="functionDev_functionUrl" xml:space="preserve">
-    <value>[z2m32][àùFunction Url !!! !]</value>
+    <value>[z2m32][ËÀFunction Url !!! !]</value>
   </data>
   <data name="functionDev_githubSelect" xml:space="preserve">
-    <value>[G33l1][ÿÒGitHub Secret !!! !!]</value>
+    <value>[G33l1][ñûGitHub Secret !!! !!]</value>
   </data>
   <data name="functionDev_hideFiles" xml:space="preserve">
-    <value>[hZWeI][¢ØHide files !!! !]</value>
+    <value>[hZWeI][ßüHide files !!! !]</value>
   </data>
   <data name="functionDev_hostErrorMessage" xml:space="preserve">
-    <value>[rzF0R][ÄßHost Error: {{error}} !!! !!! ]</value>
+    <value>[rzF0R][ûÉHost Error: {{error}} !!! !!! ]</value>
   </data>
   <data name="functionDev_Output" xml:space="preserve">
-    <value>[9j93r][õÂOutput !!!]</value>
+    <value>[9j93r][È¥Output !!!]</value>
   </data>
   <data name="functionDev_requestBody" xml:space="preserve">
-    <value>[DNy8f][þßRequest body !!! !]</value>
+    <value>[DNy8f][õóRequest body !!! !]</value>
   </data>
   <data name="functionDev_saveAndRun" xml:space="preserve">
-    <value>[pb8gF][ÕÿSave and run !!! !]</value>
+    <value>[pb8gF][öËSave and run !!! !]</value>
   </data>
   <data name="functionDev_status" xml:space="preserve">
-    <value>[wZz1H][¢ØStatus: !!!]</value>
+    <value>[wZz1H][ãØStatus: !!!]</value>
   </data>
   <data name="functionDev_viewFiles" xml:space="preserve">
-    <value>[4oKjj][ÆÖView files !!! !]</value>
+    <value>[4oKjj][üåView files !!! !]</value>
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
-    <value>[aVe0w][ÇÅChoose a template below or !!! !!! !!]</value>
+    <value>[aVe0w][úÐChoose a template below or !!! !!! !!]</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>[LdQUj][ùÇChoose a plan below to create new subscription !!! !!! !!! !!! !]</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>[qeek6][ÝïProvide a friendly subscription name !!! !!! !!! !!]</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>[Z0Xft][Ñ¢Friendly subscription name !!! !!! !!]</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>[fQmyD][Ø§Invitation code !!! !!]</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
-    <value>[oNfto][©ÊThis template is experimental and does not yet have full support. If you run into issues, please file a bug on our &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;GitHub repository.&lt;/a&gt; !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[oNfto][þñThis template is experimental and does not yet have full support. If you run into issues, please file a bug on our &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;GitHub repository.&lt;/a&gt; !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="functionNew_functionName" xml:space="preserve">
-    <value>[rtEBl][ÑÕFunction name !!! !!]</value>
+    <value>[rtEBl][ÿòFunction name !!! !!]</value>
   </data>
   <data name="functionNew_functionNameRequired" xml:space="preserve">
-    <value>[5Uup0][óÃA function name is required !!! !!! !!]</value>
+    <value>[5Uup0][ÈúA function name is required !!! !!! !!]</value>
   </data>
   <data name="functionNew_nameYourFunction" xml:space="preserve">
-    <value>[WF8As][ÚêName your function !!! !!!]</value>
+    <value>[WF8As][ÀÈName your function !!! !!!]</value>
   </data>
   <data name="gettingStarted_createGetStarted" xml:space="preserve">
-    <value>[D06QT][ãÚCreate + get started !!! !!! ]</value>
+    <value>[D06QT][ðéCreate + get started !!! !!! ]</value>
   </data>
   <data name="gettingStarted_functionApps" xml:space="preserve">
-    <value>[JzUDJ][ÂÆFunction Apps !!! !!]</value>
+    <value>[JzUDJ][òãFunction Apps !!! !!]</value>
   </data>
   <data name="gettingStarted_getStarted" xml:space="preserve">
-    <value>[vUqFJ][ÊñGet started with Azure Functions !!! !!! !!! ]</value>
+    <value>[vUqFJ][ÍâGet started with Azure Functions !!! !!! !!! ]</value>
   </data>
   <data name="gettingStarted_newFunctionApp" xml:space="preserve">
-    <value>[hnFfT][ùÇNew function app !!! !!!]</value>
+    <value>[hnFfT][¥ÊNew function app !!! !!!]</value>
   </data>
   <data name="gettingStarted_noFunApps" xml:space="preserve">
-    <value>[GIcnj][ì¢Your subscription contains no function apps. These are containers where your functions are executed. Create one now. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[GIcnj][ßèYour subscription contains no function apps. These are containers where your functions are executed. Create one now. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="gettingStarted_orCreate" xml:space="preserve">
-    <value>[Mi23r][ËÈOr create a function app from &lt;a href="https://portal.azure.com/#create/Microsoft.FunctionApp"&gt;Azure Portal&lt;/a&gt;. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[Mi23r][æÆOr create a function app from &lt;a href="https://portal.azure.com/#create/Microsoft.FunctionApp"&gt;Azure Portal&lt;/a&gt;. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="gettingStarted_selectLocation" xml:space="preserve">
-    <value>[Zm41F][ýÝSelect Location !!! !!]</value>
+    <value>[Zm41F][ÐÍSelect Location !!! !!]</value>
   </data>
   <data name="gettingStarted_selectSubscription" xml:space="preserve">
-    <value>[Qo5CI][ï©Select Subscription !!! !!! ]</value>
+    <value>[Qo5CI][îÊSelect Subscription !!! !!! ]</value>
   </data>
   <data name="gettingStarted_subIsNotWhitelisted" xml:space="preserve">
-    <value>[l0pIk][ûÄSubscription {{displayName}} ({{ subscriptionId }}) is not white listed for running functions !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[l0pIk][¥ÓSubscription {{displayName}} ({{ subscriptionId }}) is not white listed for running functions !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="gettingStarted_thisSub" xml:space="preserve">
-    <value>[z9IKp][ãßThis subscription contains one or more function apps. These are containers where your functions are executed. Select one or create a new one below. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[z9IKp][îÁThis subscription contains one or more function apps. These are containers where your functions are executed. Select one or create a new one below. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="gettingStarted_validateContainer1" xml:space="preserve">
-    <value>[u4WqF][ÄßThe name must be at least 2 characters !!! !!! !!! !!]</value>
+    <value>[u4WqF][ÂåThe name must be at least 2 characters !!! !!! !!! !!]</value>
   </data>
   <data name="gettingStarted_validateContainer2" xml:space="preserve">
-    <value>[IiOWb][ìòThe name must be at most 60 characters !!! !!! !!! !!]</value>
+    <value>[IiOWb][þÿThe name must be at most 60 characters !!! !!! !!! !!]</value>
   </data>
   <data name="gettingStarted_validateContainer3" xml:space="preserve">
-    <value>[2ldyz][ÅßThe name can contain letters, numbers, and hyphens (but the first and last character must be a letter or number) !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[2ldyz][ãáThe name can contain letters, numbers, and hyphens (but the first and last character must be a letter or number) !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="gettingStarted_validateContainer4" xml:space="preserve">
-    <value>[Cey3j][ÛÏfunction app name {{funcName}} isn't available !!! !!! !!! !!! !]</value>
+    <value>[Cey3j][Å§function app name {{funcName}} isn't available !!! !!! !!! !!! !]</value>
   </data>
   <data name="gettingStarted_youNeed" xml:space="preserve">
-    <value>[pMcuB][ÅÄYou need an Azure subscription in order to use this service. &lt;a href="https://azure.microsoft.com/en-us/free/"&gt;Click here&lt;/a&gt; to create a free trial subscription !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[pMcuB][àâYou need an Azure subscription in order to use this service. &lt;a href="https://azure.microsoft.com/en-us/free/"&gt;Click here&lt;/a&gt; to create a free trial subscription !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="gettingStarted_yourFunctionApps" xml:space="preserve">
-    <value>[6S9B6][äæYour function apps !!! !!!]</value>
+    <value>[6S9B6][ÆüYour function apps !!! !!!]</value>
   </data>
   <data name="gettingStarted_yourSubscription" xml:space="preserve">
-    <value>[6fq5Y][ÙØYour subscription !!! !!!]</value>
+    <value>[6fq5Y][ÐòYour subscription !!! !!!]</value>
   </data>
   <data name="createApp_description" xml:space="preserve">
-    <value>[rAfl6][ÄÖCreating a Function App will automatically provision a new container capable of hosting and running your code. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[rAfl6][ÉìCreating a Function App will automatically provision a new container capable of hosting and running your code. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="createApp_fail" xml:space="preserve">
-    <value>[5FLkV][ªªFailed to create app !!! !!! ]</value>
+    <value>[5FLkV][ÊÖFailed to create app !!! !!! ]</value>
   </data>
   <data name="intro_chooseLanguage" xml:space="preserve">
-    <value>[pcHSk][§Á2. Choose a language !!! !!! ]</value>
+    <value>[pcHSk][ÖÕ2. Choose a language !!! !!! ]</value>
   </data>
   <data name="intro_chooseScenario" xml:space="preserve">
-    <value>[cQIBg][ÀÝ1. Choose a scenario !!! !!! ]</value>
+    <value>[cQIBg][Ðï1. Choose a scenario !!! !!! ]</value>
   </data>
   <data name="intro_createThisFunction" xml:space="preserve">
-    <value>[2PwH3][©ÛCreate this function !!! !!! ]</value>
+    <value>[2PwH3][ÞÞCreate this function !!! !!! ]</value>
   </data>
   <data name="intro_createYourOwn" xml:space="preserve">
-    <value>[BxjYr][ÇÚcreate your own custom function !!! !!! !!! ]</value>
+    <value>[BxjYr][ÄÎcreate your own custom function !!! !!! !!! ]</value>
   </data>
   <data name="intro_customFunction" xml:space="preserve">
-    <value>[rQH0f][ßÐCustom function !!! !!]</value>
+    <value>[rQH0f][ìöCustom function !!! !!]</value>
   </data>
   <data name="intro_dataProcessing" xml:space="preserve">
-    <value>[q007q][Ü©Data processing !!! !!]</value>
+    <value>[q007q][æïData processing !!! !!]</value>
   </data>
   <data name="intro_or" xml:space="preserve">
-    <value>[6044v][ÛËor !!]</value>
+    <value>[6044v][òöor !!]</value>
   </data>
   <data name="intro_getStarted" xml:space="preserve">
-    <value>[AmEoC][æòGet started quickly with a premade function !!! !!! !!! !!! ]</value>
+    <value>[AmEoC][ÇÝGet started quickly with a premade function !!! !!! !!! !!! ]</value>
   </data>
   <data name="intro_getStartedOn" xml:space="preserve">
-    <value>[qgdAc][Å§Get started on your own !!! !!! !]</value>
+    <value>[qgdAc][ßßGet started on your own !!! !!! !]</value>
   </data>
   <data name="intro_keepUsingQuickstart" xml:space="preserve">
-    <value>[VOCqm][ÈïKeep using this quickstart !!! !!! !!]</value>
+    <value>[VOCqm][ÁõKeep using this quickstart !!! !!! !!]</value>
   </data>
   <data name="intro_ifYou" xml:space="preserve">
-    <value>[ym8CF][ªÄFor PowerShell, Python, and Batch, !!! !!! !!! !]</value>
+    <value>[ym8CF][¥ïFor PowerShell, Python, and Batch, !!! !!! !!! !]</value>
   </data>
   <data name="intro_startSC" xml:space="preserve">
-    <value>[UC498][öÞStart from source control !!! !!! !!]</value>
+    <value>[UC498][ûÃStart from source control !!! !!! !!]</value>
   </data>
   <data name="intro_timer" xml:space="preserve">
-    <value>[OwYIy][@¢Timer !!!]</value>
+    <value>[OwYIy][ÉÅTimer !!!]</value>
   </data>
   <data name="intro_webHook" xml:space="preserve">
-    <value>[hp33d][ÆðWebhook + API !!! !!]</value>
+    <value>[hp33d][ÁþWebhook + API !!! !!]</value>
   </data>
   <data name="logStreaming_clear" xml:space="preserve">
-    <value>[l94nS][ïÁClear !!!]</value>
+    <value>[l94nS][ÙöClear !!!]</value>
   </data>
   <data name="logStreaming_copied" xml:space="preserve">
-    <value>[9d0rU][ÖÓCopied! !!!]</value>
+    <value>[9d0rU][æáCopied! !!!]</value>
   </data>
   <data name="logStreaming_copyLogs" xml:space="preserve">
-    <value>[uRHXZ][©úCopy logs !!! ]</value>
+    <value>[uRHXZ][¥ÆCopy logs !!! ]</value>
   </data>
   <data name="logStreaming_pause" xml:space="preserve">
-    <value>[quafK][êÛPause !!!]</value>
+    <value>[quafK][ýÔPause !!!]</value>
   </data>
   <data name="logStreaming_start" xml:space="preserve">
-    <value>[512zy][ÀÅStart !!!]</value>
+    <value>[512zy][ùòStart !!!]</value>
   </data>
   <data name="logStreaming_tooManyLogs" xml:space="preserve">
-    <value>[MXQBR][ýÎToo many logs. Refresh rate: {{seconds}} seconds. !!! !!! !!! !!! !!]</value>
+    <value>[MXQBR][úÝToo many logs. Refresh rate: {{seconds}} seconds. !!! !!! !!! !!! !!]</value>
   </data>
   <data name="_name" xml:space="preserve">
-    <value>[cNops][Ç©Name !!]</value>
+    <value>[cNops][ÖîName !!]</value>
     <comment>Can't use "name" as key because typescript has own name property for the object</comment>
   </data>
   <data name="open" xml:space="preserve">
-    <value>[SUapk][ªÏOpen !!]</value>
+    <value>[SUapk][ÎïOpen !!]</value>
   </data>
   <data name="or" xml:space="preserve">
-    <value>[90m4i][óÙor !!]</value>
+    <value>[90m4i][øîor !!]</value>
   </data>
   <data name="readOnlySourceControlled" xml:space="preserve">
-    <value>[CtSy2][ßÑYour app is currently in read only mode because you have source control integration enabled. To change edit mode visit  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[CtSy2][ëÌYour app is currently in read only mode because you have source control integration enabled. To change edit mode visit  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="region" xml:space="preserve">
-    <value>[Xv714][ªÞRegion !!!]</value>
+    <value>[Xv714][ÍðRegion !!!]</value>
   </data>
   <data name="run" xml:space="preserve">
-    <value>[NR2Ak][ÏêRun !!]</value>
+    <value>[NR2Ak][èÃRun !!]</value>
   </data>
   <data name="save" xml:space="preserve">
-    <value>[ZTiYZ][èìSave !!]</value>
+    <value>[ZTiYZ][ÇÖSave !!]</value>
+  </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>[RGdYZ][ÖßA save operation is currently in progress.  Navigating away may cause some changes to be lost. !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="addNewSetting" xml:space="preserve">
-    <value>[eW5ij][¥Ñ+ Add new setting !!! !!!]</value>
+    <value>[eW5ij][ÛÁ+ Add new setting !!! !!!]</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
-    <value>[IUV0u][ËÙ+ Add new connection string !!! !!! !!]</value>
+    <value>[IUV0u][åâ+ Add new connection string !!! !!! !!]</value>
+  </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>[LPi4y][æý+ Add new document !!! !!!]</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>[hrIC1][õÖ+ Add new handler mapping !!! !!! !!]</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>[ZfnRd][Ïã+ Add new virtual application or directory !!! !!! !!! !!! ]</value>
   </data>
   <data name="enterName" xml:space="preserve">
-    <value>[agUQ6][üªEnter a name !!! !]</value>
+    <value>[agUQ6][ïÈEnter a name !!! !]</value>
   </data>
   <data name="enterValue" xml:space="preserve">
-    <value>[0lwKY][öÝEnter a value !!! !!]</value>
+    <value>[0lwKY][ÓÎEnter a value !!! !!]</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>[9x4RJ][ÂòEnter extension !!! !!]</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>[L8T7m][ÈÂEnter script processor !!! !!! !]</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>[972D2][ÙíEnter arguments !!! !!]</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>[ktrlc][ÿÇEnter virtual path !!! !!!]</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>[BgUUJ][ËÜEnter physical path !!! !!! ]</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>[l22NP][ØñApplication !!! !]</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>[sMGT8][õÍSlot Setting !!! !]</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
-    <value>[j2VsP][éæHidden value.  Click to show. !!! !!! !!!]</value>
+    <value>[j2VsP][ÐÛHidden value.  Click to show. !!! !!! !!!]</value>
   </data>
   <data name="sideBar_changeMade" xml:space="preserve">
-    <value>[eskne][ÎÄChanges made to function {{name}} will be lost. Are you sure you want to continue? !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[eskne][øÆChanges made to function {{name}} will be lost. Are you sure you want to continue? !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="sideBar_newFunction" xml:space="preserve">
-    <value>[mzJsh][¥äNew Function !!! !]</value>
+    <value>[mzJsh][ÉöNew Function !!! !]</value>
   </data>
   <data name="sideBar_refresh" xml:space="preserve">
-    <value>[2JBgw][ãÄRefresh !!!]</value>
+    <value>[2JBgw][ùôRefresh !!!]</value>
   </data>
   <data name="search" xml:space="preserve">
-    <value>[Wv03z][îªSearch !!!]</value>
+    <value>[Wv03z][ÌØSearch !!!]</value>
+  </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>[oOze2][µùScope to this item !!! !!!]</value>
   </data>
   <data name="searchFeatures" xml:space="preserve">
-    <value>[WeDEG][ûüSearch features !!! !!]</value>
+    <value>[WeDEG][úÖSearch features !!! !!]</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>[Exzv0][ÜóSearch Function apps !!! !!! ]</value>
   </data>
   <data name="subscription" xml:space="preserve">
-    <value>[cGfKd][ÅøSubscription ID !!! !!]</value>
+    <value>[cGfKd][¥¥Subscription ID !!! !!]</value>
   </data>
   <data name="subscriptionName" xml:space="preserve">
-    <value>[9AWwS][ÃæSubscription !!! !]</value>
+    <value>[9AWwS][§ÝSubscription !!! !]</value>
   </data>
   <data name="resourceGroup" xml:space="preserve">
-    <value>[EMtWd][ñÆResource group !!! !!]</value>
+    <value>[EMtWd][ÃÒResource group !!! !!]</value>
   </data>
   <data name="location" xml:space="preserve">
-    <value>[kfZFk][àñLocation !!! ]</value>
+    <value>[kfZFk][ÔÂLocation !!! ]</value>
   </data>
   <data name="noResults" xml:space="preserve">
-    <value>[gnNUQ][ðßNo results !!! !]</value>
+    <value>[gnNUQ][µ¢No results !!! !]</value>
   </data>
   <data name="topBar_changeMade" xml:space="preserve">
-    <value>[OfSsG][ÏêChanges made to the current function will be lost. Are you sure you want to continue? !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[OfSsG][©£Changes made to the current function will be lost. Are you sure you want to continue? !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="topBar_functionAppSettings" xml:space="preserve">
-    <value>[mVGCu][éúFunction app settings !!! !!! ]</value>
+    <value>[mVGCu][õÂFunction app settings !!! !!! ]</value>
   </data>
   <data name="topBar_newVersion" xml:space="preserve">
-    <value>[T5Tpi][ûÕA new version of Azure Functions is available. To upgrade, click here !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[T5Tpi][ÞíA new version of Azure Functions is available. To upgrade, click here !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="topBar_quickStart" xml:space="preserve">
-    <value>[cjfhr][ËþQuickstart !!! !]</value>
+    <value>[cjfhr][ß@Quickstart !!! !]</value>
   </data>
   <data name="topBar_usage" xml:space="preserve">
-    <value>[9xZ9t][ðýUsage !!!]</value>
+    <value>[9xZ9t][ÊóUsage !!!]</value>
   </data>
   <data name="all" xml:space="preserve">
-    <value>[U3vby][üÐAll !!]</value>
+    <value>[U3vby][è©All !!]</value>
   </data>
   <data name="appMonitoring_appExecutions" xml:space="preserve">
-    <value>[yo2If][ÜÚApp executions !!! !!]</value>
+    <value>[yo2If][ÝáApp executions !!! !!]</value>
   </data>
   <data name="appMonitoring_appUsage" xml:space="preserve">
-    <value>[3dLXg][àÊApp Usage(Gb Sec) !!! !!!]</value>
+    <value>[3dLXg][ÓíApp Usage(Gb Sec) !!! !!!]</value>
   </data>
   <data name="appMonitoring_functionAppUsage" xml:space="preserve">
-    <value>[b4tIr][ÚÃFunction App Usage !!! !!!]</value>
+    <value>[b4tIr][åòFunction App Usage !!! !!!]</value>
   </data>
   <data name="appMonitoring_noData" xml:space="preserve">
-    <value>[OPtrV][Í§No data available !!! !!!]</value>
+    <value>[OPtrV][¢äNo data available !!! !!!]</value>
   </data>
   <data name="appMonitoring_ofExecutions" xml:space="preserve">
-    <value>[03hIV][ÔÏof executions !!! !!]</value>
+    <value>[03hIV][ôÃof executions !!! !!]</value>
   </data>
   <data name="binding_parameterName" xml:space="preserve">
-    <value>[Wtqp5][ÌîParameter name !!! !!]</value>
+    <value>[Wtqp5][êùParameter name !!! !!]</value>
   </data>
   <data name="close" xml:space="preserve">
-    <value>[28Gw1][ß¢Close !!!]</value>
+    <value>[28Gw1][ý§Close !!!]</value>
   </data>
   <data name="config" xml:space="preserve">
-    <value>[fiRY6][ÉðConfig !!!]</value>
+    <value>[fiRY6][§öConfig !!!]</value>
   </data>
   <data name="cors" xml:space="preserve">
-    <value>[Oi4NP][çóCORS !!]</value>
+    <value>[Oi4NP][éñCORS !!]</value>
   </data>
   <data name="create" xml:space="preserve">
-    <value>[j7hh7][ÝåCreate !!!]</value>
+    <value>[j7hh7][ÃÍCreate !!!]</value>
   </data>
   <data name="dashboard_yourTrialExpiered" xml:space="preserve">
-    <value>[w6XMR][ÑæYour trial has expired !!! !!! !]</value>
+    <value>[w6XMR][ÐÁYour trial has expired !!! !!! !]</value>
   </data>
   <data name="disabled" xml:space="preserve">
-    <value>[aHE4R][ïÃDisabled !!! ]</value>
+    <value>[aHE4R][êþDisabled !!! ]</value>
   </data>
   <data name="enabled" xml:space="preserve">
-    <value>[5tA68][ùÂEnabled !!!]</value>
+    <value>[5tA68][ÝéEnabled !!!]</value>
+  </data>
+  <data name="disable" xml:space="preserve">
+    <value>[c51Q2][Íêdisable !!!]</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>[8ijrm][Íøenabled !!!]</value>
   </data>
   <data name="errorList_here" xml:space="preserve">
-    <value>[StZeI][þ©here !!]</value>
+    <value>[StZeI][Ð¢here !!]</value>
   </data>
   <data name="errorList_youMay" xml:space="preserve">
-    <value>[qnJ4m][ÒßYou may be experiencing an error. If you're having issues, please post them !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[qnJ4m][çõYou may be experiencing an error. If you're having issues, please post them !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
-    <value>[rAcqH][ôÚError parsing config: {{error}} !!! !!! !!! ]</value>
+    <value>[rAcqH][ªÕError parsing config: {{error}} !!! !!! !!! ]</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>[47CFs][ÞõFailed to {{state}} function: {{functionName}} !!! !!! !!! !!! !]</value>
   </data>
   <data name="features" xml:space="preserve">
-    <value>[m0qJa][¥üFeatures !!! ]</value>
+    <value>[m0qJa][Ñ@Features !!! ]</value>
   </data>
   <data name="filedRequired" xml:space="preserve">
-    <value>[qPCpe][ÖçThis field is required !!! !!! !]</value>
+    <value>[qPCpe][ü§This field is required !!! !!! !]</value>
   </data>
   <data name="functionDev_code" xml:space="preserve">
-    <value>[J8v9W][åÁCode !!]</value>
+    <value>[J8v9W][ò@Code !!]</value>
   </data>
   <data name="functionDev_run" xml:space="preserve">
-    <value>[wmrlO][ÇûRun !!]</value>
+    <value>[wmrlO][ÅüRun !!]</value>
   </data>
   <data name="functionEdit_readOnly" xml:space="preserve">
-    <value>[L3v4Z][ãÌRead only - because you have started editing with source control, this view is read only. !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[L3v4Z][ÆÊRead only - because you have started editing with source control, this view is read only. !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="functionIntegrate_advancedEditor" xml:space="preserve">
-    <value>[XKoih][ïªAdvanced editor !!! !!]</value>
+    <value>[XKoih][õÏAdvanced editor !!! !!]</value>
   </data>
   <data name="functionIntegrate_changesLost1" xml:space="preserve">
-    <value>[UPPmU][ûµChanges made will be lost. Are you sure you want to continue? !!! !!! !!! !!! !!! !!]</value>
+    <value>[UPPmU][ÔúChanges made will be lost. Are you sure you want to continue? !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="functionIntegrate_changesLost2" xml:space="preserve">
-    <value>[oEF4e][ÎÍChanges made to function {{name}} will be lost. Are you sure you want to continue? !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[oEF4e][ìùChanges made to function {{name}} will be lost. Are you sure you want to continue? !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="functionIntegrate_settingName" xml:space="preserve">
-    <value>[m230i][ÐæSetting name: !!! !!]</value>
+    <value>[m230i][ÝúSetting name: !!! !!]</value>
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
-    <value>[0m98f][ýöStandard editor !!! !!]</value>
+    <value>[0m98f][óîStandard editor !!! !!]</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>[bxDrp][îÒDelete Function {{name}} !!! !!! !]</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
-    <value>[ofcbI][ÿÖAre you sure you want to delete Function {{name}}? !!! !!! !!! !!! !!!]</value>
+    <value>[ofcbI][åÚAre you sure you want to delete Function {{name}}? !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="functionMonitor_loading" xml:space="preserve">
-    <value>[z94cm][øùLoading ... !!! !]</value>
+    <value>[z94cm][ïýLoading ... !!! !]</value>
   </data>
   <data name="functionMonitor_successAggregate" xml:space="preserve">
-    <value>[r059Y][éúSuccess count since !!! !!! ]</value>
+    <value>[r059Y][ûæSuccess count since !!! !!! ]</value>
   </data>
   <data name="functionMonitor_errorsAggregate" xml:space="preserve">
-    <value>[U9g38][òÓError count since !!! !!!]</value>
+    <value>[U9g38][ÍßError count since !!! !!!]</value>
   </data>
   <data name="functionMonitor_invocationLog" xml:space="preserve">
-    <value>[a9qoH][ýþInvocation log !!! !!]</value>
+    <value>[a9qoH][ØâInvocation log !!! !!]</value>
   </data>
   <data name="functionMonitor_invocationDetails" xml:space="preserve">
-    <value>[kXEkP][åìInvocation details !!! !!!]</value>
+    <value>[kXEkP][ÊöInvocation details !!! !!!]</value>
   </data>
   <data name="functionMonitor_invocationOutput" xml:space="preserve">
-    <value>[5w5KC][ÚÑLogs !!]</value>
+    <value>[5w5KC][ÝâLogs !!]</value>
   </data>
   <data name="functionMonitor_pulseUrl" xml:space="preserve">
-    <value>[gcbE8][îêlive event stream !!! !!!]</value>
+    <value>[gcbE8][õïlive event stream !!! !!!]</value>
   </data>
   <data name="functionMonitorTable_functionColumn" xml:space="preserve">
-    <value>[kN17H][ïÂFunction !!! ]</value>
+    <value>[kN17H][îçFunction !!! ]</value>
   </data>
   <data name="functionMonitorTable_statusColumn" xml:space="preserve">
-    <value>[m5m6f][ÞÀStatus !!!]</value>
+    <value>[m5m6f][à@Status !!!]</value>
   </data>
   <data name="functionMonitorTable_detailsColumn" xml:space="preserve">
-    <value>[BASuW][ÐÀDetails: Last ran !!! !!!]</value>
+    <value>[BASuW][ÂæDetails: Last ran !!! !!!]</value>
   </data>
   <data name="functionMonitorTable_durationColumn" xml:space="preserve">
-    <value>[QYcnf][àå(duration) !!! !]</value>
+    <value>[QYcnf][ÒÝ(duration) !!! !]</value>
   </data>
   <data name="functionMonitorInvocationTable_paramColumn" xml:space="preserve">
-    <value>[t55X6][£îParameter !!! ]</value>
+    <value>[t55X6][ÿíParameter !!! ]</value>
   </data>
   <data name="functionService_authIsEnabled" xml:space="preserve">
-    <value>[pie5F][ÇÜAuthentication is enabled for the function app. Disable authentication before running the function. !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[pie5F][§ÊAuthentication is enabled for the function app. Disable authentication before running the function. !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="functionService_errorRunningFunc" xml:space="preserve">
-    <value>[g55Ib][ñõThere was an error running function ({{name}}). Check logs output for the full error. !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[g55Ib][øÃThere was an error running function ({{name}}). Check logs output for the full error. !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="input" xml:space="preserve">
-    <value>[ni51t][ÝÑInputs !!!]</value>
+    <value>[ni51t][@ÓInputs !!!]</value>
   </data>
   <data name="logStreaming_logs" xml:space="preserve">
-    <value>[BxGrN][©ÿLogs !!]</value>
+    <value>[BxGrN][ÂÚLogs !!]</value>
   </data>
   <data name="newInput" xml:space="preserve">
-    <value>[9mkDf][ýÆNew Input !!! ]</value>
+    <value>[9mkDf][áÿNew Input !!! ]</value>
   </data>
   <data name="newOutput" xml:space="preserve">
-    <value>[u0x1V][ÂýNew Output !!! !]</value>
+    <value>[u0x1V][çõNew Output !!! !]</value>
   </data>
   <data name="newTrigger" xml:space="preserve">
-    <value>[fpntM][ÙÞNew Trigger !!! !]</value>
+    <value>[fpntM][ßæNew Trigger !!! !]</value>
   </data>
   <data name="next" xml:space="preserve">
-    <value>[e1rTR][îÏNext !!]</value>
+    <value>[e1rTR][©ýNext !!]</value>
   </data>
   <data name="notValidValue" xml:space="preserve">
-    <value>[azTKD][ÙùNot valid value !!! !!]</value>
+    <value>[azTKD][óòNot valid value !!! !!]</value>
   </data>
   <data name="output" xml:space="preserve">
-    <value>[F4dds][ÊáOutputs !!!]</value>
+    <value>[F4dds][@âOutputs !!!]</value>
   </data>
   <data name="select" xml:space="preserve">
-    <value>[vrdXE][åþSelect !!!]</value>
+    <value>[vrdXE][ûÈSelect !!!]</value>
   </data>
   <data name="tabNames_develop" xml:space="preserve">
-    <value>[DqD6m][éÂDevelop !!!]</value>
+    <value>[DqD6m][ÁÊDevelop !!!]</value>
   </data>
   <data name="tabNames_integrate" xml:space="preserve">
-    <value>[hvG21][áÃIntegrate !!! ]</value>
+    <value>[hvG21][ÇèIntegrate !!! ]</value>
   </data>
   <data name="tabNames_manage" xml:space="preserve">
-    <value>[50Yko][ûùManage !!!]</value>
+    <value>[50Yko][ìêManage !!!]</value>
   </data>
   <data name="tabNames_monitor" xml:space="preserve">
-    <value>[Bo1ZH][èùMonitor !!!]</value>
+    <value>[Bo1ZH][Í¥Monitor !!!]</value>
   </data>
   <data name="templatePicker_chooseInput" xml:space="preserve">
-    <value>[h8mDd][ÔÑChoose an input binding !!! !!! !]</value>
+    <value>[h8mDd][ÃÍChoose an input binding !!! !!! !]</value>
   </data>
   <data name="templatePicker_chooseOutput" xml:space="preserve">
-    <value>[FibqR][ÆüChoose an output binding !!! !!! !]</value>
+    <value>[FibqR][¥ðChoose an output binding !!! !!! !]</value>
   </data>
   <data name="templatePicker_chooseTemplate" xml:space="preserve">
-    <value>[4b5uS][ïøChoose a template !!! !!!]</value>
+    <value>[4b5uS][¢åChoose a template !!! !!!]</value>
   </data>
   <data name="templatePicker_chooseTrigger" xml:space="preserve">
-    <value>[uB8CD][@ßChoose a trigger !!! !!!]</value>
+    <value>[uB8CD][ÍñChoose a trigger !!! !!!]</value>
   </data>
   <data name="templatePicker_language" xml:space="preserve">
-    <value>[dppNp][ßËLanguage: !!! ]</value>
+    <value>[dppNp][ÛøLanguage: !!! ]</value>
   </data>
   <data name="templatePicker_scenario" xml:space="preserve">
-    <value>[AMJtI][ÃýScenario: !!! ]</value>
+    <value>[AMJtI][ïäScenario: !!! ]</value>
   </data>
   <data name="trigger" xml:space="preserve">
-    <value>[1Gq31][ôçTriggers !!! ]</value>
+    <value>[1Gq31][àÒTriggers !!! ]</value>
   </data>
   <data name="tryNow_trialExpired" xml:space="preserve">
-    <value>[Nav0l][þÎTrial expired !!! !!]</value>
+    <value>[Nav0l][þúTrial expired !!! !!]</value>
   </data>
   <data name="tutorial_changesMade" xml:space="preserve">
-    <value>[z6q5S][ßªChanges made here will affect all of the functions within your function app. !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[z6q5S][ªÛChanges made here will affect all of the functions within your function app. !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="tutorial_createNew" xml:space="preserve">
-    <value>[4WGl6][òÔ&lt;span&gt;Create a brand-new function&lt;/span&gt; - Get started with one of the pre-built function templates !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[4WGl6][ùÅ&lt;span&gt;Create a brand-new function&lt;/span&gt; - Get started with one of the pre-built function templates !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="tutorial_develop" xml:space="preserve">
-    <value>[EazO5][ÞÄDevelop !!!]</value>
+    <value>[EazO5][ÊäDevelop !!!]</value>
   </data>
   <data name="tutorial_diveIntoDocumentation" xml:space="preserve">
-    <value>[cIfph][òÎ&lt;span&gt;Dive into the documentation&lt;/span&gt; - Explore all of the Azure Functions features &lt;a target="_blank" href="http://go.microsoft.com/fwlink/?LinkId=747839"&gt;here&lt;/a&gt; !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[cIfph][üÚ&lt;span&gt;Dive into the documentation&lt;/span&gt; - Explore all of the Azure Functions features &lt;a target="_blank" href="http://go.microsoft.com/fwlink/?LinkId=747839"&gt;here&lt;/a&gt; !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="tutorial_functionAppSettings" xml:space="preserve">
-    <value>[Z0a96][ÈåFunction App Settings !!! !!! ]</value>
+    <value>[Z0a96][òéFunction App Settings !!! !!! ]</value>
   </data>
   <data name="tutorial_integrate" xml:space="preserve">
-    <value>[Xw7Ys][ÎÊIntegrate !!! ]</value>
+    <value>[Xw7Ys][©ßIntegrate !!! ]</value>
   </data>
   <data name="tutorial_integrateYourFunction" xml:space="preserve">
-    <value>[kjLVb][ò§Integrating your functions with other services and data sources is easy. !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[kjLVb][üÔIntegrating your functions with other services and data sources is easy. !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="tutorial_nextSteps" xml:space="preserve">
-    <value>[YhOTp][ÕíNext Steps !!! !]</value>
+    <value>[YhOTp][ßÖNext Steps !!! !]</value>
   </data>
   <data name="tutorial_setUpAutomated" xml:space="preserve">
-    <value>[BuAxL][£ÀSet up automated actions based on external triggers, include other input data sources, and send the output to multiple targets. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[BuAxL][ðâSet up automated actions based on external triggers, include other input data sources, and send the output to multiple targets. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="tutorial_skip" xml:space="preserve">
-    <value>[uVXps][ìÌSkip the tour and start coding !!! !!! !!!]</value>
+    <value>[uVXps][ÖÓSkip the tour and start coding !!! !!! !!!]</value>
   </data>
   <data name="tutorial_theFastestWayNode" xml:space="preserve">
-    <value>[xujYO][ÒáThe fastest way to edit code is with the code editor, but you can also use Git.This example uses NodeJS, but many other languages are also supported. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[xujYO][öÚThe fastest way to edit code is with the code editor, but you can also use Git.This example uses NodeJS, but many other languages are also supported. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="tutorial_thisPageInclude" xml:space="preserve">
-    <value>[Oeh5e][Ó§This page also includes a log stream and a test console for helping you debug your function. !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[Oeh5e][§ÅThis page also includes a log stream and a test console for helping you debug your function. !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="tutorial_tweakThisSample" xml:space="preserve">
-    <value>[SrGrl][Ëò&lt;span&gt;Tweak this sample function&lt;/span&gt; - Make it yours on the easy-to-use dashboard !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[SrGrl][ëá&lt;span&gt;Tweak this sample function&lt;/span&gt; - Make it yours on the easy-to-use dashboard !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="tutorial_yourFunction" xml:space="preserve">
-    <value>[c2DAb][ÎÝYour functions are designed to run within Azure App Service as a function app, and this is where you modify the features of that app. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[c2DAb][øëYour functions are designed to run within Azure App Service as a function app, and this is where you modify the features of that app. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="update" xml:space="preserve">
-    <value>[BsMNY][üÁUpdate !!!]</value>
+    <value>[BsMNY][ïÖUpdate !!!]</value>
   </data>
   <data name="bindingInput_select" xml:space="preserve">
-    <value>[93db5][Îåselect !!!]</value>
+    <value>[93db5][ëÈselect !!!]</value>
   </data>
   <data name="binding_delete" xml:space="preserve">
-    <value>[Px7eu][Ûìdelete !!!]</value>
+    <value>[Px7eu][Åídelete !!!]</value>
   </data>
   <data name="bindingsValidationDirectionMissed" xml:space="preserve">
-    <value>[TFETU][ÚûParameter 'direction' is missed. !!! !!! !!! ]</value>
+    <value>[TFETU][èÎParameter 'direction' is missed. !!! !!! !!! ]</value>
   </data>
   <data name="bindingsValidationDirectionUnknown" xml:space="preserve">
-    <value>[yKPGF][ÄÑUnknown direction: '{{direction}}'. !!! !!! !!! !]</value>
+    <value>[yKPGF][ÎðUnknown direction: '{{direction}}'. !!! !!! !!! !]</value>
   </data>
   <data name="bindingsValidationNameDublicate" xml:space="preserve">
-    <value>[88vLi][ÏÍParameter name must be unique in a function: '{{functionName}}' !!! !!! !!! !!! !!! !!!]</value>
+    <value>[88vLi][ÌæParameter name must be unique in a function: '{{functionName}}' !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="bindingsValidationNameMissed" xml:space="preserve">
-    <value>[wAfYV][ÝôParameter 'name' is missed. !!! !!! !!]</value>
+    <value>[wAfYV][öåParameter 'name' is missed. !!! !!! !!]</value>
   </data>
   <data name="bindingsValidationTypeMIssed" xml:space="preserve">
-    <value>[UPyLm][ÊÉParameter 'type' is missed. !!! !!! !!]</value>
+    <value>[UPyLm][øÚParameter 'type' is missed. !!! !!! !!]</value>
   </data>
   <data name="bindingsValidationTypeUnknown" xml:space="preserve">
-    <value>[dBgLF][ÀõUnknown type: '{{type}}'. !!! !!! !!]</value>
+    <value>[dBgLF][Ø¢Unknown type: '{{type}}'. !!! !!! !!]</value>
   </data>
   <data name="resourceSelect" xml:space="preserve">
-    <value>[H9FOe][ÑËWaiting for the resource !!! !!! !]</value>
+    <value>[H9FOe][ÔÃWaiting for the resource !!! !!! !]</value>
   </data>
   <data name="trialExpired_enjoyedHostingFunctions" xml:space="preserve">
-    <value>[C0x5g][øõWe've enjoyed hosting your functions ! !!! !!! !!! !!]</value>
+    <value>[C0x5g][ÊÔWe've enjoyed hosting your functions ! !!! !!! !!! !!]</value>
   </data>
   <data name="trialExpired_signupForAzure" xml:space="preserve">
-    <value>[pEr2v][èÌYour trial has now expired, but you can sign up for an extended trial which includes the rest of Azure as well. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[pEr2v][ÒÝYour trial has now expired, but you can sign up for an extended trial which includes the rest of Azure as well. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="tryLanding_chooseAnAuthProvider" xml:space="preserve">
-    <value>[MmFW5][§øChoose an auth provider !!! !!! !]</value>
+    <value>[MmFW5][ÜîChoose an auth provider !!! !!! !]</value>
   </data>
   <data name="tryLanding_microsoftAcccount" xml:space="preserve">
-    <value>[xGxmh][úÆMicrosoft Account !!! !!!]</value>
+    <value>[xGxmh][ÀåMicrosoft Account !!! !!!]</value>
   </data>
   <data name="tryNow_createFreeAzureAccount" xml:space="preserve">
-    <value>[Y7sP3][ßùCreate a free Azure account !!! !!! !!]</value>
+    <value>[Y7sP3][æñCreate a free Azure account !!! !!! !!]</value>
   </data>
   <data name="tryNow_extendTrial" xml:space="preserve">
-    <value>[MpBJl][çñExtend trial to 24 hours !!! !!! !]</value>
+    <value>[MpBJl][§ëExtend trial to 24 hours !!! !!! !]</value>
   </data>
   <data name="tryNow_trialTimeRemaining" xml:space="preserve">
-    <value>[li1Tb][òôFree Trial - Time remaining: !!! !!! !!!]</value>
+    <value>[li1Tb][éÊFree Trial - Time remaining: !!! !!! !!!]</value>
   </data>
   <data name="tryLanding_functionError" xml:space="preserve">
-    <value>[XItrU][öçFunction creation error! Please try again. !!! !!! !!! !!! ]</value>
+    <value>[XItrU][éüFunction creation error! Please try again. !!! !!! !!! !!! ]</value>
   </data>
   <data name="tryLanding_functionErrorDetails" xml:space="preserve">
-    <value>[eNJlt][ïËCreate Function Error !!! !!! ]</value>
+    <value>[eNJlt][ÝµCreate Function Error !!! !!! ]</value>
   </data>
   <data name="tryLanding_ifYou" xml:space="preserve">
-    <value>[JyFkD][ïÂIf you'd prefer another supported language, you can choose one later in the functions portal. !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[JyFkD][âèIf you'd prefer another supported language, you can choose one later in the functions portal. !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="tryNow_minutes" xml:space="preserve">
-    <value>[795ge][ÙÚ minutes !!! ]</value>
+    <value>[795ge][êø minutes !!! ]</value>
   </data>
   <data name="bindingInput_new" xml:space="preserve">
-    <value>[ECXmU][©ÿnew !!]</value>
+    <value>[ECXmU][Åªnew !!]</value>
   </data>
   <data name="integrate_inputsHelp" xml:space="preserve">
-    <value>[SP7uC][ÎÛInput bindings provide additional data provided to your function when it is triggered. For instance, you can fetch data from table storage on a new queue message. Inputs are optional. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[SP7uC][îõInput bindings provide additional data provided to your function when it is triggered. For instance, you can fetch data from table storage on a new queue message. Inputs are optional. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="integrate_outputsHelp" xml:space="preserve">
-    <value>[PEQE2][ÍâOutputs bindings allow you to output data from your function. For instance, you can add a new item to a queue. Outputs are optional. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[PEQE2][á£Outputs bindings allow you to output data from your function. For instance, you can add a new item to a queue. Outputs are optional. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="integrate_triggersHelp" xml:space="preserve">
-    <value>[l09UW][Ï¢Triggers are what will start your function. For instance, you can trigger on a new queue message. You must always have a trigger. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[l09UW][ÅÚTriggers are what will start your function. For instance, you can trigger on a new queue message. You must always have a trigger. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="binding_createNewFunction" xml:space="preserve">
-    <value>[ocAoW][ôØCreate a new function triggered by this output !!! !!! !!! !!! !]</value>
+    <value>[ocAoW][ÈæCreate a new function triggered by this output !!! !!! !!! !!! !]</value>
   </data>
   <data name="binding_documentation" xml:space="preserve">
-    <value>[wMNk4][ªåDocumentation !!! !!]</value>
+    <value>[wMNk4][çÌDocumentation !!! !!]</value>
   </data>
   <data name="binding_go" xml:space="preserve">
-    <value>[q11Kx][ßÃGo !!]</value>
+    <value>[q11Kx][ÿÖGo !!]</value>
   </data>
   <data name="copypre_copied" xml:space="preserve">
-    <value>[Gtjfq][ÖáCopied! !!!]</value>
+    <value>[Gtjfq][ãÉCopied! !!!]</value>
   </data>
   <data name="copypre_copyClipboard" xml:space="preserve">
-    <value>[BpNYe][¢ÆCopy to clipboard !!! !!!]</value>
+    <value>[BpNYe][íöCopy to clipboard !!! !!!]</value>
   </data>
   <data name="fileExplorer_changesLost" xml:space="preserve">
-    <value>[mC5qm][òöChanges made to current file will be lost. Are you sure you want to continue? !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[mC5qm][ðßChanges made to current file will be lost. Are you sure you want to continue? !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="fileExplorer_deletePromt" xml:space="preserve">
-    <value>[NAlJ6][ÏèAre you sure you want to delete {{fileName}} !!! !!! !!! !!! ]</value>
+    <value>[NAlJ6][ÊÿAre you sure you want to delete {{fileName}} !!! !!! !!! !!! ]</value>
   </data>
   <data name="fileExplorer_editingBinary" xml:space="preserve">
-    <value>[RGD9i][ÐÿEditing binary files is not supported. !!! !!! !!! !!]</value>
+    <value>[RGD9i][Ì@Editing binary files is not supported. !!! !!! !!! !!]</value>
   </data>
   <data name="fileExplorer_errorCreatingFile" xml:space="preserve">
-    <value>[TOGJS][ÛÇError creating file: {{fileName}} !!! !!! !!! !]</value>
+    <value>[TOGJS][ÓÞError creating file: {{fileName}} !!! !!! !!! !]</value>
   </data>
   <data name="fileExplorer_errorDeletingFile" xml:space="preserve">
-    <value>[KcPQJ][ÝÃError deleting file: {{fileName}} !!! !!! !!! !]</value>
+    <value>[KcPQJ][ÒûError deleting file: {{fileName}} !!! !!! !!! !]</value>
   </data>
   <data name="tutorial_theFastestWayCSharp" xml:space="preserve">
-    <value>[ODzDm][ÚôThe fastest way to edit code is with the code editor, but you can also use Git.This example uses C#, but many other languages are also supported. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[ODzDm][ÛÚThe fastest way to edit code is with the code editor, but you can also use Git.This example uses C#, but many other languages are also supported. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="binding_actions" xml:space="preserve">
-    <value>[thyZd][ÁËActions !!!]</value>
+    <value>[thyZd][ÞêActions !!!]</value>
   </data>
   <data name="tryNow_lessThanOneMinute" xml:space="preserve">
-    <value>[tFzAi][Ï§Less than 1 minute !!! !!!]</value>
+    <value>[tFzAi][ØÓLess than 1 minute !!! !!!]</value>
   </data>
   <data name="tryNow_FreeAccountToolTip" xml:space="preserve">
-    <value>[QIBBg][éêSigning up for a free Azure account unlocks all Functions capabilities without worrying about time limits! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[QIBBg][ÌÒSigning up for a free Azure account unlocks all Functions capabilities without worrying about time limits! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="error_CORSNotConfigured" xml:space="preserve">
-    <value>[BBlkj][ÝµCORS is not configured for this function app. Please add {{origin}} to your CORS list. !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[BBlkj][ËßCORS is not configured for this function app. Please add {{origin}} to your CORS list. !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="error_DnsResolution" xml:space="preserve">
-    <value>[Kw2qm][ÁÖWe are unable to reach your function app. Your app could be having a temporary issue or may be failing to start. You can check logs or try again in a couple of minutes. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[Kw2qm][ìÌWe are unable to reach your function app. Your app could be having a temporary issue or may be failing to start. You can check logs or try again in a couple of minutes. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="error_UnableToRetrieveFunctionApp" xml:space="preserve">
-    <value>[QKjJG][òÿUnable to retrieve Function App ({{functionApp}}) !!! !!! !!! !!! !!]</value>
+    <value>[QKjJG][ÙÄUnable to retrieve Function App ({{functionApp}}) !!! !!! !!! !!! !!]</value>
   </data>
   <data name="error_UnableToRetrieveFunctions" xml:space="preserve">
-    <value>[jb97o][ÂíWe are unable to reach your function app ({{statusText}}). Please try again later. !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[jb97o][ÄöWe are unable to reach your function app ({{statusText}}). Please try again later. !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="tryNow_fewMoreSeconds" xml:space="preserve">
-    <value>[0A9sc][£ÌJust a few more seconds... !!! !!! !!]</value>
+    <value>[0A9sc][@úJust a few more seconds... !!! !!! !!]</value>
   </data>
   <data name="tryNow_hangOn" xml:space="preserve">
-    <value>[7LEKN][êîHang on while we put the 'fun' in functions... !!! !!! !!! !!! !]</value>
+    <value>[7LEKN][ì£Hang on while we put the 'fun' in functions... !!! !!! !!! !!! !]</value>
   </data>
   <data name="tryNow_discoverMore" xml:space="preserve">
-    <value>[0j5Pw][ííDiscover more !!! !!]</value>
+    <value>[0j5Pw][ØÍDiscover more !!! !!]</value>
   </data>
   <data name="fileExplorer_add" xml:space="preserve">
-    <value>[oXxpn][Â©Add !!]</value>
+    <value>[oXxpn][êðAdd !!]</value>
   </data>
   <data name="fileExplorer_delete" xml:space="preserve">
-    <value>[ek1a0][ïÅDelete !!!]</value>
+    <value>[ek1a0][ª@Delete !!!]</value>
   </data>
   <data name="fileExplorer_edit" xml:space="preserve">
-    <value>[onXWc][ÇýEdit !!]</value>
+    <value>[onXWc][ÞÞEdit !!]</value>
   </data>
   <data name="fileExplorer_upload" xml:space="preserve">
-    <value>[G927o][Ñ£Upload !!!]</value>
+    <value>[G927o][ËéUpload !!!]</value>
   </data>
   <data name="storageLockNote" xml:space="preserve">
-    <value>[eJppo][ªþOne or more function apps were linked to this storage account. You can see all the function apps linked to the account under 'files' or 'Shares'. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[eJppo][ýØOne or more function apps were linked to this storage account. You can see all the function apps linked to the account under 'files' or 'Shares'. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="fileExplorer_fileAlreadyExists" xml:space="preserve">
-    <value>[X3JOA][äëA File with the name {{fileName}} already exists. !!! !!! !!! !!! !!]</value>
+    <value>[X3JOA][µðA File with the name {{fileName}} already exists. !!! !!! !!! !!! !!]</value>
   </data>
   <data name="functionNew_functionExsists" xml:space="preserve">
-    <value>[M24Zk][ê¥Function with name '{{name}}' already exists. !!! !!! !!! !!! !]</value>
+    <value>[M24Zk][ÝîFunction with name '{{name}}' already exists. !!! !!! !!! !!! !]</value>
   </data>
   <data name="binding_storageAccountKey" xml:space="preserve">
-    <value>[EnwGU][òÍAccount Key: !!! !]</value>
+    <value>[EnwGU][üÙAccount Key: !!! !]</value>
   </data>
   <data name="binding_storageAccountName" xml:space="preserve">
-    <value>[gXF2N][ïËAccount Name: !!! !!]</value>
+    <value>[gXF2N][ÔÆAccount Name: !!! !!]</value>
   </data>
   <data name="binding_storageInfoFooter" xml:space="preserve">
-    <value>[DXio5][§éYou can now view the blobs, queues and tables associated with this storage binding. !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[DXio5][ÞÐYou can now view the blobs, queues and tables associated with this storage binding. !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="binding_storageInfoHeader" xml:space="preserve">
-    <value>[X9hDS][âÈConnecting to your Storage Account !!! !!! !!! !]</value>
+    <value>[X9hDS][ÿþConnecting to your Storage Account !!! !!! !!! !]</value>
   </data>
   <data name="binding_storageInfoHeader2" xml:space="preserve">
-    <value>[c4Tku][ãüDownload Storage explorer from here:       !!! !!! !!! !!! ]</value>
+    <value>[c4Tku][Æ§Download Storage explorer from here:       !!! !!! !!! !!! ]</value>
   </data>
   <data name="binding_storageInfoHeader3" xml:space="preserve">
-    <value>[wASvF][âñConnect using these credentials: !!! !!! !!! ]</value>
+    <value>[wASvF][éÞConnect using these credentials: !!! !!! !!! ]</value>
   </data>
   <data name="topBar_learnMore" xml:space="preserve">
-    <value>[126IU][ÄûLearn more !!! !]</value>
+    <value>[126IU][ÖûLearn more !!! !]</value>
   </data>
   <data name="httpRun_addHeader" xml:space="preserve">
-    <value>[gtBG3][èéAdd header !!! !]</value>
+    <value>[gtBG3][ªÙAdd header !!! !]</value>
   </data>
   <data name="httpRun_addParameter" xml:space="preserve">
-    <value>[BKdUW][ÛËAdd parameter !!! !!]</value>
+    <value>[BKdUW][Õ@Add parameter !!! !!]</value>
   </data>
   <data name="httpRun_httpMethod" xml:space="preserve">
-    <value>[pDm22][öëHTTP method !!! !]</value>
+    <value>[pDm22][âéHTTP method !!! !]</value>
   </data>
   <data name="httpRun_query" xml:space="preserve">
-    <value>[6HP2E][íúQuery !!!]</value>
+    <value>[6HP2E][ïÙQuery !!!]</value>
   </data>
   <data name="topBar_alwaysOn" xml:space="preserve">
-    <value>[xhZqa][Üé'AlwaysOn' is not enabled. Your app may not function properly !!! !!! !!! !!! !!! !!]</value>
+    <value>[xhZqa][éô'AlwaysOn' is not enabled. Your app may not function properly !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="topBar_slotsHostId" xml:space="preserve">
-    <value>[p3kEO][ìÈValue for id has been explicitly set in host.json, which may cause unexpected behavior when using deployment slots !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[p3kEO][ìçValue for id has been explicitly set in host.json, which may cause unexpected behavior when using deployment slots !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="topBar_releaseNotes" xml:space="preserve">
-    <value>[j7Dwg][ÖéAzure Functions release notes. !!! !!! !!!]</value>
+    <value>[j7Dwg][ßäAzure Functions release notes. !!! !!! !!!]</value>
   </data>
   <data name="adminKeys_title" xml:space="preserve">
-    <value>[paZ7w][µÛHost Keys (All functions) !!! !!! !!]</value>
+    <value>[paZ7w][ÇõHost Keys (All functions) !!! !!! !!]</value>
   </data>
   <data name="functionKeys_addNewAdminKey" xml:space="preserve">
-    <value>[46BXr][öþAdd new host key !!! !!!]</value>
+    <value>[46BXr][ôÍAdd new host key !!! !!!]</value>
   </data>
   <data name="functionKeys_addNewFunctionKey" xml:space="preserve">
-    <value>[HdFLd][ÏÂAdd new function key !!! !!! ]</value>
+    <value>[HdFLd][ÆõAdd new function key !!! !!! ]</value>
   </data>
   <data name="functionKeys_clickToShow" xml:space="preserve">
-    <value>[cCZiE][üâClick to show !!! !!]</value>
+    <value>[cCZiE][úÆClick to show !!! !!]</value>
   </data>
   <data name="functionKeys_discard" xml:space="preserve">
-    <value>[mTH2T][àÜDiscard !!!]</value>
+    <value>[mTH2T][åßDiscard !!!]</value>
   </data>
   <data name="functionKeys_enterKeyName" xml:space="preserve">
-    <value>[4QSZ9][øæ(Required) !!! !]</value>
+    <value>[4QSZ9][ðÊ(Required) !!! !]</value>
   </data>
   <data name="functionKeys_enterKeyValue" xml:space="preserve">
-    <value>[EUUtC][ÉÔ(Optional) Leave empty to auto-generate a key. !!! !!! !!! !!! !]</value>
+    <value>[EUUtC][ÏÁ(Optional) Leave empty to auto-generate a key. !!! !!! !!! !!! !]</value>
   </data>
   <data name="functionKeys_keyName" xml:space="preserve">
-    <value>[erPUO][ÞôNAME !!]</value>
+    <value>[erPUO][@ÄNAME !!]</value>
   </data>
   <data name="functionKeys_keyValue" xml:space="preserve">
-    <value>[mUjmH][ÁøVALUE !!!]</value>
+    <value>[mUjmH][ÔªVALUE !!!]</value>
   </data>
   <data name="functionKeys_title" xml:space="preserve">
-    <value>[JSzQT][ÔÖFunction Keys !!! !!]</value>
+    <value>[JSzQT][ìÑFunction Keys !!! !!]</value>
   </data>
   <data name="binding_storageConnectionString" xml:space="preserve">
-    <value>[MSHjP][þÑConnection String: !!! !!!]</value>
+    <value>[MSHjP][éâConnection String: !!! !!!]</value>
   </data>
   <data name="functionAppSettings_dailyUsageQuota" xml:space="preserve">
-    <value>[ROnSW][©ÑDaily Usage Quota (GB-Sec) !!! !!! !!]</value>
+    <value>[ROnSW][áÕDaily Usage Quota (GB-Sec) !!! !!! !!]</value>
   </data>
   <data name="functionAppSettings_quotaWarning" xml:space="preserve">
-    <value>[IkdMH][ÒÝThe Function App has reached daily usage quota and has been stopped until the next 24 hours time frame. !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[IkdMH][¢ñThe Function App has reached daily usage quota and has been stopped until the next 24 hours time frame. !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="functionAppSettings_removeQuota" xml:space="preserve">
-    <value>[x3Egh][íØRemove quota !!! !]</value>
+    <value>[x3Egh][ÝÿRemove quota !!! !]</value>
   </data>
   <data name="functionAppSettings_setQuota" xml:space="preserve">
-    <value>[l3EAu][ñÁSet quota !!! ]</value>
+    <value>[l3EAu][ïäSet quota !!! ]</value>
   </data>
   <data name="functionAppSettings_quotaInfo" xml:space="preserve">
-    <value>[asz3b][ÝêWhen the daily usage quota is exceeded, the Function App is stopped until the next day at 0:00 AM UTC. !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[asz3b][ÔÿWhen the daily usage quota is exceeded, the Function App is stopped until the next day at 0:00 AM UTC. !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="functionKeys_revokeConfirmation" xml:space="preserve">
-    <value>[t45zF][ñõAre you sure you want to revoke {{name}} key? !!! !!! !!! !!! !]</value>
+    <value>[t45zF][äÙAre you sure you want to revoke {{name}} key? !!! !!! !!! !!! !]</value>
   </data>
   <data name="keys" xml:space="preserve">
-    <value>[WtYrO][ÌÁKeys !!]</value>
+    <value>[WtYrO][ÛÍKeys !!]</value>
   </data>
   <data name="functionNew_nameError" xml:space="preserve">
-    <value>[KrHSb][Â§The name must be unique within a Function App. It must start with a letter and can contain letters, numbers (0-9), dashes ("-"), and underscores ("_"). !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[KrHSb][ÁùThe name must be unique within a Function App. It must start with a letter and can contain letters, numbers (0-9), dashes ("-"), and underscores ("_"). !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="functionDev_loading" xml:space="preserve">
-    <value>[6XWuz][ááLoading.. !!! ]</value>
+    <value>[6XWuz][áåLoading.. !!! ]</value>
   </data>
   <data name="test" xml:space="preserve">
-    <value>[v8xCB][ÝÇTest !!]</value>
+    <value>[v8xCB][ªÖTest !!]</value>
   </data>
   <data name="runtimeVersion" xml:space="preserve">
-    <value>[TKXLS][è¥Runtime version !!! !!]</value>
+    <value>[TKXLS][§îRuntime version !!! !!]</value>
   </data>
   <data name="error_FunctionExceededQuota" xml:space="preserve">
-    <value>[lPVP6][ÕÏYour function app is disabled because it has exceeded the set quota. You can change that from the function app settings view on the left side bar. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[lPVP6][Ö£Your function app is disabled because it has exceeded the set quota. You can change that from the function app settings view on the left side bar. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="error_siteStopped" xml:space="preserve">
-    <value>[twIVl][ÿÔYour function app is stopped. You cannot use the functions portal when the app is stopped. You can change that by going to the function app settings view on the left side bar and then going to the app service settings blade. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[twIVl][ØéYour function app is stopped. You cannot use the functions portal when the app is stopped. You can change that by going to the function app settings view on the left side bar and then going to the app service settings blade. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="error_NoPermissionToAccessApp" xml:space="preserve">
-    <value>[XTkxH][£çYou don't have sufficient permissions to access this function app. You may still be able to see basic settings in the app service settings blade which you can access from the function app settings link on the left sidebar. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[XTkxH][ÕÃYou don't have sufficient permissions to access this function app. You may still be able to see basic settings in the app service settings blade which you can access from the function app settings link on the left sidebar. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="errorUniqueParameterName" xml:space="preserve">
-    <value>[z6S2c][ÆÖParameter name must be unique. !!! !!! !!!]</value>
+    <value>[z6S2c][ÛìParameter name must be unique. !!! !!! !!!]</value>
   </data>
   <data name="binding_useFunctionReturnValue" xml:space="preserve">
-    <value>[IjLOy][õªUse function return value !!! !!! !!]</value>
+    <value>[IjLOy][§òUse function return value !!! !!! !!]</value>
   </data>
   <data name="functionEdit_functionState" xml:space="preserve">
-    <value>[gQuLe][ÁÞFunction State !!! !!]</value>
+    <value>[gQuLe][ößFunction State !!! !!]</value>
   </data>
   <data name="off" xml:space="preserve">
-    <value>[3o2Ex][ñäOff !!]</value>
+    <value>[3o2Ex][óÙOff !!]</value>
   </data>
   <data name="on" xml:space="preserve">
-    <value>[v4Xef][ï£On !!]</value>
+    <value>[v4Xef][ÞñOn !!]</value>
   </data>
   <data name="topBar_functionApiSettings" xml:space="preserve">
-    <value>[l5gut][ôãAPI settings !!! !]</value>
+    <value>[l5gut][öüAPI settings !!! !]</value>
   </data>
   <data name="sidebar_newApiProxy" xml:space="preserve">
-    <value>[fGlxB][ÉüNew proxy !!! ]</value>
+    <value>[fGlxB][øàNew proxy !!! ]</value>
   </data>
   <data name="apiProxy_allMethods" xml:space="preserve">
-    <value>[j0s0Z][ÿÇAll methods !!! !]</value>
+    <value>[j0s0Z][îêAll methods !!! !]</value>
   </data>
   <data name="apiProxy_allowedHttpMethods" xml:space="preserve">
-    <value>[BwuPT][îÕAllowed HTTP methods !!! !!! ]</value>
+    <value>[BwuPT][éöAllowed HTTP methods !!! !!! ]</value>
   </data>
   <data name="apiProxy_backendUrl" xml:space="preserve">
-    <value>[3zNSV][ÅåBackend URL !!! !]</value>
+    <value>[3zNSV][þÏBackend URL !!! !]</value>
   </data>
   <data name="apiProxy_errorExists" xml:space="preserve">
-    <value>[HI9GS][íðProxy or function with that name already exists. !!! !!! !!! !!! !!]</value>
+    <value>[HI9GS][âÛProxy or function with that name already exists. !!! !!! !!! !!! !!]</value>
   </data>
   <data name="apiProxy_name" xml:space="preserve">
-    <value>[L8VLo][õøName !!]</value>
+    <value>[L8VLo][ÿêName !!]</value>
   </data>
   <data name="apiProxy_proxyUrl" xml:space="preserve">
-    <value>[aDXoP][ØÚProxy URL !!! ]</value>
+    <value>[aDXoP][ññProxy URL !!! ]</value>
   </data>
   <data name="apiProxy_routeTemplate" xml:space="preserve">
-    <value>[4OcB6][ßÇRoute template !!! !!]</value>
+    <value>[4OcB6][ÞÌRoute template !!! !!]</value>
   </data>
   <data name="apiProxy_seectedMethods" xml:space="preserve">
-    <value>[FYnNM][üÀSelected methods !!! !!!]</value>
+    <value>[FYnNM][¥öSelected methods !!! !!!]</value>
   </data>
   <data name="appFunctionSettings_functionAppSettings" xml:space="preserve">
-    <value>[nFUXm][ªÔfunction app settings !!! !!! ]</value>
+    <value>[nFUXm][ùñfunction app settings !!! !!! ]</value>
   </data>
   <data name="appFunctionSettings_functionAppSettings1" xml:space="preserve">
-    <value>[qso5Y][ÄÐRuntime version: {{extensionVersion}}. A newer version is available ({{latestExtensionVersion}}). !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[qso5Y][ÅÐRuntime version: {{extensionVersion}}. A newer version is available ({{latestExtensionVersion}}). !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="appFunctionSettings_functionAppSettings2" xml:space="preserve">
-    <value>[YFkSm][ÜÅRuntime version: {{exactExtensionVersion}} ({{latestExtensionVersion}}) !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[YFkSm][ÁßRuntime version: {{exactExtensionVersion}} ({{latestExtensionVersion}}) !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
-    <value>[9lEjA][øñProxies (preview) !!! !!!]</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>[rW6W8][Ì¢Proxy runtime version: {{extensionVersion}}. A newer version is available ({{latestExtensionVersion}}). !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>[jrmCP][ÍåProxy runtime version: latest ({{latestExtensionVersion}}) !!! !!! !!! !!! !!! !]</value>
+    <value>[9lEjA][ÂÉProxies (preview) !!! !!!]</value>
   </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
-    <value>[DGX5K][¢ÉEnable Azure Functions Proxies (preview) !!! !!! !!! !!!]</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>[QEqL7][éÛAzure Functions Proxies are currently disabled. To enable, visit !!! !!! !!! !!! !!! !!!]</value>
+    <value>[DGX5K][ÄóEnable Azure Functions Proxies (preview) !!! !!! !!! !!!]</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
-    <value>[ISiRw][ÙíChanges made to proxy {{name}} will be lost. Are you sure you want to continue? !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[ISiRw][ÚÞChanges made to proxy {{name}} will be lost. Are you sure you want to continue? !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="apiProxy_alreadyExists" xml:space="preserve">
-    <value>[tnqJ7][àÊProxy with name '{{name}}' already exists !!! !!! !!! !!!]</value>
+    <value>[tnqJ7][ÏÈProxy with name '{{name}}' already exists !!! !!! !!! !!!]</value>
   </data>
   <data name="slots_warningOff" xml:space="preserve">
-    <value>[7GHEr][äÅAzure functions slots (preview) is currently disabled. To enable, visit !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[7GHEr][êÀAzure functions slots (preview) is currently disabled. To enable, visit !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
-  <data name="discrard" xml:space="preserve">
-    <value>[rhlUu][ÌíDiscard !!!]</value>
+  <data name="discard" xml:space="preserve">
+    <value>[ra6uk][ãÖDiscard !!!]</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
-    <value>[xdErx][ØüFunctions !!! ]</value>
+    <value>[xdErx][¥éFunctions !!! ]</value>
   </data>
   <data name="intro_signInWithFacebook" xml:space="preserve">
-    <value>[tqw1e][æÿSign in with Facebook !!! !!! ]</value>
+    <value>[tqw1e][ÆæSign in with Facebook !!! !!! ]</value>
   </data>
   <data name="intro_signInWithGitHub" xml:space="preserve">
-    <value>[WO5nN][ÅþSign in with GitHub !!! !!! ]</value>
+    <value>[WO5nN][ÀÄSign in with GitHub !!! !!! ]</value>
   </data>
   <data name="intro_signInWithGoogle" xml:space="preserve">
-    <value>[X6DKg][ÝçSign in with Google !!! !!! ]</value>
+    <value>[X6DKg][ÀªSign in with Google !!! !!! ]</value>
   </data>
   <data name="intro_signInWithMicrosoft" xml:space="preserve">
-    <value>[FL7vG][ÆéSign in with Microsoft !!! !!! !]</value>
+    <value>[FL7vG][îÈSign in with Microsoft !!! !!! !]</value>
   </data>
   <data name="apiProxy_backanrUrlStart" xml:space="preserve">
-    <value>[nMo9Z][ÏÚBackend URL must start with 'http://' or 'https://' !!! !!! !!! !!! !!!]</value>
+    <value>[nMo9Z][áåBackend URL must start with 'http://' or 'https://' !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="functionKeys_copy" xml:space="preserve">
-    <value>[XsfS6][üæCopy !!]</value>
+    <value>[XsfS6][àæCopy !!]</value>
   </data>
   <data name="functionKeys_renew" xml:space="preserve">
-    <value>[IPDd7][ÜÕRenew !!!]</value>
+    <value>[IPDd7][ÚÍRenew !!!]</value>
   </data>
   <data name="functionKeys_revoke" xml:space="preserve">
-    <value>[g265R][ñÚRevoke !!!]</value>
+    <value>[g265R][ØäRevoke !!!]</value>
   </data>
   <data name="logStreaming_compress" xml:space="preserve">
-    <value>[8bIOe][ÆÛCollapse !!! ]</value>
+    <value>[8bIOe][ôéCollapse !!! ]</value>
   </data>
   <data name="logStreaming_expand" xml:space="preserve">
-    <value>[ocOfh][ÍëExpand !!!]</value>
+    <value>[ocOfh][üÞExpand !!!]</value>
   </data>
   <data name="functionDev_gerFunctionUrl" xml:space="preserve">
-    <value>[m6jL5][ãþ&lt;/&gt; Get function URL !!! !!! ]</value>
+    <value>[m6jL5][þÜ&lt;/&gt; Get function URL !!! !!! ]</value>
   </data>
   <data name="functionDev_gerGithubSecret" xml:space="preserve">
-    <value>[eN8G3][Ðµ&lt;/&gt; Get GitHub secret !!! !!! ]</value>
+    <value>[eN8G3][íÏ&lt;/&gt; Get GitHub secret !!! !!! ]</value>
   </data>
   <data name="httpRun_headers" xml:space="preserve">
-    <value>[2Em0O][àÖHeaders !!!]</value>
+    <value>[2Em0O][õØHeaders !!!]</value>
   </data>
   <data name="httpRun_noHeaders" xml:space="preserve">
-    <value>[1aGsR][¢ÈThere are no headers !!! !!! ]</value>
+    <value>[1aGsR][ðÌThere are no headers !!! !!! ]</value>
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
-    <value>[pmSwO][ãØAll subscriptions !!! !!!]</value>
+    <value>[pmSwO][¥ËAll subscriptions !!! !!!]</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>[tkYhP][ÌËSubscriptions !!! !!]</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
-    <value>[uMBhy][Åö{0} subscriptions !!! !!!]</value>
+    <value>[uMBhy][Ìñ{0} subscriptions !!! !!!]</value>
   </data>
   <data name="sideNav_FunctionsNoAccess" xml:space="preserve">
-    <value>[vZ7Bd][ÌãFunctions (No access) !!! !!! ]</value>
+    <value>[vZ7Bd][ËÒFunctions (No access) !!! !!! ]</value>
   </data>
   <data name="sideNav_FunctionsReadOnlyLock" xml:space="preserve">
-    <value>[O2pHZ][åÔFunctions (ReadOnly lock) !!! !!! !!]</value>
+    <value>[O2pHZ][ìªFunctions (ReadOnly lock) !!! !!! !!]</value>
   </data>
   <data name="sideNav_FunctionsStopped" xml:space="preserve">
-    <value>[EKf4n][ê¢Functions (Stopped) !!! !!! ]</value>
+    <value>[EKf4n][ÅÁFunctions (Stopped) !!! !!! ]</value>
   </data>
   <data name="sideNav_ProxiesNoAccess" xml:space="preserve">
-    <value>[8f72t][©ßProxies (No access) !!! !!! ]</value>
+    <value>[8f72t][ÕÓProxies (No access) !!! !!! ]</value>
   </data>
   <data name="sideNav_ProxiesStopped" xml:space="preserve">
-    <value>[kGBpC][µÚProxies (Stopped) !!! !!!]</value>
+    <value>[kGBpC][ëåProxies (Stopped) !!! !!!]</value>
   </data>
   <data name="sideNav_ProxiesReadOnlyLock" xml:space="preserve">
-    <value>[atLg0][ûËProxies (ReadOnly lock) !!! !!! !]</value>
+    <value>[atLg0][òØProxies (ReadOnly lock) !!! !!! !]</value>
   </data>
   <data name="functions" xml:space="preserve">
-    <value>[VHO8Q][âÖFunctions !!! ]</value>
+    <value>[VHO8Q][ðàFunctions !!! ]</value>
   </data>
   <data name="newFunction" xml:space="preserve">
-    <value>[zYKDm][ÍßNew function !!! !]</value>
+    <value>[zYKDm][òÇNew function !!! !]</value>
   </data>
   <data name="functionApps" xml:space="preserve">
-    <value>[sSKm2][úÂFunction Apps !!! !!]</value>
+    <value>[sSKm2][ìöFunction Apps !!! !!]</value>
   </data>
   <data name="stop" xml:space="preserve">
-    <value>[Suz6N][¥ÑStop !!]</value>
+    <value>[Suz6N][ÚÔStop !!]</value>
   </data>
   <data name="start" xml:space="preserve">
-    <value>[jEjj0][ýêStart !!!]</value>
+    <value>[jEjj0][Á¢Start !!!]</value>
   </data>
   <data name="restart" xml:space="preserve">
-    <value>[nsHwD][§üRestart !!!]</value>
+    <value>[nsHwD][ñÎRestart !!!]</value>
   </data>
   <data name="swap" xml:space="preserve">
-    <value>[dlgc8][ÑÐSwap !!]</value>
+    <value>[dlgc8][ïðSwap !!]</value>
   </data>
   <data name="downloadProfile" xml:space="preserve">
-    <value>[IId24][ÅÅDownload publish profile !!! !!! !]</value>
+    <value>[IId24][óÿDownload publish profile !!! !!! !]</value>
   </data>
   <data name="resetPubCredentials" xml:space="preserve">
-    <value>[4E7dY][ÝØReset publish credentials !!! !!! !!]</value>
+    <value>[4E7dY][ÉÎReset publish credentials !!! !!! !!]</value>
   </data>
   <data name="_delete" xml:space="preserve">
-    <value>[P3ijB][©ØDelete !!!]</value>
+    <value>[P3ijB][ÎÍDelete !!!]</value>
   </data>
   <data name="status" xml:space="preserve">
-    <value>[gr7nB][øÂStatus !!!]</value>
+    <value>[gr7nB][Ï©Status !!!]</value>
   </data>
   <data name="availability" xml:space="preserve">
-    <value>[PPGdx][ÎµAvailability !!! !]</value>
+    <value>[PPGdx][ääAvailability !!! !]</value>
   </data>
   <data name="available" xml:space="preserve">
-    <value>[Rg83J][ôüAvailable !!! ]</value>
+    <value>[Rg83J][ñóAvailable !!! ]</value>
   </data>
   <data name="noAccess" xml:space="preserve">
-    <value>[CXoAP][îÛNo access !!! ]</value>
+    <value>[CXoAP][ÂÒNo access !!! ]</value>
   </data>
   <data name="notApplicable" xml:space="preserve">
-    <value>[dD1nf][ñ¢Not applicable !!! !!]</value>
+    <value>[dD1nf][ííNot applicable !!! !!]</value>
   </data>
   <data name="notAvailable" xml:space="preserve">
-    <value>[v2ybf][ÌÁNot available !!! !!]</value>
+    <value>[v2ybf][ïëNot available !!! !!]</value>
   </data>
   <data name="enabledFeatures_header" xml:space="preserve">
-    <value>[WtWPr][éµConfigured features !!! !!! ]</value>
+    <value>[WtWPr][ýÙConfigured features !!! !!! ]</value>
   </data>
   <data name="enabledFeatures_description" xml:space="preserve">
-    <value>[TTRUj][ùÞQuick links to your features will show up here after you've configured them from the "Platform features" tab above. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[TTRUj][ÉÐQuick links to your features will show up here after you've configured them from the "Platform features" tab above. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+  </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>[VuY7O][ÚôUnsaved changes for the app '{0}' will be lost.  Are you sure you would like to continue? !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
-    <value>[17Hb9][ÆáThere was an error retrieving information about the app '{0}' !!! !!! !!! !!! !!! !!]</value>
+    <value>[17Hb9][¥úThere was an error retrieving information about the app '{0}' !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="siteDashboard_appNotFound" xml:space="preserve">
-    <value>[qTCMA][ÏÚThe app '{0}' could not be found !!! !!! !!! ]</value>
+    <value>[qTCMA][ÍØThe app '{0}' could not be found !!! !!! !!! ]</value>
   </data>
   <data name="siteSummary_stopConfirmation" xml:space="preserve">
-    <value>[VqLFR][§£Are you sure you would like to stop '{0}' !!! !!! !!! !!!]</value>
+    <value>[VqLFR][ÊÃAre you sure you would like to stop '{0}' !!! !!! !!! !!!]</value>
   </data>
   <data name="siteSummary_stopNotifyTitle" xml:space="preserve">
-    <value>[4CGT0][ÔÁStopping app '{0}' !!! !!!]</value>
+    <value>[4CGT0][æÚStopping app '{0}' !!! !!!]</value>
   </data>
   <data name="siteSummary_startNotifyTitle" xml:space="preserve">
-    <value>[ekCYB][ÞþStarting app '{0}' !!! !!!]</value>
+    <value>[ekCYB][íüStarting app '{0}' !!! !!!]</value>
   </data>
   <data name="siteSummary_stopNotifySuccess" xml:space="preserve">
-    <value>[7gKHc][@ãSuccessfully stopped app '{0}' !!! !!! !!!]</value>
+    <value>[7gKHc][íØSuccessfully stopped app '{0}' !!! !!! !!!]</value>
   </data>
   <data name="siteSummary_startNotifySuccess" xml:space="preserve">
-    <value>[0wR3v][ååSuccessfully started app '{0}' !!! !!! !!!]</value>
+    <value>[0wR3v][©ûSuccessfully started app '{0}' !!! !!! !!!]</value>
   </data>
   <data name="siteSummary_stopNotifyFail" xml:space="preserve">
-    <value>[2qgZZ][¢äFailed to stop app '{0}' !!! !!! !]</value>
+    <value>[2qgZZ][ÌåFailed to stop app '{0}' !!! !!! !]</value>
   </data>
   <data name="siteSummary_startNotifyFail" xml:space="preserve">
-    <value>[aGMIP][£ãFailed to start app '{0}' !!! !!! !!]</value>
+    <value>[aGMIP][ÆâFailed to start app '{0}' !!! !!! !!]</value>
   </data>
   <data name="siteSummary_resetProfileConfirmation" xml:space="preserve">
-    <value>[DFbYX][ÔµAre you sure you want to reset your publish profile? Profiles downloaded previously will become invalid. !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[DFbYX][ÜÎAre you sure you want to reset your publish profile? Profiles downloaded previously will become invalid. !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="siteSummary_resetProfileNotifyTitle" xml:space="preserve">
-    <value>[4fpVw][ÅõResetting publishing profile !!! !!! !!!]</value>
+    <value>[4fpVw][øùResetting publishing profile !!! !!! !!!]</value>
   </data>
   <data name="siteSummary_resetProfileNotifySuccess" xml:space="preserve">
-    <value>[a3Jat][ñÝSuccessfully reset publishing profile !!! !!! !!! !!]</value>
+    <value>[a3Jat][ïÄSuccessfully reset publishing profile !!! !!! !!! !!]</value>
   </data>
   <data name="siteSummary_resetProfileNotifyFail" xml:space="preserve">
-    <value>[QqK8f][óãFailed to reset publishing profile !!! !!! !!! !]</value>
+    <value>[QqK8f][ÞôFailed to reset publishing profile !!! !!! !!! !]</value>
   </data>
   <data name="siteSummary_deleteConfirmation" xml:space="preserve">
-    <value>[Z8blP][ªôAre you sure you want to delete '{0}' !!! !!! !!! !!]</value>
+    <value>[Z8blP][ÕÅAre you sure you want to delete '{0}' !!! !!! !!! !!]</value>
   </data>
   <data name="siteSummary_deleteNotifyTitle" xml:space="preserve">
-    <value>[52jLn][ûôDeleting app '{0}' !!! !!!]</value>
+    <value>[52jLn][ñòDeleting app '{0}' !!! !!!]</value>
   </data>
   <data name="siteSummary_deleteNotifySuccess" xml:space="preserve">
-    <value>[zMndx][ìÔSuccessfully deleted app '{0}' !!! !!! !!!]</value>
+    <value>[zMndx][ÚÇSuccessfully deleted app '{0}' !!! !!! !!!]</value>
   </data>
   <data name="siteSummary_deleteNotifyFail" xml:space="preserve">
-    <value>[d0Oqx][îÿFailed to delete app '{0}' !!! !!! !!]</value>
+    <value>[d0Oqx][ãÕFailed to delete app '{0}' !!! !!! !!]</value>
   </data>
   <data name="siteSummary_restartConfirmation" xml:space="preserve">
-    <value>[lKW4B][ÝýAre you sure you would like to restart '{0}' !!! !!! !!! !!! ]</value>
+    <value>[lKW4B][ÎÒAre you sure you would like to restart '{0}' !!! !!! !!! !!! ]</value>
   </data>
   <data name="siteSummary_restartNotifyTitle" xml:space="preserve">
-    <value>[Qyh1I][ÆëRestarting app '{0}' !!! !!! ]</value>
+    <value>[Qyh1I][¥ÖRestarting app '{0}' !!! !!! ]</value>
   </data>
   <data name="siteSummary_restartNotifySuccess" xml:space="preserve">
-    <value>[N5WOH][ÝæSuccessfully restarted app '{0}' !!! !!! !!! ]</value>
+    <value>[N5WOH][ûÚSuccessfully restarted app '{0}' !!! !!! !!! ]</value>
   </data>
   <data name="siteSummary_restartNotifyFail" xml:space="preserve">
-    <value>[fz1FM][ÈëFailed to restart app '{0}' !!! !!! !!]</value>
+    <value>[fz1FM][ÿöFailed to restart app '{0}' !!! !!! !!]</value>
   </data>
   <data name="featureNotSupportedConsumption" xml:space="preserve">
-    <value>[jpXTk][ÑÉThis feature is not supported for apps on a Consumption plan !!! !!! !!! !!! !!! !!]</value>
+    <value>[jpXTk][Â©This feature is not supported for apps on a Consumption plan !!! !!! !!! !!! !!! !!]</value>
+  </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>[1tXW7][ÆöThis feature is not supported for slots !!! !!! !!! !!!]</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>[xXStu][ÃõThis feature is not supported for Linux apps !!! !!! !!! !!! ]</value>
   </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
-    <value>[qd6IQ][ÔÊYou must have write permissions on the current app in order to use this feature !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[qd6IQ][üûYou must have write permissions on the current app in order to use this feature !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="featureDisabledReadOnlyLockOnApp" xml:space="preserve">
-    <value>[712lG][úïThis feature is disabled because the app has a ReadOnly lock on it !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[712lG][õêThis feature is disabled because the app has a ReadOnly lock on it !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="featureDisabledNoPermissionToPlan" xml:space="preserve">
-    <value>[EpXji][¥ÊYou must have Read permissions on the associated App Service plan in order to use this feature !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[EpXji][êðYou must have Read permissions on the associated App Service plan in order to use this feature !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="feature_api" xml:space="preserve">
-    <value>[zxYV9][Í©API !!]</value>
+    <value>[zxYV9][ÿÃAPI !!]</value>
   </data>
   <data name="feature_deploymentSourceName" xml:space="preserve">
-    <value>[CFtjV][@ýDeployment options !!! !!!]</value>
+    <value>[CFtjV][ÇèDeployment options !!! !!!]</value>
   </data>
   <data name="feature_deploymentSourceInfo" xml:space="preserve">
-    <value>[0JCcY][áÍConfigure and manage deployment options for your app, including continuous deployment from VSTS, Github and Bitbucket as well as trigger deployments from OneDrive, Dropbox, external Git and more. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[0JCcY][ÌØConfigure and manage deployment options for your app, including continuous deployment from VSTS, Github and Bitbucket as well as trigger deployments from OneDrive, Dropbox, external Git and more. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="feature_deploymentCredsName" xml:space="preserve">
-    <value>[Yvhge][ÈñDeployment credentials !!! !!! !]</value>
+    <value>[Yvhge][ëÚDeployment credentials !!! !!! !]</value>
   </data>
   <data name="feature_deploymentCredsInfo" xml:space="preserve">
-    <value>[mWkr2][ÞÔConfigure Azure account-level deployment credentials. To change your app-level credentials (also known as 'Publish Credentials'), choose 'Reset publish credentials' in the 'Overview' tab. &lt;a href="https://go.microsoft.com/fwlink/?linkid=846056"&gt;Learn more&lt;/a&gt;. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[mWkr2][©üConfigure Azure account-level deployment credentials. To change your app-level credentials (also known as 'Publish Credentials'), choose 'Reset publish credentials' in the 'Overview' tab. &lt;a href="https://go.microsoft.com/fwlink/?linkid=846056"&gt;Learn more&lt;/a&gt;. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="feature_consoleName" xml:space="preserve">
-    <value>[O6WB1][£åConsole !!!]</value>
+    <value>[O6WB1][ÿÃConsole !!!]</value>
   </data>
   <data name="feature_consoleInfo" xml:space="preserve">
-    <value>[NoMcv][¢£Explore your app's file system from an interactive web-based console. !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[NoMcv][ÓÍExplore your app's file system from an interactive web-based console. !!! !!! !!! !!! !!! !!! !]</value>
+  </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>[bNGTE][ç§SSH !!]</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>[sqOfz][åÉSSH provides a Web SSH console experience for your Linux app code !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="feature_extensionsName" xml:space="preserve">
-    <value>[oK4fh][ÔèExtensions !!! !]</value>
+    <value>[oK4fh][ÅàExtensions !!! !]</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
-    <value>[HoN7I][Î@Extensions add functionality to your entire app. !!! !!! !!! !!! !!]</value>
+    <value>[HoN7I][£ªExtensions add functionality to your entire app. !!! !!! !!! !!! !!]</value>
+  </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>[PhZwN][ôÆ(no application settings to display) !!! !!! !!! !!]</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>[UhJWe][ÿÎ(no connection strings to display) !!! !!! !!! !]</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>[wFaZU][íå(no default documents to display) !!! !!! !!! !]</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>[vj8xs][ÐÔ(no handler mappings to display) !!! !!! !!! ]</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>[ZsHQt][ýî(no virtual applications or directories to display) !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>[8KJCN][ÛÒGeneral settings !!! !!!]</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>[XlXme][ØêAuto Swap !!! ]</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>[4WLfX][ëÑDebugging !!! ]</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>[LM2DJ][þâRuntime !!!]</value>
   </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
-    <value>[4HfJf][@ÐApplication settings !!! !!! ]</value>
+    <value>[4HfJf][íãApplication settings !!! !!! ]</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
-    <value>[Jaewj][üÄManage app settings, connection strings, runtime settings, and more. !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[Jaewj][ê¢Manage app settings, connection strings, runtime settings, and more. !!! !!! !!! !!! !!! !!! !]</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>[o5op2][ðâDefault documents !!! !!!]</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>[zu67y][ÿÑHandler mappings !!! !!!]</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>[30fBa][ëãVirtual applicataions and directories !!! !!! !!! !!]</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>[l7Ted][ÕþYou must have write permissions on the current app in order to edit these settings. !!! !!! !!! !!! !!! !!! !!! !!]</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>[eJkdI][ÄèThis app has a read-only lock that prevents editing settings or retrieving secure data. Please remove the lock and try again. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>[zNEXq][ÔÿView settings in read-only mode. !!! !!! !!! ]</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>[sImY3][ïåFailed to load settings. !!! !!! !]</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>[FZLa1][êÝLoading... !!! !]</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>[O7rq1][©ÇUpdating web app settings !!! !!! !!]</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>[um7xG][ÏÍSuccessfully updated web app settings !!! !!! !!! !!]</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>[w3HzK][ÚÊFailed to update web app settings:  !!! !!! !!! !]</value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>[2oBCR][Þà{{configGroupName}} Save Error: Invlid input provided. !!! !!! !!! !!! !!! ]</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>[AzRs7][Õµ.NET Framework version !!! !!! !]</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>[hxMg7][ëËThe version used to run your web app if using the .NET Framework !!! !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>[ZvswO][ÄÁPHP version !!! !]</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>[lU4O0][ÌÌThe version used to run your web app if using PHP !!! !!! !!! !!! !!]</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>[bcY1b][ñèPython version !!! !!]</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>[wkTOz][µÛThe version used to run your web app if using Python !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>[tC31B][£üJava version !!! !]</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>[1k1gX][ößThe version used to run your web app if using Java !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>[NsMzs][¥ÒJava minor version !!! !!!]</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>[k1Hbm][ÇÍSelect the desired Java minor version. Selecting 'Newest' will keep your app using the JVM most recently added to the portal. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>[jzgjH][ÿúWeb container !!! !!]</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>[LjxPY][µ©The web container version used to run your web app if using Java !!! !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>[tSfaq][ÆÞPlatform !!! ]</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>[RmQnB][ÔÃThe platform architecture your web app runs !!! !!! !!! !!! ]</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>[D36FH][íû64-bit configuration requires a basic or higher App Service plan !!! !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>[6QpBJ][éÙWeb sockets !!! !]</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>[u7d0r][§ýWebSockets allow more flexible connectivity between web apps and modern browsers.  Your web app would need to be built to leverage these capabilities. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>[ojE0N][üïAlways On !!! ]</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>[s40IF][ô¢Indicates that your web app needs to be loaded at all times. By default, web apps are unloaded after they have been idle. It is recommended that you enable this option when you have continuous web jobs running on the web app. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>[eMe02][áâAlways on requires a basic or higher App Service plan !!! !!! !!! !!! !!! ]</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>[oRZ8H][úÆManaged Pipeline Version !!! !!! !]</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>[Vfset][ðÁAuto swap destinations cannot be configured from production slot !!! !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>[8eQty][ÆìAuto Swap !!! ]</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>[FEl09][êÉAuto Swap Slot !!! !!]</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>[Oyc0y][ò©ARR Affinity !!! !]</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>[3v1hz][ÍÄRemote debugging !!! !!!]</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>[BZL7H][ÀöRemote Visual Studio version !!! !!! !!!]</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>[caOVE][âÛStack !!!]</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>[lX4FP][ªåStartup File !!! !]</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>[0wM2b][ÞÜNewest !!!]</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>[pLhwL][êð32-bit !!!]</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>[iwPHz][áÕ64-bit !!!]</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>[rU8tZ][ÝÝClassic !!!]</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>[HtV2J][æòIntegrated !!! !]</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
-    <value>[Xf4aE][åóProperties !!! !]</value>
+    <value>[Xf4aE][ªÃProperties !!! !]</value>
   </data>
   <data name="feature_propertiesInfo" xml:space="preserve">
-    <value>[VSoAq][ËØView properties of your app. !!! !!! !!!]</value>
+    <value>[VSoAq][ñøView properties of your app. !!! !!! !!!]</value>
   </data>
   <data name="feature_backupsName" xml:space="preserve">
-    <value>[AacQo][ãÃBackups !!!]</value>
+    <value>[AacQo][õçBackups !!!]</value>
   </data>
   <data name="feature_backupsInfo" xml:space="preserve">
-    <value>[mpx8N][þÅUse Backup and Restore to easily create automatic or manual backups. !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[mpx8N][ÒÓUse Backup and Restore to easily create automatic or manual backups. !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="feature_allSettingsName" xml:space="preserve">
-    <value>[KlJLU][þíAll settings !!! !]</value>
+    <value>[KlJLU][ìÒAll settings !!! !]</value>
   </data>
   <data name="feature_allSettingsInfo" xml:space="preserve">
-    <value>[7i2fY][ôëView all App Service settings. !!! !!! !!!]</value>
+    <value>[7i2fY][äÔView all App Service settings. !!! !!! !!!]</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>[YwyI3][æÂManage settings that affect the Functions runtime for all functions within your app. !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[YwyI3][üÇManage settings that affect the Functions runtime for all functions within your app. !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
-    <value>[vYoSx][ÑÍGeneral Settings !!! !!!]</value>
+    <value>[vYoSx][ÍÄGeneral Settings !!! !!!]</value>
   </data>
   <data name="feature_codeDeployment" xml:space="preserve">
-    <value>[jBK08][ÜÉCode Deployment !!! !!]</value>
+    <value>[jBK08][©ÄCode Deployment !!! !!]</value>
   </data>
   <data name="feature_developmentTools" xml:space="preserve">
-    <value>[yFyZs][ïÑDevelopment tools !!! !!!]</value>
+    <value>[yFyZs][ÔæDevelopment tools !!! !!!]</value>
   </data>
   <data name="feature_networkingName" xml:space="preserve">
-    <value>[hsNk1][ÂþNetworking !!! !]</value>
+    <value>[hsNk1][ÚÜNetworking !!! !]</value>
   </data>
   <data name="feature_networkingInfo" xml:space="preserve">
-    <value>[McG3k][ïÇSecurely access resources through VNET Integration and Hybrid Connections. !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[McG3k][îÎSecurely access resources through VNET Integration and Hybrid Connections. !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="feature_sslInfo" xml:space="preserve">
-    <value>[2qHpU][@àConfigure SSL bindings for your app using either a certificate you purchased externally or an App Service Certificate. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[2qHpU][âåConfigure SSL bindings for your app using either a certificate you purchased externally or an App Service Certificate. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="feature_customDomainsName" xml:space="preserve">
-    <value>[Dpt6o][öéCustom domains !!! !!]</value>
+    <value>[Dpt6o][óíCustom domains !!! !!]</value>
   </data>
   <data name="feature_customDomainsInfo" xml:space="preserve">
-    <value>[2jED3][ÙÒConfigure and purchase custom domain names. !!! !!! !!! !!! ]</value>
+    <value>[2jED3][Ã£Configure and purchase custom domain names. !!! !!! !!! !!! ]</value>
   </data>
   <data name="feature_authName" xml:space="preserve">
-    <value>[A4M9T][êóAuthentication / Authorization !!! !!! !!!]</value>
+    <value>[A4M9T][ÂÞAuthentication / Authorization !!! !!! !!!]</value>
   </data>
   <data name="feature_authInfo" xml:space="preserve">
-    <value>[LDdvE][£èUse Authentication / Authorization to protect your application and work with per-user data. !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[LDdvE][èÔUse Authentication / Authorization to protect your application and work with per-user data. !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>[zHqWF][ÈËManaged service identity !!! !!! !]</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>[FZyXa][öûYour application can communicate with other Azure services as itself using a managed Azure Active Directory identity. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
-    <value>[eT8r1][ÆìPush notifications !!! !!!]</value>
+    <value>[eT8r1][îüPush notifications !!! !!!]</value>
   </data>
   <data name="feature_pushNotificationsInfo" xml:space="preserve">
-    <value>[x7Kgu][ìþSend fast, scalable, and cross-platform mobile push notifications using Notification Hubs. !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[x7Kgu][Ý©Send fast, scalable, and cross-platform mobile push notifications using Notification Hubs. !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="feature_diagnosticLogsName" xml:space="preserve">
-    <value>[LJCnd][íÞDiagnostic logs !!! !!]</value>
+    <value>[LJCnd][ÉçDiagnostic logs !!! !!]</value>
   </data>
   <data name="feature_diagnosticLogsInfo" xml:space="preserve">
-    <value>[ZvSd4][éáConfigure where and when to log application and server events. !!! !!! !!! !!! !!! !!!]</value>
+    <value>[ZvSd4][ªîConfigure where and when to log application and server events. !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="feature_logStreamingName" xml:space="preserve">
-    <value>[iTGu1][îåLog streaming !!! !!]</value>
+    <value>[iTGu1][ääLog streaming !!! !!]</value>
   </data>
   <data name="feature_logStreamingInfo" xml:space="preserve">
-    <value>[erdLM][ÉÙView real-time application logs. !!! !!! !!! ]</value>
+    <value>[erdLM][§ûView real-time application logs. !!! !!! !!! ]</value>
   </data>
   <data name="feature_processExplorerName" xml:space="preserve">
-    <value>[LxlAV][ìÏProcess explorer !!! !!!]</value>
+    <value>[LxlAV][ËØProcess explorer !!! !!!]</value>
   </data>
   <data name="feature_processExplorerInfo" xml:space="preserve">
-    <value>[aGiK7][ÔªView details on application processes, memory usage, and CPU utilization. !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[aGiK7][ÆªView details on application processes, memory usage, and CPU utilization. !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="feature_securityScanningName" xml:space="preserve">
-    <value>[KL5p5][ÃöSecurity scanning !!! !!!]</value>
+    <value>[KL5p5][ÓäSecurity scanning !!! !!!]</value>
   </data>
   <data name="feature_securityScanningInfo" xml:space="preserve">
-    <value>[eMcsP][ùþEnable security scanning for your app with Tinfoil Security. !!! !!! !!! !!! !!! !!]</value>
+    <value>[eMcsP][ôâEnable security scanning for your app with Tinfoil Security. !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="feature_monitoring" xml:space="preserve">
-    <value>[JkgTe][àüMonitoring !!! !]</value>
+    <value>[JkgTe][ô£Monitoring !!! !]</value>
   </data>
   <data name="feature_corsInfo" xml:space="preserve">
-    <value>[d63px][@ÀConfigure Cross-Origin Resource Sharing (CORS) rules for your app. !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[d63px][ÑÆConfigure Cross-Origin Resource Sharing (CORS) rules for your app. !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="feature_apiDefinitionName" xml:space="preserve">
-    <value>[HZs7I][õâAPI definition !!! !!]</value>
+    <value>[HZs7I][ÍÙAPI definition !!! !!]</value>
   </data>
   <data name="feature_apiDefinitionInfo" xml:space="preserve">
-    <value>[tPx3x][íûConfigure the location of the Swagger 2.0 metadata describing your API. This makes it easy for others to discover and consume your API. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[tPx3x][ÎúConfigure the location of the Swagger 2.0 metadata describing your API. This makes it easy for others to discover and consume your API. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="feature_appServicePlanInfo" xml:space="preserve">
-    <value>[m3I1v][ÇîAn App Service plan is the container for your app. The App Service plan settings will determine the location, features, cost and compute resources associated with your app. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[m3I1v][éæAn App Service plan is the container for your app. The App Service plan settings will determine the location, features, cost and compute resources associated with your app. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="feature_quotasName" xml:space="preserve">
-    <value>[8m1dh][åªQuotas !!!]</value>
+    <value>[8m1dh][ÙåQuotas !!!]</value>
   </data>
   <data name="feature_quotasInfo" xml:space="preserve">
-    <value>[84VZ1][§ÔMonitor file system usage quotas. !!! !!! !!! !]</value>
+    <value>[84VZ1][îËMonitor file system usage quotas. !!! !!! !!! !]</value>
   </data>
   <data name="feature_activityLogName" xml:space="preserve">
-    <value>[u4ara][ýÀActivity log !!! !]</value>
+    <value>[u4ara][öÙActivity log !!! !]</value>
   </data>
   <data name="feature_activityLogInfo" xml:space="preserve">
-    <value>[zH2Kt][äøView management operations that have been performed on your app. !!! !!! !!! !!! !!! !!!]</value>
+    <value>[zH2Kt][À£View management operations that have been performed on your app. !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="feature_accessControlName" xml:space="preserve">
-    <value>[K3627][ýçAccess control (IAM) !!! !!! ]</value>
+    <value>[K3627][íþAccess control (IAM) !!! !!! ]</value>
   </data>
   <data name="feature_accessControlInfo" xml:space="preserve">
-    <value>[rdcI0][Þ@Configure Role-Based Access Control (RBAC) for your app. !!! !!! !!! !!! !!! !]</value>
+    <value>[rdcI0][ÍÌConfigure Role-Based Access Control (RBAC) for your app. !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="feature_tagsName" xml:space="preserve">
-    <value>[axWqb][ÒÈTags !!]</value>
+    <value>[axWqb][àÏTags !!]</value>
   </data>
   <data name="feature_tagsInfo" xml:space="preserve">
-    <value>[ul9nk][ÙÆTags are key/value pairs that enable you to categorize resources and view consolidated billing by applying the same tag to multiple resources and resource groups.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[ul9nk][õÐTags are key/value pairs that enable you to categorize resources and view consolidated billing by applying the same tag to multiple resources and resource groups.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="feature_locksName" xml:space="preserve">
-    <value>[AJdtj][ÌæLocks !!!]</value>
+    <value>[AJdtj][ÀéLocks !!!]</value>
   </data>
   <data name="feature_locksInfo" xml:space="preserve">
-    <value>[ahTMZ][ÑµLock resources to prevent unexpected changes or deletions. !!! !!! !!! !!! !!! !]</value>
+    <value>[ahTMZ][àèLock resources to prevent unexpected changes or deletions. !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="feature_automationScriptName" xml:space="preserve">
-    <value>[z4HmW][ÌøAutomation script !!! !!!]</value>
+    <value>[z4HmW][àðAutomation script !!! !!!]</value>
   </data>
   <data name="feature_automationScriptInfo" xml:space="preserve">
-    <value>[vVAN4][úðAutomate deploying resources with Azure Resource Manager templates in a single, coordinated operation. Define resources and configurable input parameters and deploy with script or code. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[vVAN4][ØòAutomate deploying resources with Azure Resource Manager templates in a single, coordinated operation. Define resources and configurable input parameters and deploy with script or code. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="feature_resourceManagement" xml:space="preserve">
-    <value>[hQFVK][ÐèResource management !!! !!! ]</value>
+    <value>[hQFVK][ÃÛResource management !!! !!! ]</value>
   </data>
   <data name="feature_advancedToolsName" xml:space="preserve">
-    <value>[00JJA][èðAdvanced tools (Kudu) !!! !!! ]</value>
+    <value>[00JJA][ÞÔAdvanced tools (Kudu) !!! !!! ]</value>
   </data>
   <data name="feature_advancedToolsInfo" xml:space="preserve">
-    <value>[mDuLz][ÍÊUse Kudu to inspect environment variables, access the debug console, upload zips, view processes, and more. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[mDuLz][ÔÍUse Kudu to inspect environment variables, access the debug console, upload zips, view processes, and more. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="feature_appServiceEditorName" xml:space="preserve">
-    <value>[7SOPq][ÔïApp Service Editor !!! !!!]</value>
+    <value>[7SOPq][ÒÂApp Service Editor !!! !!!]</value>
   </data>
   <data name="feature_appServiceEditorInfo" xml:space="preserve">
-    <value>[j1sR8][ÒªApp Service Editor provides an in-browser editing experience for your code. !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[j1sR8][@ÿApp Service Editor provides an in-browser editing experience for your code. !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="feature_resourceExplorerName" xml:space="preserve">
-    <value>[9jh51][ªÈResource Explorer !!! !!!]</value>
+    <value>[9jh51][ÃÒResource Explorer !!! !!!]</value>
   </data>
   <data name="feature_resourceExplorerInfo" xml:space="preserve">
-    <value>[4jCFN][åÓExplore management APIs with Azure Resource Explorer (preview). !!! !!! !!! !!! !!! !!!]</value>
+    <value>[4jCFN][ð¥Explore management APIs with Azure Resource Explorer (preview). !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="featureEnabled_cors" xml:space="preserve">
-    <value>[F31oN][ÑñCORS Rules ({0} defined) !!! !!! !]</value>
+    <value>[F31oN][åÐCORS Rules ({0} defined) !!! !!! !]</value>
   </data>
   <data name="featureEnabled_deploymentSource" xml:space="preserve">
-    <value>[HNhDW][ÜËDeployment options configured with {0} !!! !!! !!! !!]</value>
+    <value>[HNhDW][üÁDeployment options configured with {0} !!! !!! !!! !!]</value>
   </data>
   <data name="featureEnabled_sslCert" xml:space="preserve">
-    <value>[LHVxe][ÔÍSSL certificates !!! !!!]</value>
+    <value>[LHVxe][£ÉSSL certificates !!! !!!]</value>
   </data>
   <data name="featureEnabled_webjobs" xml:space="preserve">
-    <value>[FmEKt][¥ÙWebJobs ({0} defined) !!! !!! ]</value>
+    <value>[FmEKt][í@WebJobs ({0} defined) !!! !!! ]</value>
   </data>
   <data name="featureEnabled_extensions" xml:space="preserve">
-    <value>[lgND1][ÀöExtensions ({0} installed) !!! !!! !!]</value>
+    <value>[lgND1][ÎáExtensions ({0} installed) !!! !!! !!]</value>
   </data>
   <data name="tab_overview" xml:space="preserve">
-    <value>[cEFX1][ÞËOverview !!! ]</value>
+    <value>[cEFX1][ÍÆOverview !!! ]</value>
   </data>
   <data name="tab_features" xml:space="preserve">
-    <value>[XjE8q][îéPlatform features !!! !!!]</value>
+    <value>[XjE8q][ÕÃPlatform features !!! !!!]</value>
   </data>
   <data name="tab_settings" xml:space="preserve">
-    <value>[bQrEZ][þÉSettings !!! ]</value>
+    <value>[bQrEZ][ùªSettings !!! ]</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>[wBouT][ÿêFunction settings !!! !!!]</value>
+    <value>[wBouT][åÍFunction app settings !!! !!! ]</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
-    <value>[nJYS7][ÂÊConfiguration !!! !!]</value>
+    <value>[nJYS7][¢üConfiguration !!! !!]</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>[1RTcE][çÕApplication settings !!! !!! ]</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
-    <value>[FmJBy][ë£Managing your Function app is not available for this trial. !!! !!! !!! !!! !!! !!]</value>
+    <value>[FmJBy][óêManaging your Function app is not available for this trial. !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="template" xml:space="preserve">
-    <value>[Nyxzz][ÖÒTemplate !!! ]</value>
+    <value>[Nyxzz][úÜTemplate !!! ]</value>
   </data>
   <data name="events" xml:space="preserve">
-    <value>[O9ZVx][ÂîEvents !!!]</value>
+    <value>[O9ZVx][îéEvents !!!]</value>
   </data>
   <data name="appServicePlan" xml:space="preserve">
-    <value>[XOGqi][ïÒApp Service plan !!! !!!]</value>
+    <value>[XOGqi][ÈâApp Service plan !!! !!!]</value>
   </data>
   <data name="appServicePlanPricingTier" xml:space="preserve">
-    <value>[Ep7ZZ][ëÒApp Service plan / pricing tier !!! !!! !!! ]</value>
+    <value>[Ep7ZZ][ëÿApp Service plan / pricing tier !!! !!! !!! ]</value>
   </data>
   <data name="authentication" xml:space="preserve">
-    <value>[refs6][ÈËAuthentication !!! !!]</value>
+    <value>[refs6][¥ÀAuthentication !!! !!]</value>
   </data>
   <data name="authorization" xml:space="preserve">
-    <value>[lFBC2][ÀØAuthorization !!! !!]</value>
+    <value>[lFBC2][çöAuthorization !!! !!]</value>
   </data>
   <data name="hybridConnections" xml:space="preserve">
-    <value>[d86ro][íàHybrid connections !!! !!!]</value>
+    <value>[d86ro][íüHybrid connections !!! !!!]</value>
   </data>
   <data name="supportRequest" xml:space="preserve">
-    <value>[lKqDp][ýäsupport request !!! !!]</value>
+    <value>[lKqDp][Õèsupport request !!! !!]</value>
   </data>
   <data name="scale" xml:space="preserve">
-    <value>[B5Bnd][ÿ¢scale !!!]</value>
+    <value>[B5Bnd][Áãscale !!!]</value>
   </data>
   <data name="connectionStrings" xml:space="preserve">
-    <value>[TGaI7][ðÉConnection strings !!! !!!]</value>
+    <value>[TGaI7][ðÅConnection strings !!! !!!]</value>
   </data>
   <data name="debug" xml:space="preserve">
-    <value>[c8xo6][ÆôDebug !!!]</value>
+    <value>[c8xo6][ÅÌDebug !!!]</value>
   </data>
   <data name="continuousDeployment" xml:space="preserve">
-    <value>[idt2l][ååContinuous deployment !!! !!! ]</value>
+    <value>[idt2l][ÖÌContinuous deployment !!! !!! ]</value>
   </data>
   <data name="source" xml:space="preserve">
-    <value>[vbdk7][ÜéSource !!!]</value>
+    <value>[vbdk7][ð@Source !!!]</value>
   </data>
   <data name="options" xml:space="preserve">
-    <value>[3kb02][¢çOptions !!!]</value>
+    <value>[3kb02][µÑOptions !!!]</value>
   </data>
   <data name="backend_error_CannotAccessFunctionApp" xml:space="preserve">
-    <value>[B7fBh][áÑWe are not able to access your Azure settings for your function app. !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[B7fBh][ÈíWe are not able to access your Azure settings for your function app. !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="backend_error_CannotAccessFunctionApp_action" xml:space="preserve">
-    <value>[BUnjj][ßòFirst make sure you have proper access to the Azure resource {0}. If you dotTry refreshing the portal to renew your authentication token. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[BUnjj][ÒÐFirst make sure you have proper access to the Azure resource {0}. If you dotTry refreshing the portal to renew your authentication token. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="backend_error_InvalidStorageConnectionString" xml:space="preserve">
-    <value>[KngnQ][ÐáPlease check the storage account connection string in application settings as it appears to be invalid. !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[KngnQ][õìPlease check the storage account connection string in application settings as it appears to be invalid. !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="backend_error_InvalidStorageConnectionString_action" xml:space="preserve">
-    <value>[A9CoY][ùÅUpdate the app setting with a valid storage connection string. !!! !!! !!! !!! !!! !!!]</value>
+    <value>[A9CoY][ÇóUpdate the app setting with a valid storage connection string. !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="backend_error_MissingAzureFilesConnectionString" xml:space="preserve">
-    <value>[V1vac][©Þ'{0}' application setting is missing from your app. This setting contains a connection string for an Azure Storage account that is used to host your functions content. Your app will be completely broken without this setting. You may need to delete and recreate this function app if you no longer have access to the value of that application setting. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[V1vac][Ûæ'{0}' application setting is missing from your app. This setting contains a connection string for an Azure Storage account that is used to host your functions content. Your app will be completely broken without this setting. You may need to delete and recreate this function app if you no longer have access to the value of that application setting. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="backend_error_MissingAzureFilesContentShare" xml:space="preserve">
-    <value>[SkOYm][àç'{0}' application setting is missing from your app. This setting contains a share name where your function content lives. Your app will be completely broken without this setting. You may need to delete and recreate this function app if you no longer have access to the value of that application setting. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[SkOYm][øï'{0}' application setting is missing from your app. This setting contains a share name where your function content lives. Your app will be completely broken without this setting. You may need to delete and recreate this function app if you no longer have access to the value of that application setting. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="backend_error_MissingAzureWebJobsDashboardAppSetting" xml:space="preserve">
-    <value>[6uI0W][íÈ'{0}' application setting is missing from your app. This setting contains a connection string for an Azure Storage account that is needed for the monitoring view of your functions. This is where invocation data is aggregated and then displayed in monitoring view. Your monitoring view might be broken. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[6uI0W][òÏ'{0}' application setting is missing from your app. This setting contains a connection string for an Azure Storage account that is needed for the monitoring view of your functions. This is where invocation data is aggregated and then displayed in monitoring view. Your monitoring view might be broken. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="backend_error_MissingAzureWebJobsStorageAppSetting" xml:space="preserve">
-    <value>[KPa7R][ßÖ'{0}' application setting is missing from your app. This setting contains a connection string for an Azure Storage account that is needed for the functions runtime to handle multiple instances synchronization, log invocation results, and other infrastructure jobs. Your function app will not work correctly without that setting. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[KPa7R][þò'{0}' application setting is missing from your app. This setting contains a connection string for an Azure Storage account that is needed for the functions runtime to handle multiple instances synchronization, log invocation results, and other infrastructure jobs. Your function app will not work correctly without that setting. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="backend_error_MissingAzureWebJobsStorageAppSetting_action" xml:space="preserve">
-    <value>[xMA9r][ÇøCreate the app setting with a valid storage connection string. !!! !!! !!! !!! !!! !!!]</value>
+    <value>[xMA9r][ÙÀCreate the app setting with a valid storage connection string. !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="backend_error_MissingFunctionsExtensionVersionAppSetting" xml:space="preserve">
-    <value>[KV55C][ÙÅ'{0}' application setting is missing from your app. Without this setting you'll always be running the latest version of the runtime even across major version updates which might contain breaking changes. It's advised to set that value to the current latest major version (~1) and you'll get notified with newer versions for update. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[KV55C][îÆ'{0}' application setting is missing from your app. Without this setting you'll always be running the latest version of the runtime even across major version updates which might contain breaking changes. It's advised to set that value to the current latest major version (~1) and you'll get notified with newer versions for update. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="backend_error_StorageAccountConnectionStringIsNullOrEmpty" xml:space="preserve">
-    <value>[bntRS][ìÙAzure Storage Account connection string stored in '{0}' is null or empty. This is required to have your function app working. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[bntRS][ØÛAzure Storage Account connection string stored in '{0}' is null or empty. This is required to have your function app working. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="backend_error_StorageAccountConnectionStringIsNullOrEmpty_action" xml:space="preserve">
-    <value>[aQUvT][ÈµUpdate the app setting with a valid storage connection string. !!! !!! !!! !!! !!! !!!]</value>
+    <value>[aQUvT][øÆUpdate the app setting with a valid storage connection string. !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="backend_error_StorageAccountDoesNotExist" xml:space="preserve">
-    <value>[mJiuX][åÿStorage account {0} doesn't exist. Deleting the storage account the function app is using will cause the function app to stop working.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[mJiuX][ÈÊStorage account {0} doesn't exist. Deleting the storage account the function app is using will cause the function app to stop working.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="backend_error_StorageAccountDoesNotExist_action" xml:space="preserve">
-    <value>[12MKK][è@Update the app setting with a valid existing storage connection string. !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[12MKK][Ã¢Update the app setting with a valid existing storage connection string. !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="backend_error_StorageAccountDoesntSupportQueues" xml:space="preserve">
-    <value>[zKm4a][òäStorage account {0} doesn't support Azure Queues Storage. Functions runtime require queues to work properly. You'll have to delete and recreate your function app with a storage account that supports Azure Queues Storage. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[zKm4a][ÂÝStorage account {0} doesn't support Azure Queues Storage. Functions runtime require queues to work properly. You'll have to delete and recreate your function app with a storage account that supports Azure Queues Storage. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="backend_error_UnexpectedArmError" xml:space="preserve">
-    <value>[oFzW4][ÎÀThere seem to be a problem querying Azure backend for your function app. !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[oFzW4][á©There seem to be a problem querying Azure backend for your function app. !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="backend_error_UnknownErrorWhileCallingArm" xml:space="preserve">
-    <value>[RUkcZ][É@There seem to be a problem querying Azure backend for your function app. !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[RUkcZ][ÃÖThere seem to be a problem querying Azure backend for your function app. !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="error_shareCodeWithSupport" xml:space="preserve">
-    <value>[cF2yV][õ§If the problem persists, contact support with the following code {{code}} !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[cF2yV][ÌíIf the problem persists, contact support with the following code {{code}} !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="error_parsingFunctionListReturenedFromKudu" xml:space="preserve">
-    <value>[Ak6He][ÅîWe are not able to retrieve the list of functions for this function app. !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[Ak6He][ëýWe are not able to retrieve the list of functions for this function app. !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="error_unableToCreateFunction" xml:space="preserve">
-    <value>[CUb5G][ËÊWe are not able to create function {{functionName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[CUb5G][ªàWe are not able to create function {{functionName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="error_unableToDecryptKeys" xml:space="preserve">
-    <value>[mz5ka][ÄÔWe are unable to decrypt your function access keys. This can happen if you delete and recreate the app with the same name, or if you copied your keys from a different function app. You can try following steps here to fix the issue Follow steps here https://go.microsoft.com/fwlink/?linkid=844094 !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[mz5ka][ÍæWe are unable to decrypt your function access keys. This can happen if you delete and recreate the app with the same name, or if you copied your keys from a different function app. You can try following steps here to fix the issue Follow steps here https://go.microsoft.com/fwlink/?linkid=844094 !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="error_unableToDeleteFileThroughKudu" xml:space="preserve">
-    <value>[8eHRp][ÕÒWe are not able to delete the file {{fileName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[8eHRp][ÊáWe are not able to delete the file {{fileName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="error_unableToDeleteFunction" xml:space="preserve">
-    <value>[921Pl][ßäWe are not able to delete function {{functionName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[921Pl][èúWe are not able to delete function {{functionName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="error_unableToGetFileContentFromKudu" xml:space="preserve">
-    <value>[n3ZhE][ýØWe are not able to get the content for {{fileName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[n3ZhE][ÎÑWe are not able to get the content for {{fileName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="error_unableToRetrieveFunctionListFromKudu" xml:space="preserve">
-    <value>[6xua9][ê©We are not able to retrieve your functions right now. Please try again later. !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[6xua9][¢ÁWe are not able to retrieve your functions right now. Please try again later. !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="error_UnableToRetrieveSecretsFileFromKudu" xml:space="preserve">
-    <value>[Mq223][ÕÆWe are not able to retrieve secrets file for {{functionName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[Mq223][òÆWe are not able to retrieve secrets file for {{functionName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="error_unableToSaveFileContentThroughKudu" xml:space="preserve">
-    <value>[d1vn7][íäWe are not able to save the content for {{fileName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[d1vn7][ñóWe are not able to save the content for {{fileName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="error_unableToRetrieveDirectoryContent" xml:space="preserve">
-    <value>[GCI35][§ÀWe are not able to retrieve directory content for your function. Please try again later. !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[GCI35][úîWe are not able to retrieve directory content for your function. Please try again later. !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="error_unableToRetrieveFunction" xml:space="preserve">
-    <value>[t4Mct][ÄéWe are unable to get function {{functionName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[t4Mct][ÖîWe are unable to get function {{functionName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="error_unableToRetrieveRuntimeConfig" xml:space="preserve">
-    <value>[WuvPO][ÌèWe are unable to retrieve the runtime config. Please try again later. !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[WuvPO][ÚþWe are unable to retrieve the runtime config. Please try again later. !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="error_unableToRetrieveRuntimeKey" xml:space="preserve">
-    <value>[xtFcf][õøWe are not able to retrieve the runtime master key. Please try again later. !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[xtFcf][¢àWe are not able to retrieve the runtime master key. Please try again later. !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="error_unableToUpdateFunction" xml:space="preserve">
-    <value>[b4qdt][ÏþWe are not able to update function {{functionName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[b4qdt][íýWe are not able to update function {{functionName}}. Please try again later. !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="error_functionRuntimeIsUnableToStart" xml:space="preserve">
-    <value>[NXrAF][õÙThe function runtime is unable to start. Please check the runtime logs for any errors or try again later. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[NXrAF][äëThe function runtime is unable to start. Please check the runtime logs for any errors or try again later. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="error_unableToCreateFunctionKey" xml:space="preserve">
-    <value>[hnooV][úéWe are not able to create or update the key {{keyName}} for function {{functionName}}. This can happen if the runtime is not able to load your function. Check other function errors. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[hnooV][ÐüWe are not able to create or update the key {{keyName}} for function {{functionName}}. This can happen if the runtime is not able to load your function. Check other function errors. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="error_unableToDeleteFunctionKey" xml:space="preserve">
-    <value>[YBZ0y][ÔÊWe are not able to delete the key {{keyName}} for function {{functionName}}. This can happen if the runtime is not able to load your function. Check other function errors. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[YBZ0y][áÓWe are not able to delete the key {{keyName}} for function {{functionName}}. This can happen if the runtime is not able to load your function. Check other function errors. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="error_unableToRenewFunctionKey" xml:space="preserve">
-    <value>[LM61O][ÏùWe are not able to renew the key {{keyName}} for function {{functionName}}. This can happen if the runtime is not able to load your function. Check other function errors. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[LM61O][ÆýWe are not able to renew the key {{keyName}} for function {{functionName}}. This can happen if the runtime is not able to load your function. Check other function errors. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="error_unableToRetrieveFunctionKeys" xml:space="preserve">
-    <value>[MF3jJ][þÉWe are not able to retrieve the keys for function {{functionName}}. This can happen if the runtime is not able to load your function. Check other function errors. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[MF3jJ][@íWe are not able to retrieve the keys for function {{functionName}}. This can happen if the runtime is not able to load your function. Check other function errors. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="error_appOffline" xml:space="preserve">
-    <value>[Y4myA][ªÓThe application is offline. Please check your internet connection. !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[Y4myA][õõThe application is offline. Please check your internet connection. !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="functionKeys_actions" xml:space="preserve">
-    <value>[dwixq][ÀøACTIONS !!!]</value>
+    <value>[dwixq][ìõACTIONS !!!]</value>
   </data>
   <data name="functionNew_chooseTemplateQuickstart" xml:space="preserve">
-    <value>[NYo3z][Ñªgo to the quickstart !!! !!! ]</value>
+    <value>[NYo3z][üÏgo to the quickstart !!! !!! ]</value>
   </data>
   <data name="httpRun_noQuery" xml:space="preserve">
-    <value>[TCWwD][àÎThere are no query parameters !!! !!! !!!]</value>
+    <value>[TCWwD][ÙÍThere are no query parameters !!! !!! !!!]</value>
   </data>
   <data name="swaggerDefinition_collapse" xml:space="preserve">
-    <value>[tJL99][ÒÇCollapse !!! ]</value>
+    <value>[tJL99][¥ªCollapse !!! ]</value>
   </data>
   <data name="swaggerDefinition_delete" xml:space="preserve">
-    <value>[ckWwM][©ÐAre you sure you want to delete your API definition? !!! !!! !!! !!! !!!]</value>
+    <value>[ckWwM][ÐùAre you sure you want to delete your API definition? !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="swaggerDefinition_documentation" xml:space="preserve">
-    <value>[Vv7Oc][óèDocumentation !!! !!]</value>
+    <value>[Vv7Oc][öïDocumentation !!! !!]</value>
   </data>
   <data name="swaggerDefinition_expand" xml:space="preserve">
-    <value>[jCjLN][ÇÌExpand !!!]</value>
+    <value>[jCjLN][ÜáExpand !!!]</value>
   </data>
   <data name="swaggerDefinition_external" xml:space="preserve">
-    <value>[IF9rQ][ÑùExternal URL !!! !]</value>
+    <value>[IF9rQ][ÒÚExternal URL !!! !]</value>
   </data>
   <data name="swaggerDefinition_feature_overview" xml:space="preserve">
-    <value>[4l8QL][ÿæRead the feature overview !!! !!! !!]</value>
+    <value>[4l8QL][âÖRead the feature overview !!! !!! !!]</value>
   </data>
   <data name="swaggerDefinition_getting_started" xml:space="preserve">
-    <value>[YoTQF][ÖíCheck out our getting started tutorial !!! !!! !!! !!]</value>
+    <value>[YoTQF][ÒÌCheck out our getting started tutorial !!! !!! !!! !!]</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>[GTle9][ÃïFunction !!! ]</value>
+    <value>[GTle9][ÑîFunction (preview) !!! !!!]</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
-    <value>[T84bF][áéAPI definition key !!! !!!]</value>
+    <value>[T84bF][ÿýAPI definition key !!! !!!]</value>
   </data>
   <data name="swaggerDefinition_loadDefinition" xml:space="preserve">
-    <value>[azP36][ÞÎLoad API definition !!! !!! ]</value>
+    <value>[azP36][íöLoad API definition !!! !!! ]</value>
   </data>
   <data name="swaggerDefinition_loadGeneratedDefinition" xml:space="preserve">
-    <value>[GW7Lo][âýGenerate API definition template !!! !!! !!! ]</value>
+    <value>[GW7Lo][ÏÎGenerate API definition template !!! !!! !!! ]</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>[64oB2][ÓýExport to Power Apps + Flow !!! !!! !!]</value>
+    <value>[64oB2][ÜöExport to PowerApps + Flow !!! !!! !!]</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
-    <value>[ERMjP][ÝâCannot save malformed API definition. !!! !!! !!! !!]</value>
+    <value>[ERMjP][åæCannot save malformed API definition. !!! !!! !!! !!]</value>
   </data>
   <data name="swaggerDefinition_renew" xml:space="preserve">
-    <value>[3MNSt][ããRenew !!!]</value>
+    <value>[3MNSt][ÝÁRenew !!!]</value>
   </data>
   <data name="swaggerDefinition_setExternal" xml:space="preserve">
-    <value>[DHcyM][ªìSet external definition URL !!! !!! !!]</value>
+    <value>[DHcyM][àæSet external definition URL !!! !!! !!]</value>
   </data>
   <data name="swaggerDefinition_source" xml:space="preserve">
-    <value>[pjq3N][ÕïAPI definition source !!! !!! ]</value>
+    <value>[pjq3N][óÇAPI definition source !!! !!! ]</value>
   </data>
   <data name="swaggerDefinition_subtitle" xml:space="preserve">
-    <value>[ZmaYW][ÐæConsume your HTTP triggered Functions in a variety of services using an OpenAPI 2.0 (Swagger) definition !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[ZmaYW][ðÓConsume your HTTP triggered Functions in a variety of services using an OpenAPI 2.0 (Swagger) definition !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="swaggerDefinition_title" xml:space="preserve">
-    <value>[ARPZs][ÝÞFunction API definition (Swagger) !!! !!! !!! !]</value>
+    <value>[ARPZs][àìFunction API definition (Swagger) !!! !!! !!! !]</value>
   </data>
   <data name="swaggerDefinition_url" xml:space="preserve">
-    <value>[vesbU][ÜÐAPI definition URL !!! !!!]</value>
+    <value>[vesbU][ñßAPI definition URL !!! !!!]</value>
   </data>
   <data name="swaggerDefinition_useAPIdefinition" xml:space="preserve">
-    <value>[nx1L4][þËUse your API definition !!! !!! !]</value>
+    <value>[nx1L4][ø§Use your API definition !!! !!! !]</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>[oOnhd][ãÅAPI definition (preview) !!! !!! !]</value>
+    <value>[oOnhd][ÛªAPI definition !!! !!]</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
-    <value>[fph36][úÕWe are not able to create or update the key swaggerdocumentationkey for the Swagger Endpoint. Please check the runtime logs for any errors or try again later. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[fph36][ª©We are not able to create or update the key swaggerdocumentationkey for the Swagger Endpoint. Please check the runtime logs for any errors or try again later. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="error_unableToDeleteSwaggerData" xml:space="preserve">
-    <value>[2pH3A][ûÀWe are not able to delete the API defintion. Please check the runtime logs for any errors or try again later. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[2pH3A][ÚðWe are not able to delete the API defintion. Please check the runtime logs for any errors or try again later. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="error_unableToGetSystemKey" xml:space="preserve">
-    <value>[tzO0c][ôïWe are not able to get the key {{keyName}}. Please check the runtime logs for any errors or try again later. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[tzO0c][ÖÀWe are not able to get the key {{keyName}}. Please check the runtime logs for any errors or try again later. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="error_unableToloadGeneratedAPIDefinition" xml:space="preserve">
-    <value>[0wF6y][ÎñWe are not able to load the generated API definition. Please check the runtime logs for any errors or try again later. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[0wF6y][ãÝWe are not able to load the generated API definition. Please check the runtime logs for any errors or try again later. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="error_unableToUpdateRuntimeConfig" xml:space="preserve">
-    <value>[V4UHe][ôþWe are unable to update the runtime config. Please try again later. !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[V4UHe][ÒÚWe are unable to update the runtime config. Please try again later. !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="error_unableToUpdateSwaggerData" xml:space="preserve">
-    <value>[3XtJs][ÕÊWe are not able to update the API definition. Please check the runtime logs for any errors or try again later. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[3XtJs][åÄWe are not able to update the API definition. Please check the runtime logs for any errors or try again later. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="swaggerDefinition_revert" xml:space="preserve">
-    <value>[H6hhu][ïÖRevert to last save !!! !!! ]</value>
+    <value>[H6hhu][ÿÉRevert to last save !!! !!! ]</value>
   </data>
   <data name="binding_AADLinkAuth" xml:space="preserve">
-    <value>[2hLAJ][£èConfigure App Service Authentication / Authorization !!! !!! !!! !!! !!!]</value>
+    <value>[2hLAJ][äòConfigure App Service Authentication / Authorization !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="swaggerDefinition_placeHolder" xml:space="preserve">
-    <value>[pITlI][ðñ#Click "Generate API definition template" to get started !!! !!! !!! !!! !!! !]</value>
+    <value>[pITlI][Ò£#Click "Generate API definition template" to get started !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="swaggerDefinition_confirmOverwrite" xml:space="preserve">
-    <value>[Q1Zo3][¢ÞAre you sure you want to overwrite the API definition in the editor? !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[Q1Zo3][ÍØAre you sure you want to overwrite the API definition in the editor? !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="swaggerDefinition_exporthelp" xml:space="preserve">
-    <value>[lhYWH][ÌÀUse your API definition to access your Functions from within &lt;a href="https://powerapps.microsoft.com/en-us/" target="_blank"&gt;PowerApps&lt;/a&gt; and &lt;a href="https://ms.flow.microsoft.com/en-us/" target="_blank"&gt;Flow&lt;/a&gt;.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[lhYWH][ªÑUse your API definition to access your Functions from within &lt;a href="https://powerapps.microsoft.com/en-us/" target="_blank"&gt;PowerApps&lt;/a&gt; and &lt;a href="https://ms.flow.microsoft.com/en-us/" target="_blank"&gt;Flow&lt;/a&gt;.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="swaggerDefinition_generateHelp" xml:space="preserve">
-    <value>[SXxOE][âÉCreate a sparse definition with the metadata from your HTTP triggered functions. !!! !!! !!! !!! !!! !!! !!! !]
-[SXxOE][ÕõFill in the &lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;operation objects&lt;/a&gt;, and other information about your API before use. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[SXxOE][ßÒCreate a sparse definition with the metadata from your HTTP triggered functions. !!! !!! !!! !!! !!! !!! !!! !]
+[SXxOE][ÉÝFill in the &lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;operation objects&lt;/a&gt;, and other information about your API before use. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="swaggerDefinition_keyHelp" xml:space="preserve">
-    <value>[5MTfU][ïÛThis key secures your API Definition from access to anyone without the key. !!! !!! !!! !!! !!! !!! !!!]
-[5MTfU][£øIt does not secure the underlying API. See each Function to see their key security. !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[5MTfU][ïÀThis key secures your API Definition from access to anyone without the key. !!! !!! !!! !!! !!! !!! !!!]
+[5MTfU][ÙøIt does not secure the underlying API. See each Function to see their key security. !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="swaggerDefinition_sourceHelp" xml:space="preserve">
-    <value>[Swwu3][ÀÖSet to "Function" to enable a hosted API definition and template definition generation. !!! !!! !!! !!! !!! !!! !!! !!!]
-[Swwu3][îúSet to "External URL" to use an API definition that is hosted elsewhere. !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[Swwu3][ÞõSet to "Function" to enable a hosted API definition and template definition generation. !!! !!! !!! !!! !!! !!! !!! !!!]
+[Swwu3][ÖÏSet to "External URL" to use an API definition that is hosted elsewhere. !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="swaggerDefinition_urlHelp" xml:space="preserve">
-    <value>[6UDTj][@ÿUse this URL to directly access your API definition and import into 3rd party tools  !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[6UDTj][ÍÑUse this URL to directly access your API definition and import into 3rd party tools  !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="featureEnabled_appInsights" xml:space="preserve">
-    <value>[EzURR][åûApplication Insights !!! !!! ]</value>
+    <value>[EzURR][ØÔApplication Insights !!! !!! ]</value>
   </data>
   <data name="appFunctionSettings_changeEditMode" xml:space="preserve">
-    <value>[mEQmo][éÍChange the edit mode of your function app !!! !!! !!! !!!]</value>
+    <value>[mEQmo][ÐúChange the edit mode of your function app !!! !!! !!! !!!]</value>
   </data>
   <data name="appFunctionSettings_editMode" xml:space="preserve">
-    <value>[4eTe5][îëFunction app edit mode !!! !!! !]</value>
+    <value>[4eTe5][åâFunction app edit mode !!! !!! !]</value>
   </data>
   <data name="appFunctionSettings_readOnlyMode" xml:space="preserve">
-    <value>[nJom2][ùïRead Only !!! ]</value>
+    <value>[nJom2][éÓRead Only !!! ]</value>
   </data>
   <data name="appFunctionSettings_readWriteMode" xml:space="preserve">
-    <value>[U4pE3][ÕÙRead\Write !!! !]</value>
+    <value>[U4pE3][þÁRead/Write !!! !]</value>
   </data>
   <data name="validation_duplicateError" xml:space="preserve">
-    <value>[GCMGe][ÏÅDuplicate values are not allowed !!! !!! !!! ]</value>
+    <value>[GCMGe][ÖÏDuplicate values are not allowed !!! !!! !!! ]</value>
   </data>
   <data name="validation_requiredError" xml:space="preserve">
-    <value>[woMWd][óÎThis field is required !!! !!! !]</value>
+    <value>[woMWd][ëÿThis field is required !!! !!! !]</value>
   </data>
   <data name="validation_siteNameMinChars" xml:space="preserve">
-    <value>[FJCjM][ÝòThe name must be at least 2 characters !!! !!! !!! !!]</value>
+    <value>[FJCjM][Ì@The name must be at least 2 characters !!! !!! !!! !!]</value>
   </data>
   <data name="validation_siteNameMaxChars" xml:space="preserve">
-    <value>[HNHBo][Â§The name must be fewer than 60 characters !!! !!! !!! !!!]</value>
+    <value>[HNHBo][ßÀThe name must be fewer than 60 characters !!! !!! !!! !!!]</value>
   </data>
   <data name="validation_siteNameInvalidChar" xml:space="preserve">
-    <value>[Z4hHw][õö'{0}' is an invalid character !!! !!! !!!]</value>
+    <value>[Z4hHw][¥ê'{0}' is an invalid character !!! !!! !!!]</value>
   </data>
   <data name="validation_siteNameNotAvailable" xml:space="preserve">
-    <value>[uP4uR][øëThe app name '{0}' is not available !!! !!! !!! !]</value>
+    <value>[uP4uR][âÃThe app name '{0}' is not available !!! !!! !!! !]</value>
   </data>
   <data name="error_unableToUpdateFunctionAppEditMode" xml:space="preserve">
-    <value>[ZA4jK][é¥We are unable to update your function app's edit mode. Please try again later. !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[ZA4jK][Û§We are unable to update your function app's edit mode. Please try again later. !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="readOnly" xml:space="preserve">
-    <value>[p67R2][¥òYour app is currently in read only mode because you've set the edit mode to read only. To change edit mode visit  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[p67R2][ÑÛYour app is currently in read only mode because you've set the edit mode to read only. To change edit mode visit  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="readWriteSourceControlled" xml:space="preserve">
-    <value>[H4d2E][ªÿYour app is currently in read\write mode because you've set the edit mode to read\write despite having source control enabled. Any changes you make may get overwritten with your next deployment. To change edit mode visit  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[H4d2E][äàYour app is currently in read\write mode because you've set the edit mode to read\write despite having source control enabled. Any changes you make may get overwritten with your next deployment. To change edit mode visit  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+  </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>[aFR98][óëYour app is currently in read-only mode because you have published a generated function.json. Changes made to function.json will not be honored by the Functions runtime.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="copypre_copy" xml:space="preserve">
-    <value>[g9tRk][æÝCopy !!]</value>
+    <value>[g9tRk][ÈêCopy !!]</value>
   </data>
   <data name="keysDialog_getFunctionUrl" xml:space="preserve">
-    <value>[DBggp][ÜõGet function URL !!! !!!]</value>
+    <value>[DBggp][µÊGet function URL !!! !!!]</value>
   </data>
   <data name="keysDialog_key" xml:space="preserve">
-    <value>[TaSk1][ôÑKey !!]</value>
+    <value>[TaSk1][ûÝKey !!]</value>
   </data>
   <data name="keysDialog_url" xml:space="preserve">
-    <value>[rpLfL][ßîURL !!]</value>
+    <value>[rpLfL][ßøURL !!]</value>
   </data>
   <data name="downloadFunctionAppContent" xml:space="preserve">
-    <value>[cwf16][ÆÔDownload app content !!! !!! ]</value>
+    <value>[cwf16][öÿDownload app content !!! !!! ]</value>
   </data>
   <data name="functionKeys_renewConfirmation" xml:space="preserve">
-    <value>[EFtI8][ÔÀAre you sure you want to renew {{name}} key? !!! !!! !!! !!! ]</value>
+    <value>[EFtI8][þïAre you sure you want to renew {{name}} key? !!! !!! !!! !!! ]</value>
   </data>
   <data name="emptyBrowse" xml:space="preserve">
-    <value>[5Ipct][ÇÌAzure Functions are an event-based serverless compute experience to accelerate your development. Scale based on demand and pay only for the resources you consume. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[5Ipct][ìçAzure Functions are an event-based serverless compute experience to accelerate your development. Scale based on demand and pay only for the resources you consume. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="emptyBrowse_learnMore" xml:space="preserve">
-    <value>[lWp2b][õüLearn more about azure functions !!! !!! !!! ]</value>
+    <value>[lWp2b][ÅÜLearn more about azure functions !!! !!! !!! ]</value>
   </data>
   <data name="eventHubPicker_eventHub" xml:space="preserve">
-    <value>[8RrXM][å©Event Hub !!! ]</value>
+    <value>[8RrXM][ÓÛEvent Hub !!! ]</value>
   </data>
   <data name="eventHubPicker_namespace" xml:space="preserve">
-    <value>[aaleI][çàNamespace !!! ]</value>
+    <value>[aaleI][ÂÀNamespace !!! ]</value>
   </data>
   <data name="notFound" xml:space="preserve">
-    <value>[UHcee][ÒîNot found. !!! !]</value>
+    <value>[UHcee][ÈóNot found. !!! !]</value>
   </data>
   <data name="eventHubPicker_IOTEndpoint" xml:space="preserve">
-    <value>[20U9s][ñøEndpoint !!! ]</value>
+    <value>[20U9s][£ÂEndpoint !!! ]</value>
   </data>
   <data name="emptyBrowse_title" xml:space="preserve">
-    <value>[yejjZ][ÂÈNo function apps to display !!! !!! !!]</value>
+    <value>[yejjZ][ÎñNo function apps to display !!! !!! !!]</value>
   </data>
   <data name="appFunctionSettings_slotsOptinSettings" xml:space="preserve">
-    <value>[x0DPN][ßõSlots (preview) !!! !!]</value>
+    <value>[x0DPN][úïSlots (preview) !!! !!]</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>[mKJji][ìéEnable deployment slots (preview). This is a one-time opt-in on the Function app that cannot be disabled and will reset any pre-existing secrets. After the update, the secrets may be copied from under the  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[mKJji][ÆÃEnable deployment slots (preview). !!! !!! !!! !]</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>[B3igj][Íµ'Manage' node for each function. !!! !!! !!! ]</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>[Q79Iw][ÿèKnown issues: !!! !!]</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>[3IbBo][åúLogic apps integration with Functions does not work when Slots(preview) is enabled. !!! !!! !!! !!! !!! !!! !!! !!]</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>[SytoJ][ÓéOpting into this preview feature will reset any pre-existing secrets. Function secrets can be found under the !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>[OSJlv][øý'Manage' !!! ]</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>[01pD8][@Ínode for each function. !!! !!! !]</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
-    <value>[g5FTm][êüName !!]</value>
+    <value>[g5FTm][üÍName !!]</value>
   </data>
   <data name="slotNew_heading" xml:space="preserve">
-    <value>[rjVnr][ÈØCreate a new deployment slot !!! !!! !!!]</value>
+    <value>[rjVnr][ÉàCreate a new deployment slot !!! !!! !!!]</value>
   </data>
   <data name="slotNew_desc" xml:space="preserve">
-    <value>[wt9Bn][ýÙDeployment slots let you deploy different versions of your function app to different URLs. You can test a certain version and then swap content and configuration between slots. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[wt9Bn][ÁÌDeployment slots let you deploy different versions of your function app to different URLs. You can test a certain version and then swap content and configuration between slots. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="slotNew_startCreateNotifyTitle" xml:space="preserve">
-    <value>[P5HvO][ÌáCreating new slot {0}  !!! !!! !]</value>
+    <value>[P5HvO][øòCreating new slot {0}  !!! !!! !]</value>
   </data>
   <data name="slotNew_startCreateSuccessNotifyTitle" xml:space="preserve">
-    <value>[VYz2A][©ìSuccessfully created slot {0}  !!! !!! !!!]</value>
+    <value>[VYz2A][ñõSuccessfully created slot {0}  !!! !!! !!!]</value>
   </data>
   <data name="slotNew_startCreateFailureNotifyTitle" xml:space="preserve">
-    <value>[AwcrL][ëÈFailed to create slot {0}  !!! !!! !!]</value>
+    <value>[AwcrL][ÃÂFailed to create slot {0}  !!! !!! !!]</value>
   </data>
   <data name="error_unableToLoadSlotsList" xml:space="preserve">
-    <value>[4D09u][ãÍUnable to upate the list of slots !!! !!! !!! !]</value>
+    <value>[4D09u][ûïUnable to upate the list of slots !!! !!! !!! !]</value>
   </data>
   <data name="slotNew_noAccess" xml:space="preserve">
-    <value>[VevG5][éÃNo access to create a slot. Please ensure you have the right RBAC access for the function app and do not have read locks enabled either. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[VevG5][ÝÖNo access to create a slot. Please ensure you have the right RBAC access for the function app and do not have read locks enabled either. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="slotsList_nameHeader" xml:space="preserve">
-    <value>[LKyiE][ÓîName !!]</value>
+    <value>[LKyiE][ØÒName !!]</value>
   </data>
   <data name="slotsList_statusHeader" xml:space="preserve">
-    <value>[gG2Mn][ÚõStatus !!!]</value>
+    <value>[gG2Mn][ÙÞStatus !!!]</value>
   </data>
   <data name="slotsList_serverfarmHeader" xml:space="preserve">
-    <value>[Dy7Lz][èÝApp service plan !!! !!!]</value>
+    <value>[Dy7Lz][ÁÓApp service plan !!! !!!]</value>
   </data>
   <data name="slotsList_title" xml:space="preserve">
-    <value>[zro6b][þñSlots (preview) !!! !!]</value>
+    <value>[zro6b][íïSlots (preview) !!! !!]</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>[Y5Ffx][èþFor a richer monitoring experience, including live metrics and custom queries, we recommend using &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights.&lt;/a&gt; !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[Y5Ffx][¥µFor a richer monitoring experience, including live metrics and custom queries, &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;enable Application Insights for your Function app&lt;/a&gt; !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
-    <value>[6I6Zu][ïþThis value will be appended to your main web app's URL and will serve as the public address of the slot.  For example if you have a web app named 'contoso' and a slot named ‘staging’ then the new slot will have a URL like ‘http://contoso-staging.azurewebsites.net’. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+    <value>[6I6Zu][ÉóThis value will be appended to your main web app's URL and will serve as the public address of the slot.  For example if you have a web app named 'contoso' and a slot named ‘staging’ then the new slot will have a URL like ‘http://contoso-staging.azurewebsites.net’. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
   </data>
   <data name="slotNew_dynamicQuotaReached" xml:space="preserve">
-    <value>[Fh049][ð£Consumption plan allows only for a single slot. If you need more than one slot, please use dedicated App Service plans. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+    <value>[Fh049][ÍùConsumption plan allows only for a single slot. If you need more than one slot, please use dedicated App Service plans. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
   </data>
   <data name="functionsList_searchFunctions" xml:space="preserve">
-    <value>[1cMFu][áúSearch functions !!! !!!]</value>
+    <value>[1cMFu][þØSearch functions !!! !!!]</value>
   </data>
   <data name="new_" xml:space="preserve">
-    <value>[LRWQt][ÄüNew !!]</value>
+    <value>[LRWQt][ØÑNew !!]</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
+    <value>[x5Q2C][çµCreate new !!! !]</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
-    <value>[k41rD][ÓÊDelete function !!! !!]</value>
+    <value>[k41rD][ÅÎDelete function !!! !!]</value>
   </data>
   <data name="functionService_clientCertEnabled" xml:space="preserve">
-    <value>[lx92w][æÙA client certificate is required to call run this function. To run it from the portal you have to disable client certificate. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[lx92w][àáA client certificate is required to call run this function. To run it from the portal you have to disable client certificate. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="readOnlySlots" xml:space="preserve">
-    <value>[VtvSH][ÛÄYour app is currently in read only mode because you have slot(s) configured. To change edit mode visit !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[VtvSH][ÚÄYour app is currently in read only mode because you have slot(s) configured. To change edit mode visit !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="functionRuntime_manageAppSettings" xml:space="preserve">
-    <value>[pzNRc][ÖÞManage application settings !!! !!! !!]</value>
+    <value>[pzNRc][ÛÌManage application settings !!! !!! !!]</value>
   </data>
   <data name="eventHubPicker_IOTHub" xml:space="preserve">
-    <value>[E7oyl][ÒþIoT hub !!!]</value>
+    <value>[E7oyl][¥§IoT hub !!!]</value>
   </data>
   <data name="eventHubPicker_appSettingName" xml:space="preserve">
-    <value>[KH97Q][åÄKey !!]</value>
+    <value>[KH97Q][ïÎKey !!]</value>
   </data>
   <data name="eventHubPicker_appSettingValue" xml:space="preserve">
-    <value>[F7c1R][òÑValue !!!]</value>
+    <value>[F7c1R][ûýValue !!!]</value>
   </data>
   <data name="eventHubPicker_connection" xml:space="preserve">
-    <value>[FmFxE][âåConnection !!! !]</value>
+    <value>[FmFxE][£¥Connection !!! !]</value>
   </data>
   <data name="eventHubPicker_custom" xml:space="preserve">
-    <value>[zby0Q][ýÿCustom !!!]</value>
+    <value>[zby0Q][ãµCustom !!!]</value>
   </data>
   <data name="eventHubPicker_IOTEvents" xml:space="preserve">
-    <value>[ZWlMm][ìüEvents (built-in endpoint) !!! !!! !!]</value>
+    <value>[ZWlMm][êÀEvents (built-in endpoint) !!! !!! !!]</value>
   </data>
   <data name="eventHubPicker_IOTMonitoring" xml:space="preserve">
-    <value>[Z5ZPz][îÈOperations monitoring !!! !!! ]</value>
+    <value>[Z5ZPz][ãÚOperations monitoring !!! !!! ]</value>
   </data>
   <data name="eventHubPicker_policy" xml:space="preserve">
-    <value>[TI96d][ÑùPolicy !!!]</value>
+    <value>[TI96d][áçPolicy !!!]</value>
   </data>
   <data name="error_schemaValidationProxies" xml:space="preserve">
-    <value>[4VkS7][Èøproxies.json schema validation error !!! !!! !!! !!]</value>
+    <value>[4VkS7][æâproxies.json schema validation error !!! !!! !!! !!]</value>
   </data>
   <data name="functionAppSettings_dailyUsageQuotaHelp" xml:space="preserve">
-    <value>[tY43Y][é¢On a Consumption plan, you can limit platform usage by setting a daily usage quota, in gigabytes-seconds. Once the daily usage quota is reached, the Function App is stopped until the next day at 0:00 AM UTC. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
+    <value>[tY43Y][äÖOn a Consumption plan, you can limit platform usage by setting a daily usage quota, in gigabytes-seconds. Once the daily usage quota is reached, the Function App is stopped until the next day at 0:00 AM UTC. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !]</value>
   </data>
   <data name="eventHubPicker_eventHubPolicy" xml:space="preserve">
-    <value>[2fYk0][õø(hub policy) !!! !]</value>
+    <value>[2fYk0][Êê(hub policy) !!! !]</value>
   </data>
   <data name="eventHubPicker_namespacePolicy" xml:space="preserve">
-    <value>[K8FZV][ÊÎ(namespace policy) !!! !!!]</value>
+    <value>[K8FZV][èþ(namespace policy) !!! !!!]</value>
   </data>
   <data name="serviceBusPicker_serviceBus" xml:space="preserve">
-    <value>[LTeqh][ÆÄService Bus !!! !]</value>
+    <value>[LTeqh][ÞæService Bus !!! !]</value>
   </data>
   <data name="bindingInput_appSettingNotFound" xml:space="preserve">
-    <value>[Gaeet][§ÛApp setting is not found. !!! !!! !!]</value>
+    <value>[Gaeet][ÎþApp setting is not found. !!! !!! !!]</value>
   </data>
   <data name="bindingInput_show" xml:space="preserve">
-    <value>[7zRjt][ãûshow value !!! !]</value>
+    <value>[7zRjt][öûshow value !!! !]</value>
   </data>
   <data name="appSettingPicker_add" xml:space="preserve">
-    <value>[1TSkP][£øAdd app setting !!! !!]</value>
+    <value>[1TSkP][ÐýAdd app setting !!! !!]</value>
   </data>
   <data name="download" xml:space="preserve">
-    <value>[lZ40c][Ú@Download !!! ]</value>
+    <value>[lZ40c][§ýDownload !!! ]</value>
   </data>
   <data name="downloadFunctionAppContent_includeAppSettings" xml:space="preserve">
-    <value>[X4DJu][Þ¥Include app settings in the download !!! !!! !!! !!]</value>
+    <value>[X4DJu][ïÄInclude app settings in the download !!! !!! !!! !!]</value>
   </data>
   <data name="downloadFunctionAppContent_includeAppSettingsHelp" xml:space="preserve">
-    <value>[GaH6W][îÂThis will include a file called local.settings.json which will contain your app settings values. This file will not be encrypted on download, but can be encrypted using the Azure Functions Core Tools command line. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+    <value>[GaH6W][èüThis will include a file called local.settings.json which will contain your app settings values. This file will not be encrypted on download, but can be encrypted using the Azure Functions Core Tools command line. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
   </data>
   <data name="downloadFunctionAppContent_siteContent" xml:space="preserve">
-    <value>[Lw6h3][ñÙSite content !!! !]</value>
+    <value>[Lw6h3][§£Site content !!! !]</value>
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
-    <value>[p1ON6][ÄßContent and Visual Studio project !!! !!! !!! !]</value>
+    <value>[p1ON6][þÞContent and Visual Studio project !!! !!! !!! !]</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>[XoZZE][ÓÛretrieve !!! ]</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>[w14cI][ÆÁDelete proxy !!! !]</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>[cSEIi][ù©New proxy !!! ]</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>[PyIlD][ÌÔNo override !!! !]</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>[AFdQO][ÜûExpress AAD Registration !!! !!! !]</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>[bddiW][@Ácreate !!!]</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>[yYNx2][åñYou need to add Event Grid subscription after function creation. !!! !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>[yeMVM][ÉçEvent Grid Subscription URL !!! !!! !!]</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>[2cXar][ÇÔEvent Grid Subscription URL !!! !!! !!]</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>[b5lFs][êðManage Event Grid subscriptions !!! !!! !!! ]</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>[jMclh][¢ÅAdd Event Grid subscription !!! !!! !!]</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>[YxLqo][ÌÊAll locations !!! !!]</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>[LEsTI][Çæ{0} locations !!! !!]</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>[Jpoxb][éúLocation: !!! ]</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>[gRZrb][ÚþGroup by location !!! !!!]</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>[exfIA][ÞíNo grouping !!! !]</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>[oGE50][ÍÄGroup by resource group !!! !!! !]</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>[00Oih][ôÉGroup by subscription !!! !!! ]</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>[3yiMx][ªæSouth Central US !!! !!!]</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>[EUzvP][¢ßNorth Europe !!! !]</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>[guPGZ][öýWest Europe !!! !]</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>[xS9TN][ÛíSoutheast Asia !!! !!]</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>[kg5k6][úóKorea Central !!! !!]</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>[TAcHH][ûÛKorea South !!! !]</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>[oTtF2][ÔäWest US !!!]</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>[E2QYb][ÍãEast US !!!]</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>[lOg0d][ÅµJapan West !!! !]</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>[17plQ][ÿÌJapan East !!! !]</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>[5T1Ay][êÖEast Asia !!! ]</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>[1urMP][ùøEast US 2 !!! ]</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>[66n1n][ÛöNorth Central US !!! !!!]</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>[qhVOZ][úöCentral US !!! !]</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>[4C1Ym][ñòBrazil South !!! !]</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>[RKZvt][£ÚAustralia East !!! !!]</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>[NJBiv][ý¥Australia Southeast !!! !!! ]</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>[XMaSa][çÆWest India !!! !]</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>[nH0IH][ÊÀCentral India !!! !!]</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>[JxQIz][ôÐSouth India !!! !]</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>[JaRYE][çáCanada Central !!! !!]</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>[CRBb4][ñôCanada East !!! !]</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>[FU30n][ßËWest Central US !!! !!]</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>[j1Z6n][äúUK West !!!]</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>[uCcvA][öÄUK South !!! ]</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>[cCuEK][çõWest US 2 !!! ]</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>[AvkK3][þÀAll resource groups !!! !!! ]</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>[2QtJL][âþResource Group: !!! !!]</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>[GpXkv][¢Ï{0} resource groups !!! !!! ]</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>[msE4p][ðªBody !!]</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>[Dtfy3][@þStatus code !!! !]</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>[jUqZr][ÙÅStatus message !!! !!]</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>[zj3oN][ãýRequest override !!! !!!]</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>[VJAdo][ÝÔResponse override !!! !!!]</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>[cTz7g][§ÐOptional !!! ]</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>[4eS5j][ñãYou're using a prerelease version of Azure Functions. Thanks for trying it out! !!! !!! !!! !!! !!! !!! !!! !]</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>[kUC52][ÆÑClick to hide !!! !!]</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>[kbNfC][ÞðLogic Apps allow you to easily utilize your function across multiple platforms !!! !!! !!! !!! !!! !!! !!! ]</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>[04P41][ÂÁLogic Apps !!! !]</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>[gQgYV][ÊÊAssociated Logic Apps !!! !!! ]</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>[IlI8F][ñ¥Orchestrate with Logic Apps !!! !!! !!]</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>[ZxCEE][¥ëCreate Logic Apps !!! !!!]</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>[G0cDC][ðÛNo Logic Apps to display !!! !!! !]</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>[YIctd][ô§Logic Apps !!! !]</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>[582ZC][ýáLogic Apps lets you quickly build integrations with SaaS and Enterprise apps, as well as visually design processes and workflows. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>[qwwjj][ÛµExpand or Collapse !!! !!!]</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>[TZ4re][ØóApp service Authentication / Authorization: !!! !!! !!! !!! ]</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>[ruQYi][ÅâConfigure AAD now !!! !!!]</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>[ilUpe][ÁëAdd permissions now !!! !!! ]</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>[74NLd][ñ©configured !!! !]</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>[bZcbD][ìÐIdentity requirements (not satisfied) !!! !!! !!! !!]</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>[0CSVV][áènot configured !!! !!]</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>[X20JH][£ÆRequired permissions !!! !!! ]</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>[gsUHu][ËÑThe template needs the following permission: !!! !!! !!! !!! ]</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>[ODiaG][µöThis integration requires an AAD configuration for the function app. !!! !!! !!! !!! !!! !!! !]</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>[2YR4l][ãÀThis template requires an AAD configuration for the function app. !!! !!! !!! !!! !!! !!! ]</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>[0Fx0t][ÀÙYou may need to configure any additional permissions you function requires. Please see the documentation for this binding. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! ]</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>[L7kot][êÀManage App Service Authentication / Authorization !!! !!! !!! !!! !!]</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>[jNMub][þìAuth configuration required !!! !!! !!]</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>[TOWSF][üÀIdentity requirements !!! !!! ]</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>[GAHPn][çÂManage !!!]</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>[r2SOZ][§ÕWe are not able to get the list of installed runtime extensions !!! !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>[1GZb6][ëÓWe are not able to install runtime extension {{extensionId}} !!! !!! !!! !!! !!! !!]</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>[h3P90][çÎWe are not able to uninstall runtime extension {{extensionId}} !!! !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>[MOdU2][ëÅInstalling runtime extensions is taking longer than expected !!! !!! !!! !!! !!! !!]</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>[q4RGN][ÄÕThe extension {{extensionId}} with a different version is already installed !!! !!! !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>[t592D][ÌÀOpen Application Insights !!! !!! !!]</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>[ekL3i][ÝçApp Insights is enabled for your function. !!! !!! !!! !!! ]</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>[FyKZE][ÿÑNo Monitoring data to display !!! !!! !!!]</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>[xeWsw][ùÀInstall !!!]</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>[Ntn02][ËâExtension Installation Succeeded !!! !!! !!! ]</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>[s1W3p][ÜÞExtensions not Installed !!! !!! !]</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>[cl2t5][ÿÖThis integration requires the following extensions. !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>[m06uq][ÓÚThis template requires the following extensions. !!! !!! !!! !!! !!]</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>[hkEiW][ßäInstalling required extensions. It may take upto 10 minutes for this operation. !!! !!! !!! !!! !!! !!! !!! !]</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>[1gFO9][§õWe are not able to install runtime extension. Install id {{installationId}} !!! !!! !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>[tmqqB][ÌËEnter value in GB-sec !!! !!! ]</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>[ws1Kg][àÇConnection !!! !]</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>[FZED7][ïßNotification Hub !!! !!!]</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>[RbFwl][ÿüJava Functions can be built, tested and deployed locally from your machine. No portal required! !!! !!! !!! !!! !!! !!! !!! !!! !!]</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>[rSeSX][ÜÚClick below to get started with documentation on how to build your first Azure Function with Java. !!! !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>[ub1oe][ÅôProxies has been enabled. To disable again, delete or disable all individual proxies. !!! !!! !!! !!! !!! !!! !!! !!!]</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>[nI5EQ][î©Java on Azure Functions Quickstart !!! !!! !!! !]</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/ru-RU/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/ru-RU/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>Настроить</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>Чтобы включить поддержку, измените план</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>Выделить все</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>Выбраны все элементы</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>Выбрано элементов: {0}</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>Ошибка при создании функции: {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>Выберите шаблон ниже или</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>Выберите ниже план для создания подписки</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>Укажите понятное имя подписки</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>Понятное имя подписки</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>Код приглашения</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>Этот шаблон является экспериментальным и пока не поддерживается полностью. При возникновении проблем зарегистрируйте ошибку в нашем &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;репозитории GitHub.&lt;/a&gt;</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>Сохранить</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>Сейчас идет операция сохранения. Переход отсюда может привести к потере части изменений.</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ Добавить новый параметр</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ Добавить новую строку подключения</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ Добавить новый документ</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ Добавить новое сопоставление обработчика</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ Добавить новое виртуальное приложение или каталог</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>Введите имя</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>Введите значение</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>Ввести расширение</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>Ввести обработчик сценария</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>Ввести аргументы</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>Ввести виртуальный путь</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>Ввести физический путь</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>Приложение</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>Параметр слота</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>Скрытое значение. Щелкните, чтобы показать.</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>Поиск</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>Ограничить область этим элементом</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>Функции поиска</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>Поиск среди приложений-функций</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>Идентификатор подписки</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>Включено</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>отключить</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>включено</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>здесь</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>Ошибка при анализе конфигурации: {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>Не удалось {{state}} функцию: {{functionName}}</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>Функции</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>Обычный редактор</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>Удалить функцию {{name}}</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>Вы действительно хотите удалить функцию {{name}}?</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>Прокси-серверы (предварительная версия)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>Версия среды выполнения прокси-сервера: {{extensionVersion}}. Доступна новая версия ({{latestExtensionVersion}}).</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>Версия среды выполнения прокси-сервера: последняя ({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>Включить прокси-серверы для функций Azure (предварительная версия)</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>Прокси-серверы для функций Azure сейчас отключены. Чтобы включить их, перейдите на страницу</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>Изменения параметров прокси-сервера {{name}} будут утрачены. Вы действительно хотите продолжить?</value>
@@ -967,7 +1033,7 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Слоты функций Azure (предварительная версия) сейчас отключены. Чтобы включить их, перейдите на страницу</value>
   </data>
-  <data name="discrard" xml:space="preserve">
+  <data name="discard" xml:space="preserve">
     <value>Отменить</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
@@ -983,7 +1049,7 @@
     <value>Войти по учетным данным Google</value>
   </data>
   <data name="intro_signInWithMicrosoft" xml:space="preserve">
-    <value>Вход с учетной записью Майкрософт</value>
+    <value>Вход с помощью учетной записи Майкрософт</value>
   </data>
   <data name="apiProxy_backanrUrlStart" xml:space="preserve">
     <value>URL-адрес сервера должен начинаться с префикса "http://" или "https://"</value>
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>Все подписки</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>Подписки</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>Подписок: {0}</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>Здесь появятся быстрые ссылки на ваши функции после того, как вы настроите их на вкладке "Функции платформы" выше.</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>Несохраненные изменения в приложении "{0}" будут утеряны.  Вы действительно хотите продолжить?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>Ошибка при получении сведений о приложении "{0}"</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>Эта функция не поддерживается для приложений, которые используют план потребления</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>Эта функция не поддерживается для слотов</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Эта функция не поддерживается для приложений Linux</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>Для использования этой функции у вас должны быть разрешения на запись для текущего приложения</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>Просматривайте файловую систему приложения из интерактивной веб-консоли.</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>SSH предоставляет веб-консоль SSH для кода вашего приложения Linux</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>Расширения</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>Расширения дополняют функции всего приложения.</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(нет отображаемых параметров приложений)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(нет отображаемых строк подключения)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(нет отображаемых документов по умолчанию)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(нет отображаемых сопоставлений обработчиков)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(нет отображаемых виртуальных приложений или каталогов)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>Общие параметры</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>Автоматическое переключение</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>Отладка</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>Среда выполнения</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>Параметры приложения</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>Управляйте параметрами приложения, строками подключения, параметрами среды выполнения и многим другим.</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>Документы по умолчанию</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>Сопоставления обработчика</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>Виртуальные приложения и каталоги</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>Для изменения этих параметров вам требуются разрешения на запись в текущем приложении.</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>Это приложение доступно только для чтения. В нем запрещено изменять параметры или извлекать защищенные данные. Снимите блокировку и повторите попытку.</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>Просмотреть параметры в режиме "только для чтения".</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>Не удалось загрузить параметры.</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>Идет загрузка...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>Параметры веб-приложения обновляются</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>Параметры веб-приложения успешно обновлены.</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>Не удалось обновить параметры веб-приложения: </value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>{{configGroupName}} Ошибка сохранения: недопустимые входные данные.</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>Версия .NET Framework</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>Версия для запуска веб-приложения, если используется .NET Framework</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>Версия PHP</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>Версия для запуска веб-приложения, если используется PHP</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Версия Python</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>Версия для запуска веб-приложения, если используется Python</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Версия Java</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>Версия для запуска веб-приложения, если используется Java</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Дополнительный номер версии Java</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>Выберите необходимый дополнительный номер версии Java. Если выбрать "Самые новые", то приложение будет использовать JVM, недавно добавленную на портал.</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Веб-контейнер</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>Версия веб-контейнера, использующаяся для запуска веб-приложения с помощью Java</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>Платформа</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>Архитектура платформы, на которой запущено приложение</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>Для 64-разрядной конфигурации необходим план службы приложений "Базовый" или выше</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Веб-сокеты</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>Соединения WebSocket обеспечивают более гибкое подключение между веб-приложениями и современными браузерами. Ваше веб-приложение должно использовать эти возможности.</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>Всегда включено</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>Указывает, что веб-приложение должно быть постоянно загружено. По умолчанию веб-приложения выгружаются после определенного времени простоя. Рекомендуется включить этот параметр, если в вашем веб-приложении запущены постоянные веб-задания</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>Для AlwaysOn необходим план службы приложений "Базовый" или выше</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>Версия управляемого конвейера</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>Назначения автоматического переключения нельзя настроить из рабочего слота</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>Автоматическое переключение</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>Слот автоматического переключения</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>Сходство для маршрутизации запросов приложений</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>Удаленная отладка</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>Версия удаленной службы Visual Studio</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>Стек</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>Загрузочный файл</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>Самые новые</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32-разрядный</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64-разрядный</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>Классический</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>Интегрированный</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>Свойства</value>
@@ -1220,7 +1469,7 @@
     <value>Просматривайте все параметры службы приложений.</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>Управление параметрами среды выполнения всех функций в вашем приложении.</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>Общие параметры</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>Используйте проверку подлинности и авторизацию, чтобы защитить приложение и работать с данными каждого пользователя.</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>Управляемое удостоверение службы</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>Приложение может взаимодействовать с другими службами Azure, так как использует управляемое удостоверение Azure Active Directory.</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>Push-уведомления</value>
@@ -1379,10 +1634,13 @@
     <value>Параметры</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>Параметры приложения-функции</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>Конфигурация</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>Параметры приложения</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>Управление приложением-функцией недоступно в этой пробной версии.</value>
@@ -1574,7 +1832,7 @@
     <value>Ознакомьтесь с учебником по началу работы.</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>Функция</value>
+    <value>Функция (предварительная версия)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>Ключ определения API</value>
@@ -1586,7 +1844,7 @@
     <value>Создать шаблон определения API</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>Экспорт в Power Apps + Flow</value>
+    <value>Экспорт в PowerApps и Flow</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
     <value>Не удается сохранить определение API в неправильном формате.</value>
@@ -1613,7 +1871,7 @@
     <value>Использовать определение API</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>Определение API (предварительная версия)</value>
+    <value>Определение API</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>Не удалось создать или обновить ключ swaggerdocumentationkey для конечной точки Swagger. Проверьте журналы среды выполнения на предмет ошибок или повторите попытку позже.</value>
@@ -1705,6 +1963,9 @@
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>Приложение сейчас находится в режиме "чтение и запись", так как вы перевели его в режим правки, несмотря на включенную систему управления версиями. Любые вносимые изменения могут быть переопределены при следующем развертывании. Чтобы изменить режим правки, посетите </value>
   </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>Ваше приложение сейчас находится в режиме "только для чтения", так как вы опубликовали созданный function.json. Изменения, вносимые в function.json, не будут учитываться средой выполнения Функций Azure. </value>
+  </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>Копировать</value>
   </data>
@@ -1748,10 +2009,22 @@
     <value>Слоты (предварительная версия)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>Включить слоты развертывания (предварительная версия). Это однократное действие в приложении-функции, которое невозможно отменить. Оно сбросит все существующие секреты. После обновления секреты можно скопировать на </value>
+    <value>Включить слоты развертывания (предварительная версия).</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>узле "Управление" для каждой функции.</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>Известные проблемы:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>Когда включены Слоты (предварительная версия), интеграция Logic Apps с Функциями не работает.</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>Если вы решите использовать эту предварительную версию, имеющиеся секреты будут сброшены. Секреты можно найти в узле</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>"Управление"</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>для каждой функции.</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>Имя</value>
@@ -1790,7 +2063,7 @@
     <value>Слоты (предварительная версия)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>Дополнительные возможности мониторинга, включая метрики в реальном времени и пользовательские запросы, можно получить в &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights&lt;/a&gt;.</value>
+    <value>Чтобы получить дополнительные возможности мониторинга, включая пользовательские запросы и метрики в реальном времени, &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;активируйте для своего приложения-функции службу Application Insights.&lt;/a&gt;</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>Это значение будет добавлено к URL-адресу вашего главного веб-приложения и будет общедоступным адресом слота. Например, если у вас есть веб-приложение "contoso" и слот "staging", то новый слот будет иметь URL-адрес вида "http://contoso-staging.azurewebsites.net".</value>
@@ -1802,6 +2075,9 @@
     <value>Поиск по функциям</value>
   </data>
   <data name="new_" xml:space="preserve">
+    <value>Создать</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
     <value>Создать</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
@@ -1878,5 +2154,308 @@
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>Содержимое и проект Visual Studio</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>Извлечь</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>Удалить прокси</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>Создать прокси-сервер</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>Нет переопределений</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>Экспресс-регистрация в AAD</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>create</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>После создания функции нужно добавить подписку сетки событий.</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>URL-адрес подписки сетки событий</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>URL-адрес подписки сетки событий</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>Управление подписками сетки событий</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>Добавить подписку сетки событий</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>Все расположения</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>Расположений: {0}</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>Расположение:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>Группировать по местоположению</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>Без группирования</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>Группировать по группе ресурсов</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>Группировать по подписке</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>Юг и центр США</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>Северная Европа</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>Западная Европа</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>Юго-Восточная Азия</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>Центральная Корея</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>Южная Корея</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>Западная часть США</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>Восточная часть США</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>Западная Япония</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>Восточная Япония</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>Восточная Азия</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>Восточная часть США 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>Северо-центральный регион США</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>Центральная часть США</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>Южная Бразилия</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>Восточная часть Австралии</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>Западная Индия</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>Центральная Индия</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>Южная Индия</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>Центральная Канада</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>Восточная Канада</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>Западно-Центральная часть США</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>Западная часть Соединенного Королевства</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>Южная часть Соединенного Королевства</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>Западная часть США 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>Все группы ресурсов</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>Группа ресурсов:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>Групп ресурсов: {0}</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>Текст</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>Код состояния</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>Сообщение о состоянии</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>Переопределение запроса</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>Переопределение ответа</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>Необязательно</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>Вы используете предварительную версию функций Azure. Спасибо за участие!</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>Щелкните, чтобы скрыть</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>Приложения логики позволяют легко использовать функцию на нескольких платформах.</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>Связанные приложения логики</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>Оркестрация с приложениями логики</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>Создать приложения логики</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>Нет приложений логики для отображения</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>Приложения логики</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>Приложения логики позволяют быстро наладить интеграцию с приложениями SaaS и корпоративными приложениями, а также наглядно проектировать процессы и рабочие процессы.</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>Развернуть или свернуть</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>Проверка подлинности или авторизация службы приложений:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>Настроить AAD сейчас</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>Добавить разрешения сейчас</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>настроено</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>Требования к удостоверению (не выполнены)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>не настроено</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>Требуемые разрешения</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>Шаблону требуется следующее разрешение:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>Этой интеграции требуется конфигурация AAD для приложения-функции.</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>Этому шаблону требуется конфигурация AAD для приложения-функции.</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>Возможно, вам нужно будет настроить для функции необходимые ей дополнительные разрешения. См. документацию для этой привязки.</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>Управление проверкой подлинности или авторизацией службы приложений</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>Требуется настройка проверки подлинности</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>Требования к удостоверению</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>Управление</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>Не удалось получить список установленных расширений среды выполнения</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Не удалось установить расширение среды выполнения {{extensionId}}</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Не удалось удалить расширение среды выполнения {{extensionId}}</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>Установка расширений среды выполнения занимает больше времени, чем ожидалось</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>Расширение {{extensionId}} с другой версией уже установлено</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>Открыть Application Insights</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>Служба App Insights для вашей функции активна.</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>Нет данных мониторинга для отображения</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>Установить</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>Расширение установлено</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>Расширения не установлены</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>Для интеграции требуются следующие расширения.</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>Для шаблона требуются следующие расширения.</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>Устанавливаются нужные расширения. Операция может занять до 10 минут.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>Установить расширение среды выполнения не удалось. Идентификатор установки: {{installationId}}</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>Введите значение в ГБ/с</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>Подключение</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>Концентратор уведомлений</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>Сборку, тестирование и развертывание функций Java можно выполнять локально с вашего компьютера. Использовать портал не требуется!</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>Щелкните ниже, чтобы приступить к работе с документацией по созданию первой функции Azure на основе Java.</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>Прокси-серверы включены. Чтобы отключить их, удалите или отключите их все по отдельности.</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Краткое руководство по функциям Java в Azure</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/sv-SE/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/sv-SE/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>Konfigurera</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>Uppgradera för att aktivera</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>Markera alla</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>Alla objekt har valts</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>{0} objekt har valts</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>Fel när funktion skapades: {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>Välj en mall nedan eller</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>Skapa en ny prenumeration genom att först välja en plan nedan</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>Ange ett eget namn på prenumerationen</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>Eget namn på prenumeration</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>Inbjudningskod</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>Det här är en experimentell mall som ännu inte stöds fullt ut. Om du får problem kan du rapportera programfelet till vår &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;GitHub-lagringsplats.&lt;/a&gt;</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>Spara</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>En åtgärd för att spara pågår för tillfället. Om du lämnar platsen kan vissa ändringar gå förlorade.</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ Lägg till ny inställning</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ Lägg till ny anslutningssträng</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ Lägg till nytt dokument</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ Lägg till ny hanterarmappning</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ Lägg till ny virtuell installation eller katalog</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>Ange ett namn</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>Ange ett värde</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>Ange tillägg</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>Ange skriptprocessor</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>Ange argument</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>Ange virtuell sökväg</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>Ange fysisk sökväg</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>Program</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>Platsinställning</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>Dolt värde. Klicka för att visa.</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>Sök</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>Styr till det här objektet</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>Sök efter funktioner</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>Sök funktionsappar</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>Prenumerations-ID</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>Aktiverad</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>inaktivera</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>aktiverad</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>här</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>Fel vid parsning av konfiguration: {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>Det gick inte att {{state}} funktionen: {{functionName}}</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>Egenskaper</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>Standardredigeringsprogram</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>Ta bort funktionen {{name}}</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>Vill du ta bort funktionen {{name}}?</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>Proxyservrar (förhandsgranskning)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>Körningsversion av proxyserver: {{extensionVersion}}. En senare version är tillgänglig ({{latestExtensionVersion}}).</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>Körningsversion av proxyserver: senaste ({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>Aktivera Azure Functions-proxyservrar (förhandsgranskning)</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>Azure Functions-proxyservrar är för närvarande inaktiverade. Aktivera dem genom att gå till</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>Ändringar i proxyservern {{name}} går förlorade. Vill du fortsätta?</value>
@@ -967,8 +1033,8 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Azure Functions-platser (förhandsversion) är för närvarande inaktiverat. Aktivera det på</value>
   </data>
-  <data name="discrard" xml:space="preserve">
-    <value>Ta bort</value>
+  <data name="discard" xml:space="preserve">
+    <value>Ignorera</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
     <value>Funktioner</value>
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>Alla prenumerationer</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>Prenumerationer</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>{0} prenumerationer</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>Snabblänkar till funktionerna visas här när du har konfigurerat dem på fliken "Plattformsfunktioner" ovan.</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>Ändringar som inte har sparats för appen {0} kommer att försvinna. Vill du fortsätta?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>Ett fel uppstod när informationen om appen {0} skulle hämtas</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>Den här funktionen stöds inte för appar i en förbrukningsplan</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>Den här funktionen stöds inte för platser</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Den här funktionen stöds inte för Linux-appar</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>Du måste ha skrivbehörighet för den aktuella appen för att kunna använda den här funktionen</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>Utforska appfilsystemet från en interaktiv webbaserad konsol.</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>SSH tillhandahåller en SSH-webbkonsol för din Linux-appkod</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>Tillägg</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>Med tillägg får du fler funktioner i hela appen.</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(det finns inga programinställningar att visa)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(det finns inga anslutningssträngar att visa)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(det finns inga standarddokument att visa)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(det finns inga hanterarmappningar att visa)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(det finns inga virtuella installationer eller kataloger att visa)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>Allmänna ändringar</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>Autoväxling</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>Felsökning</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>Körning</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>Programinställningar</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>Hantera appinställningar, anslutningssträngar, körtidsinställningar och mycket mer.</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>Standarddokument</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>Hanterarmappningar</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>Virtuella installationer och kataloger</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>Du måste ha skrivbehörighet för den aktuella appen för att redigera de här inställningarna.</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>Den här appen har ett skrivskyddat lås som förhindrar redigering av inställningar och hämtning av skyddade data. Ta bort låset och försök igen.</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>Visa inställningar i skrivskyddat läge.</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>Det gick inte att läsa in inställningar.</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>Läser in…</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>Uppdaterar webbappinställningar</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>Webbprograminställningarna har uppdaterats</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>Det gick inte att uppdatera webbappinställningar: </value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>{{configGroupName}} Fel vid sparande: Ogiltiga indata.</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>.NET Framework-version</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>Den version som används för att köra ditt webbprogram om det använder .NET Framework</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>PHP-version</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>Den version som används för att köra ditt webbprogram om det använder PHP</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Python-version</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>Den version som används för att köra ditt webbprogram om det använder Python</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Java-version</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>Den version som används för att köra ditt webbprogram om det använder Java</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Java minor-version</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>Välj önskad Java minor-version. Om du väljer Nyaste kommer din app att använda den JVM som senast lades till på portalen.</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Webbehållare</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>Den webbehållarversion som används för att köra ditt webbprogram om det använder Java</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>Plattform</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>Den plattformsarkitektur som ditt webbprogram kör</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>För 64-bitarskonfiguration krävs en grundläggande eller högre App Service-plan</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Web Sockets</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>WebSockets möjliggör mer flexibel anslutning mellan webbprogram och moderna webbläsare.  Ditt webbprogram bör skapas så att det kan utnyttja dessa funktioner.</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>Alltid på</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>Anger att ditt webbprogram alltid måste aktiveras. Webbprogram inaktiveras alltid som standard när de inte har använts. Det rekommenderas att du aktiverar det här alternativet om du har webbjobb som körs kontinuerligt i webbprogrammet.</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>För "Alltid på" krävs en grundläggande eller högre App Service-plan</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>Hanterad pipelineversion</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>Autoväxlingsmålen kan inte konfigureras från produktionsplatsen</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>Autoväxling</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>Autoväxlingsplats</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>ARR-tillhörighet</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>Fjärrfelsökning</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>Visual Studio-fjärrversion</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>Stack</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>Startfil</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>Nyast</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32-bitars</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64-bitars</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>Klassisk</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>Integrerad</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>Egenskaper</value>
@@ -1220,7 +1469,7 @@
     <value>Visa alla App Service-inställningar.</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>Hantera inställningar som påverkar Functions-körningstiden för alla funktioner i appen.</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>Allmänna inställningar</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>Använd autentisering/auktorisering för att skydda program och arbeta med data per användare.</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>Hanterad tjänstidentitet</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>Ditt program kan kommunicera med andra Azure-tjänster som sig självt med hjälp av en hanterad Azure Active Directory-identitet.</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>Push-meddelanden</value>
@@ -1379,10 +1634,13 @@
     <value>Inställningar</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>Funktionsappinställningar</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>Konfiguration</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>Programinställningar</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>Det går inte att hantera funktionsappen i den här utvärderingsversionen.</value>
@@ -1574,7 +1832,7 @@
     <value>Kolla in våra komma igång-tips</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>Funktion</value>
+    <value>Funktion (förhandsversion)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>API-definitionsnyckel</value>
@@ -1586,7 +1844,7 @@
     <value>Generera API-definitionsmall</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>Exportera till Power Apps och Flow</value>
+    <value>Exportera till PowerApps + Flow</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
     <value>Det går inte att spara felaktigt formaterad API-definition.</value>
@@ -1613,7 +1871,7 @@
     <value>Använd API-definitionen</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>API-definition (förhandsversion)</value>
+    <value>API-definition</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>Vi kunde inte skapa eller uppdatera nyckeln swaggerdocumentationkey för Swagger-slutpunkten. Se efter i körtidsloggarna om det finns fel eller försök igen senare.</value>
@@ -1649,16 +1907,16 @@
     <value>Använd API-definitionen för att komma åt dina funktioner inifrån &lt;a href="https://powerapps.microsoft.com/en-us/" target="_blank"&gt;PowerApps&lt;/a&gt; och &lt;a href="https://ms.flow.microsoft.com/en-us/" target="_blank"&gt;Flow&lt;/a&gt;. </value>
   </data>
   <data name="swaggerDefinition_generateHelp" xml:space="preserve">
-    <value>Skapa en sparse-definition med metadata från de utlösta HTTP-funktionerna.
-Fyll i &lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;åtgärdsobjekten&lt;/a&gt; och annan information om API:t före användning.</value>
+    <value>Skapa en sparse-definition med metadata från dina HTTP-utlösta funktioner.
+Fyll i &lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;åtgärdsobjekten&lt;/a&gt; och annan information om ditt API före användning.</value>
   </data>
   <data name="swaggerDefinition_keyHelp" xml:space="preserve">
-    <value>Den här nyckeln skyddar API-definitionen från åtkomst för alla som saknar nyckel.
-Det underliggande API:t skyddas inte. Varje funktion innehåller information om dess nyckelskydd.</value>
+    <value>Den här nyckeln skyddar din API-definition från åtkomst för alla som saknar nyckeln.
+Det underliggande API:t skyddas inte. Se varje funktion för att se deras nyckelsäkerhet.</value>
   </data>
   <data name="swaggerDefinition_sourceHelp" xml:space="preserve">
-    <value>Ställ in på "Funktion" för att aktivera funktioner för att skapa en värdbaserad API-definition och malldefinition.
-Ställ in på "Extern URL" för att använda en API-definition med värd på annan plats.</value>
+    <value>Ställ in på funktion för att aktivera skapandet av en värdbaserad API-definition och malldefinition.
+Ställ in på extern URL för att använda en API-definition som finns på någon annan plats.</value>
   </data>
   <data name="swaggerDefinition_urlHelp" xml:space="preserve">
     <value>Använd den här webbadressen för att komma åt API-definitionen direkt och importera till verktyg från tredje part </value>
@@ -1676,7 +1934,7 @@ Ställ in på "Extern URL" för att använda en API-definition med värd på ann
     <value>Skrivskyddad</value>
   </data>
   <data name="appFunctionSettings_readWriteMode" xml:space="preserve">
-    <value>Läs\skriv</value>
+    <value>Läsa/skriva</value>
   </data>
   <data name="validation_duplicateError" xml:space="preserve">
     <value>Dubblettvärden tillåts inte</value>
@@ -1704,6 +1962,9 @@ Ställ in på "Extern URL" för att använda en API-definition med värd på ann
   </data>
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>Appen är för närvarande i läs\skrivläge eftersom redigeringsläget har angetts till läs\skriv trots att källkontroll är aktiverat. Eventuella ändringar som du gör kanske skrivs över vid nästa distribution. Om du vill ändra redigeringsläget går du till </value>
+  </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>Appen är nu i skrivskyddat läge eftersom du har publicerat en genererad function.json. Ändringar i function.json kommer inte att hanteras av Functions-körningen. </value>
   </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>Kopiera</value>
@@ -1748,10 +2009,22 @@ Ställ in på "Extern URL" för att använda en API-definition med värd på ann
     <value>Platser (förhandsversion)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>Aktivera distributionsplatser (förhandsversion). Det här är ett engångsval i funktionsappen som inte kan inaktiveras och som återställer alla eventuella tidigare hemligheter. Efter uppdateringen kan hemligheterna kopieras från </value>
+    <value>Aktivera distributionsplatser (förhandsgranskning).</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>Hanteringsnod för varje funktion.</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>Kända problem:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>Logikprogramintegrering med funktioner fungerar inte när Platser (förhandsgranskning) aktiveras.</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>Val av förhandsgranskningsfunktionen återställer alla befintliga hemligheter. Funktionshemligheter finns under</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>Hantera</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>nod för varje funktion.</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>Namn</value>
@@ -1790,7 +2063,7 @@ Ställ in på "Extern URL" för att använda en API-definition med värd på ann
     <value>Platser (förhandsversion)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>Om du är ute efter mer avancerad övervakning med Live Metrics och anpassade sökfrågor rekommenderar vi att du använder &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights.&lt;/a&gt;</value>
+    <value>Om du är ute efter mer avancerad övervakning med Live Metrics och anpassade sökfrågor så &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;aktivera Application Insights för din funktionsapp&lt;/a&gt;</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>Det här värdet läggs till ditt huvudwebbprograms URL och fungerar som platsens offentliga adress. Om du t.ex. har ett webbprogram med namnet "contoso" och en plats med namnet "staging" får den nya platsen en adress som ser ut så här: http://contoso-staging.azurewebsites.net.</value>
@@ -1803,6 +2076,9 @@ Ställ in på "Extern URL" för att använda en API-definition med värd på ann
   </data>
   <data name="new_" xml:space="preserve">
     <value>Ny</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
+    <value>Skapa ny</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
     <value>Ta bort funktion</value>
@@ -1878,5 +2154,308 @@ Ställ in på "Extern URL" för att använda en API-definition med värd på ann
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>Innehålls- och Visual Studio-projekt</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>hämta</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>Ta bort proxy</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>Ny proxyserver</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>Ingen åsidosättning</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>AAD-expressregistrering</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>skapa</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>Du måste lägga till Event Grid-prenumeration när du har skapat en funktion.</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>Webbadress för Event Grid-prenumeration</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>Webbadress för Event Grid-prenumeration</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>Hantera Event Grid-prenumerationer</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>Lägg till Event Grid-prenumeration</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>Alla platser</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>{0} platser</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>Plats:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>Gruppera efter plats</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>Ingen gruppering</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>Gruppera efter resursgrupp</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>Gruppera efter prenumeration</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>Södra centrala USA</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>Nordeuropa</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>Västeuropa</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>Sydostasien</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>Centrala Korea</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>Södra Korea</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>Västra USA</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>Östra USA</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>Västra Japan</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>Östra Japan</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>Östasien</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>Östra USA 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>Norra centrala USA</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>Centrala USA</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>Södra Brasilien</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>Östra Australien</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>Indien, västra</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>Indien, centrala</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>Indien, södra</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>Kanada, centrala</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>Kanada, östra</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>Västra centrala USA</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>Västra Storbritannien</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>Södra Storbritannien</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>Västra USA 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>Alla resursgrupper</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>Resursgrupp:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>{0} resursgrupper</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>Text</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>Statuskod</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>Statusmeddelande</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>Begär åsidosättning</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>Åsidosätt svar</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>Valfritt</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>Du använder en förhandsversion av Azure Functions. Tack för att du testar den!</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>Klicka för att dölja</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>Med Logic Apps kan du enkelt använda din funktion på flera plattformar</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>Tillhörande Logic Apps</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>Samordna med Logic Apps</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>Skapa Logic Apps</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>Det finns inga Logic Apps att visa</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>Logikappar</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>Med Logic Apps kan du snabbt skapa integreringar med SaaS- och Enterprise-appar och visuellt utforma processer och arbetsflöden.</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>Visa eller dölja</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>App Service autentisering/auktorisering:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>Konfigurera AAD nu</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>Lägg till behörigheter nu</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>konfigurerad</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>Identitetskrav (inte uppfyllda)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>inte konfigurerad</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>Nödvändiga behörigheter</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>Mallen behöver följande behörighet:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>Den här integrationen kräver en AAD-konfiguration för funktionsappen.</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>Den här mallen kräver en AAD-konfiguration för funktionsappen.</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>Du kan behöva konfigurera ytterligare behörigheter som din funktion kräver. Se dokumentationen för den här bindningen.</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>Hantera App Service autentisering/auktorisering</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>Autentiseringskonfiguration krävs</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>Identitetskrav</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>Hantera</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>Vi kunde inte hämta listan över installerade runtime-tillägg</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Vi kunde inte installera runtime-tillägget {{extensionId}}</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>Vi kunde inte avinstallera runtime-tillägget {{extensionId}}</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>Installationen av runtime-tillägg tar längre tid än beräknat</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>Tillägget {{extensionId}} har redan installerats med en annan version</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>Öppna Application Insights</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>App Insights har aktiverats för din funktion.</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>Det finns inga övervakningsdata att visa</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>Installera</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>Tillägget har installerats</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>Tillägg som inte har installerats</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>Den här integrationen kräver följande tillägg.</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>Den här mallen kräver följande tillägg.</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>Installerar tillägg som krävs. Det kan ta upp till 10 minuter för den här åtgärden.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>Vi kunde inte installera runtime-tillägget. Installations-ID {{installationId}}</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>Ange värdet i GB-s</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>Anslutning</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>Notification Hub</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>Java-funktioner kan byggas, testas och distribueras lokalt från din dator. Ingen portal krävs!</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>Klicka nedan för att komma igång med dokumentation om hur du skapar din första Azure-funktion med Java.</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>Proxyservrar har aktiverats. Om du vill inaktivera det igen tar du bort eller inaktiverar enskilda proxyservrar.</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Snabbstart för Java på Azure Functions</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/tr-TR/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/tr-TR/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>Yapılandır</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>Etkinleştirmek için yükseltin</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>Tümünü seç</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>Tüm öğeler seçildi</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>{0} öğe seçildi</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>İşlev Oluşturma Hatası: {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>Aşağıdan bir şablon seçin veya</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>Yeni abonelik oluşturmak için aşağıdan bir plan seçin</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>Abonelik için bir kolay ad belirtin</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>Aboneliğin kolay adı</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>Davet kodu</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>Bu şablon deneysel ve henüz tam destek içermiyor. Sorun yaşarsanız lütfen &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;GitHub depomuzda bir hata oluşturun.&lt;/a&gt;</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>Kaydet</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>Devam eden bir kayıt işlemi var. Sayfadan ayrılırsanız bazı değişiklikler kaybolabilir.</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ Yeni ayar ekle</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ Yeni bağlantı dizesi ekle</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ Yeni belge ekle</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ Yeni işleyici eşlemesi ekle</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ Yeni sanal uygulama veya dizin ekle</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>Bir ad girin</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>Bir değer girin</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>Uzantıyı girin</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>Betik işleyicisini girin</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>Bağımsız değişkenleri girin</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>Sanal yolu girin</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>Fiziksel yolu girin</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>Uygulama</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>Yuva Ayarı</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>Gizli değer. Göstermek için tıklayın.</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>Ara</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>Bu öğeye yönelik kapsam</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>Özelliklerde ara</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>İşlevi uygulamaları ara</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>Abone Kimliği</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>Etkin</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>devre dışı bırak</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>etkin</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>buraya</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>Yapılandırma ayrıştırma hatası: {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>{{functionName}} işlevi için {{state}} başarısız</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>Özellikler</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>Standart düzenleyici</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>{{name}} İşlevini sil</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>{{name}} İşlevini silmek istediğinizden emin misiniz?</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>Proxy'ler (önizleme)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>Proxy çalışma zamanı sürümü: {{extensionVersion}}. Daha yeni bir sürüm ({{latestExtensionVersion}}) mevcut.</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>Proxy çalışma zamanı sürümü: güncel ({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>Azure İşlevleri Proxy'lerini (önizleme) etkinleştir</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>Azure İşlevleri Proxy'leri şu anda devre dışı. Etkinleştirmek için şu sayfayı ziyaret edin:</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>{{name}} adlı proxy'de yapılan değişiklikler kaybolacak. Devam etmek istediğinizden emin misiniz?</value>
@@ -967,7 +1033,7 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Azure İşlevleri yuvaları (önizleme) şu anda devre dışı. Etkinleştirmek için şuraya gidin:</value>
   </data>
-  <data name="discrard" xml:space="preserve">
+  <data name="discard" xml:space="preserve">
     <value>At</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>Tüm abonelikler</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>Abonelikler</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>{0} abonelik</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>Yukarıdaki "Platform özellikleri" sekmesinden özelliklerinizin hızlı bağlantılarını yapılandırarak, hızlı bağlantıların burada görüntülenmesini sağlayabilirsiniz.</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>'{0}' uygulaması için kaydedilmemiş değişiklikler kaybolacak. Devam etmek istediğinizden emin misiniz?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>'{0}' uygulamasıyla ilgili bilgiler alınırken bir hata oluştu</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>Bu özellik, Tüketim planlarındaki uygulamalarda desteklenmez</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>Bu özellik yuvalar için desteklenmiyor</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Bu özellik Linux uygulamalarında desteklenmiyor</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>Bu özelliği kullanabilmek için, geçerli uygulamada yazma izinlerine sahip olmanız gerekir</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>Uygulamanızın dosya sistemini etkileşimli bir web tabanlı konsoldan inceleyin.</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>SSH, Linux uygulama kodunuz için bir Web SSH konsol deneyimi sağlar</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>Uzantılar</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>Uzantılar, uygulamanızın tamamına yönelik işlevler ekler.</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(görüntülenecek uygulama ayarı yok)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(görüntülenecek bağlantı dizesi yok)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(görüntülenecek varsayılan belge yok)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(görüntülenecek işleyici eşlemesi yok)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(görüntülenecek sanal uygulama veya dizin yok)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>Genel ayarlar</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>Otomatik Değiştirme</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>Hata ayıklama</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>Çalışma Zamanı</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>Uygulama ayarları</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>Uygulama ayarlarını, bağlantı dizelerini, çalışma zamanı ayarlarını ve daha fazlasını yönetin.</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>Varsayılan belgeler</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>İşleyici eşlemeleri</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>Sanal uygulamalar ve dizinler</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>Bu ayarları düzenleyebilmeniz için, geçerli uygulamada yazma izinlerine sahip olmanız gerekir.</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>Bu uygulamada, ayarların düzenlenmesini veya güvenli verilerin indirilmesini önleyen bir salt okunur kilidi var.</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>Ayarları salt okunur modda görüntüleyin.</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>Ayarlar yüklenemedi.</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>Yükleniyor...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>Web uygulaması ayarları güncelleştiriliyor</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>Web uygulaması ayarları başarıyla güncelleştirildi</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>Web uygulaması ayarları güncelleştirilemedi: </value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>{{configGroupName}} Kayıt Hatası: Geçersiz değerler girildi.</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>.NET Framework sürümü</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>.NET Framework kullanılıyorsa web uygulamanızı çalıştırmak için kullanılan sürüm</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>PHP sürümü</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>PHP kullanılıyorsa web uygulamanızı çalıştırmak için kullanılan sürüm</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Python sürümü</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>Python kullanılıyorsa web uygulamanızı çalıştırmak için kullanılan sürüm</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Java sürümü</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>Java kullanılıyorsa web uygulamanızı çalıştırmak için kullanılan sürüm</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Java ikincil sürümü</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>İstediğiniz Java minor sürümünü seçin. 'En Yeni'yi seçerseniz, uygulamanız portala eklenen en son JVM'yi kullanmaya devam eder.</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Web kapsayıcısı</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>Java kullanılıyorsa web uygulamanızı çalıştırmak için kullanılan web kapsayıcı sürümü</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>Platform</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>Web uygulamanızın çalıştırdığı platformun mimarisi</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>64 bit yapılandırma için temel veya daha yüksek bir App Service planı gerekir</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Web soketleri</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>WebSockets, web uygulamaları ve modern tarayıcılar arasında daha esnek bağlantı sağlar. Web uygulamanız bu özelliklerden yararlanacak şekilde oluşturulması gerekir.</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>Her Zaman Açık</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>Web uygulamanızın her zaman yüklenmesi gerektiğini belirtir. Web uygulamaları boşta kaldıktan sonra varsayılan olarak kaldırılır. Web uygulamasında çalışan sürekli web işleriniz olduğunda bu seçeneği etkinleştirmeniz önerilir.</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>Always On için temel veya daha yüksek bir App Service planı gerekir</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>Yönetilen Ardışık Düzen Sürümü</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>Otomatik değiştirme hedefleri üretim yuvasından yapılandırılamaz</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>Otomatik Değiştirme</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>Otomatik Değiştirme Yuvası</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>ARR Benzeşimi</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>Uzak hata ayıklama</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>Uzak Visual Studio sürümü</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>Yığın</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>Başlangıç Dosyası</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>En Yeni</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32 bit</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64 bit</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>Klasik</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>Tümleşik</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>Özellikler</value>
@@ -1220,7 +1469,7 @@
     <value>Tüm App Service ayarlarını görüntüleyin.</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>Uygulamanız içindeki tüm işlevler içinde, İşlevler çalışma zamanını etkileyen ayarları yönetin.</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>Genel Ayarlar</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>Uygulamanızı korumak ve kullanıcı başına verilerle çalışmak için Kimlik Doğrulaması / Yetkilendirme kullanın.</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>Yönetilen hizmet kimliği</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>Uygulamanız diğer Azure hizmetleriyle kendisi olarak iletişim kurmak için, yönetilen bir Azure Active Directory kimliği kullanabilir.</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>Anında iletme bildirimleri</value>
@@ -1379,10 +1634,13 @@
     <value>Ayarlar</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>İşlev uygulaması ayarları</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>Yapılandırma</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>Uygulama ayarları</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>Bu deneme sürümünde İşlev uygulamanızı yönetemezsiniz.</value>
@@ -1574,7 +1832,7 @@
     <value>Başlarken öğreticimize göz atın</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>İşlev</value>
+    <value>İşlev (önizleme)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>API tanımı anahtarı</value>
@@ -1586,7 +1844,7 @@
     <value>API tanımı şablonu oluşturun</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>PowerApps + Flow'a aktar</value>
+    <value>PowerApps + Flow'a Aktar</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
     <value>Hatalı biçimlendirilmiş API tanımı kaydedilemiyor.</value>
@@ -1613,7 +1871,7 @@
     <value>API tanımınızı kullanın</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>API tanımı (önizleme)</value>
+    <value>API tanımı</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>Swagger Uç Noktası için swaggerdocumentationkey anahtarı oluşturulamıyor veya güncelleştirilemiyor. Hatalar için çalışma zamanı günlüklerini kontrol edin veya daha sonra tekrar deneyin.</value>
@@ -1653,12 +1911,12 @@
 Kullanmadan önce, &lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;işlem nesnelerini&lt;/a&gt; ve API'niz hakkındaki diğer bilgileri doldurun.</value>
   </data>
   <data name="swaggerDefinition_keyHelp" xml:space="preserve">
-    <value>Bu anahtar, API Tanımınıza anahtarı olmayanlar tarafından erişilmesini engeller.
-Temel API'yi korumaz. Anahtar güvenliklerini görmek için İşlevleri ayrı ayrı inceleyin.</value>
+    <value>Bu anahtar, anahtara sahip olmayanların API Tanımınıza erişmesini engeller.
+Temel API'nin güvenliğini sağlamaz. Anahtar güvenliklerini görmek için İşlevleri ayrı ayrı inceleyin.</value>
   </data>
   <data name="swaggerDefinition_sourceHelp" xml:space="preserve">
-    <value>Barındırılan API tanımını ve şablon tanımı oluşturmayı etkinleştirmek için "İşlev" olarak ayarlayın.
-Başka bir yerde barındırılan API tanımını kullanmak için "Dış URL" olarak ayarlayın.</value>
+    <value>Barındırılan bir API tanımını ve şablon tanımı oluşturmayı etkinleştirmek için "İşlev" olarak ayarlayın.
+Başka yerde barındırılan bir API tanımı kullanmak için "Dış URL" olarak ayarlayın.</value>
   </data>
   <data name="swaggerDefinition_urlHelp" xml:space="preserve">
     <value>API tanımınıza doğrudan erişmek ve tanımı üçüncü taraf uygulamalarına aktarmak için bu URL'yi kullanın </value>
@@ -1676,7 +1934,7 @@ Başka bir yerde barındırılan API tanımını kullanmak için "Dış URL" ola
     <value>Salt Okunur</value>
   </data>
   <data name="appFunctionSettings_readWriteMode" xml:space="preserve">
-    <value>Okuma\Yazma</value>
+    <value>Okuma/Yazma</value>
   </data>
   <data name="validation_duplicateError" xml:space="preserve">
     <value>Yinelenen değerlere izin verilmez</value>
@@ -1704,6 +1962,9 @@ Başka bir yerde barındırılan API tanımını kullanmak için "Dış URL" ola
   </data>
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>Kaynak denetimini etkinleştirmiş olmanıza karşın düzenleme modunu okuma\yazma olarak ayarladığınız için uygulamanız şu anda okuma\yazma modunda. Bir sonraki dağıtımınızda, yaptığınız tüm değişikliklerin üzerine yazılabilir. Düzenleme modunu değiştirmek için şurayı ziyaret edin:</value>
+  </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>Oluşturulan bir function.json yayımlamış olduğundan uygulamanız şu anda salt okunur modda çalışıyor. Function.json içinde yapılan değişiklikler, İşlevler çalışma zamanı tarafından kullanılmaz. </value>
   </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>Kopyala</value>
@@ -1748,10 +2009,22 @@ Başka bir yerde barındırılan API tanımını kullanmak için "Dış URL" ola
     <value>Yuvalar (önizleme)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>Dağıtım yuvalarını (önizleme) etkinleştirin. Bu, İşlev uygulaması düzeyinde olan tek seferlik bir katılım olup devre dışı bırakılamaz ve önceden mevcut olan tüm gizli diziler sıfırlanır. Güncelleştirme sonrasında, gizli diziler her işlev için </value>
+    <value>Dağıtım yuvalarını etkinleştirin (önizleme).</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>'Yönet' düğümünden kopyalanabilir.</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>Bilinen sorunlar:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>Yuvalar (Önizleme) etkinleştirildiğinde İşlevler ile Logic Apps tümleştirmesi çalışmaz.</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>Bu önizleme özelliğine katılmayı seçmek, önceden mevcut olan tüm gizli dizileri sıfırlar. İşlev gizli dizileri her işlev için</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>'Yönet'</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>düğümünde bulunabilir.</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>Ad</value>
@@ -1790,7 +2063,7 @@ Başka bir yerde barındırılan API tanımını kullanmak için "Dış URL" ola
     <value>Yuvalar (önizleme)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>Canlı ölçümler ve özel sorgular içeren daha zengin bir izleme deneyimi için &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights&lt;/a&gt;'ın kullanılması önerilir.</value>
+    <value>Canlı ölçümler ve özel sorgular içeren daha zengin bir izleme deneyimi için &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;İşlev uygulamanız için Application Insights'ı etkinleştirin&lt;/a&gt;</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>Bu değer ana web uygulamanızın URL'sine eklenir ve yuvanın genel adresi görevini görür. Örneğin, 'contoso' adında bir web uygulamanız ve ‘staging’ adında bir yuvanız varsa, yeni yuvanın URL'si ‘http://contoso-staging.azurewebsites.net’ olacaktır.</value>
@@ -1803,6 +2076,9 @@ Başka bir yerde barındırılan API tanımını kullanmak için "Dış URL" ola
   </data>
   <data name="new_" xml:space="preserve">
     <value>Yeni</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
+    <value>Yeni oluştur</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
     <value>İşlevi sil</value>
@@ -1878,5 +2154,308 @@ Başka bir yerde barındırılan API tanımını kullanmak için "Dış URL" ola
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>İçerik ve Visual Studio projesi</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>al</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>Ara sunucuyu sil</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>Yeni proxy</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>Geçersiz kılma yok</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>Hızlı AAD Kaydı</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>oluştur</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>Event Grid aboneliğini işlev oluşturma işleminden sonra eklemeniz gerekir.</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>Event Grid Abonelik URL'si</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>Event Grid Abonelik URL'si</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>Event Grid aboneliklerini yönet</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>Event Grid aboneliği ekle</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>Tüm konumlar</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>{0} konum</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>Konum:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>Konuma göre gruplandır</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>Gruplandırma yok</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>Kaynak grubuna göre gruplandır</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>Aboneliğe göre gruplandır</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>Orta Güney ABD</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>Kuzey Avrupa</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>Batı Avrupa</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>Güneydoğu Asya</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>Kore Orta</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>Kore Güney</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>Batı ABD</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>Doğu ABD</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>Batı Japonya</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>Doğu Japonya</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>Doğu Asya</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>Doğu ABD 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>Orta Kuzey ABD</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>Orta ABD</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>Güney Brezilya</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>Doğu Avustralya</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>Batı Hindistan</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>Orta Hindistan</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>Güney Hindistan</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>Kanada Orta</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>Kanada Doğu</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>Orta Batı ABD</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>Birleşik Krallık Batı</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>Birleşik Krallık Güney</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>Batı ABD 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>Tüm kaynak grupları</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>Kaynak Grubu:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>{0} kaynak grubu</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>Gövde</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>Durum kodu</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>Durum iletisi</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>Geçersiz kılma iste</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>Geçersiz kılmayı yanıtla</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>İsteğe bağlı</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>Azure İşlevleri'nin yayın öncesi sürümlerinden birini kullanıyorsunuz. Denediğiniz için teşekkür ederiz!</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>Gizlemek için tıklayın </value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>Logic Apps, işlevinizi birden çok platformda kolayca kullanmanıza olanak sağlar</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>İlişkili Mantıksal Uygulamalar</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>Mantıksal Uygulamalar ile Düzenleme</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>Mantıksal Uygulama Oluşturma</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>Görüntülenecek Mantıksal Uygulama yok</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>Logic Apps, SaaS uygulamalarıyla ve Kurumsal uygulamalarla hızla tümleştirme olanağı sunmanın yanı sıra işlemleri ve iş akışlarını görsel olarak tasarlamanıza da olanak tanır.</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>Genişlet veya Daralt</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>App Service Kimlik Doğrulaması / Yetkilendirmesi:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>AAD'yi şimdi yapılandırın</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>İzinleri şimdi ekleyin</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>yapılandırıldı</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>Kimlik gereksinimleri (karşılanmadı)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>yapılandırılmadı</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>Gerekli izinler</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>Şablon için aşağıdaki izinler gerekiyor:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>Bu tümleştirme, işlev uygulaması için bir AAD yapılandırması gerektirir.</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>Bu şablon, işlev uygulaması için bir AAD yapılandırması gerektirir.</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>İşlevinizin gerektirdiği ek izinleri yapılandırmanız gerekebilir. Lütfen bu bağlama için belgelere bakın.</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>App Service Kimlik Doğrulamasını / Yetkilendirmesini Yönet</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>Kimlik doğrulaması yapılandırması gerekiyor</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>Kimlik gereksinimleri</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>Yönet</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>Yüklü çalışma zamanı uzantılarının listesini alamıyoruz</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>{{extensionId}} çalışma zamanı uzantısını yükleyemiyoruz</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>{{extensionId}} çalışma zamanı uzantısını kaldıramıyoruz</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>Çalışma zamanı uzantılarının yüklenmesi beklenenden uzun sürüyor</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>{{extensionId}} adlı uzantının farklı bir sürümü zaten yüklü</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>Application Insights'ı Aç</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>İşleviniz için App Insights etkin.</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>Görüntülenecek İzleme verisi yok</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>Yükle</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>Uzantı Yüklemesi Başarılı Oldu</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>Uzantılar yüklü değil</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>Bu tümleştirme aşağıdaki uzantıları gerektirir.</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>Bu şablon aşağıdaki uzantıları gerektirir.</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>Gerekli uzantılar yükleniyor. Bu işlem 10 dakikaya kadar sürebilir.</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>Çalışma zamanı uzantısını yükleyemiyoruz. Yükleme kimliği {{installationId}}</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>Değeri GB-sn cinsinden girin</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>Bağlantı</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>Bildirim Hub'ı</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>Java İşlevleri makinenizde yerel olarak derlenebilir, test edilebilir ve dağıtılabilir. Portala gerek yoktur!</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>Java ile ilk Azure İşlevinizi nasıl oluşturacağınız hakkındaki belgeleri kullanmaya başlamak için aşağıdaki bağlantıya tıklayın.</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>Proxy'ler etkinleştirildi. Tekrar devre dışı bırakmak için tüm bireysel proxy'leri silin veya devre dışı bırakın.</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Azure İşlevleri Üzerinde Java Hızlı Başlangıç</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/zh-CN/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/zh-CN/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>配置</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>升级以启用</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>全选</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>已选择所有项</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>已选择 {0} 项</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>创建函数出错: {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>选择下面的模板或</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>选择下面的一个计划以创建新订阅</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>提供一个友好的订阅名称</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>友好的订阅名称</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>邀请代码</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>此模板是实验模板，尚无完全支持。如果遇到问题，请将 bug 提交于我们的 &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;GitHub 存储库。&lt;/a&gt;</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>保存</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>当前正在进行保存操作。离开页面可能会导致某些更改丢失。</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ 添加新设置</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ 添加新连接字符串</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ 添加新文档</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ 添加新的处理程序映射</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ 添加新的虚拟应用程序或目录</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>输入名称</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>输入一个值</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>输入扩展</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>输入脚本处理器</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>输入参数</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>输入虚拟路径</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>输入物理路径</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>应用程序</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>插槽设置</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>隐藏值。单击以显示。</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>搜索</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>此项的范围</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>搜索功能</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>搜索 Function 应用</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>订阅 ID</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>已启用</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>禁用</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>已启用</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>此处</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>错误分析配置: {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>未能切换函数 {{functionName}} 的状态 {{state}} </value>
   </data>
   <data name="features" xml:space="preserve">
     <value>功能</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>标准编辑器</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>删除函数 {{name}}</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>是否确实要删除函数 {{name}}?</value>
@@ -761,7 +836,7 @@
     <value>编辑</value>
   </data>
   <data name="fileExplorer_upload" xml:space="preserve">
-    <value>上传</value>
+    <value>上载</value>
   </data>
   <data name="storageLockNote" xml:space="preserve">
     <value>已将一个或多个 Function App 链接到此存储帐户。可以在“文件”或“共享”下看到所有链接到该帐户的 Function App。</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>代理(预览)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>代理运行时版本: {{extensionVersion}}。已提供较新的版本({{latestExtensionVersion}})。</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>代理运行时版本: 最新版本({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>启用 Azure Functions 代理(预览)</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>当前已禁用 Azure Functions 代理。若要启用，请访问</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>对代理 {{name}} 所作的更改将丢失。是否确定要继续?</value>
@@ -967,7 +1033,7 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Azure Functions 槽位(预览)当前已禁用。要启用，请访问</value>
   </data>
-  <data name="discrard" xml:space="preserve">
+  <data name="discard" xml:space="preserve">
     <value>放弃</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
@@ -983,7 +1049,7 @@
     <value>使用 Google 登录</value>
   </data>
   <data name="intro_signInWithMicrosoft" xml:space="preserve">
-    <value>通过 Microsoft 登录</value>
+    <value>Microsoft 登录</value>
   </data>
   <data name="apiProxy_backanrUrlStart" xml:space="preserve">
     <value>后端 URL 必须以 "http://" 或 "https://" 开头</value>
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>所有订阅</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>订阅</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>{0} 个订阅</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>从上面的“平台功能”选项卡配置指向功能的快速链接后，这些快速链接将在此处显示。</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>应用“{0}”未保存的更改将丢失。确实要继续吗?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>检索应用“{0}”相关信息时发生错误</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>“消耗”计划上的应用不支持此功能</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>槽不支持此功能</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Linux 应用不支持此功能</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>必须具有当前应用的写入权限才可使用此功能</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>通过基于 Web 的交互式控制台浏览应用文件系统。</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>SSH 为 Linux 应用代码提供 Web SSH 控制台体验</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>扩展</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>扩展可向整个应用添加功能。</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(没有要显示的应用程序设置)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(没有要显示的连接字符串)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(没有要显示的默认文档)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(没有要显示的处理程序映射)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(没有要显示的虚拟应用程序或目录)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>常规设置</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>自动交换</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>调试</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>运行时</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>应用程序设置</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>管理应用设置、连接字符串、运行时设置等。</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>默认文档</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>处理程序映射</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>虚拟应用程序和目录</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>必须具有当前应用的写入权限才可编辑这些设置。</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>此应用具有一个阻止编辑设置或阻止检索安全数据的只读锁定。请删除该锁定并重试。</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>在只读模式下查看设置。</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>未能加载设置。</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>正在加载...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>正在更新 Web 应用设置</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>已成功更新 Web 应用设置</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>未能更新 Web 应用设置: </value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>{{configGroupName}} 保存错误: 提供了无效的输入。</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>.NET Framework 版本</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>使用 .NET Framework 时用于运行 Web 应用的版本</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>PHP 版本</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>使用 PHP 时用于运行 Web 应用的版本</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Python 版本</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>使用 Python 时用于运行 Web 应用的版本</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Java 版本</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>使用 Java 时用于运行 Web 应用的版本</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Java 次要版本</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>选择所需的 Java 次要版本。选择“最新”将保持应用使用最近添加到门户的 JVM。</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Web 容器</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>使用 Java 时用于运行 Web 应用的 Web 容器版本</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>平台</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>Web 应用运行的平台体系结构</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>64 位配置需要基本或更高级别的应用服务计划</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Web 套接字</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>WebSocket 让 Web 应用和现代浏览器之间拥有更灵活的连接性。你的 Web 应用可能需要利用这些功能进行构建。</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>始终可用</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>指示需要一直加载你的 Web 应用。默认情况下，Web 应用在空闲时将被卸载。建议当 Web 应用上有正在运行的连续 Web 作业时启用此选项。</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>始终开启需要基本或更高级别的应用服务计划</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>托管管道版本</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>不能在生产槽中配置自动交换目标</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>自动交换</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>自动交换槽</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>ARR 相关性</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>远程调试</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>远程　Visual Studio　版本</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>堆栈</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>启动文件</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>最新</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32 位</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64 位</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>经典</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>集成</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>属性</value>
@@ -1220,7 +1469,7 @@
     <value>查看所有应用服务设置。</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>管理影响应用内所有功能的 Functions 运行时的设置。</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>常规设置</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>使用身份验证/授权来保护应用程序，并使用按用户划分的数据工作。</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>托管的服务标识</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>应用程序可以与其他 Azure 服务通信，因为它本身使用的是托管 Azure Active Directory 标识。</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>推送通知</value>
@@ -1331,7 +1586,7 @@
     <value>自动化脚本</value>
   </data>
   <data name="feature_automationScriptInfo" xml:space="preserve">
-    <value>通过 Azure Resource Manager 模板在单一、协调的操作中自动部署资源。定义资源和可配置的输入参数并使用脚本或代码进行部署。</value>
+    <value>通过 Azure 资源管理器模板在单一、协调的操作中自动部署资源。定义资源和可配置的输入参数并使用脚本或代码进行部署。</value>
   </data>
   <data name="feature_resourceManagement" xml:space="preserve">
     <value>资源管理</value>
@@ -1379,10 +1634,13 @@
     <value>设置</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>Function App 设置</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>配置</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>应用程序设置</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>此试用版不支持管理 Function App。</value>
@@ -1574,7 +1832,7 @@
     <value>查看我们的入门教程</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>函数</value>
+    <value>功能(预览)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>API 定义密钥</value>
@@ -1586,7 +1844,7 @@
     <value>生成 API 定义模板</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>导出到 Power Apps + Flow</value>
+    <value>导出到 PowerApps 和 Flow</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
     <value>无法保存格式不正确的 API 定义。</value>
@@ -1613,7 +1871,7 @@
     <value>使用你的 API 定义</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>API 定义(预览)</value>
+    <value>API 定义</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>我们无法创建或更新 Swagger 终结点的密钥 swaggerdocumentationkey。请检查运行时日志以查看是否有任何错误，或稍后重试。</value>
@@ -1649,11 +1907,11 @@
     <value>使用你的 API 定义，从 &lt;a href="https://powerapps.microsoft.com/en-us/" target="_blank"&gt;PowerApps&lt;/a&gt; 和 &lt;a href="https://ms.flow.microsoft.com/en-us/" target="_blank"&gt;Flow&lt;/a&gt; 内部访问你的函数。</value>
   </data>
   <data name="swaggerDefinition_generateHelp" xml:space="preserve">
-    <value>通过从 HTTP 触发功能获取的元数据创建稀疏定义
+    <value>通过从 HTTP 触发功能获取的元数据创建稀疏定义。
 使用之前，请填充&lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;操作对象&lt;/a&gt;和有关 API 的其他信息。</value>
   </data>
   <data name="swaggerDefinition_keyHelp" xml:space="preserve">
-    <value>此密钥可保护你的 API 定义，阻止没有此密钥的任何人访问。
+    <value>此密钥可保护 API 定义，阻止没有此密钥的任何人访问。
 它不能保护基础 API。请查看每个函数以了解其密钥安全性。</value>
   </data>
   <data name="swaggerDefinition_sourceHelp" xml:space="preserve">
@@ -1676,7 +1934,7 @@
     <value>只读</value>
   </data>
   <data name="appFunctionSettings_readWriteMode" xml:space="preserve">
-    <value>读取\写入</value>
+    <value>读/写</value>
   </data>
   <data name="validation_duplicateError" xml:space="preserve">
     <value>不允许重复值</value>
@@ -1704,6 +1962,9 @@
   </data>
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>尽管已启用源控件，但由于你已将读取/写入模式设为“读取\写入”，因此应用当前处于读取\写入模式。下次部署可能会替代所做的所有更改。若要更改编辑模式，请访问 </value>
+  </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>应用当前处于只读模式，因为你发布了生成的 function.json。Functions 运行时不会采用对 function.json 所做的更改。</value>
   </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>复制</value>
@@ -1748,10 +2009,22 @@
     <value>槽位(预览)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>启用部署槽位(预览)。这是对无法被禁用并将重置任何预存在密码的 Function App 的一次性选择加入。更新后，可从每个函数的“管理”节点下复制</value>
+    <value>启用部署槽位(预览)。</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>密码。</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>已知问题:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>启用槽位(预览)后，逻辑应用与 Functions 集成无法运行。</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>选择加入此预览功能将重置任何预先存在的密码。无法在每个函数的</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>“管理”</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>节点找到函数密码。</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>名称</value>
@@ -1790,7 +2063,7 @@
     <value>槽位(预览)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>若要获得更丰富的监视体验，包括实时指标和自定义查询，我们建议使用 &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights&lt;/a&gt;。</value>
+    <value>要获得更丰富的监视体验(包括实时指标和自定义查询)，&lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;请为函数应用启用 Azure Application Insights&lt;/a&gt;</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>此值将附加到主 Web 应用程序的 URL 并作为插槽的公用地址。例如，如果你有一个名为 "contoso" 的 Web 应用程序以及一个名为 "staging" 的插槽，则新插槽将有一个类似于“http://contoso-staging.azurewebsites.net”的 URL。</value>
@@ -1802,6 +2075,9 @@
     <value>搜索函数</value>
   </data>
   <data name="new_" xml:space="preserve">
+    <value>新建</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
     <value>新建</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
@@ -1878,5 +2154,308 @@
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>内容和 Visual Studio 项目</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>检索</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>删除代理</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>新增代理</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>无替代</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>快速 AAD 注册</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>创建</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>创建函数后需要添加事件网格订阅。</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>事件网格订阅 URL</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>事件网格订阅 URL</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>管理事件网格订阅</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>添加事件网格订阅</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>所有位置</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>{0} 个位置</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>位置:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>按位置分组</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>不进行分组</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>按资源组分组</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>按订阅分组</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>美国中南部</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>北欧</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>西欧</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>东南亚</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>韩国中部</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>韩国南部</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>美国西部</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>美国东部</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>日本西部</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>日本东部</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>东亚</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>美国东部 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>美国中北部</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>美国中部</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>巴西南部</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>澳大利亚东部</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>印度西部</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>印度中部</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>印度南部</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>加拿大中部</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>加拿大东部</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>美国中西部</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>英国西部</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>英国南部</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>美国西部 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>所有资源组</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>资源组:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>{0} 个资源组</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>正文</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>状态代码</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>状态消息</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>请求替代</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>响应替代</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>可选</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>你正在使用 Azure Functions 的预发行版本。感谢试用!</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>单击以隐藏</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>通过逻辑应用，可以轻松地跨多个平台利用函数</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>逻辑应用 </value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>关联逻辑应用</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>与逻辑应用协调</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>创建逻辑应用</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>无可显示的逻辑应用</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>通过逻辑应用，可以快速构建与 SaaS 和企业应用的集成，并可以可视方式设计进程和工作流。</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>展开或折叠</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>应用服务身份验证/授权:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>立即配置 AAD</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>立即添加权限</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>已配置</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>标识要求(未满足)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>未配置</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>所需权限</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>模板需要以下权限:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>此集成需要对函数应用进行 AAD 配置。</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>此模板需要对函数应用进行 AAD 配置。</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>可能需要配置你的函数所需的任何额外权限。请查看文档了解此绑定。</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>管理应用服务身份验证/授权</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>需要身份验证配置</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>标识要求</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>管理</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>我们无法获取已安装的运行时扩展的列表</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>我们无法安装运行时扩展 {{extensionId}}</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>我们无法卸载运行时扩展 {{extensionId}}</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>安装运行时扩展所用的时间比预期时间长</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>已安装不同版本的扩展 {{extensionId}}</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>打开 Application Insights</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>为函数启用 App Insights。</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>没有要显示的监视数据</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>安装</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>扩展安装成功</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>未安装扩展</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>此集成需要以下扩展。</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>此模板需要以下扩展。</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>正在安装所需的扩展。此操作可能需要多达 10 分钟。</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>我们无法安装运行时扩展。安装 ID {{installationId}}</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>在“GB/秒”中输入值</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>连接</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>通知中心</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>可以从本地计算机生成、测试和部署 Java 函数。无需任何门户!</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>单击下面的链接，了解有关如何使用 Java 生成第一个 Azure 函数的信息。</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>已启用代理。若要再次禁用，删除或禁用所有单独的代理。</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>使用 Java 编写 Azure Functions 快速入门</value>
   </data>
 </root>

--- a/AzureFunctions/ResourcesPortal/zh-TW/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/zh-TW/AzureFunctions/ResourcesPortal/Resources.resx
@@ -129,6 +129,18 @@
   <data name="configure" xml:space="preserve">
     <value>設定</value>
   </data>
+  <data name="upgradeToEnable" xml:space="preserve">
+    <value>升級即可啟用</value>
+  </data>
+  <data name="selectAll" xml:space="preserve">
+    <value>全選</value>
+  </data>
+  <data name="allItemsSelected" xml:space="preserve">
+    <value>已選取所有項目</value>
+  </data>
+  <data name="numItemsSelected" xml:space="preserve">
+    <value>已選取 {0} 個項目</value>
+  </data>
   <data name="functionCreateErrorDetails" xml:space="preserve">
     <value>建立函式發生錯誤: {{error}}</value>
   </data>
@@ -170,6 +182,18 @@
   </data>
   <data name="functionNew_chooseTemplate" xml:space="preserve">
     <value>選擇以下範本，或</value>
+  </data>
+  <data name="subNew_chooseTemplate" xml:space="preserve">
+    <value>選擇以下的方案可建立新的訂閱</value>
+  </data>
+  <data name="subNew_nameYourFriendlySubName" xml:space="preserve">
+    <value>提供易記的訂閱名稱</value>
+  </data>
+  <data name="subNew_friendlySubNameName" xml:space="preserve">
+    <value>易記的訂閱名稱</value>
+  </data>
+  <data name="subNew_invitationCode" xml:space="preserve">
+    <value>邀請代碼</value>
   </data>
   <data name="functionNew_experimentalTemplate" xml:space="preserve">
     <value>此範本為實驗性質，且尚未具備完整支援。若您遇到問題，請於 &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt; GitHub 存放庫&lt;/a&gt;提出 Bug。</value>
@@ -322,17 +346,50 @@
   <data name="save" xml:space="preserve">
     <value>儲存</value>
   </data>
+  <data name="saveOperationInProgressWarning" xml:space="preserve">
+    <value>儲存作業目前進行中。瀏覽到別處可能會導致某些變更遺失。</value>
+  </data>
   <data name="addNewSetting" xml:space="preserve">
     <value>+ 新增設定</value>
   </data>
   <data name="addNewConnectionString" xml:space="preserve">
     <value>+ 新增連接字串</value>
   </data>
+  <data name="addNewDocument" xml:space="preserve">
+    <value>+ 新增文件</value>
+  </data>
+  <data name="addNewHandlerMapping" xml:space="preserve">
+    <value>+ 新增處理常式對應</value>
+  </data>
+  <data name="addNewVirtualDirectory" xml:space="preserve">
+    <value>+ 新增虛擬應用程式或目錄</value>
+  </data>
   <data name="enterName" xml:space="preserve">
     <value>輸入名稱</value>
   </data>
   <data name="enterValue" xml:space="preserve">
     <value>輸入值</value>
+  </data>
+  <data name="enterExtension" xml:space="preserve">
+    <value>輸入副檔名</value>
+  </data>
+  <data name="enterScriptProcessor" xml:space="preserve">
+    <value>輸入指令碼處理器</value>
+  </data>
+  <data name="enterArguments" xml:space="preserve">
+    <value>輸入引數</value>
+  </data>
+  <data name="enterVirtualPath" xml:space="preserve">
+    <value>輸入虛擬路徑</value>
+  </data>
+  <data name="enterPhysicalPath" xml:space="preserve">
+    <value>輸入實體路徑</value>
+  </data>
+  <data name="isApplication" xml:space="preserve">
+    <value>應用程式</value>
+  </data>
+  <data name="isSlotSetting" xml:space="preserve">
+    <value>位置設定</value>
   </data>
   <data name="hiddenValueClickToShow" xml:space="preserve">
     <value>隱藏的值。按一下即可顯示。</value>
@@ -349,8 +406,14 @@
   <data name="search" xml:space="preserve">
     <value>搜尋</value>
   </data>
+  <data name="scopeToItem" xml:space="preserve">
+    <value>將範圍定義為此項目</value>
+  </data>
   <data name="searchFeatures" xml:space="preserve">
     <value>搜尋功能</value>
+  </data>
+  <data name="searchFunctionApps" xml:space="preserve">
+    <value>搜尋函數應用程式</value>
   </data>
   <data name="subscription" xml:space="preserve">
     <value>訂用帳戶 ID</value>
@@ -424,6 +487,12 @@
   <data name="enabled" xml:space="preserve">
     <value>已啟用</value>
   </data>
+  <data name="disable" xml:space="preserve">
+    <value>停用</value>
+  </data>
+  <data name="enable" xml:space="preserve">
+    <value>已啟用</value>
+  </data>
   <data name="errorList_here" xml:space="preserve">
     <value>這裡</value>
   </data>
@@ -432,6 +501,9 @@
   </data>
   <data name="errorParsingConfig" xml:space="preserve">
     <value>剖析設定時發生錯誤: {{error}}</value>
+  </data>
+  <data name="failedToSwitchFunctionState" xml:space="preserve">
+    <value>無法 {{state}} 函式: {{functionName}}</value>
   </data>
   <data name="features" xml:space="preserve">
     <value>功能</value>
@@ -462,6 +534,9 @@
   </data>
   <data name="functionIntegrate_standardEditor" xml:space="preserve">
     <value>標準編輯器</value>
+  </data>
+  <data name="functionManage_delete" xml:space="preserve">
+    <value>刪除函式 {{name}}</value>
   </data>
   <data name="functionManage_areYouSure" xml:space="preserve">
     <value>確定要刪除函式 {{name}} 嗎?</value>
@@ -946,17 +1021,8 @@
   <data name="appFunctionSettings_apiProxies" xml:space="preserve">
     <value>Proxy (預覽)</value>
   </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion1" xml:space="preserve">
-    <value>Proxy 執行階段版本: {{extensionVersion}}。有較新的版本可供使用 ({{latestExtensionVersion}})。</value>
-  </data>
-  <data name="appFunctionSettings_proxyRuntimeVersion2" xml:space="preserve">
-    <value>Proxy 執行階段版本: 最新版 ({{latestExtensionVersion}})</value>
-  </data>
   <data name="appFunctionSettings_useApiProxies" xml:space="preserve">
     <value>啟用 Azure Functions Proxy (預覽)</value>
-  </data>
-  <data name="apiProxies_warningOff" xml:space="preserve">
-    <value>Azure Functions Proxy 目前已停用。若要啟用，請瀏覽</value>
   </data>
   <data name="sideBar_changeMadeApiProxy" xml:space="preserve">
     <value>對 Proxy {{name}} 所進行的變更都將遺失。確定要繼續嗎?</value>
@@ -967,7 +1033,7 @@
   <data name="slots_warningOff" xml:space="preserve">
     <value>Azure Functions 位置 (預覽) 目前已停用。若要啟用，請瀏覽</value>
   </data>
-  <data name="discrard" xml:space="preserve">
+  <data name="discard" xml:space="preserve">
     <value>捨棄</value>
   </data>
   <data name="sidebar_Functions" xml:space="preserve">
@@ -983,7 +1049,7 @@
     <value>以 Google 登入</value>
   </data>
   <data name="intro_signInWithMicrosoft" xml:space="preserve">
-    <value>使用 Microsoft 登入</value>
+    <value>使用 Microsoft 帳戶登入</value>
   </data>
   <data name="apiProxy_backanrUrlStart" xml:space="preserve">
     <value>後端 URL 必須以 'http://' 或 'https://' 為開頭</value>
@@ -1017,6 +1083,9 @@
   </data>
   <data name="sideNav_AllSubscriptions" xml:space="preserve">
     <value>所有訂用帳戶</value>
+  </data>
+  <data name="sideNav_Subscriptions" xml:space="preserve">
+    <value>訂閱</value>
   </data>
   <data name="sideNav_SubscriptionCount" xml:space="preserve">
     <value>{0} 個訂用帳戶</value>
@@ -1093,6 +1162,9 @@
   <data name="enabledFeatures_description" xml:space="preserve">
     <value>從上方的 [平台功能] 索引標籤設定快速連結之後，此處即會顯示您功能的快速連結。</value>
   </data>
+  <data name="siteDashboard_confirmLoseChanges" xml:space="preserve">
+    <value>應用程式 '{0}' 未儲存的變更將會遺失。確定要繼續嗎?</value>
+  </data>
   <data name="siteDashboard_getAppError" xml:space="preserve">
     <value>擷取應用程式 '{0}' 的相關資訊時出現錯誤</value>
   </data>
@@ -1159,6 +1231,12 @@
   <data name="featureNotSupportedConsumption" xml:space="preserve">
     <value>對使用情況方案上的應用程式，不支援此功能</value>
   </data>
+  <data name="featureNotSupportedForSlots" xml:space="preserve">
+    <value>位置不支援此功能</value>
+  </data>
+  <data name="featureNotSupportedForLinuxApps" xml:space="preserve">
+    <value>Linux 應用程式不支援此功能</value>
+  </data>
   <data name="featureRequiresWritePermissionOnApp" xml:space="preserve">
     <value>您必須對目前的應用程式具有寫入權限，才可使用此功能</value>
   </data>
@@ -1189,17 +1267,188 @@
   <data name="feature_consoleInfo" xml:space="preserve">
     <value>從互動式 Web 主控台探索您的應用程式檔案系統。</value>
   </data>
+  <data name="feature_sshName" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="feature_sshInfo" xml:space="preserve">
+    <value>SSH 提供 Linux 應用程式程式碼的 Web SSH 主控台體驗</value>
+  </data>
   <data name="feature_extensionsName" xml:space="preserve">
     <value>擴充功能</value>
   </data>
   <data name="feature_extensionsInfo" xml:space="preserve">
     <value>整個應用程式的延伸模組與功能。</value>
   </data>
+  <data name="emptyAppSettings" xml:space="preserve">
+    <value>(沒有應用程式設定可供顯示)</value>
+  </data>
+  <data name="emptyConnectionStrings" xml:space="preserve">
+    <value>(沒有連接字串可供顯示)</value>
+  </data>
+  <data name="emptyDefaultDocuments" xml:space="preserve">
+    <value>(沒有預設文件可供顯示)</value>
+  </data>
+  <data name="emptyHandlerMappings" xml:space="preserve">
+    <value>(沒有處理常式對應可供顯示)</value>
+  </data>
+  <data name="emptyVirtualDirectories" xml:space="preserve">
+    <value>(沒有虛擬應用程式或目錄可供顯示)</value>
+  </data>
+  <data name="feature_generalSettingsName" xml:space="preserve">
+    <value>一般設定</value>
+  </data>
+  <data name="feature_autoSwapSettingsName" xml:space="preserve">
+    <value>自動交換</value>
+  </data>
+  <data name="feature_debuggingSettingsName" xml:space="preserve">
+    <value>偵錯</value>
+  </data>
+  <data name="feature_linuxRuntimeName" xml:space="preserve">
+    <value>執行階段</value>
+  </data>
   <data name="feature_applicationSettingsName" xml:space="preserve">
     <value>應用程式設定</value>
   </data>
   <data name="feature_applicationSettingsInfo" xml:space="preserve">
     <value>管理應用程式設定、連接字串、執行階段設定等等。</value>
+  </data>
+  <data name="feature_defaultDocumentsName" xml:space="preserve">
+    <value>預設文件</value>
+  </data>
+  <data name="feature_handlerMappingsName" xml:space="preserve">
+    <value>處理常式對應</value>
+  </data>
+  <data name="feature_virtualDirectoriesName" xml:space="preserve">
+    <value>虛擬應用程式及目錄</value>
+  </data>
+  <data name="configRequiresWritePermissionOnApp" xml:space="preserve">
+    <value>您必須對目前的應用程式具有寫入權限，才能編輯這些設定。</value>
+  </data>
+  <data name="configDisabledReadOnlyLockOnApp" xml:space="preserve">
+    <value>此應用程式有唯讀鎖定，導致無法編輯設定或擷取安全資料。請移除鎖定並再試一次。</value>
+  </data>
+  <data name="configViewReadOnlySettings" xml:space="preserve">
+    <value>以唯讀模式檢視設定。</value>
+  </data>
+  <data name="configLoadFailure" xml:space="preserve">
+    <value>無法載入設定。</value>
+  </data>
+  <data name="loading" xml:space="preserve">
+    <value>正在載入...</value>
+  </data>
+  <data name="configUpdating" xml:space="preserve">
+    <value>正在更新 Web 應用程式設定</value>
+  </data>
+  <data name="configUpdateSuccess" xml:space="preserve">
+    <value>已成功更新 Web 應用程式設定</value>
+  </data>
+  <data name="configUpdateFailure" xml:space="preserve">
+    <value>無法更新 Web 應用程式設定: </value>
+  </data>
+  <data name="configUpdateFailureInvalidInput" xml:space="preserve">
+    <value>{{configGroupName}} 儲存錯誤: 提供的輸入無效。</value>
+  </data>
+  <data name="netFrameWorkVersionLabel" xml:space="preserve">
+    <value>.NET Framework 版本</value>
+  </data>
+  <data name="netFrameWorkVersionLabelHelp" xml:space="preserve">
+    <value>使用 .NET Framework 時，用以執行您 Web 應用程式的版本</value>
+  </data>
+  <data name="phpVersionLabel" xml:space="preserve">
+    <value>PHP 版本</value>
+  </data>
+  <data name="phpVersionLabelHelp" xml:space="preserve">
+    <value>使用 PHP 時，用以執行您 Web 應用程式的版本</value>
+  </data>
+  <data name="pythonVersionLabel" xml:space="preserve">
+    <value>Python 版本</value>
+  </data>
+  <data name="pythonVersionLabelHelp" xml:space="preserve">
+    <value>使用 Python 時，用以執行您 Web 應用程式的版本</value>
+  </data>
+  <data name="javaVersionLabel" xml:space="preserve">
+    <value>Java 版本</value>
+  </data>
+  <data name="javaVersionLabelHelp" xml:space="preserve">
+    <value>使用 Java 時，用以執行您 Web 應用程式的版本</value>
+  </data>
+  <data name="javaMinorVersionLabel" xml:space="preserve">
+    <value>Java 次要版本</value>
+  </data>
+  <data name="javaMinorVersionLabelHelp" xml:space="preserve">
+    <value>選取想要的 Java 次要版本。若是選取「最新的」，則可讓您的 App 使用最新加入入口網站的 JVM。</value>
+  </data>
+  <data name="javaWebContainerLabel" xml:space="preserve">
+    <value>Web 容器</value>
+  </data>
+  <data name="javaWebContainerLabelHelp" xml:space="preserve">
+    <value>使用 Java 時，用以執行您 Web 應用程式的 Web 容器版本</value>
+  </data>
+  <data name="use32BitWorkerProcessLabel" xml:space="preserve">
+    <value>平台</value>
+  </data>
+  <data name="use32BitWorkerProcessLabelHelp" xml:space="preserve">
+    <value>您 Web 應用程式執行所在的平台架構</value>
+  </data>
+  <data name="use32BitWorkerProcessUpsell" xml:space="preserve">
+    <value>64 位元設定需要基本或更高的 App Service 方案</value>
+  </data>
+  <data name="webSocketsEnabledLabel" xml:space="preserve">
+    <value>Web 通訊端</value>
+  </data>
+  <data name="webSocketsEnabledLabelHelp" xml:space="preserve">
+    <value>WebSocket 可以增加 Web 應用程式與現代化瀏覽器之間連接彈性。您必須建置 Web 應用程式，才能應用這些功能。</value>
+  </data>
+  <data name="alwaysOnLabel" xml:space="preserve">
+    <value>一律開啟</value>
+  </data>
+  <data name="alwaysOnLabelHelp" xml:space="preserve">
+    <value>指出無論何時都需要載入您的 Web 應用程式。Web 應用程式預設會在閒置後卸載。當您需要在 Web 應用程式上連續 Web 工作時，建議啟用此選項。</value>
+  </data>
+  <data name="alwaysOnUpsell" xml:space="preserve">
+    <value>Always on 需要基本或更高的 App Service 方案</value>
+  </data>
+  <data name="managedPipelineModeLabel" xml:space="preserve">
+    <value>Managed 管線版本</value>
+  </data>
+  <data name="autoSwapNotSupportedFromProd" xml:space="preserve">
+    <value>無法從生產位置設定自動交換目的地</value>
+  </data>
+  <data name="autoSwapEnabledLabel" xml:space="preserve">
+    <value>自動交換</value>
+  </data>
+  <data name="autoSwapSlotNameLabel" xml:space="preserve">
+    <value>自動交換位置</value>
+  </data>
+  <data name="clientAffinityEnabledLabel" xml:space="preserve">
+    <value>ARR 同質性</value>
+  </data>
+  <data name="remoteDebuggingEnabledLabel" xml:space="preserve">
+    <value>遠端偵錯</value>
+  </data>
+  <data name="remoteDebuggingVersionLabel" xml:space="preserve">
+    <value>遠端 Visual Studio 版本</value>
+  </data>
+  <data name="linuxFxVersionLabel" xml:space="preserve">
+    <value>堆疊</value>
+  </data>
+  <data name="appCommandLineLabel" xml:space="preserve">
+    <value>啟動檔案</value>
+  </data>
+  <data name="newest" xml:space="preserve">
+    <value>最新</value>
+  </data>
+  <data name="architecture32" xml:space="preserve">
+    <value>32 位元</value>
+  </data>
+  <data name="architecture64" xml:space="preserve">
+    <value>64 位元</value>
+  </data>
+  <data name="pipelineModeClassic" xml:space="preserve">
+    <value>傳統</value>
+  </data>
+  <data name="pipelineModeIntegrated" xml:space="preserve">
+    <value>整合</value>
   </data>
   <data name="feature_propertiesName" xml:space="preserve">
     <value>屬性</value>
@@ -1220,7 +1469,7 @@
     <value>檢視所有 App Service 設定。</value>
   </data>
   <data name="feature_functionSettingsInfo" xml:space="preserve">
-    <value>Manage settings that affect the Functions runtime for all functions within your app.</value>
+    <value>管理會影響您應用程式中所有功能之 Functions 執行階段的設定。</value>
   </data>
   <data name="feature_generalSettings" xml:space="preserve">
     <value>一般設定</value>
@@ -1251,6 +1500,12 @@
   </data>
   <data name="feature_authInfo" xml:space="preserve">
     <value>使用驗證/授權保護您的應用程式及使用個別使用者的資料。</value>
+  </data>
+  <data name="feature_msiName" xml:space="preserve">
+    <value>受管理服務識別</value>
+  </data>
+  <data name="feature_msiInfo" xml:space="preserve">
+    <value>因為您的應用程式使用受管理的 Azure Active Directory 身分識別，所以可與其他 Azure 服務通訊。</value>
   </data>
   <data name="feature_pushNotificationsName" xml:space="preserve">
     <value>推播通知</value>
@@ -1379,10 +1634,13 @@
     <value>設定</value>
   </data>
   <data name="tab_functionSettings" xml:space="preserve">
-    <value>Function settings</value>
+    <value>函數應用程式設定</value>
   </data>
   <data name="tab_configuration" xml:space="preserve">
     <value>設定</value>
+  </data>
+  <data name="tab_applicationSettings" xml:space="preserve">
+    <value>應用程式設定</value>
   </data>
   <data name="try_appDisabled" xml:space="preserve">
     <value>此試用版無法管理函數應用程式。</value>
@@ -1574,7 +1832,7 @@
     <value>了解我們的快速入門教學課程</value>
   </data>
   <data name="swaggerDefinition_internal" xml:space="preserve">
-    <value>函式</value>
+    <value>函式 (預覽)</value>
   </data>
   <data name="swaggerDefinition_key" xml:space="preserve">
     <value>API 定義金鑰</value>
@@ -1586,7 +1844,7 @@
     <value>產生 API 定義範本</value>
   </data>
   <data name="swaggerDefinition_powerAppsFlow" xml:space="preserve">
-    <value>匯出至 Power Apps + Flow</value>
+    <value>匯出至 PowerApps + Flow</value>
   </data>
   <data name="swaggerDefinition_prompt" xml:space="preserve">
     <value>無法儲存格式不正確的 API 定義。</value>
@@ -1613,7 +1871,7 @@
     <value>使用您的 API 定義</value>
   </data>
   <data name="tab_api_definition" xml:space="preserve">
-    <value>API 定義 (預覽)</value>
+    <value>API 定義</value>
   </data>
   <data name="error_unableToCreateSwaggerKey" xml:space="preserve">
     <value>無法為 Swagger 端點建立或更新索引鍵 swaggerdocumentationkey。請查看執行階段記錄中有無任何錯誤，並於稍後再試一次。</value>
@@ -1649,16 +1907,16 @@
     <value>使用 API 定義可存取來自 &lt;a href="https://powerapps.microsoft.com/en-us/" target="_blank"&gt;PowerApps&lt;/a&gt; 與 &lt;a href="https://ms.flow.microsoft.com/en-us/" target="_blank"&gt;Flow&lt;/a&gt; 中的函數。</value>
   </data>
   <data name="swaggerDefinition_generateHelp" xml:space="preserve">
-    <value>利用來自您 HTTP 所觸發之函數的中繼資料，建立疏鬆定義。
-使用前請填入&lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;作業物件&lt;/a&gt;，及 API 的其他相關資訊。</value>
+    <value>使用您 HTTP 觸發之函式的中繼資料建立疏鬆定義。
+使用前請先填入&lt;a href="http://swagger.io/specification/#operationObject" target="_blank"&gt;作業物件&lt;/a&gt;及 API 的其他相關資訊。</value>
   </data>
   <data name="swaggerDefinition_keyHelp" xml:space="preserve">
-    <value>此金鑰可保護 API 定義免受任何沒有金鑰的人員加以存取。
-它無法保護基礎 API。請參閱每個函數，以了解其金鑰安全性。</value>
+    <value>此金鑰可保護 API 定義免遭不具金鑰的人員存取。
+此金鑰不會保護基礎 API。如需了解函式的金鑰安全性，請參閱每個函式的相關資訊。</value>
   </data>
   <data name="swaggerDefinition_sourceHelp" xml:space="preserve">
-    <value>設定為「函數」即可產生主控的 API 定義與範本定義。
-設定為「外部 URL」則可使用其他位置所主控的 API 定義。</value>
+    <value>設為 [函式] 表示允許在主機上產生 API 定義與範本定義。
+設定為 [外部 URL] 表示可使用裝載在其他位置上的 API 定義。</value>
   </data>
   <data name="swaggerDefinition_urlHelp" xml:space="preserve">
     <value>使用此 URL 可直接存取您的 API 定義，並將其匯入協力廠商的工具中 </value>
@@ -1676,7 +1934,7 @@
     <value>唯讀</value>
   </data>
   <data name="appFunctionSettings_readWriteMode" xml:space="preserve">
-    <value>讀取\寫入</value>
+    <value>讀取/寫入</value>
   </data>
   <data name="validation_duplicateError" xml:space="preserve">
     <value>不允許重複的值</value>
@@ -1704,6 +1962,9 @@
   </data>
   <data name="readWriteSourceControlled" xml:space="preserve">
     <value>因為雖然已啟用了原始檔控制，但您仍已將編輯模式設定為讀寫，所以應用程式目前是讀寫模式。您所進行的任何變更，都會覆寫下一次的部署。若要變更編輯模式，請瀏覽</value>
+  </data>
+  <data name="readOnlyGeneratedBy" xml:space="preserve">
+    <value>因為您已發行產生的 function.json，所以應用程式目前為唯讀模式。Functions 執行階段不會接受 Function.json 的變更。</value>
   </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>複製</value>
@@ -1748,10 +2009,22 @@
     <value>位置 (預覽)</value>
   </data>
   <data name="appFunctionSettings_slotsDesc" xml:space="preserve">
-    <value>啟用部署位置 (預覽)。這是函數應用程式的單次加入，無法停用，而且會重設任何原有的祕密。在更新後，可以從各函數的 </value>
+    <value>啟用部署位置 (預覽)。</value>
   </data>
-  <data name="appFunctionSettings_slotsDescBold" xml:space="preserve">
-    <value>[管理] 節點下複製祕密。</value>
+  <data name="appFunctionSettings_warning_1" xml:space="preserve">
+    <value>已知問題:</value>
+  </data>
+  <data name="appFunctionSettings_warning_2" xml:space="preserve">
+    <value>當位置 (預覽) 啟用時，邏輯應用程式與 Functions 的整合即無法運作。</value>
+  </data>
+  <data name="appFunctionSettings_warning_3" xml:space="preserve">
+    <value>加入此預覽功能將會重設任何既存的祕密。函式祕密會位在各函式的</value>
+  </data>
+  <data name="appFunctionSettings_warning_4" xml:space="preserve">
+    <value>[管理]</value>
+  </data>
+  <data name="appFunctionSettings_warning_5" xml:space="preserve">
+    <value>節點下。</value>
   </data>
   <data name="slotNew_nameLabel" xml:space="preserve">
     <value>名稱</value>
@@ -1790,7 +2063,7 @@
     <value>位置 (預覽)</value>
   </data>
   <data name="monitoring_appInsights" xml:space="preserve">
-    <value>如需更豐富的監視體驗 (包括即時計量和自訂查詢)，建議您使用 &lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;Azure Application Insights。&lt;/a&gt;</value>
+    <value>如需更豐富的監視體驗 (包括即時計量及自訂查詢)，請&lt;a target="_blank" href="https://go.microsoft.com/fwlink/?linkid=848587"&gt;為函數應用程式啟用 Application Insights&lt;/a&gt;</value>
   </data>
   <data name="slotNew_nameLabel_balloonText" xml:space="preserve">
     <value>此值之後會附加您主要 Web 應用程式的 URL，並會用為位置的公用位址。例如，若您的 Web 應用程式名稱為 'contoso'，位置名稱為 'staging'，則新位置的 URL 會類似於 'http://contoso-staging.azurewebsites.net'。</value>
@@ -1803,6 +2076,9 @@
   </data>
   <data name="new_" xml:space="preserve">
     <value>新增</value>
+  </data>
+  <data name="createNew" xml:space="preserve">
+    <value>建立新項目</value>
   </data>
   <data name="functionManage_deleteFunction" xml:space="preserve">
     <value>刪除函式</value>
@@ -1878,5 +2154,308 @@
   </data>
   <data name="downloadFunctionAppContent_vsProject" xml:space="preserve">
     <value>內容與 Visual Studio 專案</value>
+  </data>
+  <data name="bindingInput_retrieve" xml:space="preserve">
+    <value>擷取</value>
+  </data>
+  <data name="apiProxy_delete" xml:space="preserve">
+    <value>刪除 Proxy</value>
+  </data>
+  <data name="apiProxy_new" xml:space="preserve">
+    <value>新增 Proxy</value>
+  </data>
+  <data name="apiProxy_noOverride" xml:space="preserve">
+    <value>禁止覆寫</value>
+  </data>
+  <data name="expressAADRegistration" xml:space="preserve">
+    <value>AAD 快速註冊</value>
+  </data>
+  <data name="eventGrid_create" xml:space="preserve">
+    <value>create</value>
+  </data>
+  <data name="eventGrid_createMessage" xml:space="preserve">
+    <value>您必須在函式建立之後新增事件格線訂用帳戶。</value>
+  </data>
+  <data name="eventGrid_help" xml:space="preserve">
+    <value>事件格線訂用帳戶 URL</value>
+  </data>
+  <data name="eventGrid_label" xml:space="preserve">
+    <value>事件格線訂用帳戶 URL</value>
+  </data>
+  <data name="eventGrid_manageSubscriptions" xml:space="preserve">
+    <value>管理事件格線訂用帳戶</value>
+  </data>
+  <data name="functionDev_addEventGrid" xml:space="preserve">
+    <value>新增事件格線訂用帳戶</value>
+  </data>
+  <data name="allLocations" xml:space="preserve">
+    <value>所有位置</value>
+  </data>
+  <data name="locationCount" xml:space="preserve">
+    <value>{0} 個位置</value>
+  </data>
+  <data name="locationColon" xml:space="preserve">
+    <value>位置:</value>
+  </data>
+  <data name="grouping_location" xml:space="preserve">
+    <value>依位置分組</value>
+  </data>
+  <data name="grouping_none" xml:space="preserve">
+    <value>未分組</value>
+  </data>
+  <data name="grouping_resourceGroup" xml:space="preserve">
+    <value>依資源群組分組</value>
+  </data>
+  <data name="grouping_subscription" xml:space="preserve">
+    <value>依訂用帳戶分組</value>
+  </data>
+  <data name="southcentralus" xml:space="preserve">
+    <value>美國中南部</value>
+  </data>
+  <data name="northeurope" xml:space="preserve">
+    <value>北歐</value>
+  </data>
+  <data name="westeurope" xml:space="preserve">
+    <value>西歐</value>
+  </data>
+  <data name="southeastasia" xml:space="preserve">
+    <value>東南亞</value>
+  </data>
+  <data name="koreacentral" xml:space="preserve">
+    <value>韓國中部</value>
+  </data>
+  <data name="koreasouth" xml:space="preserve">
+    <value>韓國南部</value>
+  </data>
+  <data name="westus" xml:space="preserve">
+    <value>美國西部</value>
+  </data>
+  <data name="eastus" xml:space="preserve">
+    <value>美國東部</value>
+  </data>
+  <data name="japanwest" xml:space="preserve">
+    <value>日本西部</value>
+  </data>
+  <data name="japaneast" xml:space="preserve">
+    <value>日本東部</value>
+  </data>
+  <data name="eastasia" xml:space="preserve">
+    <value>東亞</value>
+  </data>
+  <data name="eastus2" xml:space="preserve">
+    <value>美國東部 2</value>
+  </data>
+  <data name="northcentralus" xml:space="preserve">
+    <value>美國中北部</value>
+  </data>
+  <data name="centralus" xml:space="preserve">
+    <value>美國中部</value>
+  </data>
+  <data name="brazilsouth" xml:space="preserve">
+    <value>巴西南部</value>
+  </data>
+  <data name="australiaeast" xml:space="preserve">
+    <value>澳洲東部</value>
+  </data>
+  <data name="australiasoutheast" xml:space="preserve">
+    <value>Australia Southeast</value>
+  </data>
+  <data name="westindia" xml:space="preserve">
+    <value>印度西部</value>
+  </data>
+  <data name="centralindia" xml:space="preserve">
+    <value>印度中部</value>
+  </data>
+  <data name="southindia" xml:space="preserve">
+    <value>印度南部</value>
+  </data>
+  <data name="canadacentral" xml:space="preserve">
+    <value>加拿大中部</value>
+  </data>
+  <data name="canadaeast" xml:space="preserve">
+    <value>加拿大東部</value>
+  </data>
+  <data name="westcentralus" xml:space="preserve">
+    <value>美國中西部</value>
+  </data>
+  <data name="ukwest" xml:space="preserve">
+    <value>英國西部</value>
+  </data>
+  <data name="uksouth" xml:space="preserve">
+    <value>英國南部</value>
+  </data>
+  <data name="westus2" xml:space="preserve">
+    <value>美國西部 2</value>
+  </data>
+  <data name="allResourceGroups" xml:space="preserve">
+    <value>所有資源群組</value>
+  </data>
+  <data name="resourceGroupColon" xml:space="preserve">
+    <value>資源群組:</value>
+  </data>
+  <data name="resourceGroupCount" xml:space="preserve">
+    <value>{0} 個資源群組</value>
+  </data>
+  <data name="rrOverride_boby" xml:space="preserve">
+    <value>本文</value>
+  </data>
+  <data name="rrOverride_code" xml:space="preserve">
+    <value>狀態碼</value>
+  </data>
+  <data name="rrOverride_message" xml:space="preserve">
+    <value>狀態訊息</value>
+  </data>
+  <data name="rrOverride_request" xml:space="preserve">
+    <value>要求覆寫</value>
+  </data>
+  <data name="rrOverride_response" xml:space="preserve">
+    <value>回應覆寫</value>
+  </data>
+  <data name="optional" xml:space="preserve">
+    <value>選擇性</value>
+  </data>
+  <data name="topBar_runtimeV2" xml:space="preserve">
+    <value>您使用的是 Azure Functions 發行前版本。感謝您的試用!</value>
+  </data>
+  <data name="functionKeys_clickToHide" xml:space="preserve">
+    <value>按一下可隱藏</value>
+  </data>
+  <data name="feature_logicAppsInfo" xml:space="preserve">
+    <value>Logic Apps 可讓您輕鬆在多個平台間利用函數</value>
+  </data>
+  <data name="tab_logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="associatedLogicApps_title" xml:space="preserve">
+    <value>相關的 Logic Apps</value>
+  </data>
+  <data name="orchestrateWithLogicApps_title" xml:space="preserve">
+    <value>透過 Logic Apps 協調</value>
+  </data>
+  <data name="createLogicApps" xml:space="preserve">
+    <value>建立 Logic Apps</value>
+  </data>
+  <data name="noLogicApps_title" xml:space="preserve">
+    <value>沒有任何 Logic Apps 可顯示</value>
+  </data>
+  <data name="logicApps" xml:space="preserve">
+    <value>Logic Apps</value>
+  </data>
+  <data name="logicApp_description" xml:space="preserve">
+    <value>Logic Apps 可讓您迅速建置 SaaS 與企業應用程式的整合，並以視覺化方式設計程序與工作流程。</value>
+  </data>
+  <data name="expandCollapse" xml:space="preserve">
+    <value>展開或摺疊</value>
+  </data>
+  <data name="aadreg_appService" xml:space="preserve">
+    <value>App Service 驗證/授權:</value>
+  </data>
+  <data name="aadreg_configureAADNow" xml:space="preserve">
+    <value>立即設定 AAD</value>
+  </data>
+  <data name="aadreg_configureAADPermissionsNow" xml:space="preserve">
+    <value>立即新增權限</value>
+  </data>
+  <data name="aadreg_configured" xml:space="preserve">
+    <value>已設定</value>
+  </data>
+  <data name="aadreg_identityRequirements" xml:space="preserve">
+    <value>身分識別需求 (不符合)</value>
+  </data>
+  <data name="aadreg_notConfigured" xml:space="preserve">
+    <value>未設定</value>
+  </data>
+  <data name="aadreg_requiredPerm" xml:space="preserve">
+    <value>必要權限</value>
+  </data>
+  <data name="aadreg_templateNeeds" xml:space="preserve">
+    <value>此範本需要下列權限:</value>
+  </data>
+  <data name="aadreg_thisIntegration" xml:space="preserve">
+    <value>此整合需要為函式應用程式設定 AAD。</value>
+  </data>
+  <data name="aadreg_thisTemplate" xml:space="preserve">
+    <value>此範本需要為函式應用程式設定 AAD。</value>
+  </data>
+  <data name="aadreg_youMayNeed" xml:space="preserve">
+    <value>您必須為您需要的功能設定其他權限。如需了解此繫結，請參閱文件。</value>
+  </data>
+  <data name="asdreg_manageAppService" xml:space="preserve">
+    <value>管理 App Service 驗證/授權</value>
+  </data>
+  <data name="aadreg_authConfRequired" xml:space="preserve">
+    <value>需要設定驗證</value>
+  </data>
+  <data name="aadreg_identityRequirementsInfo" xml:space="preserve">
+    <value>身分識別需求</value>
+  </data>
+  <data name="aadreg_manage" xml:space="preserve">
+    <value>管理</value>
+  </data>
+  <data name="failedToGetFunctionRuntimeExtensions" xml:space="preserve">
+    <value>無法取得安裝的執行階段延伸模組清單</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>無法安裝執行階段延伸模組 {{extensionId}}</value>
+  </data>
+  <data name="failedToUnInstallFunctionRuntimeExtension" xml:space="preserve">
+    <value>無法將執行階段延伸模組 {{extensionId}} 解除安裝</value>
+  </data>
+  <data name="timeoutInstallingFunctionRuntimeExtension" xml:space="preserve">
+    <value>安裝執行階段延伸模組花費了超出預期的時間</value>
+  </data>
+  <data name="extensionAlreadyInstalledWithDifferentVersion" xml:space="preserve">
+    <value>已安裝不同版本的延伸模組 {{extensionId}}</value>
+  </data>
+  <data name="monitoring_appInsightsOpen" xml:space="preserve">
+    <value>開啟 Application Insights</value>
+  </data>
+  <data name="monitoring_appInsightsSetUp" xml:space="preserve">
+    <value>已為您的函數啟用 App Insights。</value>
+  </data>
+  <data name="monitoring_noMonitoring" xml:space="preserve">
+    <value>無任何可顯示的資料</value>
+  </data>
+  <data name="extension_install_button" xml:space="preserve">
+    <value>安裝</value>
+  </data>
+  <data name="extension_install_success" xml:space="preserve">
+    <value>延伸模組安裝成功</value>
+  </data>
+  <data name="extension_install_warning" xml:space="preserve">
+    <value>延伸模組未安裝</value>
+  </data>
+  <data name="extension_integrate_warning" xml:space="preserve">
+    <value>此整合需要下列延伸模組。</value>
+  </data>
+  <data name="extension_template_warning" xml:space="preserve">
+    <value>此範本需要下列延伸模組。</value>
+  </data>
+  <data name="installingExtension" xml:space="preserve">
+    <value>正在安裝必要的延伸模組。此作業最長需要 10 分鐘的時間。</value>
+  </data>
+  <data name="failedToInstallFunctionRuntimeExtensionForId" xml:space="preserve">
+    <value>無法安裝執行階段延伸模組。安裝識別碼 {{installationId}}</value>
+  </data>
+  <data name="functionAppSettings_quotaPlaceHolder" xml:space="preserve">
+    <value>輸入值 (GB/秒)</value>
+  </data>
+  <data name="notificationHubPicker_connection" xml:space="preserve">
+    <value>連接</value>
+  </data>
+  <data name="notificationHubPicker_notificationHub" xml:space="preserve">
+    <value>通知中樞</value>
+  </data>
+  <data name="java_splash_line_1" xml:space="preserve">
+    <value>不需要入口網站即可透過您的電腦於本機建置、測試及部署 Java Functions!</value>
+  </data>
+  <data name="java_splash_line_2" xml:space="preserve">
+    <value>按一下下方，利用說明如何使用 Java 建置您第一個 Azure 函數的文件開始著手。</value>
+  </data>
+  <data name="appFunctionSettings_proxyEnabled" xml:space="preserve">
+    <value>Proxy 已啟用。若要再次停用，請刪除或停用所有個別的 Proxy。</value>
+  </data>
+  <data name="java_splash_button" xml:space="preserve">
+    <value>Azure Functions 上的 Java 快速入門</value>
   </data>
 </root>


### PR DESCRIPTION
Includes the following fixes:
- RDBug 10476258:[App Settings] - Rename "Web Container" to "Java Web Container"
- RDBug 10207698:Tuxedo: Add UI Hint for Startup File
- RDBug 10485284:[App Settings] Label overflow
- RDBug 10462943:[Ibiza][Application settings] the Connection string unit will be covered in the Connection strings table when the ‘Application settings’ blade is narrow
- Replacing auto swap warning with an info box in GeneralSettingsComponent
- Adding info boxes for Python and ARR in GeneralSettingsComponent
- Fixed logic for displaying/hiding auto-swap settings and added auto-swap upsell
- RDBug 10485426:[App Settings] Linux - Default Document, Handler Mappings and Virtual Applications should be hidden

![generalsettings_free-shared](https://user-images.githubusercontent.com/5387224/32302761-adfdba02-bf21-11e7-95e1-23b828d112a1.png)
![generalsettings_basic](https://user-images.githubusercontent.com/5387224/32302769-b3d2855c-bf21-11e7-803b-cc2b4a472ba7.PNG)
![generalsettings_standard](https://user-images.githubusercontent.com/5387224/32302776-b7d8c6de-bf21-11e7-90e9-c09883d04ac5.PNG)
![generalsettings_standard slot-settings](https://user-images.githubusercontent.com/5387224/32302783-bb5ff926-bf21-11e7-8e15-f63c61cd877b.PNG)
![generalsettings_standard_darktheme](https://user-images.githubusercontent.com/5387224/32302789-c274fb62-bf21-11e7-9240-86765c0b66d9.PNG)
