### PR TITLE
Accessibility and style updates for RadioSelectorComponent

### DIFF
--- a/AzureFunctions.AngularClient/src/app/radio-selector/radio-selector.component.html
+++ b/AzureFunctions.AngularClient/src/app/radio-selector/radio-selector.component.html
@@ -1,12 +1,16 @@
 <div
     *ngIf="options"
-    class="switch"
-    [class.dirty]="control?.dirty">
+    role="radiogroup"
+    [class.dirty]="control?.dirty"
+    [attr.aria-disabled]="control ? control.disabled : disabled"
+    [tabIndex]="(control && control.disabled) || disabled ? -1 : 0"
+    [attr.aria-activedescendant]="activeDescendantId"
+    (keydown)="onKeyDown($event)">
 
     <div *ngFor="let option of options"
-        class="switch-label"
-        [class.selected]="option.value === selectedValue"
-        [class.disabled]="control ? control.disabled : disabled"
+        role="radio"
+        [id]="id + '-' + option.id"
+        [attr.aria-checked]="option.value === selectedValue"
         (click)="select(option)">
         {{option.displayLabel}}
     </div>

--- a/AzureFunctions.AngularClient/src/app/radio-selector/radio-selector.component.scss
+++ b/AzureFunctions.AngularClient/src/app/radio-selector/radio-selector.component.scss
@@ -1,21 +1,23 @@
 @import '../../sass/common/variables';
 
-.switch {
+[role="radiogroup"] {
     position: relative;
     display: inline-block;
     height: 25px;
 
-    &.disabled {
-        background: $background-color-disabled;
+    &:focus {
+        outline: none;
     }
 }
 
 $border-light: 1px $primary-color solid;
 
-.switch-label {
+[role="radio"] {
+    display: block;
     border-top: $border-light;
     border-left: $border-light;
     border-bottom: $border-light;
+    border-right: $border-light;
     position: relative;
     z-index: 2;
     float: left;
@@ -26,47 +28,56 @@ $border-light: 1px $primary-color solid;
     padding-left: 20px;
     padding-right: 20px;
     color: $primary-color;
+
+    background: $body-bg-color;
 }
 
-.switch-label ~ .switch-label{
-    border-right: $border-light;
+[role="radio"] ~ [role="radio"] {
+    border-left-width: 0px;
 }
 
-.switch-input {
-    display: none;
-}
-
-.switch-input:checked + .switch-label {
-    font-weight: bold;
-}
-
-.selected {
-    display: block;
-    z-index: 1;
-    background-color: $primary-color;
-    color: $body-bg-color;
-
-    &.disabled{
-        background-color: $disabled-color;
-    }
-
-    &:hover{
-        background-color: lighten($primary-color, 10%);
-    }
-
-    &:active{
-        background-color: darken($primary-color, 10%)
+[role="radiogroup"]:not([aria-disabled="true"]):focus {
+    [role="radio"][aria-checked="true"] {
+        outline: $border-focus;
     }
 }
 
-.dirty {
-    .selected {
-        background-color: $alt1-color;
+[role="radiogroup"]:not([aria-disabled="true"]) {
+    [role="radio"]:hover {
+        background-color: $item-hover-color;
+        color: $primary-color;
+    }
+    
+    [role="radio"][aria-checked="true"] {
+        background-color: $primary-color;
+        color: $body-bg-color;
+    }
+    
+    &.dirty {
+        [role="radio"][aria-checked="true"] {
+            background-color: $alt1-color;
+        }
+    }
+}
+
+[role="radiogroup"][aria-disabled="true"] {
+    [role="radio"] {
+        border-color: $disabled-color;
+        color: $disabled-color;
+
+        &:hover {
+            cursor: default;
+        }
     }
 
-    &.disabled {
-        .selected {
-            background-color: $alt1-color-faded;
+    [role="radio"][aria-checked="true"] {
+        background: $background-color-disabled;
+    }
+    
+    &.dirty {
+        [role="radio"][aria-checked="true"] {
+            background: $background-color-disabled;
+            color: $alt1-color-faded;
         }
     }
 }
@@ -74,43 +85,53 @@ $border-light: 1px $primary-color solid;
 :host-context(#app-root[theme=dark]){
     $border-dark: 1px $primary-color-dark solid;
 
-    .switch-label{
+    [role="radio"] {
         border-top: $border-dark;
         border-left: $border-dark;
         border-bottom: $border-dark;
-        color: $primary-color-dark;
-    }
-
-    .switch-label ~ .switch-label{
         border-right: $border-dark;
+        color: $primary-color-dark;
+
+        background: $body-bg-color-dark;
     }
 
-    .selected{
-        background-color: $primary-color-dark;
-        color: $body-bg-color-dark;
-
-        &.disabled{
-            background-color: $disabled-color-dark;
-            color: lighten($disabled-color-dark, 20%);
-        }
-
-        &:hover{
-            background-color: lighten($primary-color-dark, 10%);
-        }
-    
-        &:active{
-            background-color: darken($primary-color-dark, 10%)
-        }
+    [role="radio"] ~ [role="radio"] {
+        border-left-width: 0px;
     }
 
-    .dirty {
-        .selected {
-            background-color: $alt1-color-faded;
+    [role="radiogroup"]:not([aria-disabled="true"]) {
+        [role="radio"]:hover {
+            background-color: $item-hover-color-dark;
+            color: $primary-color-dark;
         }
-    
-        &.disabled {
-            .selected {
+        
+        [role="radio"][aria-checked="true"] {
+            background-color: $primary-color-dark;
+            color: $body-bg-color-dark;
+        }
+        
+        &.dirty {
+            [role="radio"][aria-checked="true"] {
                 background-color: $alt1-color-faded;
+            }
+        }
+    }
+
+    [role="radiogroup"][aria-disabled="true"] {
+        [role="radio"] {
+            border-color: $disabled-color-dark;
+            color: $disabled-color-dark;
+        }
+
+        [role="radio"][aria-checked="true"] {
+            background: $background-color-disabled;
+            color: $disabled-color;
+        }
+        
+        &.dirty {
+            [role="radio"][aria-checked="true"] {
+                background: $background-color-disabled;
+                color: $alt1-color-faded;
             }
         }
     }

--- a/AzureFunctions.AngularClient/src/app/radio-selector/radio-selector.component.ts
+++ b/AzureFunctions.AngularClient/src/app/radio-selector/radio-selector.component.ts
@@ -2,6 +2,8 @@ import { Component, EventEmitter, Input, Output, OnInit, OnChanges, SimpleChange
 import { FormGroup, FormControl } from '@angular/forms';
 import { Subject } from 'rxjs/Subject';
 import { SelectOption } from '../shared/models/select-option';
+import { KeyCodes } from '../shared/models/constants';
+import { Guid } from '../shared/Utilities/Guid';
 
 @Component({
     selector: 'radio-selector',
@@ -19,11 +21,15 @@ export class RadioSelectorComponent<T> implements OnInit, OnChanges {
     @Input() defaultValue: T;
     @Output() value: Subject<T>;
 
+    public id: string;
+    public activeDescendantId: string;
+
     private _initialized: boolean = false;
     private _originalValue: T = null;
 
     constructor() {
         this.value = new EventEmitter<T>();
+        this.id = Guid.newGuid();
     }
 
     private _setControlValue(value: T) {
@@ -72,6 +78,67 @@ export class RadioSelectorComponent<T> implements OnInit, OnChanges {
                 this.value.next(value);
             }
         }
+
+        if (changes['options'] && !!this.options) {
+            for (let i = 0; i < this.options.length; i++) {
+                this.options[i].id = i;
+            }
+        }
+
+        if (valueChanged || changes['options']) {
+            const activeOptionIndex = this._getActiveOptionIndex();
+            this.activeDescendantId = activeOptionIndex >= 0 ? `${this.id}-${activeOptionIndex}` : null;
+        }
+    }
+
+    private _getActiveOptionIndex(): number {
+        if (this.selectedValue === undefined || !this.options) {
+            return null;
+        }
+
+        for (let i = 0; i < this.options.length; i++) {
+            if (this.options[i].value === this.selectedValue) {
+                return i;
+            }
+        }
+
+        return null;
+    }
+
+    private _selectAdjacent(direction: 'forward' | 'reverse') {
+        if (!this.options || this.options.length === 0) {
+            return;
+        }
+
+        let newIndex = 0;
+
+        const activeOptionIndex = this._getActiveOptionIndex();
+        if (activeOptionIndex >= 0) {
+            if (direction === 'forward') {
+                newIndex = activeOptionIndex === this.options.length - 1 ? 0 : activeOptionIndex + 1;
+            }
+            else {
+                newIndex = activeOptionIndex === 0 ? this.options.length - 1 : activeOptionIndex - 1;
+            }
+        }
+        else {
+            newIndex = direction === 'forward' ? 0 : this.options.length - 1;
+        }
+
+        this.select(this.options[newIndex]);
+    }
+
+    onKeyDown(event: KeyboardEvent) {
+        if (this.control ? !this.control.disabled : !this.disabled) {
+            if (event.keyCode === KeyCodes.arrowLeft || event.keyCode === KeyCodes.arrowUp) {
+                this._selectAdjacent('reverse');
+                event.preventDefault();
+            }
+            else if (event.keyCode === KeyCodes.arrowRight || event.keyCode === KeyCodes.arrowDown) {
+                this._selectAdjacent('forward');
+                event.preventDefault();
+            }
+        }
     }
 
     select(option: SelectOption<T>) {
@@ -79,6 +146,7 @@ export class RadioSelectorComponent<T> implements OnInit, OnChanges {
             this._setControlValue(option.value);
             this.selectedValue = option.value;
             this.value.next(option.value);
+            this.activeDescendantId = `${this.id}-${option.id}`
         }
     }
 }


### PR DESCRIPTION
This includes the following changes to RadioSelectorComponent:
- Added keyboard accessibility
- Added ARIA attributes for accessibility
- Style fixes

When updating the styles, I was aiming to be consistent with the following two controls from Office UI Fabric:
- https://developer.microsoft.com/en-us/fabric#/components/choicegroup
- https://developer.microsoft.com/en-us/fabric#/components/toggle

Below are five sets of screen captures that illustrate the updated styles for the control in all its possible states for both the light and dark theme.

![image](https://user-images.githubusercontent.com/5387224/32362398-41b268d8-c026-11e7-9797-e9669f865ea0.png)


* **Set 1**
    * control is disabled
    * control is pristine
    * "2015" is the selected option
    * hover/focus have no effect

* **Set 2**
    * control is enabled
    * control is pristine
    * "2015" is the selected option
    * no items have hover/focus

* **Set 3**
    * control is enabled
    * control is pristine
    * "2015" is the selected option
    * "2015" item has focus
    * no item has hover

* **Set 4**
    * control is enabled
    * control is dirty
    * "2013" is the selected option
    * "2013" item has focus
    * "2012" item has hover

* **Set 5**
    * control is disabled
    * control is dirty
    * "2013" is the selected option
    * hover/focus have no effect