### PR TITLE
Simplifying tree loading logic (Part 1)

### DIFF
--- a/AzureFunctions.AngularClient/src/app/api/api-details/api-details.component.html
+++ b/AzureFunctions.AngularClient/src/app/api/api-details/api-details.component.html
@@ -12,7 +12,7 @@
     </div>
   </div>
 
-  <app-edit-mode-warning [functionApp]="functionApp" [appNode]="appNode"></app-edit-mode-warning>
+  <app-edit-mode-warning [context]="context"></app-edit-mode-warning>
 
   <form [formGroup]="complexForm">
 

--- a/AzureFunctions.AngularClient/src/app/api/api-details/api-details.component.ts
+++ b/AzureFunctions.AngularClient/src/app/api/api-details/api-details.component.ts
@@ -163,9 +163,8 @@ export class ApiDetailsComponent implements OnDestroy {
                 this._broadcastService.broadcastEvent<TreeUpdateEvent>(BroadcastEvent.TreeUpdate, {
                     operation: 'remove',
                     resourceId: `${this.context.site.id}/proxies/${this.apiProxyEdit.name}`
-                })
+                });
 
-                // this.proxiesNode.removeChild(this.apiProxyEdit);
             });
         });
     }

--- a/AzureFunctions.AngularClient/src/app/api/api-new/api-new.component.html
+++ b/AzureFunctions.AngularClient/src/app/api/api-new/api-new.component.html
@@ -2,7 +2,7 @@
 
   <h2>{{ 'apiProxy_new' | translate }} </h2>
 
-  <app-edit-mode-warning [functionApp]="functionApp" [appNode]="appNode"></app-edit-mode-warning>
+  <app-edit-mode-warning [context]="context"></app-edit-mode-warning>
 
   <form [formGroup]="complexForm" (ngSubmit)="submitForm()">
 

--- a/AzureFunctions.AngularClient/src/app/api/api-new/api-new.component.ts
+++ b/AzureFunctions.AngularClient/src/app/api/api-new/api-new.component.ts
@@ -1,5 +1,7 @@
+import { SiteDescriptor } from 'app/shared/resourceDescriptors';
+import { FunctionsService, FunctionAppContext } from './../../shared/services/functions-service';
 import { DashboardType } from 'app/tree-view/models/dashboard-type';
-import { Component, ViewChild, OnDestroy } from '@angular/core';
+import { Component, ViewChild, OnDestroy, Injector } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { TranslateService } from '@ngx-translate/core';
@@ -32,6 +34,7 @@ export class ApiNewComponent implements OnDestroy {
     complexForm: FormGroup;
     isMethodsVisible = false;
 
+    public context: FunctionAppContext;
     public functionApp: FunctionApp;
     public apiProxies: ApiProxy[];
     public functionsInfo: FunctionInfo[];
@@ -46,7 +49,9 @@ export class ApiNewComponent implements OnDestroy {
         private _translateService: TranslateService,
         private _broadcastService: BroadcastService,
         private _aiService: AiService,
-        private _cacheService: CacheService) {
+        private _cacheService: CacheService,
+        private _functionsService: FunctionsService,
+        private _injector: Injector) {
 
         this.complexForm = fb.group({
             // We can set default values by passing in the corresponding value or leave blank if we wish to not set the value. For our example, we�ll default the gender to female.
@@ -74,8 +79,20 @@ export class ApiNewComponent implements OnDestroy {
             .switchMap(viewInfo => {
                 this._globalStateService.setBusyState();
                 this._proxiesNode = <ProxiesNode>viewInfo.node;
-                this.functionApp = this._proxiesNode.functionApp;
                 this.appNode = (<AppNode>this._proxiesNode.parent);
+
+                const descriptor = new SiteDescriptor(viewInfo.resourceId);
+
+                return this._functionsService.getAppContext(descriptor.getTrimmedResourceId());
+            })
+            .switchMap(context => {
+                this.context = context;
+
+                if (this.functionApp) {
+                    this.functionApp.dispose();
+                }
+
+                this.functionApp = new FunctionApp(context.site, this._injector);
 
                 // Should be okay to query app settings without checkout RBAC/locks since this component
                 // shouldn't load unless you have write access.
@@ -83,7 +100,7 @@ export class ApiNewComponent implements OnDestroy {
                     this.functionApp.getFunctions(),
                     this.functionApp.getApiProxies(),
                     this._cacheService.postArm(`${this.functionApp.site.id}/config/appsettings/list`, true),
-                    (f, p, a) => ({ fcs: f, proxies: p, appSettings: a.json() }))
+                    (f, p, a) => ({ fcs: f, proxies: p, appSettings: a.json() }));
             })
             .do(null, e => {
                 this._aiService.trackException(e, '/errors/proxy-create');
@@ -153,6 +170,9 @@ export class ApiNewComponent implements OnDestroy {
 
     ngOnDestroy() {
         this._ngUnsubscribe.next();
+        if (this.functionApp) {
+            this.functionApp.dispose();
+        }
     }
 
     submitForm() {

--- a/AzureFunctions.AngularClient/src/app/api/request-respose-override/request-respose-override.component.ts
+++ b/AzureFunctions.AngularClient/src/app/api/request-respose-override/request-respose-override.component.ts
@@ -51,6 +51,10 @@ export class RequestResposeOverrideComponent {
 
     @Input() set proxy(value: any) {
 
+        if(!value){
+            return;
+        }
+
         this.initModel();
 
         if (value.requestOverrides) {

--- a/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.html
+++ b/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.html
@@ -1,6 +1,6 @@
 <div class="browse-container">
 <img src="image/functions.svg" />
-<h2>{{ 'functionApps' | translate }}</h2><i *ngIf="appsNode?.isLoading" class="fa fa-refresh fa-spin fa-fw"></i>
+<h2>{{ 'functionApps' | translate }}</h2><i *ngIf="isLoading" class="fa fa-refresh fa-spin fa-fw"></i>
 
 <div class="bars">
   <label>{{ 'locationColon' | translate }}</label>
@@ -25,7 +25,7 @@
 
   <drop-down id="groupingDropDown"
     [options]="groupOptions"
-    (value)=onGroupSelect($event)>
+    (value)="onGroupSelect($event)">
   </drop-down>
 </div>
 <tbl [items]="tableItems" #table="tbl" id="apps-list" [name]="'functionApps' | translate" groupColName="title">
@@ -56,13 +56,13 @@
     </ng-container>
   </tr>
 
-  <tr *ngIf="appsNode?.isLoading">
+  <tr *ngIf="isLoading">
     <td colspan="4">{{'functionMonitor_loading' | translate}}</td>
     <td colspan="4"></td>
   </tr>
 </tbl>
 
-<div *ngIf="!appsNode?.isLoading && initialized && table.items.length === 0" class="empty-browse">
+<div *ngIf="!isLoading && table.items.length === 0" class="empty-browse">
   <img src="image/emptybrowse-functions.svg" />
   <h4>{{'emptyBrowse_title' | translate}}</h4>
   <span>{{'emptyBrowse' | translate}}</span>

--- a/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.ts
+++ b/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.ts
@@ -1,4 +1,3 @@
-import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { ActivatedRoute } from '@angular/router';
 import { BroadcastEvent } from 'app/shared/models/broadcast-event';
 import { BroadcastService } from 'app/shared/services/broadcast.service';
@@ -8,9 +7,7 @@ import { DropDownElement } from './../shared/models/drop-down-element';
 import { PortalResources } from './../shared/models/portal-resources';
 import { Component, OnDestroy, ViewChild } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
-import { AppsNode } from './../tree-view/apps-node';
 import { AppNode } from './../tree-view/app-node';
-import { TreeViewInfo, SiteData } from './../tree-view/models/tree-view-info';
 
 interface AppTableItem extends TableItem {
   title: string;
@@ -28,10 +25,8 @@ interface AppTableItem extends TableItem {
 export class AppsListComponent implements OnDestroy {
   public apps: AppNode[] = [];
   public tableItems: TableItem[] = [];
-  public appsNode: AppsNode;
   public Resources = PortalResources;
-
-  public initialized = false;
+  public isLoading = true;
 
   public allLocations = this.translateService.instant(PortalResources.allLocations);
   public numberLocations = this.translateService.instant(PortalResources.locationCount);
@@ -63,18 +58,13 @@ export class AppsListComponent implements OnDestroy {
     public broadcastService: BroadcastService,
     public route: ActivatedRoute) {
 
-    this.broadcastService.getEvents<TreeViewInfo<SiteData>>(BroadcastEvent.TreeNavigation)
-      .filter(viewInfo => viewInfo.dashboardType === DashboardType.AppsDashboard)
+    this.broadcastService.getEvents<AppNode[]>(BroadcastEvent.UpdateAppsList)
       .takeUntil(this._ngUnsubscribe)
       .distinctUntilChanged()
-      .switchMap(viewInfo => {
-        this.appsNode = (<AppsNode>viewInfo.node);
-        this.initialized = false;
-        return (<AppsNode>viewInfo.node).childrenStream;
-      })
       .subscribe(children => {
-        this.apps = children;
-        this.initialized = true;
+        this.isLoading = !children;
+        this.apps = children ? children : [];
+
         this.tableItems = this.apps.map(app => (<AppTableItem>{
           title: app.title,
           subscription: app.subscription,
@@ -121,6 +111,10 @@ export class AppsListComponent implements OnDestroy {
 
   onLocationsSelect(locations: string[]) {
     this.selectedLocations = locations;
+    if (!this.apps) {
+      return;
+    }
+
     const newItems = this.tableItems.filter(item => item.type === 'group');
     const filteredItems = this.apps.filter(app => this.selectedLocations.find(l => l === this.translateService.instant(app.location)))
       .filter(app => this.selectedResourceGroups.find(r => r === app.resourceGroup))

--- a/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.ts
+++ b/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.ts
@@ -164,6 +164,10 @@ export class AppsListComponent implements OnDestroy {
   }
 
   onResourceGroupsSelect(resourceGroups: string[]) {
+    if(!this.apps){
+      return;
+    }
+
     this.selectedResourceGroups = resourceGroups;
     const newItems = this.tableItems.filter(item => item.type === 'group');
     const filteredItems = this.apps.filter(app => this.selectedResourceGroups.find(r => r === app.resourceGroup))

--- a/AzureFunctions.AngularClient/src/app/edit-mode-warning/edit-mode-warning.component.html
+++ b/AzureFunctions.AngularClient/src/app/edit-mode-warning/edit-mode-warning.component.html
@@ -1,34 +1,34 @@
 <div *ngIf="readOnly">
   <br />
   <div class="alert alert-warning alert-dismissible" role="alert">
-    {{ 'readOnly' | translate }} <span *ngIf="appNode" class="link" (click)="onFunctionAppSettingsClicked()">{{ 'appFunctionSettings_functionAppSettings' | translate }}</span>.
+    {{ 'readOnly' | translate }} <span *ngIf="context" class="link" (click)="onFunctionAppSettingsClicked()">{{ 'appFunctionSettings_functionAppSettings' | translate }}</span>.
   </div>
 </div>
 
 <div *ngIf="readOnlySourceControlled">
   <br />
   <div class="alert alert-warning alert-dismissible" role="alert">
-    {{ 'readOnlySourceControlled' | translate }} <span *ngIf="appNode" class="link" (click)="onFunctionAppSettingsClicked()">{{ 'appFunctionSettings_functionAppSettings' | translate }}</span>.
+    {{ 'readOnlySourceControlled' | translate }} <span *ngIf="context" class="link" (click)="onFunctionAppSettingsClicked()">{{ 'appFunctionSettings_functionAppSettings' | translate }}</span>.
   </div>
 </div>
 
 <div *ngIf="readWriteSourceControlled">
   <br />
   <div class="alert alert-warning alert-dismissible" role="alert">
-    {{ 'readWriteSourceControlled' | translate }} <span *ngIf="appNode" class="link" (click)="onFunctionAppSettingsClicked()">{{ 'appFunctionSettings_functionAppSettings' | translate }}</span>.
+    {{ 'readWriteSourceControlled' | translate }} <span *ngIf="context" class="link" (click)="onFunctionAppSettingsClicked()">{{ 'appFunctionSettings_functionAppSettings' | translate }}</span>.
   </div>
 </div>
 
 <div *ngIf="readOnlySlots">
   <br />
   <div class="alert alert-warning alert-dismissible" role="alert">
-    {{ 'readOnlySlots' | translate }} <span *ngIf="appNode" class="link" (click)="onFunctionAppSettingsClicked()">{{ 'appFunctionSettings_functionAppSettings' | translate }}</span>.
+    {{ 'readOnlySlots' | translate }} <span *ngIf="context" class="link" (click)="onFunctionAppSettingsClicked()">{{ 'appFunctionSettings_functionAppSettings' | translate }}</span>.
   </div>
 </div>
 
 <div *ngIf="ReadOnlyVSGenerated">
   <br />
   <div class="alert alert-warning alert-dismissible" role="alert">
-    {{ 'readOnlyGeneratedBy' | translate }} <a *ngIf="appNode" class="link" href="https://go.microsoft.com/fwlink/?linkid=856288" target="_blank">{{ 'topBar_learnMore' | translate }}</a>.
+    {{ 'readOnlyGeneratedBy' | translate }} <a *ngIf="context" class="link" href="https://go.microsoft.com/fwlink/?linkid=856288" target="_blank">{{ 'topBar_learnMore' | translate }}</a>.
   </div>
 </div>

--- a/AzureFunctions.AngularClient/src/app/edit-mode-warning/edit-mode-warning.component.ts
+++ b/AzureFunctions.AngularClient/src/app/edit-mode-warning/edit-mode-warning.component.ts
@@ -1,5 +1,8 @@
-import { AppNode } from './../tree-view/app-node';
-import { FunctionApp } from './../shared/function-app';
+import { BroadcastService } from 'app/shared/services/broadcast.service';
+import { SiteTabIds } from './../shared/models/constants';
+import { BroadcastEvent } from 'app/shared/models/broadcast-event';
+import { TreeUpdateEvent } from './../shared/models/broadcast-event';
+import { FunctionAppContext, FunctionsService } from './../shared/services/functions-service';
 import { Component, OnInit, Input } from '@angular/core';
 import { FunctionAppEditMode } from '../shared/models/function-app-edit-mode';
 
@@ -10,8 +13,7 @@ import { FunctionAppEditMode } from '../shared/models/function-app-edit-mode';
 })
 export class EditModeWarningComponent implements OnInit {
 
-  @Input() functionApp: FunctionApp;
-  @Input() appNode: AppNode;
+  @Input() context: FunctionAppContext;
 
   public readOnly = false;
   public readOnlySourceControlled = false;
@@ -19,10 +21,12 @@ export class EditModeWarningComponent implements OnInit {
   public readOnlySlots = false;
   public ReadOnlyVSGenerated = false;
 
+  constructor(private _functionsService: FunctionsService, private _broadcastService: BroadcastService) { }
+
   ngOnInit() {
-    if (this.functionApp) {
-      this.functionApp
-        .getFunctionAppEditMode()
+    if (this.context) {
+      this._functionsService
+        .getFunctionAppEditMode(this.context)
         .subscribe(editMode => {
           if (editMode === FunctionAppEditMode.ReadOnly) {
             this.readOnly = true;
@@ -36,10 +40,14 @@ export class EditModeWarningComponent implements OnInit {
             this.ReadOnlyVSGenerated = true;
           }
         });
-      }
+    }
   }
 
   onFunctionAppSettingsClicked() {
-    this.appNode.openSettings();
+    this._broadcastService.broadcastEvent<TreeUpdateEvent>(BroadcastEvent.TreeUpdate, {
+      operation: 'navigate',
+      resourceId: this.context.site.id,
+      data: SiteTabIds.functionRuntime
+    });
   }
 }

--- a/AzureFunctions.AngularClient/src/app/function-edit/function-edit.component.html
+++ b/AzureFunctions.AngularClient/src/app/function-edit/function-edit.component.html
@@ -1,15 +1,15 @@
 <div *ngIf="tabId === 'develop'" class="function-edit-content-dev">
-    <app-edit-mode-warning [functionApp]="functionApp" [appNode]="appNode"></app-edit-mode-warning>
+    <app-edit-mode-warning [context]="context"></app-edit-mode-warning>
     <function-dev [selectedFunction]="selectedFunction"></function-dev>
 </div>
 <div *ngIf="tabId === 'integrate'" class="function-edit-content">
-    <app-edit-mode-warning [functionApp]="functionApp" [appNode]="appNode"></app-edit-mode-warning>
+    <app-edit-mode-warning [context]="context"></app-edit-mode-warning>
     <function-integrate-v2 *ngIf="editorType === 'standard'" (changeEditor)="onEditorChange($event)" [viewInfo]="viewInfo" [selectedFunction]="selectedFunction"></function-integrate-v2>
     <function-integrate *ngIf="editorType === 'advanced'" (changeEditor)="onEditorChange($event)" [selectedFunction]="selectedFunction"></function-integrate>
 </div>
 <div *ngIf="tabId === 'manage'" class="function-edit-content">
-    <app-edit-mode-warning [functionApp]="functionApp" [appNode]="appNode"></app-edit-mode-warning>
-    <function-manage [viewInfoInput]="viewInfo"></function-manage>
+    <app-edit-mode-warning [context]="context"></app-edit-mode-warning>
+    <function-manage [selectedFunction]="selectedFunction"></function-manage>
 </div>
 <div *ngIf="tabId === 'monitor'" class="function-edit-content">
     <function-monitor [selectedFunction]="selectedFunction"></function-monitor>

--- a/AzureFunctions.AngularClient/src/app/function-edit/function-edit.component.ts
+++ b/AzureFunctions.AngularClient/src/app/function-edit/function-edit.component.ts
@@ -19,7 +19,6 @@ import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { BroadcastEvent } from 'app/shared/models/broadcast-event';
 import { Component, ViewChild, OnDestroy, Injector } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
-import 'rxjs/add/operator/switchMap';
 import { TranslateService } from '@ngx-translate/core';
 import { FunctionApp } from '../shared/function-app';
 import { PortalService } from '../shared/services/portal.service';
@@ -138,7 +137,6 @@ export class FunctionEditComponent implements OnDestroy {
                 this._globalStateService.clearBusyState();
                 this._setupPollingTasks();
 
-                // this.appNode = <AppNode>viewInfo.node.parent.parent;
                 const segments = this.viewInfo.resourceId.split('/');
                 // support for both site & slots
                 if (segments.length === 13 && segments[11] === 'functions' || segments.length === 11 && segments[9] === 'functions') {

--- a/AzureFunctions.AngularClient/src/app/function-edit/function-edit.component.ts
+++ b/AzureFunctions.AngularClient/src/app/function-edit/function-edit.component.ts
@@ -1,7 +1,23 @@
+import { TreeUpdateEvent } from './../shared/models/broadcast-event';
+import { GlobalStateService } from './../shared/services/global-state.service';
+import { ConfigService } from './../shared/services/config.service';
+import { AiService } from './../shared/services/ai.service';
+import { PortalResources } from './../shared/models/portal-resources';
+import { ErrorIds } from './../shared/models/error-ids';
+import { TopBarNotification } from './../top-bar/top-bar-models';
+import { Site } from './../shared/models/arm/site';
+import { ArmObj } from './../shared/models/arm/arm-obj';
+import { SiteService } from './../shared/services/slots.service';
+import { CacheService } from 'app/shared/services/cache.service';
+import { Observable } from 'rxjs/Observable';
+import { LogCategories, NotificationIds, Constants, SiteTabIds } from './../shared/models/constants';
+import { LogService } from './../shared/services/log.service';
+import { FunctionsService, FunctionAppContext } from './../shared/services/functions-service';
+import { FunctionDescriptor } from 'app/shared/resourceDescriptors';
+import { SiteDescriptor } from './../shared/resourceDescriptors';
 import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { BroadcastEvent } from 'app/shared/models/broadcast-event';
-import { AppNode } from './../tree-view/app-node';
-import { Component, ViewChild, OnDestroy } from '@angular/core';
+import { Component, ViewChild, OnDestroy, Injector } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/operator/switchMap';
 import { TranslateService } from '@ngx-translate/core';
@@ -12,7 +28,10 @@ import { FunctionInfo } from '../shared/models/function-info';
 import { FunctionDevComponent } from '../function-dev/function-dev.component';
 import { BroadcastService } from '../shared/services/broadcast.service';
 import { TreeViewInfo } from '../tree-view/models/tree-view-info';
-import { FunctionNode } from '../tree-view/function-node';
+import { Subscription as RxSubscription } from 'rxjs/Subscription';
+import { ErrorEvent, ErrorType } from '../shared/models/error-event';
+import { Response } from '@angular/http';
+import { FunctionsVersionInfoHelper } from '../../../../common/models/functions-version-info';
 
 @Component({
     selector: 'function-edit',
@@ -34,17 +53,25 @@ export class FunctionEditComponent implements OnDestroy {
     public ManageTab: string;
     public tabId = '';
 
-    private _viewInfoStream: Subject<TreeViewInfo<any>>;
+    private _pollingTask: RxSubscription;
     private _ngUnsubscribe = new Subject<void>();
 
-    private appNode: AppNode;
     private functionApp: FunctionApp;
+    public context: FunctionAppContext;
 
     constructor(
         private _userService: UserService,
         private _broadcastService: BroadcastService,
         private _portalService: PortalService,
-        _translateService: TranslateService) {
+        private _functionsService: FunctionsService,
+        private _injector: Injector,
+        private _logService: LogService,
+        private _cacheService: CacheService,
+        private _siteService: SiteService,
+        private _translateService: TranslateService,
+        private _aiService: AiService,
+        private _configService: ConfigService,
+        private _globalStateService: GlobalStateService) {
 
         this.inIFrame = this._userService.inIFrame;
 
@@ -53,15 +80,66 @@ export class FunctionEditComponent implements OnDestroy {
         this.MonitorTab = _translateService.instant('tabNames_monitor');
         this.ManageTab = _translateService.instant('tabNames_manage');
 
-        this._viewInfoStream = new Subject<TreeViewInfo<any>>();
-        this._viewInfoStream
+        this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.TreeNavigation)
             .takeUntil(this._ngUnsubscribe)
-            .subscribe(viewInfo => {
+            .filter(info => {
+                if (this.viewInfo) {
+
+                    // If clicking on the same dashboard type for a different function, the component
+                    // is already initialized, so we can respond to the update
+                    if (this.viewInfo.dashboardType === info.dashboardType
+                        && this.viewInfo.resourceId !== info.resourceId) {
+
+                        return true;
+
+                    } else {
+                        // If the dashboard type or resourceId doesn't match, then don't respond
+                        // to the event because a new component instance will be created to handle it
+                        return false;
+                    }
+                } else {
+
+                    // If this is first click, then make sure to only respond to these dashboard types
+                    return info.dashboardType === DashboardType.FunctionDashboard
+                        || info.dashboardType === DashboardType.FunctionIntegrateDashboard
+                        || info.dashboardType === DashboardType.FunctionManageDashboard
+                        || info.dashboardType === DashboardType.FunctionMonitorDashboard;
+                }
+            })
+            .distinctUntilChanged()
+            .switchMap(viewInfo => {
+                this._globalStateService.setBusyState();
                 this.viewInfo = viewInfo;
-                this.selectedFunction = (<FunctionNode>viewInfo.node).functionInfo;
-                this.functionApp = this.selectedFunction.functionApp;
-                this.appNode = <AppNode>viewInfo.node.parent.parent;
-                const segments = viewInfo.resourceId.split('/');
+                const siteDescriptor = new SiteDescriptor(viewInfo.resourceId);
+                return this._functionsService.getAppContext(siteDescriptor.getTrimmedResourceId());
+            })
+            .switchMap(context => {
+                this.context = context;
+                const functionDescriptor = new FunctionDescriptor(this.viewInfo.resourceId);
+                return this._functionsService.getFunction(context, functionDescriptor.name);
+            })
+            .switchMap(functionInfo => {
+                this.selectedFunction = functionInfo;
+
+                if (this.functionApp) {
+                    this.functionApp.dispose();
+                }
+
+                this.functionApp = new FunctionApp(this.selectedFunction.context.site, this._injector);
+                functionInfo.functionApp = this.functionApp;
+                return this.functionApp.initKeysAndWarmupMainSite();
+            })
+            .do(null, err => {
+                this._globalStateService.clearBusyState();
+                this._logService.error(LogCategories.FunctionEdit, '/loading', err);
+            })
+            .retry()
+            .subscribe(() => {
+                this._globalStateService.clearBusyState();
+                this._setupPollingTasks();
+
+                // this.appNode = <AppNode>viewInfo.node.parent.parent;
+                const segments = this.viewInfo.resourceId.split('/');
                 // support for both site & slots
                 if (segments.length === 13 && segments[11] === 'functions' || segments.length === 11 && segments[9] === 'functions') {
                     this.tabId = 'develop';
@@ -69,26 +147,147 @@ export class FunctionEditComponent implements OnDestroy {
                     this.tabId = segments[segments.length - 1];
                 }
             });
-
-        this._broadcastService.getEvents<TreeViewInfo<any>>(BroadcastEvent.TreeNavigation)
-            .filter(info => {
-                return info.dashboardType === DashboardType.FunctionDashboard
-                    || info.dashboardType === DashboardType.FunctionIntegrateDashboard
-                    || info.dashboardType === DashboardType.FunctionManageDashboard
-                    || info.dashboardType === DashboardType.FunctionMonitorDashboard;
-            })
-            .takeUntil(this._ngUnsubscribe)
-            .subscribe(info => {
-                this._viewInfoStream.next(info);
-            });
     }
 
     ngOnDestroy() {
         this._ngUnsubscribe.next();
+
+        if(this._pollingTask){
+            this._pollingTask.unsubscribe();
+        }
+
+        if (this.functionApp) {
+            this.functionApp.dispose();
+        }
     }
 
     onEditorChange(editorType: string) {
         this._portalService.logAction('function-edit', 'switchEditor', { type: editorType });
         this.editorType = editorType;
+    }
+
+    private _setupPollingTasks() {
+        if (this._pollingTask) {
+            this._pollingTask.unsubscribe();
+        }
+
+        this._pollingTask = Observable.timer(1, 60000)
+            .takeUntil(this._ngUnsubscribe)
+            .concatMap(() => {
+                const val = Observable.zip(
+                    this.functionApp.getHostErrors().catch(() => Observable.of([])),
+                    this._cacheService.getArm(`${this.context.site.id}/config/web`, true),
+                    this._cacheService.postArm(`${this.context.site.id}/config/appsettings/list`, true),
+                    this._siteService.getSlotsList(`${this.context.site.id}`),
+                    this.functionApp.pingScmSite(),
+                    (e: string[], c: Response, a: Response, s: ArmObj<Site>[]) => ({ errors: e, configResponse: c, appSettingResponse: a, slotsResponse: s }));
+                return val;
+            })
+            .catch(() => Observable.of({}))
+            .subscribe((result: { errors: string[], configResponse: Response, appSettingResponse: Response, slotsResponse: ArmObj<Site>[] }) => {
+                this._handlePollingTaskResult(result);
+            });
+    }
+
+    private _handlePollingTaskResult(result: { errors: string[], configResponse: Response, appSettingResponse: Response, slotsResponse: ArmObj<Site>[] }) {
+        if (result) {
+
+            const notifications: TopBarNotification[] = [];
+
+            if (result.errors) {
+
+                this._broadcastService.broadcast<string>(BroadcastEvent.ClearError, ErrorIds.generalHostErrorFromHost);
+                // Give clearing a chance to run
+                setTimeout(() => {
+                    result.errors.forEach(e => {
+                        this._broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
+                            message: this._translateService.instant(PortalResources.functionDev_hostErrorMessage, { error: e }),
+                            details: this._translateService.instant(PortalResources.functionDev_hostErrorMessage, { error: e }),
+                            errorId: ErrorIds.generalHostErrorFromHost,
+                            errorType: ErrorType.RuntimeError,
+                            resourceId: this.functionApp.site.id
+                        });
+
+                        this._aiService.trackEvent('/errors/host', { error: e, app: this.context.site.id });
+                    });
+                });
+            }
+
+            if (result.configResponse) {
+                const config = result.configResponse.json();
+                this.functionApp.isAlwaysOn = config.properties.alwaysOn === true || this.functionApp.site.properties.sku === 'Dynamic';
+
+                if (!this.functionApp.isAlwaysOn) {
+                    notifications.push({
+                        id: NotificationIds.alwaysOn,
+                        message: this._translateService.instant(PortalResources.topBar_alwaysOn),
+                        iconClass: 'fa fa-exclamation-triangle warning',
+                        learnMoreLink: 'https://go.microsoft.com/fwlink/?linkid=830855',
+                        clickCallback: null
+                    });
+                }
+            }
+
+            if (result.appSettingResponse) {
+                const appSettings: ArmObj<any> = result.appSettingResponse.json();
+                const extensionVersion = appSettings.properties[Constants.runtimeVersionAppSettingName];
+                let isLatestFunctionRuntime = null;
+                if (extensionVersion) {
+                    if (extensionVersion === 'beta') {
+                        isLatestFunctionRuntime = true;
+                        notifications.push({
+                            id: NotificationIds.runtimeV2,
+                            message: this._translateService.instant(PortalResources.topBar_runtimeV2),
+                            iconClass: 'fa fa-exclamation-triangle warning',
+                            learnMoreLink: '',
+                            clickCallback: () => {
+                                this._broadcastService.broadcastEvent<TreeUpdateEvent>(BroadcastEvent.TreeUpdate, {
+                                    operation: 'navigate',
+                                    resourceId: this.context.site.id,
+                                    data: SiteTabIds.functionRuntime
+                                });
+                            }
+                        });
+                    } else {
+                        isLatestFunctionRuntime = !FunctionsVersionInfoHelper.needToUpdateRuntime(this._configService.FunctionsVersionInfo, extensionVersion);
+                        this._aiService.trackEvent('/values/runtime_version', { runtime: extensionVersion, appName: this.context.site.id });
+                    }
+                }
+
+                if (!isLatestFunctionRuntime) {
+                    notifications.push({
+                        id: NotificationIds.newRuntimeVersion,
+                        message: this._translateService.instant(PortalResources.topBar_newVersion),
+                        iconClass: 'fa fa-info link',
+                        learnMoreLink: 'https://go.microsoft.com/fwlink/?linkid=829530',
+                        clickCallback: () => {
+                            this._broadcastService.broadcastEvent<TreeUpdateEvent>(BroadcastEvent.TreeUpdate, {
+                                operation: 'navigate',
+                                resourceId: this.context.site.id,
+                                data: SiteTabIds.functionRuntime
+                            });
+                        }
+                    });
+                }
+                if (result.slotsResponse) {
+                    let slotsStorageSetting = appSettings.properties[Constants.slotsSecretStorageSettingsName];
+                    if (!!slotsStorageSetting) {
+                        slotsStorageSetting = slotsStorageSetting.toLowerCase();
+                    }
+                    const numSlots = result.slotsResponse.length;
+                    if (numSlots > 0 && slotsStorageSetting !== Constants.slotsSecretStorageSettingsValue.toLowerCase()) {
+                        notifications.push({
+                            id: NotificationIds.slotsHostId,
+                            message: this._translateService.instant(PortalResources.topBar_slotsHostId),
+                            iconClass: 'fa fa-exclamation-triangle warning',
+                            learnMoreLink: '',
+                            clickCallback: null
+                        });
+                    }
+                }
+            }
+
+            this._globalStateService.setTopBarNotifications(notifications);
+        }
     }
 }

--- a/AzureFunctions.AngularClient/src/app/function-manage/function-manage.component.ts
+++ b/AzureFunctions.AngularClient/src/app/function-manage/function-manage.component.ts
@@ -1,5 +1,8 @@
+import { BroadcastEvent } from 'app/shared/models/broadcast-event';
+import { TreeUpdateEvent } from './../shared/models/broadcast-event';
+import { BroadcastService } from './../shared/services/broadcast.service';
 import { ConfigService } from './../shared/services/config.service';
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/retry';
@@ -13,15 +16,12 @@ import { PortalService } from '../shared/services/portal.service';
 import { GlobalStateService } from '../shared/services/global-state.service';
 import { PortalResources } from '../shared/models/portal-resources';
 import { FunctionApp } from '../shared/function-app';
-import { TreeViewInfo } from '../tree-view/models/tree-view-info';
-import { FunctionManageNode } from '../tree-view/function-node';
 import { BindingManager } from '../shared/models/binding-manager';
 
 @Component({
     selector: 'function-manage',
     templateUrl: './function-manage.component.html',
-    styleUrls: ['./function-manage.component.css'],
-    inputs: ['viewInfoInput']
+    styleUrls: ['./function-manage.component.css']
 })
 export class FunctionManageComponent {
     public functionStatusOptions: SelectOption<boolean>[];
@@ -30,26 +30,15 @@ export class FunctionManageComponent {
     public isStandalone: boolean;
     public isHttpFunction = false;
 
-    private _viewInfoStream: Subject<TreeViewInfo<any>>;
-    private _functionNode: FunctionManageNode;
     private functionStateValueChange: Subject<boolean>;
 
     constructor(private _portalService: PortalService,
         private _globalStateService: GlobalStateService,
         private _translateService: TranslateService,
+        private _broadcastService: BroadcastService,
         configService: ConfigService) {
 
         this.isStandalone = configService.isStandalone();
-
-        this._viewInfoStream = new Subject<TreeViewInfo<any>>();
-        this._viewInfoStream
-            .retry()
-            .subscribe(viewInfo => {
-                this._functionNode = <FunctionManageNode>viewInfo.node;
-                this.functionInfo = this._functionNode.functionInfo;
-                this.functionApp = this.functionInfo.functionApp;
-                this.isHttpFunction = BindingManager.isHttpFunction(this.functionInfo);
-            });
 
         this.functionStatusOptions = [
             {
@@ -76,11 +65,18 @@ export class FunctionManageComponent {
             .subscribe((fi: FunctionInfo) => {
                 this._globalStateService.clearBusyState();
                 this.functionInfo.config.disabled = fi.config.disabled;
+                this._broadcastService.broadcastEvent<TreeUpdateEvent>(BroadcastEvent.TreeUpdate, {
+                    resourceId: `${this.functionApp.site.id}/functions/${this.functionInfo.name}`,
+                    operation: 'update',
+                    data: fi.config.disabled
+                });
             });
     }
 
-    set viewInfoInput(viewInfo: TreeViewInfo<any>) {
-        this._viewInfoStream.next(viewInfo);
+    @Input() set selectedFunction(functionInfo: FunctionInfo) {
+        this.functionInfo = functionInfo;
+        this.functionApp = this.functionInfo.functionApp;
+        this.isHttpFunction = BindingManager.isHttpFunction(this.functionInfo);
     }
 
     deleteFunction() {
@@ -89,10 +85,13 @@ export class FunctionManageComponent {
             this._globalStateService.setBusyState();
             this._portalService.logAction('edit-component', 'delete');
             // Clone node for removing as it can be change during http call
-            const clone = Object.create(this._functionNode);
             this.functionApp.deleteFunction(this.functionInfo)
                 .subscribe(() => {
-                    clone.remove();
+
+                    this._broadcastService.broadcastEvent<TreeUpdateEvent>(BroadcastEvent.TreeUpdate, {
+                        resourceId: `${this.functionInfo.context.site.id}/functions/${this.functionInfo.name}`,
+                        operation: 'remove'
+                    });
                     // this._broadcastService.broadcast(BroadcastEvent.FunctionDeleted, this.functionInfo);
                     this._globalStateService.clearBusyState();
                 });

--- a/AzureFunctions.AngularClient/src/app/function-new/function-new.component.html
+++ b/AzureFunctions.AngularClient/src/app/function-new/function-new.component.html
@@ -1,6 +1,6 @@
 <div class="newfunc-container" >
 
-    <app-edit-mode-warning [functionApp]="functionApp" [appNode]="appNode"></app-edit-mode-warning>
+    <app-edit-mode-warning [context]="context"></app-edit-mode-warning>
 
     <div *ngIf="functionsInfo" [fnWriteAccess]="functionApp">
         <div class="choose">

--- a/AzureFunctions.AngularClient/src/app/function-new/function-new.component.ts
+++ b/AzureFunctions.AngularClient/src/app/function-new/function-new.component.ts
@@ -1,4 +1,7 @@
-import { Component, ElementRef, Inject } from '@angular/core';
+import { FunctionsService, FunctionAppContext } from './../shared/services/functions-service';
+import { SiteDescriptor } from './../shared/resourceDescriptors';
+import { CacheService } from 'app/shared/services/cache.service';
+import { Component, ElementRef, Inject, OnDestroy, Injector } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/retry';
@@ -32,7 +35,8 @@ import { Regex } from './../shared/models/constants';
     outputs: ['functionAdded'],
     inputs: ['viewInfoInput']
 })
-export class FunctionNewComponent {
+export class FunctionNewComponent implements OnDestroy {
+    public context: FunctionAppContext;
     private functionsNode: FunctionsNode;
     public functionApp: FunctionApp;
     public functionsInfo: FunctionInfo[];
@@ -71,17 +75,33 @@ export class FunctionNewComponent {
         private _portalService: PortalService,
         private _globalStateService: GlobalStateService,
         private _translateService: TranslateService,
-        private _aiService: AiService) {
+        private _aiService: AiService,
+        private _cacheService: CacheService,
+        private _functionsService: FunctionsService,
+        private _injector: Injector) {
+
         this.elementRef = elementRef;
         this.disabled = !!_broadcastService.getDirtyState("function_disabled");
 
         this._viewInfoStream
             .switchMap(viewInfo => {
-                this.viewInfo = viewInfo;
                 this._globalStateService.setBusyState();
+                this.viewInfo = viewInfo;
                 this.functionsNode = <FunctionsNode>viewInfo.node;
                 this.appNode = <AppNode>viewInfo.node.parent;
-                this.functionApp = this.functionsNode.functionApp;
+
+                const descriptor = new SiteDescriptor(viewInfo.resourceId);
+                return this._functionsService.getAppContext(descriptor.getTrimmedResourceId());
+            })
+            .switchMap(context => {
+                this.context = context;
+
+                if (this.functionApp) {
+                    this.functionApp.dispose();
+                }
+
+                this.functionApp = new FunctionApp(context.site, this._injector);
+
                 if (this.functionsNode.action) {
                     this.action = Object.create(this.functionsNode.action);
                     delete this.functionsNode.action;
@@ -105,6 +125,12 @@ export class FunctionNewComponent {
 
     set viewInfoInput(viewInfoInput: TreeViewInfo<any>) {
         this._viewInfoStream.next(viewInfoInput);
+    }
+
+    ngOnDestroy() {
+        if (this.functionApp) {
+            this.functionApp.dispose();
+        }
     }
 
     onTemplatePickUpComplete(templateName: string) {
@@ -280,13 +306,18 @@ export class FunctionNewComponent {
 
         this._globalStateService.setBusyState();
         this.functionApp.createFunctionV2(this.functionName, this.selectedTemplate.files, this.bc.UIToFunctionConfig(this.model.config))
-            .subscribe(res => {
+            .subscribe(newFunctionInfo => {
                 this._portalService.logAction('new-function', 'success', { template: this.selectedTemplate.id, name: this.functionName });
                 this._aiService.trackEvent('new-function', { template: this.selectedTemplate.id, result: 'success', first: 'false' });
 
+                this._cacheService.clearCachePrefix(this.functionApp.getScmUrl());
+
+                newFunctionInfo.context = this.context;
+
                 // If someone refreshed the app, it would created a new set of child nodes under the app node.
                 this.functionsNode = <FunctionsNode>this.appNode.children.find(node => node.title === this.functionsNode.title);
-                this.functionsNode.addChild(res);
+                this.functionsNode.addChild(newFunctionInfo);
+                this._globalStateService.clearBusyState();
             },
             () => {
                 this._globalStateService.clearBusyState();

--- a/AzureFunctions.AngularClient/src/app/functions-list/functions-list.component.html
+++ b/AzureFunctions.AngularClient/src/app/functions-list/functions-list.component.html
@@ -5,7 +5,7 @@
             [fnWriteAccess]="functionApp"></command>
 </command-bar>
 
-<app-edit-mode-warning [functionApp]="functionApp" [appNode]="appNode"></app-edit-mode-warning>
+<app-edit-mode-warning [context]="context"></app-edit-mode-warning>
 
 <div class="browse-container">
     <img src="image/function_f.svg" />

--- a/AzureFunctions.AngularClient/src/app/main/main.component.ts
+++ b/AzureFunctions.AngularClient/src/app/main/main.component.ts
@@ -4,7 +4,7 @@ import { PortalService } from './../shared/services/portal.service';
 import { ArmTryService } from './../shared/services/arm-try.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FunctionApp } from './../shared/function-app';
-import { Component, ViewChild, AfterViewInit, OnDestroy } from '@angular/core';
+import { Component, ViewChild, AfterViewInit, OnDestroy, Injector } from '@angular/core';
 import { TreeViewInfo } from '../tree-view/models/tree-view-info';
 import { DashboardType } from '../tree-view/models/dashboard-type';
 import { UserService } from '../shared/services/user.service';
@@ -52,6 +52,7 @@ export class MainComponent implements AfterViewInit, OnDestroy {
         private _cacheService: CacheService,
         private _portalService: PortalService,
         private _broadcastService: BroadcastService,
+        private _injector: Injector,
         _ngHttp: Http,
         _translateService: TranslateService,
         _armService: ArmService,
@@ -138,27 +139,15 @@ export class MainComponent implements AfterViewInit, OnDestroy {
                 // get list of functions from function app listed in resourceID
                 const siteDescriptor: SiteDescriptor = new SiteDescriptor(info.resourceId);
 
-                this._cacheService.getArm(siteDescriptor.getResourceId())
+                this._cacheService.getArm(siteDescriptor.getTrimmedResourceId())
                     .mergeMap(response => {
                         const site = <ArmObj<Site>>response.json();
-                        const functionApp: FunctionApp = new FunctionApp(site,
-                            _ngHttp,
-                            _userService,
-                            _globalStateService,
-                            _translateService,
-                            _broadcastService,
-                            _armService,
-                            _cacheService,
-                            _languageService,
-                            _authZService,
-                            _aiService,
-                            _configService,
-                            _slotsService);
+                        const functionApp: FunctionApp = new FunctionApp(site, this._injector);
                         return functionApp.getFunctions();
                     })
                     .subscribe(functions => {
                         const fnDescriptor: FunctionDescriptor = new FunctionDescriptor(info.resourceId);
-                        const targetName: string = fnDescriptor.functionName;
+                        const targetName: string = fnDescriptor.name;
                         const selectedFunction = functions.find(f => f.name === targetName);
 
                         if (selectedFunction) {

--- a/AzureFunctions.AngularClient/src/app/pickers/microsoft-graph/microsoft-graph-helper.ts
+++ b/AzureFunctions.AngularClient/src/app/pickers/microsoft-graph/microsoft-graph-helper.ts
@@ -238,11 +238,11 @@ export class MicrosoftGraphHelper {
         }
         else if (method.toLowerCase() === Constants.httpMethods.PUT) {
             headers.append('Content-Type', 'application/json');
-            return this._cacheService.put(url, force, headers, jsonPayload);
+            return this._cacheService.put(url, headers, jsonPayload);
         }
         else if (method.toLowerCase() === Constants.httpMethods.PATCH) {
             headers.append('Content-Type', 'application/json; charset=utf-8');
-            return this._cacheService.patch(url, force, headers, jsonPayload);
+            return this._cacheService.patch(url, headers, jsonPayload);
         }
         return this._cacheService.get(url, force, headers);
     }

--- a/AzureFunctions.AngularClient/src/app/shared/directives/log-message.directive.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/directives/log-message.directive.ts
@@ -1,0 +1,27 @@
+import { Directive, Input, SimpleChange, OnChanges } from '@angular/core';
+import 'rxjs/add/operator/debounceTime';
+import 'rxjs/add/operator/switchMap';
+import { LogService, LogLevel, LogLevelString } from 'app/shared/services/log.service';
+
+
+@Directive({
+    selector: '[log-message]',
+})
+export class LogMessageDirective implements OnChanges {
+
+    @Input('log-message') message: string;
+    @Input('log-level') level: LogLevelString = 'verbose';
+    @Input('log-category') category: string;
+
+    constructor(
+        private _logService: LogService) {
+    }
+
+    ngOnChanges(changes: { [key: string]: SimpleChange }) {
+        if(!this.category || !this.message){
+            throw Error("message and category are required");
+        }
+
+        this._logService.log(LogLevel[this.level], this.category, this.message);
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/shared/function-app.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/function-app.ts
@@ -518,24 +518,6 @@ export class FunctionApp {
             });
     }
 
-    getNewFunctionNode(): FunctionInfo {
-        return {
-            name: this._translateService.instant(PortalResources.newFunction),
-            href: null,
-            config: null,
-            script_href: null,
-            template_id: null,
-            clientOnly: true,
-            isDeleted: false,
-            secrets_file_href: null,
-            test_data: null,
-            script_root_path_href: null,
-            config_href: null,
-            functionApp: null,
-            context: null
-        };
-    }
-
     statusCodeToText(code: number) {
         const statusClass = Math.floor(code / 100) * 100;
         return this.statusCodeMap[code] || this.genericStatusCodeMap[statusClass] || 'Unknown Status Code';

--- a/AzureFunctions.AngularClient/src/app/shared/function-app.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/function-app.ts
@@ -1,4 +1,7 @@
-﻿import { ArmUtil } from 'app/shared/Utilities/arm-utils';
+﻿import { BroadcastService } from 'app/shared/services/broadcast.service';
+import { AiService } from 'app/shared/services/ai.service';
+import { Injector } from '@angular/core';
+import { ArmUtil } from 'app/shared/Utilities/arm-utils';
 import { UrlTemplates } from './url-templates';
 import { Subject } from 'rxjs/Subject';
 import { SiteService } from './services/slots.service';
@@ -21,7 +24,6 @@ import { ErrorIds } from './models/error-ids';
 import { DiagnosticsResult } from './models/diagnostics-result';
 import { WebApiException, FunctionRuntimeError } from './models/webapi-exception';
 import { FunctionsResponse } from './models/functions-response';
-import { AiService } from './services/ai.service';
 import { AuthzService } from './services/authz.service';
 import { LanguageService } from './services/language.service';
 import { SiteConfig } from './models/arm/site-config';
@@ -41,7 +43,6 @@ import { Cache, ClearCache, ClearAllFunctionCache } from './decorators/cache.dec
 import { GlobalStateService } from './services/global-state.service';
 import { PortalResources } from './models/portal-resources';
 import { Cookie } from 'ng2-cookies/ng2-cookies';
-import { BroadcastService } from './services/broadcast.service';
 import { ArmService } from './services/arm.service';
 import { BroadcastEvent } from './models/broadcast-event';
 import { ErrorEvent, ErrorType } from './models/error-event';
@@ -62,6 +63,8 @@ export class FunctionApp {
     private masterKey: string;
     private token: string;
     private siteName: string;
+    private ngUnsubscribe = new Subject();
+
     public selectedFunction: string;
     public selectedLanguage: string;
     public selectedProvider: string;
@@ -128,25 +131,39 @@ export class FunctionApp {
     public tryFunctionsScmCreds: string;
     private _http: NoCorsHttpService;
 
-    constructor(
-        public site: ArmObj<Site>,
-        _ngHttp: Http,
-        private _userService: UserService,
-        private _globalStateService: GlobalStateService,
-        private _translateService: TranslateService,
-        private _broadcastService: BroadcastService,
-        private _armService: ArmService,
-        private _cacheService: CacheService,
-        private _languageService: LanguageService,
-        private _authZService: AuthzService,
-        private _aiService: AiService,
-        private _configService: ConfigService,
-        private _slotsService: SiteService) {
+    private _ngHttp: Http;
+    private _userService: UserService;
+    private _globalStateService: GlobalStateService;
+    private _translateService: TranslateService;
+    private _broadcastService: BroadcastService;
+    private _armService: ArmService;
+    private _cacheService: CacheService;
+    private _languageService: LanguageService;
+    private _authZService: AuthzService;
+    private _aiService: AiService;
+    private _configService: ConfigService;
+    private _slotsService: SiteService;
 
-        this._http = new NoCorsHttpService(_ngHttp, _broadcastService, _aiService, _translateService, () => this.getPortalHeaders());
+    constructor(public site: ArmObj<Site>, injector: Injector) {
 
-        if (!_globalStateService.showTryView) {
+        this._ngHttp = injector.get(Http);
+        this._userService = injector.get(UserService);
+        this._globalStateService = injector.get(GlobalStateService);
+        this._translateService = injector.get(TranslateService);
+        this._broadcastService = injector.get(BroadcastService);
+        this._armService = injector.get(ArmService);
+        this._cacheService = injector.get(CacheService);
+        this._languageService = injector.get(LanguageService);
+        this._authZService = injector.get(AuthzService);
+        this._aiService = injector.get(AiService);
+        this._configService = injector.get(ConfigService);
+        this._slotsService = injector.get(SiteService);
+
+        this._http = new NoCorsHttpService(this._cacheService, this._ngHttp, this._broadcastService, this._aiService, this._translateService, () => this.getPortalHeaders());
+
+        if (!this._globalStateService.showTryView) {
             this._userService.getStartupInfo()
+                .takeUntil(this.ngUnsubscribe)
                 .mergeMap(info => {
                     this.token = info.token;
                     return Observable.zip(
@@ -229,7 +246,7 @@ export class FunctionApp {
             .map((r: Response) => {
                 try {
                     fcs = r.json() as FunctionInfo[];
-                    fcs.forEach(fc => fc.functionApp = this);
+                    // fcs.forEach(fc => fc.functionApp = this);
                     return fcs;
                 } catch (e) {
                     // We have seen this happen when kudu was returning JSON that contained
@@ -526,7 +543,8 @@ export class FunctionApp {
             test_data: null,
             script_root_path_href: null,
             config_href: null,
-            functionApp: null
+            functionApp: null,
+            context: null
         };
     }
 
@@ -648,7 +666,10 @@ export class FunctionApp {
     deleteFunction(functionInfo: FunctionInfo) {
         return this._http.delete(functionInfo.href, { headers: this.getScmSiteHeaders() })
             .map(r => r.statusText)
-            .do(_ => this._broadcastService.broadcast<string>(BroadcastEvent.ClearError, ErrorIds.unableToDeleteFunction + functionInfo.name),
+            .do(_ => {
+                this._cacheService.clearCachePrefix(this.urlTemplates.functionsUrl);
+                this._broadcastService.broadcast<string>(BroadcastEvent.ClearError, ErrorIds.unableToDeleteFunction + functionInfo.name);
+            },
             (error: FunctionsResponse) => {
                 if (!error.isHandled) {
                     this._broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
@@ -674,17 +695,11 @@ export class FunctionApp {
     }
 
     initKeysAndWarmupMainSite() {
-        const warmupSite = this._http.post(this.urlTemplates.pingUrl, '')
+        this._http.post(this.urlTemplates.pingUrl, '')
             .retryWhen(this.retryAntares)
-            .catch(() => Observable.of(null));
+            .subscribe(() =>{});
 
-        const observable = Observable.zip(
-            warmupSite,
-            this.getHostSecretsFromScm(),
-            (w: any, s: any) => ({ warmUp: w, secrets: s })
-        );
-
-        return observable;
+        return this.getHostSecretsFromScm();
     }
 
     @Cache('secrets_file_href')
@@ -1935,5 +1950,9 @@ export class FunctionApp {
         } else {
             return Observable.of(null);
         }
+    }
+
+    dispose() {
+        this.ngUnsubscribe.next();
     }
 }

--- a/AzureFunctions.AngularClient/src/app/shared/function-app.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/function-app.ts
@@ -7,17 +7,7 @@ import { Subject } from 'rxjs/Subject';
 import { SiteService } from './services/slots.service';
 import { Http, Headers, Response, ResponseType } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/catch';
-import 'rxjs/add/operator/delay';
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/mergeMap';
-import 'rxjs/add/operator/retryWhen';
-import 'rxjs/add/operator/scan';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/observable/zip';
 import { TranslateService } from '@ngx-translate/core';
-
 import { ConfigService } from './services/config.service';
 import { NoCorsHttpService } from './no-cors-http-service';
 import { ErrorIds } from './models/error-ids';
@@ -54,7 +44,6 @@ import { Site } from './models/arm/site';
 import { AuthSettings } from './models/auth-settings';
 import { FunctionAppEditMode } from './models/function-app-edit-mode';
 import { HostStatus } from './models/host-status';
-
 import * as jsonschema from 'jsonschema';
 import { reachableInternalLoadBalancerApp } from '../shared/Utilities/internal-load-balancer';
 
@@ -246,7 +235,6 @@ export class FunctionApp {
             .map((r: Response) => {
                 try {
                     fcs = r.json() as FunctionInfo[];
-                    // fcs.forEach(fc => fc.functionApp = this);
                     return fcs;
                 } catch (e) {
                     // We have seen this happen when kudu was returning JSON that contained

--- a/AzureFunctions.AngularClient/src/app/shared/models/api-proxy.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/api-proxy.ts
@@ -66,6 +66,7 @@ export class ApiProxy {
         if (key === 'functionApp') {
             return undefined;
         }
+
         return value;
     }
 

--- a/AzureFunctions.AngularClient/src/app/shared/models/broadcast-event.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/broadcast-event.ts
@@ -1,5 +1,6 @@
 export enum BroadcastEvent {
     TreeNavigation,
+    TreeUpdate,
     FunctionDeleted,
     FunctionAdded,
     FunctionSelected,
@@ -15,7 +16,8 @@ export enum BroadcastEvent {
     RefreshPortal,
     ClearError,
     OpenTab,
-    DirtyStateChange
+    DirtyStateChange,
+    UpdateAppsList
 }
 
 export interface DirtyStateEvent {
@@ -27,4 +29,10 @@ export interface BusyStateEvent{
     busyComponentName: string;
     action: 'setBusyState' | 'clearBusyState' | 'clearOverallBusyState';
     busyStateKey: string;
+}
+
+export interface TreeUpdateEvent{
+    operation: 'add' | 'remove' | 'removeChild' | 'update' | 'navigate';
+    resourceId: string;
+    data?: any;
 }

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -177,6 +177,7 @@ export class ScenarioIds {
     public static readonly enableAlwaysOn = 'EnableAlwaysOn';
     public static readonly deleteAppDirectly = 'deleteAppDirectly';
     public static readonly enableAutoSwap = 'EnableAutoSwap';
+    public static readonly filterAppNodeChildren = 'FilterAppNodeChildren';
 }
 
 export class ServerFarmSku {
@@ -197,6 +198,7 @@ export class NationalCloudArmUris {
 }
 
 export class LogCategories {
+    public static readonly FunctionEdit = 'FunctionEdit';
     public static readonly FunctionMonitor = 'FunctionMonitor';
     public static readonly SideNav = 'SideNav';
     public static readonly siteDashboard = 'SiteDashboard';
@@ -215,6 +217,8 @@ export class LogCategories {
     public static readonly virtualDirectories = 'VirtualDirectories';
     public static readonly logicapps = 'LogicApps';
     public static readonly subsCriptions = 'SubsCriptions';
+    public static readonly functionAppSettings = 'FunctionAppSettings';
+    public static readonly swaggerDefinition = 'SwaggerDefinition';
 }
 
 export class KeyCodes {

--- a/AzureFunctions.AngularClient/src/app/shared/models/function-info.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/function-info.ts
@@ -1,3 +1,4 @@
+import { FunctionAppContext } from './../services/functions-service';
 import { FunctionConfig } from '../models/function-config';
 import { FunctionApp } from '../function-app';
 
@@ -14,6 +15,7 @@ export interface FunctionInfo {
     test_data: string;
     config_href: string;
     functionApp: FunctionApp;
+    context: FunctionAppContext;
 }
 
 export class FunctionInfoHelper {

--- a/AzureFunctions.AngularClient/src/app/shared/models/portal-resources.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/portal-resources.ts
@@ -1,5 +1,6 @@
 // This file is auto generated
-    export class PortalResources
+
+export class PortalResources
 {
     public static azureFunctions: string = "azureFunctions";
     public static azureFunctionsRuntime: string = "azureFunctionsRuntime";

--- a/AzureFunctions.AngularClient/src/app/shared/no-cors-http-service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/no-cors-http-service.ts
@@ -1,3 +1,4 @@
+import { CacheService } from './services/cache.service';
 import { Http, RequestOptionsArgs, Response, ResponseType, Headers } from '@angular/http';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs/Observable';
@@ -14,30 +15,40 @@ import { BroadcastEvent } from './models/broadcast-event';
 
 export class NoCorsHttpService {
     constructor(
+        private _cacheService: CacheService,
         private _http: Http,
         private _broadcastService: BroadcastService,
         private _aiService: AiService,
         private _translateService: TranslateService,
         private portalHeadersCallback: () => Headers) { }
 
-    request(url: string, options?: RequestOptionsArgs): Observable<Response> {
-        return this._http.request(url, options)
-            .catch(e => this.tryPassThroughController(e, options.method.toString(), url, options.body, options));
+    request(url: string, options: RequestOptionsArgs, force?: boolean): Observable<Response> {
+        if (!options || !options.method) {
+            throw Error('options and method are required');
+        }
+
+        return this._cacheService.send(url, options.method as string, force, options.headers, options.body)
+            .catch(e => this.tryPassThroughController(e, options.method.toString(), url, options.body, options))
+            .do(() => {
+                if (options.method === 'PUT' || options.method === 'PATCH' || options.method === 'DELETE') {
+                    this._cacheService.clearCachePrefix(this._getBaseUrl(url));
+                }
+            });
     }
 
     /**
      * Performs a request with `get` http method.
      */
-    get(url: string, options?: RequestOptionsArgs): Observable<Response> {
-        return this._http.get(url, options)
+    get(url: string, options?: RequestOptionsArgs, force?: boolean): Observable<Response> {
+        return this._cacheService.get(url, force, options && options.headers ? options.headers : new Headers())
             .catch(e => this.tryPassThroughController(e, 'GET', url, null, options));
     }
 
     /**
      * Performs a request with `post` http method.
      */
-    post(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
-        return this._http.post(url, body, options)
+    post(url: string, body: any, options?: RequestOptionsArgs, force?: boolean): Observable<Response> {
+        return this._cacheService.post(url, force, options && options.headers ? options.headers : new Headers(), body)
             .catch(e => this.tryPassThroughController(e, 'POST', url, body, options));
     }
 
@@ -45,39 +56,48 @@ export class NoCorsHttpService {
      * Performs a request with `put` http method.
      */
     put(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
-        return this._http.put(url, body, options)
-            .catch(e => this.tryPassThroughController(e, 'PUT', url, body, options));
+        return this._cacheService.put(url, options && options.headers ? options.headers : new Headers(), body)
+            .catch(e => this.tryPassThroughController(e, 'PUT', url, body, options))
+            .do(() => {
+                this._cacheService.clearCachePrefix(this._getBaseUrl(url));
+            });
     }
 
     /**
      * Performs a request with `delete` http method.
      */
     delete(url: string, options?: RequestOptionsArgs): Observable<Response> {
-        return this._http.delete(url, options)
-            .catch(e => this.tryPassThroughController(e, 'DELETE', url, null, options));
+        return this._cacheService.delete(url, options && options.headers ? options.headers : new Headers())
+            .catch(e => this.tryPassThroughController(e, 'DELETE', url, null, options))
+            .do(() => {
+                this._cacheService.clearCachePrefix(this._getBaseUrl(url));
+            });
     }
 
     /**
      * Performs a request with `patch` http method.
      */
     patch(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
-        return this._http.patch(url, body, options)
-            .catch(e => this.tryPassThroughController(e, 'PATCH', url, null, options));
+        return this._cacheService.patch(url, options && options.headers ? options.headers : new Headers())
+            .catch(e => this.tryPassThroughController(e, 'PATCH', url, null, options))
+            .do(() => {
+                this._cacheService.clearCachePrefix(this._getBaseUrl(url));
+            });
     }
 
     /**
      * Performs a request with `head` http method.
      */
-    head(url: string, options?: RequestOptionsArgs): Observable<Response> {
-        return this._http.head(url, options)
+    head(url: string, options?: RequestOptionsArgs, force?: boolean): Observable<Response> {
+        return this._cacheService.head(url, force, options && options.headers ? options.headers : new Headers())
             .catch(e => this.tryPassThroughController(e, 'HEAD', url, null, options));
     }
 
     /**
      * Performs a request with `options` http method.
      */
-    options(url: string, options?: RequestOptionsArgs): Observable<Response> {
-        return this._http.options(url, options)
+    options(url: string, options?: RequestOptionsArgs, force?: boolean): Observable<Response> {
+        return this._cacheService.options(url, force, options && options.headers ? options.headers : new Headers())
             .catch(e => this.tryPassThroughController(e, 'OPTIONS', url, null, options));
     }
 
@@ -130,6 +150,16 @@ export class NoCorsHttpService {
                 });
         } else {
             throw error;
+        }
+    }
+
+    private _getBaseUrl(url: string) {
+        const l = document.createElement('a');
+        l.href = url;
+        if (url.toLowerCase().startsWith('https')) {
+            return `https://${l.hostname}`;
+        } else {
+            return `http://${l.hostname}`;
         }
     }
 }

--- a/AzureFunctions.AngularClient/src/app/shared/resourceDescriptors.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/resourceDescriptors.ts
@@ -5,7 +5,9 @@ export enum ResourceType {
     site,
     serverFarm,
     hostingEnvironment,
-    slot
+    slot,
+    function,
+    proxy
 }
 
 export class Descriptor {
@@ -13,27 +15,30 @@ export class Descriptor {
     public subscription: string;
     public resourceGroup: string;
     public parts: string[];
-    public resourceType = ResourceType.none;
 
     constructor(resourceId: string) {
         this.resourceId = resourceId;
         this.parts = resourceId.split('/').filter(part => !!part);
 
         if (this.parts.length < 4) {
-            throw `resourceId length is too short: ${resourceId}`;
+            throw Error(`resourceId length is too short: ${resourceId}`);
         }
 
         if (this.parts[0].toLowerCase() !== 'subscriptions') {
-            throw `Expected subscriptions segment in resourceId: ${resourceId}`;
+            throw Error(`Expected subscriptions segment in resourceId: ${resourceId}`);
         }
 
         if (this.parts[2].toLowerCase() !== 'resourcegroups') {
-            throw `Expected resourceGroups segment in resourceId: ${resourceId}`;
+            throw Error(`Expected resourceGroups segment in resourceId: ${resourceId}`);
         }
 
         this.subscription = this.parts[1];
         this.resourceGroup = this.parts[3];
     }
+
+    getTrimmedResourceId() {
+        return this.resourceId;
+    };
 
     static getDescriptor(resourceId: string) {
         let parts = resourceId.split('/').filter(part => !!part);
@@ -50,7 +55,6 @@ export class Descriptor {
 export class SiteDescriptor extends Descriptor {
     public site: string;
     public slot: string;
-    public resourceType = ResourceType.site;
 
     private _websiteId: WebsiteId;
 
@@ -58,26 +62,25 @@ export class SiteDescriptor extends Descriptor {
         super(resourceId);
 
         if (this.parts.length < 8) {
-            throw `resourceId length is too short for site descriptor: ${resourceId}`;
+            throw Error(`resourceId length is too short for site descriptor: ${resourceId}`);
         }
 
         if (this.parts[6].toLowerCase() !== 'sites') {
-            throw `Expected sites segment in resourceId: ${resourceId}`;
+            throw Error(`Expected sites segment in resourceId: ${resourceId}`);
         }
 
         this.site = this.parts[7];
 
-        if (this.parts.length > 8 && this.parts[8].toLowerCase() === "slots") {
+        if (this.parts.length > 8 && this.parts[8].toLowerCase() === 'slots') {
             this.slot = this.parts[9];
-            this.resourceType = ResourceType.slot;
         }
     }
 
-    getSiteOnlyResourceId() : string{
+    getSiteOnlyResourceId(): string {
         return `/subscriptions/${this.subscription}/resourceGroups/${this.resourceGroup}/providers/Microsoft.Web/sites/${this.site}`;
     }
 
-    getResourceId() : string{
+    getTrimmedResourceId(): string {
         // resource id without slot information
         let resource = this.getSiteOnlyResourceId();
         // add slots if available
@@ -87,8 +90,8 @@ export class SiteDescriptor extends Descriptor {
         return resource;
     }
 
-    getWebsiteId() : WebsiteId{
-        if(!this._websiteId){
+    getWebsiteId(): WebsiteId {
+        if (!this._websiteId) {
             let name = !this.slot ? this.site : `${this.site}(${this.slot})`;
             this._websiteId = {
                 Name: name,
@@ -101,14 +104,14 @@ export class SiteDescriptor extends Descriptor {
     }
 
     public static getSiteDescriptor(resourceId: string): SiteDescriptor {
-        let parts = resourceId.split("/").filter(part => !!part);
-        let siteId = "";
+        let parts = resourceId.split('/').filter(part => !!part);
+        let siteId = '';
         let maxIndex: number;
 
-        if (parts.length >= 10 && parts[8].toLowerCase() === "slots") {
+        if (parts.length >= 10 && parts[8].toLowerCase() === 'slots') {
             maxIndex = 9;
         }
-        else if (parts.length >= 8 && parts[6].toLowerCase() === "sites") {
+        else if (parts.length >= 8 && parts[6].toLowerCase() === 'sites') {
             maxIndex = 7;
         }
         else {
@@ -116,29 +119,46 @@ export class SiteDescriptor extends Descriptor {
         }
 
         for (let i = 0; i <= maxIndex; i++) {
-            siteId = siteId + "/" + parts[i];
+            siteId = siteId + '/' + parts[i];
         }
 
         return new SiteDescriptor(siteId);
     }
 }
 
-export class FunctionDescriptor extends Descriptor {
-    public functionName;
+export class FunctionDescriptor extends SiteDescriptor {
+    public name;
+    private _isProxy: boolean;
 
     constructor(resourceId: string) {
         super(resourceId);
 
-        if (this.parts.length < 10) {
-            throw "Not enough segments in function id";
-        }
+        if (!this.slot) {
+            if (this.parts.length < 10) {
+                throw Error('Not a site function/proxy id');
+            }
 
-        if ((this.parts[6].toLowerCase() !== "sites" || this.parts[8].toLowerCase() !== "functions")
-            && (this.parts[6].toLowerCase() !== "sites" || this.parts[8].toLowerCase() !== "proxies")) {
-            throw "Not a function/proxy id";
-        }
+            if (this.parts[8].toLowerCase() !== 'functions' && this.parts[8].toLowerCase() !== 'proxies') {
+                throw Error('Not a site function/proxy id');
+            }
 
-        this.functionName = this.parts[9];
+            this._isProxy = this.parts[8].toLowerCase() === 'proxies';
+            this.name = this.parts[9];
+        } else {
+            if (this.parts.length < 12) {
+                throw Error('Not a slot function/proxy id');
+            }
+
+            if (this.parts[10].toLowerCase() !== 'functions' && this.parts[10].toLowerCase() !== 'proxies') {
+                throw Error('Not a slot function/proxy id');
+            }
+
+            this._isProxy = this.parts[10].toLowerCase() === 'proxies';
+            this.name = this.parts[11];
+        }
     }
 
+    getTrimmedResourceId() {
+        return `${super.getTrimmedResourceId()}/${this._isProxy ? 'proxies' : 'functions'}/${this.name}`;
+    }
 }

--- a/AzureFunctions.AngularClient/src/app/shared/services/broadcast.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/broadcast.service.ts
@@ -52,9 +52,10 @@ export class BroadcastService {
         // upper limit so that we don't lose events.
         this._streamMap[BroadcastEvent.UpdateBusyState] = new ReplaySubject(128);
         this._streamMap[BroadcastEvent.TreeNavigation] = new ReplaySubject(1);
+        this._streamMap[BroadcastEvent.TreeUpdate] = new Subject();
         this._streamMap[BroadcastEvent.OpenTab] = new ReplaySubject(1);
         this._streamMap[BroadcastEvent.DirtyStateChange] = new ReplaySubject(1);
-
+        this._streamMap[BroadcastEvent.UpdateAppsList] = new ReplaySubject(1);
     }
 
     // DEPRECATED - Use broadcastEvent

--- a/AzureFunctions.AngularClient/src/app/shared/services/cache.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/cache.service.ts
@@ -39,45 +39,55 @@ export class CacheService {
 
     getArm(resourceId: string, force?: boolean, apiVersion?: string, invokeApi?: boolean): Observable<Response> {
         const url = this._getArmUrl(resourceId, apiVersion);
-        return this._send(url, 'GET', force, null, null, invokeApi);
+        return this.send(url, 'GET', force, null, null, invokeApi);
     }
 
     deleteArm(resourceId: string, force?: boolean, apiVersion?: string, invokeApi?: boolean): Observable<Response> {
         const url = this._getArmUrl(resourceId, apiVersion);
-        return this._send(url, 'DELETE', force, null, null, invokeApi);
+        return this.send(url, 'DELETE', force, null, null, invokeApi);
     }
 
     postArm(resourceId: string, force?: boolean, apiVersion?: string): Observable<Response> {
         const url = this._getArmUrl(resourceId, apiVersion);
-        return this._send(url, 'POST', force);
+        return this.send(url, 'POST', force);
     }
 
     putArm(resourceId: string, apiVersion?: string, content?: any) {
         const url: string = this._getArmUrl(resourceId, apiVersion);
-        delete this._cache[url.toLowerCase()];
         return this._armService.send('PUT', url, content);
     }
 
     patchArm(resourceId: string, apiVersion?: string, content?: any) {
         const url: string = this._getArmUrl(resourceId, apiVersion);
-        delete this._cache[url.toLowerCase()];
         return this._armService.send('PATCH', url, content);
     }
 
     get(url: string, force?: boolean, headers?: Headers, invokeApi?: boolean) {
-        return this._send(url, 'GET', force, headers, null, invokeApi);
+        return this.send(url, 'GET', force, headers, null, invokeApi);
     }
 
     post(url: string, force?: boolean, headers?: Headers, content?: any) {
-        return this._send(url, 'POST', force, headers, content);
+        return this.send(url, 'POST', force, headers, content);
     }
 
-    put(url: string, force?: boolean, headers?: Headers, content?: any) {
-        return this._send(url, 'PUT', force, headers, content);
+    put(url: string, headers?: Headers, content?: any) {
+        return this.send(url, 'PUT', true, headers, content);
     }
 
-    patch(url: string, force?: boolean, headers?: Headers, content?: any) {
-        return this._send(url, "PATCH", force, headers, content);
+    patch(url: string, headers?: Headers, content?: any) {
+        return this.send(url, 'PATCH', true, headers, content);
+    }
+
+    head(url: string, force?: boolean, headers?: Headers) {
+        return this.send(url, 'HEAD', force, headers);
+    }
+
+    delete(url: string, headers?: Headers) {
+        return this.send(url, 'DELETE', true, headers);
+    }
+
+    options(url: string, force?: boolean, headers?: Headers) {
+        return this.send(url, 'OPTIONS', force, headers);
     }
 
     @ClearCache('clearAllCachedData')
@@ -100,45 +110,7 @@ export class CacheService {
         }
     }
 
-    // searchArm(term : string, subs: Subscription[], nextLink : string){
-    //     let url : string;
-    //     if(nextLink){
-    //         url = nextLink;
-    //     }
-    //     else{
-    //         url = `${this._armService.armUrl}/resources?api-version=${this._armService.armApiVersion}&$filter=(`;
-
-    //         for(let i = 0; i < subs.length; i++){
-    //             url += `subscriptionId eq '${subs[i].subscriptionId}'`;
-    //             if(i < subs.length - 1){
-    //                 url += ` or `;
-    //             }
-    //         }
-
-    //         url += `) and (substringof('${term}', name)) and (resourceType eq 'microsoft.web/sites')`;
-    //     }
-
-    //     return this.get(url).map<ArmArrayResult<any>>(r => r.json());
-    // }
-
-    private _cleanUp() {
-        if (!this.cleanUpEnabled) {
-            return;
-        }
-
-        for (const key in this._cache) {
-            if (this._cache.hasOwnProperty(key)) {
-                const item = this._cache[key];
-                if (Date.now() >= item.expireTime) {
-                    delete this._cache[key];
-                }
-            }
-        }
-
-        setTimeout(this._cleanUp.bind(this), this._cleanUpMS);
-    }
-
-    public _send(
+    public send(
         url: string,
         method: string,
         force: boolean,
@@ -170,7 +142,7 @@ export class CacheService {
 
             const responseObs = this._armService.send(method, url, content, etag, headers, invokeApi)
                 .map(response => {
-                    return this._mapAndCacheResponse(response, key);
+                    return this._mapAndCacheResponse(method, response, key);
                 })
                 .share()
                 .catch(error => {
@@ -199,9 +171,16 @@ export class CacheService {
         }
     }
 
-    public _mapAndCacheResponse(response: Response, key: string) {
-        const responseETag = response.headers.get('ETag');
-        this._cache[key] = this.createCacheItem(key, response, responseETag, null, true);
+    public _mapAndCacheResponse(method: string, response: Response, key: string) {
+        // Clear cache for update requests.  Not doing this for POST because ARM doesn't consider that
+        // as an update.  For non-ARM, caller needs to manually clear cache entry.
+        if (method === 'PUT' || method === 'PATCH' || method === 'DELETE') {
+            delete this._cache[key];
+        } else {
+            const responseETag = response.headers.get('ETag');
+            this._cache[key] = this.createCacheItem(key, response, responseETag, null, true);
+        }
+
         return response;
     }
 
@@ -224,6 +203,23 @@ export class CacheService {
             responseObservable: responseObs,
             isRawResponse: isRawResponse
         };
+    }
+
+    private _cleanUp() {
+        if (!this.cleanUpEnabled) {
+            return;
+        }
+
+        for (const key in this._cache) {
+            if (this._cache.hasOwnProperty(key)) {
+                const item = this._cache[key];
+                if (Date.now() >= item.expireTime) {
+                    delete this._cache[key];
+                }
+            }
+        }
+
+        setTimeout(this._cleanUp.bind(this), this._cleanUpMS);
     }
 
     private _getArmUrl(resourceId: string, apiVersion?: string) {

--- a/AzureFunctions.AngularClient/src/app/shared/services/functions-service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/functions-service.ts
@@ -1,0 +1,519 @@
+import { TryFunctionsService } from './try-functions.service';
+import { ApiProxy } from './../models/api-proxy';
+import { WebApiException, FunctionRuntimeError } from './../models/webapi-exception';
+import { AuthSettings } from './../models/auth-settings';
+import { HostingEnvironment } from './../models/arm/hosting-environment';
+import { SiteService } from './slots.service';
+import { FunctionAppEditMode } from 'app/shared/models/function-app-edit-mode';
+import { SiteConfig } from './../models/arm/site-config';
+import { PortalResources } from './../models/portal-resources';
+import { BroadcastEvent } from 'app/shared/models/broadcast-event';
+import { TranslateService } from '@ngx-translate/core';
+import { AiService } from 'app/shared/services/ai.service';
+import { NoCorsHttpService } from './../no-cors-http-service';
+import { BroadcastService } from './broadcast.service';
+import { GlobalStateService } from './global-state.service';
+import { FunctionAppContext } from './functions-service';
+import { Observable } from 'rxjs/Observable';
+import { UserService } from './user.service';
+import { FunctionsResponse } from './../models/functions-response';
+import { ArmUtil } from 'app/shared/Utilities/arm-utils';
+import { ConfigService } from './config.service';
+import { Site } from './../models/arm/site';
+import { ArmObj } from './../models/arm/arm-obj';
+import { FunctionInfo } from './../models/function-info';
+import { CacheService } from 'app/shared/services/cache.service';
+import { Injectable } from '@angular/core';
+import { UrlTemplates } from 'app/shared/url-templates';
+import { Http, Headers, Response } from '@angular/http';
+import { ErrorIds } from '../models/error-ids';
+import { ErrorEvent, ErrorType } from '../models/error-event';
+import { Constants } from 'app/shared/models/constants';
+import * as jsonschema from 'jsonschema';
+
+export interface FunctionAppContext {
+    site: ArmObj<Site>;
+    scmUrl: string;
+    mainSiteUrl: string;
+    urlTemplates: UrlTemplates;
+    tryFunctionsScmCreds?: string;
+    masterKey?: string;
+}
+
+@Injectable()
+export class FunctionsService {
+    private _token: string;
+
+    private _http: NoCorsHttpService;
+
+    constructor(
+        private _cacheService: CacheService,
+        private _configService: ConfigService,
+        private _userService: UserService,
+        private _globalStateService: GlobalStateService,
+        private _broadcastService: BroadcastService,
+        private _ngHttp: Http,
+        private _aiService: AiService,
+        private _translateService: TranslateService,
+        private _siteService: SiteService,
+        private _tryFunctionsService: TryFunctionsService) {
+
+        this._http = new NoCorsHttpService(this._cacheService, this._ngHttp, this._broadcastService, this._aiService, this._translateService, () => this._getPortalHeaders());
+
+        this._userService.getStartupInfo()
+            .subscribe(info => {
+                this._token = info.token;
+            });
+    }
+
+    getAppContext(siteResourceId: string): Observable<FunctionAppContext> {
+        let context: FunctionAppContext;
+
+        return this._cacheService.getArm(siteResourceId)
+            .switchMap(r => {
+                const site: ArmObj<Site> = r.json();
+                const scmUrl = this.getScmUrl(site);
+                const mainSiteUrl = this.getMainUrl(site);
+
+                context = {
+                    site: site,
+                    scmUrl: scmUrl,
+                    mainSiteUrl: mainSiteUrl,
+                    urlTemplates: new UrlTemplates(scmUrl, mainSiteUrl, ArmUtil.isLinuxApp(site))
+                };
+
+                return this._initKeysAndWarmupMainSite(context);
+            })
+            .map(r => context);
+    }
+
+    getFunction(context: FunctionAppContext, functionName: string) {
+        return this.getFunctions(context)
+            .map(fcs => {
+                return fcs && fcs.find(f => f.name.toLowerCase() === functionName.toLowerCase());
+            });
+    }
+
+    getFunctions(context: FunctionAppContext) {
+        let fcs: FunctionInfo[];
+
+        return this._cacheService.get(context.urlTemplates.functionsUrl, false, this._getScmSiteHeaders(context))
+            .catch(() => this._http.get(context.urlTemplates.functionsUrl, { headers: this._getScmSiteHeaders(context) }))
+            .retryWhen(this.retryAntares)
+            .map((r: Response) => {
+                try {
+                    fcs = r.json() as FunctionInfo[];
+                    // fcs.forEach(fc => fc.functionApp = this);
+                    fcs.forEach(fc => fc.context = context);
+                    return fcs;
+                } catch (e) {
+                    // We have seen this happen when kudu was returning JSON that contained
+                    // comments because Json.NET is okay with comments in the JSON file.
+                    // We can't parse that JSON in browser, so this is just to handle the error correctly.
+                    this._broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
+                        message: this._translateService.instant(PortalResources.error_parsingFunctionListReturenedFromKudu),
+                        errorId: ErrorIds.deserializingKudusFunctionList,
+                        errorType: ErrorType.Fatal,
+                        resourceId: context.site.id
+                    });
+                    this._trackEvent(context, ErrorIds.deserializingKudusFunctionList, {
+                        error: e,
+                        content: r.text(),
+                    });
+                    return <FunctionInfo[]>[];
+                }
+            })
+            .do(() => this._broadcastService.broadcast<string>(BroadcastEvent.ClearError, ErrorIds.unableToRetrieveFunctionsList),
+            (error: FunctionsResponse) => {
+                if (!error.isHandled) {
+                    this._broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
+                        message: this._translateService.instant(PortalResources.error_unableToRetrieveFunctionListFromKudu),
+                        errorId: ErrorIds.unableToRetrieveFunctionsList,
+                        errorType: ErrorType.RuntimeError,
+                        resourceId: context.site.id
+                    });
+                    this._trackEvent(context, ErrorIds.unableToRetrieveFunctionsList, {
+                        content: error.text(),
+                        status: error.status.toString()
+                    });
+                }
+            });
+    }
+
+    getApiProxies(context: FunctionAppContext) {
+        return Observable.zip(
+            this._cacheService.get(context.urlTemplates.proxiesJsonUrl, false, this._getScmSiteHeaders(context))
+                .catch(() => this._http.get(context.urlTemplates.proxiesJsonUrl, { headers: this._getScmSiteHeaders(context) }))
+                .retryWhen(e => e.scan((errorCount: number, err: Response) => {
+                    if (err.status === 404 || errorCount >= 10) {
+                        throw err;
+                    }
+                    return errorCount + 1;
+                }, 0).delay(200))
+                .catch(_ => Observable.of({
+                    json: () => { return {}; }
+                })),
+            this._cacheService.get('assets/schemas/proxies.json', false, this._getPortalHeaders()),
+            (p, s) => ({ proxies: p, schema: s.json() })
+        ).map(r => {
+            let proxies = null;
+            try {
+                proxies = r.proxies.json();
+            } catch (e) {
+                this._broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
+                    message: `${this._translateService.instant(PortalResources.error_schemaValidationProxies)}. ${e}`,
+                    errorId: ErrorIds.proxySchemaValidationFails,
+                    errorType: ErrorType.Fatal,
+                    resourceId: context.site.id
+                });
+                return ApiProxy.fromJson({});
+            }
+
+            if (proxies.proxies) {
+                const validateResult = jsonschema.validate(proxies, r.schema).toString();
+
+                if (validateResult) {
+                    this._broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
+                        message: `${this._translateService.instant(PortalResources.error_schemaValidationProxies)}. ${validateResult}`,
+                        errorId: ErrorIds.proxySchemaValidationFails,
+                        errorType: ErrorType.Fatal,
+                        resourceId: context.site.id
+                    });
+                    return ApiProxy.fromJson({});
+                }
+            }
+            return ApiProxy.fromJson(proxies);
+        });
+    }
+
+    getScmUrl(site: ArmObj<Site>) {
+        if (this._configService.isStandalone()) {
+            return this.getMainUrl(site);
+        } else {
+            return `https://${site.properties.hostNameSslStates.find(s => s.hostType === 1).name}`;
+        }
+    }
+
+    getMainUrl(site: ArmObj<Site>) {
+        if (this._configService.isStandalone()) {
+            return `https://${site.properties.defaultHostName}/functions/${site.name}`;
+        } else {
+            return `https://${site.properties.defaultHostName}`;
+        }
+    }
+
+    // private _editModeSubject: Subject<FunctionAppEditMode>;
+    getFunctionAppEditMode(context: FunctionAppContext): Observable<FunctionAppEditMode> {
+        // The we have 2 settings to check here. There is the SourceControl setting which comes from /config/web
+        // and there is FUNCTION_APP_EDIT_MODE which comes from app settings.
+        // editMode (true -> readWrite, false -> readOnly)
+        // Table
+        // |Slots | SourceControl | AppSettingValue | EditMode                      |
+        // |------|---------------|-----------------|-------------------------------|
+        // | No   | true          | readWrite       | ReadWriteSourceControlled     |
+        // | No   | true          | readOnly        | ReadOnlySourceControlled      |
+        // | No   | true          | undefined       | ReadOnlySourceControlled      |
+        // | No   | false         | readWrite       | ReadWrite                     |
+        // | No   | false         | readOnly        | ReadOnly                      |
+        // | No   | false         | undefined       | ReadWrite                     |
+
+        // | Yes  | true          | readWrite       | ReadWriteSourceControlled     |
+        // | Yes  | true          | readOnly        | ReadOnlySourceControlled      |
+        // | Yes  | true          | undefined       | ReadOnlySourceControlled      |
+        // | Yes  | false         | readWrite       | ReadWrite                     |
+        // | Yes  | false         | readOnly        | ReadOnly                      |
+        // | Yes  | false         | undefined       | ReadOnlySlots                 |
+        // |______|_______________|_________________|_______________________________|
+        // if (!this._editModeSubject) {
+        //     this._editModeSubject = new Subject<FunctionAppEditMode>();
+        // }
+
+        return Observable.zip(
+            this._checkIfSourceControlEnabled(context.site),
+            this._cacheService.postArm(`${context.site.id}/config/appsettings/list`, true),
+            SiteService.isSlot(context.site.id)
+                ? Observable.of(true)
+                : this._siteService.getSlotsList(context.site.id).map(r => r.length > 0),
+            this.getFunctions(context),
+            (a, b, s, f: FunctionInfo[]) => ({ sourceControlEnabled: a, appSettingsResponse: b, hasSlots: s, functions: f })
+        )
+            .map(result => {
+                const appSettings: ArmObj<any> = result.appSettingsResponse.json();
+                const sourceControlled = result.sourceControlEnabled;
+
+                let editModeSettingString: string = appSettings.properties[Constants.functionAppEditModeSettingName] || '';
+                editModeSettingString = editModeSettingString.toLocaleLowerCase();
+                const vsCreatedFunc = result.functions.find((fc: any) => !!fc.config.generatedBy);
+                if (vsCreatedFunc) {
+                    return FunctionAppEditMode.ReadOnlyVSGenerated;
+                }
+                if (editModeSettingString === Constants.ReadWriteMode) {
+                    return sourceControlled ? FunctionAppEditMode.ReadWriteSourceControlled : FunctionAppEditMode.ReadWrite;
+                } else if (editModeSettingString === Constants.ReadOnlyMode) {
+                    return sourceControlled ? FunctionAppEditMode.ReadOnlySourceControlled : FunctionAppEditMode.ReadOnly;
+                } else if (sourceControlled) {
+                    return FunctionAppEditMode.ReadOnlySourceControlled;
+                } else {
+                    return result.hasSlots ? FunctionAppEditMode.ReadOnlySlots : FunctionAppEditMode.ReadWrite;
+                }
+            })
+            .catch(() => Observable.of(FunctionAppEditMode.ReadWrite))
+        // .subscribe(r => this._editModeSubject.next(r));
+
+        // return this._editModeSubject;
+    }
+
+    reachableInternalLoadBalancerApp(context: FunctionAppContext, http: CacheService): Observable<boolean> {
+        if (context && context.site &&
+            context.site.properties.hostingEnvironmentProfile &&
+            context.site.properties.hostingEnvironmentProfile.id) {
+            return http.getArm(context.site.properties.hostingEnvironmentProfile.id, false, '2016-09-01')
+                .mergeMap(r => {
+                    const ase: ArmObj<HostingEnvironment> = r.json();
+                    if (ase.properties.internalLoadBalancingMode &&
+                        ase.properties.internalLoadBalancingMode !== 'None') {
+                        return this.pingScmSite(context);
+                    } else {
+                        return Observable.of(true);
+                    }
+                });
+        } else {
+            return Observable.of(true);
+        }
+    }
+
+    /**
+     * This method just pings the root of the SCM site. It doesn't care about the response in anyway or use it.
+     */
+    pingScmSite(context: FunctionAppContext): Observable<boolean> {
+        return this._http.get(context.urlTemplates.pingScmSiteUrl, { headers: this._getScmSiteHeaders(context) })
+            .map(_ => true)
+            .catch(() => Observable.of(false));
+    }
+
+    public getAuthSettings(context: FunctionAppContext): Observable<AuthSettings> {
+        if (context.tryFunctionsScmCreds) {
+            return Observable.of({
+                easyAuthEnabled: false,
+                AADConfigured: false,
+                AADNotConfigured: false,
+                clientCertEnabled: false
+            });
+        }
+
+        return this._cacheService.postArm(`${context.site.id}/config/authsettings/list`)
+            .map(r => {
+                const auth: ArmObj<any> = r.json();
+                return {
+                    easyAuthEnabled: auth.properties['enabled'] && auth.properties['unauthenticatedClientAction'] !== 1,
+                    AADConfigured: auth.properties['clientId'] ? true : false,
+                    AADNotConfigured: auth.properties['clientId'] ? false : true,
+                    clientCertEnabled: context.site.properties.clientCertEnabled
+                };
+            });
+    }
+
+    private _initKeysAndWarmupMainSite(context: FunctionAppContext) {
+        this._http.post(context.urlTemplates.pingUrl, '')
+            .retryWhen(this.retryAntares)
+            .subscribe(() => { });
+
+        return this._getHostSecretsFromScm(context);
+    }
+
+    private _getHostSecretsFromScm(context: FunctionAppContext) {
+        return this.reachableInternalLoadBalancerApp(context, this._cacheService)
+            .filter(i => i)
+            .mergeMap(() => this.getAuthSettings(context))
+            .mergeMap(authSettings => {
+                return authSettings.clientCertEnabled
+                    ? Observable.of()
+                    : this._getHostToken(context)
+                        .retryWhen(this.retryAntares)
+                        .map(r => r.json())
+                        .mergeMap((token: string) => {
+                            // Call the main site to get the masterKey
+                            // build authorization header
+                            const authHeader = new Headers();
+                            authHeader.append('Authorization', `Bearer ${token}`);
+                            return this._http.get(context.urlTemplates.masterKeyUrl, { headers: authHeader })
+                                .catch((error: FunctionsResponse) => {
+                                    if (error.status === 405) {
+                                        // If the result from calling the API above is 405, that means they are running on an older runtime.
+                                        // It should be safe to call kudu for the master key since they won't be using slots.
+                                        return this._http.get(context.urlTemplates.deprecatedKuduMasterKeyUrl, { headers: this._getScmSiteHeaders(context) });
+                                    } else {
+                                        throw error;
+                                    }
+                                })
+                                .retryWhen(error => error.scan((errorCount: number, err: FunctionsResponse) => {
+                                    if (err.isHandled || (err.status < 500 && err.status !== 401) || errorCount >= 30) {
+                                        throw err;
+                                    } else {
+                                        return errorCount + 1;
+                                    }
+                                }, 0).delay(1000))
+                                .catch(e => this._http.get(context.urlTemplates.runtimeStatusUrl, { headers: authHeader })
+                                    .do(null, _ => this._broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
+                                        message: this._translateService.instant(PortalResources.error_functionRuntimeIsUnableToStart),
+                                        errorId: ErrorIds.functionRuntimeIsUnableToStart,
+                                        errorType: ErrorType.Fatal,
+                                        resourceId: context.site.id
+                                    })).map(_ => { throw e; })) // if /status call is successful, then throw the original error
+                                .do((r: Response) => {
+                                    // Since we fall back to kudu above, use a union of kudu and runtime types.
+                                    const key: { name: string, value: string } & { masterKey: string } = r.json();
+                                    if (key.masterKey) {
+                                        context.masterKey = key.masterKey;
+                                    } else {
+                                        context.masterKey = key.value;
+                                    }
+                                });
+                        })
+                        .do(() => {
+                            this._broadcastService.broadcast<string>(BroadcastEvent.ClearError, ErrorIds.unableToRetrieveRuntimeKeyFromScm);
+                        },
+                        (error: FunctionsResponse) => {
+                            if (!error.isHandled) {
+                                try {
+                                    const exception: WebApiException & FunctionRuntimeError = error.json();
+                                    if (exception.ExceptionType === 'System.Security.Cryptography.CryptographicException') {
+                                        this._broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
+                                            message: this._translateService.instant(PortalResources.error_unableToDecryptKeys),
+                                            errorId: ErrorIds.unableToDecryptKeys,
+                                            errorType: ErrorType.RuntimeError,
+                                            resourceId: context.site.id
+                                        });
+                                        this._trackEvent(context, ErrorIds.unableToDecryptKeys, {
+                                            content: error.text(),
+                                            status: error.status.toString()
+                                        });
+                                        return;
+                                    } else if (exception.message || exception.messsage) {
+                                        this._broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
+                                            message: exception.message || exception.messsage,
+                                            errorId: ErrorIds.unableToDecryptKeys,
+                                            errorType: ErrorType.RuntimeError,
+                                            resourceId: context.site.id
+                                        });
+                                        this._trackEvent(context, ErrorIds.unableToDecryptKeys, {
+                                            content: error.text(),
+                                            status: error.status.toString()
+                                        });
+                                        return;
+                                    }
+                                } catch (e) {
+                                    // no-op
+                                }
+                                this._broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
+                                    message: this._translateService.instant(PortalResources.error_unableToRetrieveRuntimeKey),
+                                    errorId: ErrorIds.unableToRetrieveRuntimeKeyFromScm,
+                                    errorType: ErrorType.RuntimeError,
+                                    resourceId: context.site.id
+                                });
+                                this._trackEvent(context, ErrorIds.unableToRetrieveRuntimeKeyFromScm, {
+                                    status: error.status.toString(),
+                                    content: error.text(),
+                                });
+                            }
+                        });
+            });
+    }
+
+    fireSyncTrigger(context: FunctionAppContext) {
+        const url = context.urlTemplates.syncTriggersUrl;
+        this._http.post(url, '', { headers: this._getScmSiteHeaders(context) })
+            .subscribe(success => console.log(success), error => console.log(error));
+    }
+
+    private _getHostToken(context: FunctionAppContext) {
+        return ArmUtil.isLinuxApp(context.site)
+            ? this._http.get(Constants.serviceHost + `api/runtimetoken${context.site.id}`, { headers: this._getPortalHeaders() })
+            : this._http.get(context.urlTemplates.scmTokenUrl, { headers: this._getScmSiteHeaders(context) });
+    }
+
+    private _checkIfSourceControlEnabled(site: ArmObj<Site>): Observable<boolean> {
+        return this._cacheService.getArm(`${site.id}/config/web`)
+            .map(r => {
+                const config: ArmObj<SiteConfig> = r.json();
+                return !config.properties['scmType'] || config.properties['scmType'] !== 'None';
+            })
+            .catch(() => Observable.of(false));
+    }
+
+    // to talk to scm site
+    private _getScmSiteHeaders(context: FunctionAppContext, contentType?: string): Headers {
+        contentType = contentType || 'application/json';
+
+        const headers = new Headers();
+        headers.append('Content-Type', contentType);
+        headers.append('Accept', 'application/json,*/*');
+        if (!this._globalStateService.showTryView && this._token) {
+            headers.append('Authorization', `Bearer ${this._token}`);
+        }
+
+        if (this._tryFunctionsService.functionContainer && this._tryFunctionsService.functionContainer.tryScmCred) {
+            headers.append('Authorization', `Basic ${this._tryFunctionsService.functionContainer.tryScmCred}`);
+        }
+
+        if (context.masterKey) {
+            headers.append('x-functions-key', context.masterKey);
+        }
+
+        return headers;
+    }
+
+    // private _getMainSiteHeaders(contentType?: string): Headers {
+    //     contentType = contentType || 'application/json';
+    //     const headers = new Headers();
+    //     headers.append('Content-Type', contentType);
+    //     headers.append('Accept', 'application/json,*/*');
+    //     headers.append('x-functions-key', this.masterKey);
+    //     return headers;
+    // }
+
+    // to talk to Functions Portal
+    private _getPortalHeaders(contentType?: string): Headers {
+        contentType = contentType || 'application/json';
+        const headers = new Headers();
+        headers.append('Content-Type', contentType);
+        headers.append('Accept', 'application/json,*/*');
+
+        if (this._token) {
+            headers.append('client-token', this._token);
+            headers.append('portal-token', this._token);
+        }
+
+        return headers;
+    }
+
+    /**
+     * This function is just a wrapper around AiService.trackEvent. It injects default params expected from this class.
+     * Currently that's only scmUrl
+     * @param params any additional parameters to get added to the default parameters that this class reports to AppInsights
+     */
+    private _trackEvent(context: FunctionAppContext, name: string, params: { [name: string]: string }) {
+        const standardParams = {
+            scmUrl: context.urlTemplates.pingScmSiteUrl
+        };
+
+        for (const key in params) {
+            if (params.hasOwnProperty(key)) {
+                standardParams[key] = params[key];
+            }
+        }
+
+        this._aiService.trackEvent(name, standardParams);
+    }
+
+
+    private retryAntares(error: Observable<any>): Observable<any> {
+        return error.scan((errorCount: number, err: FunctionsResponse) => {
+            if (err.isHandled || err.status < 500 || errorCount >= 10) {
+                throw err;
+            } else {
+                return errorCount + 1;
+            }
+        }, 0).delay(1000);
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/shared/services/functions-service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/functions-service.ts
@@ -103,7 +103,6 @@ export class FunctionsService {
             .map((r: Response) => {
                 try {
                     fcs = r.json() as FunctionInfo[];
-                    // fcs.forEach(fc => fc.functionApp = this);
                     fcs.forEach(fc => fc.context = context);
                     return fcs;
                 } catch (e) {
@@ -202,7 +201,6 @@ export class FunctionsService {
         }
     }
 
-    // private _editModeSubject: Subject<FunctionAppEditMode>;
     getFunctionAppEditMode(context: FunctionAppContext): Observable<FunctionAppEditMode> {
         // The we have 2 settings to check here. There is the SourceControl setting which comes from /config/web
         // and there is FUNCTION_APP_EDIT_MODE which comes from app settings.
@@ -224,9 +222,6 @@ export class FunctionsService {
         // | Yes  | false         | readOnly        | ReadOnly                      |
         // | Yes  | false         | undefined       | ReadOnlySlots                 |
         // |______|_______________|_________________|_______________________________|
-        // if (!this._editModeSubject) {
-        //     this._editModeSubject = new Subject<FunctionAppEditMode>();
-        // }
 
         return Observable.zip(
             this._checkIfSourceControlEnabled(context.site),
@@ -257,10 +252,7 @@ export class FunctionsService {
                     return result.hasSlots ? FunctionAppEditMode.ReadOnlySlots : FunctionAppEditMode.ReadWrite;
                 }
             })
-            .catch(() => Observable.of(FunctionAppEditMode.ReadWrite))
-        // .subscribe(r => this._editModeSubject.next(r));
-
-        // return this._editModeSubject;
+            .catch(() => Observable.of(FunctionAppEditMode.ReadWrite));
     }
 
     reachableInternalLoadBalancerApp(context: FunctionAppContext, http: CacheService): Observable<boolean> {
@@ -462,15 +454,6 @@ export class FunctionsService {
 
         return headers;
     }
-
-    // private _getMainSiteHeaders(contentType?: string): Headers {
-    //     contentType = contentType || 'application/json';
-    //     const headers = new Headers();
-    //     headers.append('Content-Type', contentType);
-    //     headers.append('Accept', 'application/json,*/*');
-    //     headers.append('x-functions-key', this.masterKey);
-    //     return headers;
-    // }
 
     // to talk to Functions Portal
     private _getPortalHeaders(contentType?: string): Headers {

--- a/AzureFunctions.AngularClient/src/app/shared/services/functions.service.spec.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/functions.service.spec.ts
@@ -2,14 +2,14 @@ import { AppModule } from './../../app.module';
 /* tslint:disable:no-unused-variable */
 
 import { TestBed, async, inject } from '@angular/core/testing';
-import { FunctionsService } from './functions.service';
+import { TryFunctionsService } from './try-functions.service';
 
 describe('Service: Functions', () => {
   beforeEach(() => {
     TestBed.configureTestingModule(AppModule.moduleDefinition);
   });
 
-  it('should ...', inject([FunctionsService], (service: FunctionsService) => {
+  it('should ...', inject([TryFunctionsService], (service: TryFunctionsService) => {
     expect(service).toBeTruthy();
   }));
 });

--- a/AzureFunctions.AngularClient/src/app/shared/services/global-state.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/global-state.service.ts
@@ -8,11 +8,11 @@ import { TopBarNotification } from './../../top-bar/top-bar-models';
 import { FunctionContainer } from '../models/function-container';
 import { UserService } from './user.service';
 import { BusyStateComponent } from '../../busy-state/busy-state.component';
-import { FunctionsService } from './functions.service';
+import { TryFunctionsService } from './try-functions.service';
 
 @Injectable()
 export class GlobalStateService {
-    public _functionsService: FunctionsService;
+    public _functionsService: TryFunctionsService;
     public showTryView: boolean;
     public showTopbar: boolean;
     public isAlwaysOn = true;

--- a/AzureFunctions.AngularClient/src/app/shared/services/log.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/log.service.ts
@@ -2,12 +2,14 @@ import { AiService } from 'app/shared/services/ai.service';
 import { Injectable } from '@angular/core';
 import { Url } from 'app/shared/Utilities/url';
 
-enum LogLevel {
+export enum LogLevel {
     error,
     warning,
     debug,
     verbose
 }
+
+export type LogLevelString = 'error' | 'warning' | 'debug' | 'verbose';
 
 @Injectable()
 export class LogService {
@@ -36,7 +38,7 @@ export class LogService {
             throw Error('You must provide a category, id, and data');
         }
 
-        const errorId = `/errors${id}`;
+        const errorId = `/errors/${category}/${id}`;
 
         // Always log errors to App Insights
         this._aiService.trackEvent(errorId, data);
@@ -51,7 +53,7 @@ export class LogService {
             throw Error('You must provide a category, id, and data');
         }
 
-        const warningId = `/warnings${id}`;
+        const warningId = `/warnings/${category}/${id}`;
 
         // Always log warnings to App Insights
         this._aiService.trackEvent(warningId, data);
@@ -67,7 +69,7 @@ export class LogService {
         }
 
         if (this._shouldLog(category, LogLevel.debug)) {
-            console.log(`%c[${category}] - ${data}`, 'color: #0058ad');
+            console.log(`${this._getTime()} %c[${category}] - ${data}`, 'color: #0058ad');
         }
     }
 
@@ -78,6 +80,22 @@ export class LogService {
 
         if (this._shouldLog(category, LogLevel.verbose)) {
             console.log(`${this._getTime()} [${category}] - ${data}`);
+        }
+    }
+
+    public log(level: LogLevel, category: string, data: any, id?: string){
+        if(!id && (level === LogLevel.error || level === LogLevel.warning)){
+            throw Error('Error and Warning log levels require an id');
+        }
+
+        if(level === LogLevel.error){
+            this.error(category, id, data);
+        } else if(level === LogLevel.warning){
+            this.warn(category, id, data);
+        } else if(level === LogLevel.debug){
+            this.debug(category, data);
+        } else{
+            this.verbose(category, data);
         }
     }
 

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/azure-try.environment.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/azure-try.environment.ts
@@ -1,0 +1,32 @@
+import { DashboardType } from 'app/tree-view/models/dashboard-type';
+import { ScenarioCheckInput, ScenarioResult } from './scenario.models';
+import { ScenarioIds } from './../../models/constants';
+import { Environment } from 'app/shared/services/scenario/scenario.models';
+import { Url } from 'app/shared/Utilities/url';
+
+export class AzureTryEnvironment extends Environment {
+    name = 'Azure';
+
+    constructor() {
+        super();
+
+        this.scenarioChecks[ScenarioIds.filterAppNodeChildren] = {
+            id: ScenarioIds.filterAppNodeChildren,
+            runCheck: (input: ScenarioCheckInput) => {
+                return this._filterAppNodeChildren(input);
+            }
+        };
+    }
+
+    public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {
+        return Url.getParameterByName(null, 'trial') === 'true';
+    }
+
+    private _filterAppNodeChildren(input: ScenarioCheckInput){
+        const data = input.appNodeChildren.find(c => c.dashboardType === DashboardType.FunctionsDashboard);
+        return <ScenarioResult>{
+            status: 'enabled',
+            data: [data]
+        };
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/scenario.models.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/scenario.models.ts
@@ -1,9 +1,11 @@
+import { TreeNode } from './../../../tree-view/tree-node';
 import { Observable } from 'rxjs/Observable';
 import { Site } from './../../models/arm/site';
 import { ArmObj } from './../../models/arm/arm-obj';
 
 export interface ScenarioCheckInput {
     site?: ArmObj<Site>;
+    appNodeChildren?: TreeNode[];
 }
 
 export type ScenarioStatus = 'enabled' | 'disabled' | null;

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/site-slot.environment.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/site-slot.environment.ts
@@ -1,9 +1,10 @@
+import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { PortalResources } from './../../models/portal-resources';
 import { TranslateService } from '@ngx-translate/core';
 import { SiteDescriptor } from 'app/shared/resourceDescriptors';
 import { ScenarioCheckInput } from './scenario.models';
 import { ScenarioIds } from './../../models/constants';
-import { Environment } from 'app/shared/services/scenario/scenario.models';
+import { Environment, ScenarioResult } from 'app/shared/services/scenario/scenario.models';
 
 export class SiteSlotEnvironment extends Environment {
     name = 'SiteSlot';
@@ -27,6 +28,12 @@ export class SiteSlotEnvironment extends Environment {
             }
         };
 
+        this.scenarioChecks[ScenarioIds.filterAppNodeChildren] = {
+            id: ScenarioIds.filterAppNodeChildren,
+            runCheck: (input: ScenarioCheckInput) => {
+                return this._filterAppNodeChildren(input);
+            }
+        };
     }
 
     public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {
@@ -36,5 +43,19 @@ export class SiteSlotEnvironment extends Environment {
         }
 
         return false;
+    }
+
+    private _filterAppNodeChildren(input: ScenarioCheckInput) {
+        const descriptor = new SiteDescriptor(input.site.id);
+        let data = input.appNodeChildren;
+
+        if (descriptor.slot) {
+            data = input.appNodeChildren.filter(c => c.dashboardType !== DashboardType.SlotsDashboard);
+        }
+
+        return <ScenarioResult>{
+            status: 'enabled',
+            data: data
+        };
     }
 }

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/stand-alone.environment.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/stand-alone.environment.ts
@@ -1,4 +1,5 @@
-import { ScenarioCheckInput } from './scenario.models';
+import { DashboardType } from 'app/tree-view/models/dashboard-type';
+import { ScenarioCheckInput, ScenarioResult } from './scenario.models';
 import { ScenarioIds } from './../../models/constants';
 import { Environment } from 'app/shared/services/scenario/scenario.models';
 
@@ -48,9 +49,24 @@ export class StandaloneEnvironment extends Environment {
                 return { status: 'enabled' };
             }
         };
+
+        this.scenarioChecks[ScenarioIds.filterAppNodeChildren] = {
+            id: ScenarioIds.filterAppNodeChildren,
+            runCheck: (input: ScenarioCheckInput) => {
+                return this._filterAppNodeChildren(input);
+            }
+        };
     }
 
     public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {
         return window.appsvc.env.runtimeType === 'Standalone';
+    }
+
+    private _filterAppNodeChildren(input: ScenarioCheckInput){
+        const data = input.appNodeChildren.find(c => c.dashboardType === DashboardType.FunctionsDashboard);
+        return <ScenarioResult>{
+            status: 'enabled',
+            data: [data]
+        };
     }
 }

--- a/AzureFunctions.AngularClient/src/app/shared/services/try-functions.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/try-functions.service.ts
@@ -19,9 +19,8 @@ import { UIResource, ITryAppServiceTemplate } from '../models/ui-resource';
 import { Cookie } from 'ng2-cookies/ng2-cookies';
 
 @Injectable()
-export class FunctionsService {
+export class TryFunctionsService {
     private token: string;
-    private _scmUrl: string;
     public isEasyAuthEnabled: boolean;
     public selectedFunction: string;
     public selectedLanguage: string;
@@ -31,7 +30,7 @@ export class FunctionsService {
     public isMultiKeySupported = true;
 
     private tryAppServiceUrl = 'https://tryappservice.azure.com';
-    private functionContainer: FunctionContainer;
+    public functionContainer: FunctionContainer;
 
     constructor(private _http: Http,
         private _userService: UserService,
@@ -107,16 +106,6 @@ export class FunctionsService {
         return this._http.post(url, JSON.stringify(template), { headers: this.getTryAppServiceHeaders() })
             .retryWhen(this.retryCreateTrialResource)
             .map(r => <UIResource>r.json());
-    }
-
-    getFunctionAppArmId() {
-        if (this.functionContainer && this.functionContainer.id && this.functionContainer.id.trim().length !== 0) {
-            return this.functionContainer.id;
-        } else if (this._scmUrl) {
-            return this._scmUrl;
-        } else {
-            return 'Unknown';
-        }
     }
 
     // to talk to Functions Portal

--- a/AzureFunctions.AngularClient/src/app/shared/shared.module.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/shared.module.ts
@@ -1,3 +1,4 @@
+import { FunctionsService } from './services/functions-service';
 import { IsDirtyDirective } from './directives/is-dirty.directive';
 import { LoadImageDirective } from './../controls/load-image/load-image.directive';
 import { SlideToggleComponent } from './../controls/slide-toggle/slide-toggle.component';
@@ -19,7 +20,7 @@ import { FunctionMonitorService } from './services/function-monitor.service';
 import { BroadcastService } from 'app/shared/services/broadcast.service';
 import { PortalService } from './services/portal.service';
 import { LanguageService } from './services/language.service';
-import { FunctionsService } from './services/functions.service';
+import { TryFunctionsService } from './services/try-functions.service';
 import { ConfigService } from 'app/shared/services/config.service';
 import { SearchBoxComponent } from './../search-box/search-box.component';
 import { CopyPreComponent } from './../copy-pre/copy-pre.component';
@@ -50,6 +51,7 @@ import { ArmService } from 'app/shared/services/arm.service';
 import { Url } from 'app/shared/Utilities/url';
 import { EmptyDashboardComponent } from 'app/main/empty-dashboard.component';
 import { InfoBoxComponent } from './../controls/info-box/info-box.component';
+import { LogMessageDirective } from 'app/shared/directives/log-message.directive';
 
 export function ArmServiceFactory(
     http: Http,
@@ -81,6 +83,7 @@ export function AiServiceFactory() {
         CommandComponent,
         CheckScenarioDirective,
         DynamicLoaderDirective,
+        LogMessageDirective,
         IsDirtyDirective,
         RadioSelectorComponent,
         PopOverComponent,
@@ -111,6 +114,7 @@ export function AiServiceFactory() {
         CommandComponent,
         CheckScenarioDirective,
         DynamicLoaderDirective,
+        LogMessageDirective,
         IsDirtyDirective,
         RadioSelectorComponent,
         PopOverComponent,
@@ -138,6 +142,7 @@ export class SharedModule {
             ngModule: SharedModule,
             providers: [
                 ConfigService,
+                TryFunctionsService,
                 FunctionsService,
                 UserService,
                 LanguageService,

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
@@ -10,9 +10,6 @@ import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/mergeMap';
-import 'rxjs/add/observable/of';
 import { TranslateService } from '@ngx-translate/core';
 import { ConfigService } from './../shared/services/config.service';
 import { FunctionApp } from './../shared/function-app';
@@ -39,7 +36,6 @@ import { DashboardType } from '../tree-view/models/dashboard-type';
 import { Subscription } from '../shared/models/subscription';
 import { SiteService } from './../shared/services/slots.service';
 import { Url } from 'app/shared/Utilities/url';
-
 
 @Component({
     selector: 'side-nav',
@@ -240,7 +236,6 @@ export class SideNavComponent implements AfterViewInit {
                 }
 
                 this.selectedNode.handleDeselection(newSelectedNode);
-                // this.globalStateService.clearBusyState();
             }
         }
 

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
@@ -5,7 +5,7 @@ import { StoredSubscriptions } from './../shared/models/localStorage/local-stora
 import { Dom } from './../shared/Utilities/dom';
 import { SubUtil } from './../shared/Utilities/sub-util';
 import { SearchBoxComponent } from './../search-box/search-box.component';
-import { Component, ViewChild, AfterViewInit, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewChild, AfterViewInit, Input, Injector } from '@angular/core';
 import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -29,7 +29,7 @@ import { AppNode } from '../tree-view/app-node';
 import { ArmService } from '../shared/services/arm.service';
 import { CacheService } from '../shared/services/cache.service';
 import { UserService } from '../shared/services/user.service';
-import { FunctionsService } from '../shared/services/functions.service';
+import { TryFunctionsService } from '../shared/services/try-functions.service';
 import { GlobalStateService } from '../shared/services/global-state.service';
 import { BroadcastService } from '../shared/services/broadcast.service';
 import { AiService } from '../shared/services/ai.service';
@@ -42,7 +42,6 @@ import { Url } from 'app/shared/Utilities/url';
 
 
 @Component({
-    changeDetection : ChangeDetectionStrategy.OnPush,
     selector: 'side-nav',
     templateUrl: './side-nav.component.html',
     styleUrls: ['./side-nav.component.scss']
@@ -81,10 +80,11 @@ export class SideNavComponent implements AfterViewInit {
     }
 
     constructor(
+        public injector: Injector,
         public configService: ConfigService,
         public armService: ArmService,
         public cacheService: CacheService,
-        public functionsService: FunctionsService,
+        public functionsService: TryFunctionsService,
         public http: Http,
         public globalStateService: GlobalStateService,
         public broadcastService: BroadcastService,
@@ -239,7 +239,8 @@ export class SideNavComponent implements AfterViewInit {
                     return Observable.of(false);
                 }
 
-                this.selectedNode.dispose(newSelectedNode);
+                this.selectedNode.handleDeselection(newSelectedNode);
+                // this.globalStateService.clearBusyState();
             }
         }
 

--- a/AzureFunctions.AngularClient/src/app/site/function-runtime/function-runtime.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/function-runtime/function-runtime.component.ts
@@ -1,11 +1,13 @@
+import { LogCategories } from 'app/shared/models/constants';
+import { LogService } from './../../shared/services/log.service';
+import { FunctionsService } from './../../shared/services/functions-service';
 import { BusyStateScopeManager } from './../../busy-state/busy-state-scope-manager';
 import { ConfigService } from './../../shared/services/config.service';
 import { EditModeHelper } from './../../shared/Utilities/edit-mode.helper';
-import { Component, Input, OnDestroy } from '@angular/core';
+import { Component, Input, OnDestroy, Injector } from '@angular/core';
 import { Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
-import { Subscription as RxSubscription } from 'rxjs/Subscription';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/retry';
@@ -63,7 +65,6 @@ export class FunctionRuntimeComponent implements OnDestroy {
 
   private _viewInfoStream = new Subject<TreeViewInfo<SiteData>>();
   private _viewInfo: TreeViewInfo<SiteData>;
-  private _viewInfoSub: RxSubscription;
   private _appNode: AppNode;
 
   public functionAppEditMode = true;
@@ -75,6 +76,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
   public slotsEnabled: boolean;
   public slotsValueChange: Subject<boolean>;
   private _busyManager: BusyStateScopeManager;
+  private _ngUnsubscribe = new Subject();
 
   constructor(
     private _armService: ArmService,
@@ -85,30 +87,40 @@ export class FunctionRuntimeComponent implements OnDestroy {
     private _translateService: TranslateService,
     private _slotsService: SiteService,
     private _configService: ConfigService,
-  ) {
+    private _functionsService: FunctionsService,
+    private _injector: Injector,
+    private _logService: LogService) {
 
     this._busyManager = new BusyStateScopeManager(_broadcastService, 'site-tabs');
 
-    this._viewInfoSub = this._viewInfoStream
+    this._viewInfoStream
+      .takeUntil(this._ngUnsubscribe)
       .switchMap(viewInfo => {
         this._viewInfo = viewInfo;
         this._busyManager.setBusy();
 
         this._appNode = (<AppNode>viewInfo.node);
 
+        return this._functionsService.getAppContext(this._viewInfo.resourceId);
+      })
+      .switchMap(context => {
+        this.site = context.site;
+
+        if (this.functionApp) {
+          this.functionApp.dispose();
+        }
+
+        this.functionApp = new FunctionApp(context.site, this._injector);
+
         return Observable.zip(
-          this._cacheService.getArm(viewInfo.resourceId),
-          this._cacheService.postArm(`${viewInfo.resourceId}/config/appsettings/list`, true),
-          this._appNode.functionAppStream,
-          this._slotsService.getSlotsList(viewInfo.resourceId),
-          (s: Response, a: Response, fa: FunctionApp, slots: ArmObj<Site>[]) => ({ siteResponse: s, appSettingsResponse: a, functionApp: fa, slotsList: slots }))
+          this._cacheService.postArm(`${this._viewInfo.resourceId}/config/appsettings/list`, true),
+          this._slotsService.getSlotsList(this._viewInfo.resourceId),
+          (a: Response, slots: ArmObj<Site>[]) => ({ appSettingsResponse: a, slotsList: slots }))
           .mergeMap(result => {
-            return Observable.zip(result.functionApp.getFunctionAppEditMode(), result.functionApp.getFunctionHostStatus(),
+            return Observable.zip(this.functionApp.getFunctionAppEditMode(), this.functionApp.getFunctionHostStatus(),
               (editMode: FunctionAppEditMode, hostStatus: HostStatus) => ({ editMode: editMode, hostStatus: hostStatus }))
               .map(r => ({
-                siteResponse: result.siteResponse,
                 appSettingsResponse: result.appSettingsResponse,
-                functionApp: result.functionApp,
                 editMode: r.editMode,
                 hostStatus: r.hostStatus,
                 slotsList: result.slotsList
@@ -117,14 +129,13 @@ export class FunctionRuntimeComponent implements OnDestroy {
           });
       })
       .do(null, e => {
-        this._aiService.trackException(e, 'function-runtime');
+        this._logService.error(LogCategories.functionAppSettings, 'function-runtime-load', e);
+        this._busyManager.clearBusy();
       })
       .retry()
       .subscribe(r => {
         const appSettings: ArmObj<any> = r.appSettingsResponse.json();
 
-        this.functionApp = r.functionApp;
-        this.site = r.siteResponse.json();
         this.exactExtensionVersion = r.hostStatus ? r.hostStatus.version : '';
         this._isSlotApp = SiteService.isSlot(this.site.id);
         this.dailyMemoryTimeQuota = this.site.properties.dailyMemoryTimeQuota
@@ -274,7 +285,7 @@ export class FunctionRuntimeComponent implements OnDestroy {
         })
         .do(null, e => {
           this._busyManager.clearBusy();
-          this._aiService.trackException(e, 'function-runtime');
+          this._logService.error(LogCategories.functionAppSettings, '/save-slot-change', e);
         })
         .retry()
         .subscribe(() => {
@@ -304,9 +315,10 @@ export class FunctionRuntimeComponent implements OnDestroy {
   }
 
   ngOnDestroy() {
-    if (this._viewInfoSub) {
-      this._viewInfoSub.unsubscribe();
-      this._viewInfoSub = null;
+    this._ngUnsubscribe.next();
+
+    if (this.functionApp) {
+      this.functionApp.dispose();
     }
   }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-dashboard.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-dashboard/site-dashboard.component.ts
@@ -121,7 +121,10 @@ export class SiteDashboardComponent implements OnDestroy, OnInit {
                     this._openTabSubscription = this._broadcastService.getEvents<string>(BroadcastEvent.OpenTab)
                         .takeUntil(this._ngUnsubscribe)
                         .subscribe(tabId => {
-                            this.openFeature(tabId);
+                            if (tabId) {
+                                this.openFeature(tabId);
+                                this._broadcastService.broadcastEvent<string>(BroadcastEvent.OpenTab, null);
+                            }
                         });
                 }
 

--- a/AzureFunctions.AngularClient/src/app/top-bar/top-bar.component.ts
+++ b/AzureFunctions.AngularClient/src/app/top-bar/top-bar.component.ts
@@ -48,7 +48,7 @@ export class TopBarComponent implements OnInit {
                     const descriptor = <SiteDescriptor>Descriptor.getDescriptor(this.resourceId);
                     this.appName = descriptor.site;
                     const fnDescriptor = new FunctionDescriptor(this.resourceId);
-                    this.fnName = fnDescriptor.functionName;
+                    this.fnName = fnDescriptor.name;
                 });
         }
 

--- a/AzureFunctions.AngularClient/src/app/tree-view/app-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/app-node.ts
@@ -1,8 +1,16 @@
-import { SiteTabIds } from './../shared/models/constants';
-import { SiteService } from './../shared/services/slots.service';
-import { Response } from '@angular/http';
+import { DashboardType } from 'app/tree-view/models/dashboard-type';
+// import { TreeUpdateEvent } from './../shared/models/broadcast-event';
+import { BroadcastService } from 'app/shared/services/broadcast.service';
+// import { Subscription as RxSubscription } from 'rxjs/Subscription';
+import { Subject } from 'rxjs/Subject';
+import { FunctionsService } from './../shared/services/functions-service';
+import { LogCategories } from 'app/shared/models/constants';
+import { LogService } from './../shared/services/log.service';
+import { CacheService } from './../shared/services/cache.service';
+import { ScenarioService } from './../shared/services/scenario/scenario.service';
+import { SiteTabIds, ScenarioIds } from './../shared/models/constants';
+// import { SiteService } from './../shared/services/slots.service';
 import { Observable } from 'rxjs/Observable';
-import { Subscription as RxSubscription } from 'rxjs/Subscription';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/concatMap';
@@ -16,26 +24,24 @@ import 'rxjs/add/observable/timer';
 import 'rxjs/add/observable/zip';
 
 import { PortalResources } from './../shared/models/portal-resources';
-import { ErrorIds } from './../shared/models/error-ids';
-import { AuthzService } from './../shared/services/authz.service';
-import { TopBarNotification } from './../top-bar/top-bar-models';
+// import { ErrorIds } from './../shared/models/error-ids';
+// import { TopBarNotification } from './../top-bar/top-bar-models';
 import { ArmObj } from './../shared/models/arm/arm-obj';
-import { Subscription } from './../shared/models/subscription';
 import { SiteDescriptor } from './../shared/resourceDescriptors';
 import { AppsNode } from './apps-node';
 import { TreeNode, Disposable, Removable, CustomSelection, Collection, Refreshable, CanBlockNavChange } from './tree-node';
-import { DashboardType } from './models/dashboard-type';
 import { SideNavComponent } from '../side-nav/side-nav.component';
 import { Site } from '../shared/models/arm/site';
 import { SlotsNode } from './slots-node';
 import { FunctionsNode } from './functions-node';
 import { ProxiesNode } from './proxies-node';
 import { FunctionApp } from '../shared/function-app';
-import { Constants, NotificationIds } from '../shared/models/constants';
-import { BroadcastEvent } from '../shared/models/broadcast-event';
-import { ErrorEvent, ErrorType } from '../shared/models/error-event';
-import { FunctionsVersionInfoHelper } from '../../../../common/models/functions-version-info';
-import { ArmUtil } from 'app/shared/Utilities/arm-utils';
+import { Subscription } from 'app/shared/models/subscription';
+// import { Constants, NotificationIds } from '../shared/models/constants';
+// import { BroadcastEvent } from '../shared/models/broadcast-event';
+// import { ErrorEvent, ErrorType } from '../shared/models/error-event';
+// import { FunctionsVersionInfoHelper } from '../../../../common/models/functions-version-info';
+// import { ArmUtil } from 'app/shared/Utilities/arm-utils';
 
 export class AppNode extends TreeNode
     implements Disposable, Removable, CustomSelection, Collection, Refreshable, CanBlockNavChange {
@@ -56,14 +62,19 @@ export class AppNode extends TreeNode
 
     public functionAppStream = new ReplaySubject<FunctionApp>(1);
     public slotProperties: any;
-    private _functionApp: FunctionApp;
     public openTabId: string | null;
 
     public iconClass = 'tree-node-svg-icon';
     public iconUrl = 'image/functions.svg';
 
-    private _pollingTask: RxSubscription;
-    private _loadingObservable: Observable<any>;
+    // private _treeUpdateSubscription: RxSubscription;
+    private _ngUnsubscribe = new Subject();
+
+    private _functionsService: FunctionsService;
+    private _scenarioService: ScenarioService;
+    private _cacheService: CacheService;
+    private _logService: LogService;
+    private _broadcastService: BroadcastService;
 
     constructor(sideBar: SideNavComponent,
         private _siteArmCacheObj: ArmObj<Site>,
@@ -71,6 +82,12 @@ export class AppNode extends TreeNode
         private _subscriptions: Subscription[],
         disabled?: boolean) {
         super(sideBar, _siteArmCacheObj.id, parentNode);
+
+        this._functionsService = this.sideNav.injector.get(FunctionsService);
+        this._scenarioService = this.sideNav.injector.get(ScenarioService);
+        this._cacheService = this.sideNav.injector.get(CacheService);
+        this._logService = this.sideNav.injector.get(LogService);
+        this._broadcastService = this.sideNav.injector.get(BroadcastService);
 
         this.disabled = !!disabled;
         if (disabled) {
@@ -94,85 +111,58 @@ export class AppNode extends TreeNode
     }
 
     public handleSelection(): Observable<any> {
-        if (!this.disabled) {
-            return this.initialize(false);
-        }
+        // if (!this._treeUpdateSubscription) {
+        //     this._treeUpdateSubscription = this._broadcastService.getEvents<TreeUpdateEvent>(BroadcastEvent.TreeUpdate)
+        //         .takeUntil(this._ngUnsubscribe)
+        //         .subscribe(event => {
+        //             if (event.dashboardType === DashboardType.FunctionDashboard) {
+
+        //                 const functionsNode = <FunctionsNode>this.children.find(c => c.dashboardType === DashboardType.FunctionsDashboard);
+        //                 if (event.operation === 'delete') {
+        //                     functionsNode.removeChild(event.resourceId);
+        //                 } else if(event.operation === 'update'){
+        //                     functionsNode.updateChild(event.resourceId, event.data);
+        //                 }
+        //             }
+        //         });
+        // }
 
         return Observable.of({});
     }
 
     public loadChildren() {
-        if (!this.disabled) {
-            return this.initialize(true);
-        }
-
-        return Observable.of({});
-    }
-
-    public initialize(expandOnly?: boolean): Observable<any> {
-
-        if (!expandOnly) {
-            this.inSelectedTree = true;
-        }
 
         this.supportsRefresh = false;
         this.isLoading = true;
-
-        if (this._loadingObservable) {
-            return this._loadingObservable;
-        }
-
-        this._loadingObservable = Observable.zip(
-            this.sideNav.authZService.hasPermission(this._siteArmCacheObj.id, [AuthzService.writeScope]),
-            this.sideNav.authZService.hasReadOnlyLock(this._siteArmCacheObj.id),
-            this.sideNav.cacheService.getArm(this._siteArmCacheObj.id),
-
-            (h, r, s) => ({ hasWritePermission: h, hasReadOnlyLock: r, siteResponse: s })
-        )
-            .mergeMap(r => {
-                const site: ArmObj<Site> = r.siteResponse.json();
-
-                if (!this._functionApp) {
-                    return this._setupFunctionApp(site)
-                        .mergeMap(() => {
-                            if (site.properties.state === 'Running' && r.hasWritePermission && !r.hasReadOnlyLock) {
-                                return this._setupBackgroundTasks()
-                                    .map(() => {
-                                        this.supportsRefresh = true;
-                                    });
-                            } else {
-                                this.dispose();
-                                this.supportsRefresh = true;
-                                return Observable.of(null);
-                            }
-                        });
-                }
-
+        return this._functionsService.getAppContext(this.resourceId)
+            .do(context => {
+                this.isLoading = false;
                 this.supportsRefresh = true;
-                return Observable.of(null);
-            })
-            .do(() => {
-                // Temporary workaround to make sure we clear loading
-                // https://github.com/Azure/azure-functions-ux/issues/1872
-                setTimeout(() => {
-                    this.isLoading = false;
+
+                const children = [
+                    new FunctionsNode(this.sideNav, context, this),
+                    new ProxiesNode(this.sideNav, context, this),
+                    new SlotsNode(this.sideNav, this._subscriptions, this._siteArmCacheObj, this)
+                ];
+
+                const filteredChildren = this._scenarioService.checkScenario(ScenarioIds.filterAppNodeChildren, {
+                    site: context.site,
+                    appNodeChildren: children
                 });
 
-                if (this.inSelectedTree) {
-                    this.children.forEach(c => c.inSelectedTree = true);
-                }
-
-                this._loadingObservable = null;
-            }, () => {
-                // Temporary workaround to make sure we clear loading
-                // https://github.com/Azure/azure-functions-ux/issues/1872
-                setTimeout(() => {
-                    this.isLoading = false;
+                this.children = filteredChildren && filteredChildren.data ? filteredChildren.data : children;
+                this.children.forEach(c => {
+                    if (c.dashboardType === DashboardType.FunctionsDashboard) {
+                        c.toggle(null);
+                    }
                 });
-            })
-            .share();
 
-        return this._loadingObservable;
+            }, err => {
+                this.supportsRefresh = true;
+                this.isLoading = false;
+                this._logService.error(LogCategories.SideNav, '/app-node/loadChildren', err);
+            })
+            .map(context => context);
     }
 
     public shouldBlockNavChange() {
@@ -182,7 +172,7 @@ export class AppNode extends TreeNode
         if (isDirty) {
             canSwitchNodes = confirm(
                 this.sideNav.translateService.instant(
-                    PortalResources.siteDashboard_confirmLoseChanges).format(this._functionApp.site.name));
+                    PortalResources.siteDashboard_confirmLoseChanges).format(this._siteArmCacheObj.name));
 
             if (canSwitchNodes) {
                 this.sideNav.broadcastService.clearAllDirtyStates();
@@ -192,85 +182,21 @@ export class AppNode extends TreeNode
         return !canSwitchNodes;
     }
 
-    private _setupFunctionApp(site: ArmObj<Site>) {
-        let result = Observable.of(null);
-
-        if (this.sideNav.tryFunctionApp) {
-            this._functionApp = this.sideNav.tryFunctionApp;
-
-            const functionsNode = new FunctionsNode(this.sideNav, this._functionApp, this);
-            functionsNode.toggle(null);
-            this.children = [functionsNode];
-        } else {
-            this._functionApp = new FunctionApp(
-                site,
-                this.sideNav.http,
-                this.sideNav.userService,
-                this.sideNav.globalStateService,
-                this.sideNav.translateService,
-                this.sideNav.broadcastService,
-                this.sideNav.armService,
-                this.sideNav.cacheService,
-                this.sideNav.languageService,
-                this.sideNav.authZService,
-                this.sideNav.aiService,
-                this.sideNav.configService,
-                this.sideNav.slotsService
-            );
-
-            const postFunctionApp = () => {
-                this.functionAppStream.next(this._functionApp);
-
-                const functionsNode = new FunctionsNode(this.sideNav, this._functionApp, this);
-                functionsNode.toggle(null);
-                this.children = [functionsNode];
-
-                if (!this.sideNav.configService.isStandalone()) {
-                    const proxiesNode = new ProxiesNode(this.sideNav, this._functionApp, this);
-                    const slotsNode = new SlotsNode(this.sideNav, this._subscriptions, this._siteArmCacheObj, this);
-                    proxiesNode.toggle(null);
-                    // Do not auto expand slotsNode
-                    // for slots Node hide the slots as child Node
-                    if (this.isSlot) {
-                        this.supportsScope = false;
-                        this.children.push(proxiesNode);
-                    } else {
-                        this.supportsScope = true;
-                        this.children.push(proxiesNode, slotsNode);
-                    }
-                }
-            };
-
-            if (ArmUtil.isLinuxApp(this._functionApp.site)) {
-                result = this._functionApp.getHostSecretsFromScm().do(() => postFunctionApp());
-            } else {
-                postFunctionApp();
-            }
-        }
-
-        return result;
-    }
-
     public handleRefresh(): Observable<any> {
         if (this.sideNav.selectedNode.shouldBlockNavChange()) {
             return Observable.of(null);
         }
 
-        // Make sure there isn't a load operation currently being performed
-        const loadObs = this._loadingObservable ? this._loadingObservable : Observable.of({});
-        return loadObs
-            .mergeMap(() => {
-                this.sideNav.aiService.trackEvent('/actions/refresh');
-                this._functionApp.fireSyncTrigger();
-                this.sideNav.cacheService.clearCache();
-                this.dispose();
-                this._functionApp = null;
-                this.functionAppStream.next(null);
+        // Don't need to check for existing loadChildren operations because the refresh button shouldn't
+        // be visible during load.
+        this.sideNav.aiService.trackEvent('/actions/refresh');
+        this.sideNav.cacheService.clearCache();
+        // this.dispose();
+        this.functionAppStream.next(null);
 
-                return this.initialize();
-            })
-            .do(() => {
-                this.isLoading = false;
+        return this.loadChildren()
+            .do(context => {
+                this._functionsService.fireSyncTrigger(context);
                 if (this.children && this.children.length === 1 && !this.children[0].isExpanded) {
                     this.children[0].toggle(null);
                 }
@@ -284,35 +210,32 @@ export class AppNode extends TreeNode
             (<AppsNode>this.parent).removeChild(this, false);
         }
         this.sideNav.cacheService.clearArmIdCachePrefix(this.resourceId);
-        this.dispose();
+        this.handleDeselection();
     }
 
-    public dispose(newSelectedNode?: TreeNode) {
+    public handleDeselection(newSelectedNode?: TreeNode) {
         // Ensures that we're only disposing if you're selecting a node that's not a child of the
         // the current app node.
-        if (newSelectedNode) {
+        // if (newSelectedNode) {
 
-            // Tests whether you've selected a child node or newselectedNode is not a slot node
-            if (newSelectedNode.resourceId !== this.resourceId
-                && newSelectedNode.resourceId.startsWith(this.resourceId + '/')
-                && !SiteService.isSlot(newSelectedNode.resourceId)) {
-                return;
-            } else if (newSelectedNode.resourceId === this.resourceId && newSelectedNode === this) {
-                // Tests whether you're navigating to this node from a child node
-                return;
-            }
-        }
+        //     // Tests whether you've selected a child node or newselectedNode is not a slot node
+        //     if (newSelectedNode.resourceId !== this.resourceId
+        //         && newSelectedNode.resourceId.startsWith(this.resourceId + '/')
+        //         && !SiteService.isSlot(newSelectedNode.resourceId)) {
+        //         return;
+        //     } else if (newSelectedNode.resourceId === this.resourceId && newSelectedNode === this) {
+        //         // Tests whether you're navigating to this node from a child node
+        //         return;
+        //     }
+        // }
 
         this.inSelectedTree = false;
         this.children.forEach(c => c.inSelectedTree = false);
 
-        if (this._loadingObservable) {
-            this._loadingObservable.subscribe(() => {
-                this._dispose();
-            });
-        } else {
-            this._dispose();
-        }
+        this.sideNav.globalStateService.setTopBarNotifications([]);
+        this.sideNav.broadcastService.clearAllDirtyStates();
+
+        this._ngUnsubscribe.next();
     }
 
     public clearNotification(id: string) {
@@ -329,140 +252,126 @@ export class AppNode extends TreeNode
         this.select(true /* force */);
     }
 
-    private _dispose() {
-        if (this._pollingTask && !this._pollingTask.closed) {
-            this._pollingTask.unsubscribe();
-            this._pollingTask = null;
-        }
+    // private _setupBackgroundTasks() {
 
-        if (this._functionApp) {
-            this._functionApp.isDeleted = true;
-        }
+    //     return this._functionApp.initKeysAndWarmupMainSite()
+    //         .catch(() => Observable.of(null))
+    //         .map(() => {
 
-        this.sideNav.globalStateService.setTopBarNotifications([]);
-        this.sideNav.broadcastService.clearAllDirtyStates();
-    }
+    //             if (!this._pollingTask) {
 
-    private _setupBackgroundTasks() {
+    //                 this._pollingTask = Observable.timer(1, 60000)
+    //                     .concatMap(() => {
+    //                         const val = Observable.zip(
+    //                             this._functionApp.getHostErrors().catch(() => Observable.of([])),
+    //                             this.sideNav.cacheService.getArm(`${this.resourceId}/config/web`, true),
+    //                             this.sideNav.cacheService.postArm(`${this.resourceId}/config/appsettings/list`, true),
+    //                             this.sideNav.slotsService.getSlotsList(`${this.resourceId}`),
+    //                             this._functionApp.pingScmSite(),
+    //                             (e: string[], c: Response, a: Response, s: ArmObj<Site>[]) => ({ errors: e, configResponse: c, appSettingResponse: a, slotsResponse: s }));
+    //                         return val;
+    //                     })
+    //                     .catch(() => Observable.of({}))
+    //                     .subscribe((result: { errors: string[], configResponse: Response, appSettingResponse: Response, slotsResponse: ArmObj<Site>[] }) => {
+    //                         this._handlePollingTaskResult(result);
+    //                     });
+    //             }
+    //         });
+    // }
 
-        return this._functionApp.initKeysAndWarmupMainSite()
-            .catch(() => Observable.of(null))
-            .map(() => {
+    // private _handlePollingTaskResult(result: { errors: string[], configResponse: Response, appSettingResponse: Response, slotsResponse: ArmObj<Site>[] }) {
+    //     if (result) {
 
-                if (!this._pollingTask) {
+    //         const notifications: TopBarNotification[] = [];
 
-                    this._pollingTask = Observable.timer(1, 60000)
-                        .concatMap(() => {
-                            const val = Observable.zip(
-                                this._functionApp.getHostErrors().catch(() => Observable.of([])),
-                                this.sideNav.cacheService.getArm(`${this.resourceId}/config/web`, true),
-                                this.sideNav.cacheService.postArm(`${this.resourceId}/config/appsettings/list`, true),
-                                this.sideNav.slotsService.getSlotsList(`${this.resourceId}`),
-                                this._functionApp.pingScmSite(),
-                                (e: string[], c: Response, a: Response, s: ArmObj<Site>[]) => ({ errors: e, configResponse: c, appSettingResponse: a, slotsResponse: s }));
-                            return val;
-                        })
-                        .catch(() => Observable.of({}))
-                        .subscribe((result: { errors: string[], configResponse: Response, appSettingResponse: Response, slotsResponse: ArmObj<Site>[] }) => {
-                            this._handlePollingTaskResult(result);
-                        });
-                }
-            });
-    }
+    //         if (result.errors) {
 
-    private _handlePollingTaskResult(result: { errors: string[], configResponse: Response, appSettingResponse: Response, slotsResponse: ArmObj<Site>[] }) {
-        if (result) {
+    //             this.sideNav.broadcastService.broadcast<string>(BroadcastEvent.ClearError, ErrorIds.generalHostErrorFromHost);
+    //             // Give clearing a chance to run
+    //             setTimeout(() => {
+    //                 result.errors.forEach(e => {
+    //                     this.sideNav.broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
+    //                         message: this.sideNav.translateService.instant(PortalResources.functionDev_hostErrorMessage, { error: e }),
+    //                         details: this.sideNav.translateService.instant(PortalResources.functionDev_hostErrorMessage, { error: e }),
+    //                         errorId: ErrorIds.generalHostErrorFromHost,
+    //                         errorType: ErrorType.RuntimeError,
+    //                         resourceId: this._functionApp.site.id
+    //                     });
+    //                     this.sideNav.aiService.trackEvent('/errors/host', { error: e, app: this.resourceId });
+    //                 });
+    //             });
+    //         }
 
-            const notifications: TopBarNotification[] = [];
+    //         if (result.configResponse) {
+    //             const config = result.configResponse.json();
+    //             this._functionApp.isAlwaysOn = config.properties.alwaysOn === true || this._functionApp.site.properties.sku === 'Dynamic';
 
-            if (result.errors) {
+    //             if (!this._functionApp.isAlwaysOn) {
+    //                 notifications.push({
+    //                     id: NotificationIds.alwaysOn,
+    //                     message: this.sideNav.translateService.instant(PortalResources.topBar_alwaysOn),
+    //                     iconClass: 'fa fa-exclamation-triangle warning',
+    //                     learnMoreLink: 'https://go.microsoft.com/fwlink/?linkid=830855',
+    //                     clickCallback: null
+    //                 });
+    //             }
+    //         }
 
-                this.sideNav.broadcastService.broadcast<string>(BroadcastEvent.ClearError, ErrorIds.generalHostErrorFromHost);
-                // Give clearing a chance to run
-                setTimeout(() => {
-                    result.errors.forEach(e => {
-                        this.sideNav.broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
-                            message: this.sideNav.translateService.instant(PortalResources.functionDev_hostErrorMessage, { error: e }),
-                            details: this.sideNav.translateService.instant(PortalResources.functionDev_hostErrorMessage, { error: e }),
-                            errorId: ErrorIds.generalHostErrorFromHost,
-                            errorType: ErrorType.RuntimeError,
-                            resourceId: this._functionApp.site.id
-                        });
-                        this.sideNav.aiService.trackEvent('/errors/host', { error: e, app: this.resourceId });
-                    });
-                });
-            }
+    //         if (result.appSettingResponse) {
+    //             const appSettings: ArmObj<any> = result.appSettingResponse.json();
+    //             const extensionVersion = appSettings.properties[Constants.runtimeVersionAppSettingName];
+    //             let isLatestFunctionRuntime = null;
+    //             if (extensionVersion) {
+    //                 if (extensionVersion === 'beta') {
+    //                     isLatestFunctionRuntime = true;
+    //                     notifications.push({
+    //                         id: NotificationIds.runtimeV2,
+    //                         message: this.sideNav.translateService.instant(PortalResources.topBar_runtimeV2),
+    //                         iconClass: 'fa fa-exclamation-triangle warning',
+    //                         learnMoreLink: '',
+    //                         clickCallback: () => {
+    //                             this.openSettings();
+    //                         }
+    //                     });
+    //                 } else {
+    //                     isLatestFunctionRuntime = !FunctionsVersionInfoHelper.needToUpdateRuntime(this.sideNav.configService.FunctionsVersionInfo, extensionVersion);
+    //                     this.sideNav.aiService.trackEvent('/values/runtime_version', { runtime: extensionVersion, appName: this.resourceId });
+    //                 }
+    //             }
 
-            if (result.configResponse) {
-                const config = result.configResponse.json();
-                this._functionApp.isAlwaysOn = config.properties.alwaysOn === true || this._functionApp.site.properties.sku === 'Dynamic';
+    //             if (!isLatestFunctionRuntime) {
+    //                 notifications.push({
+    //                     id: NotificationIds.newRuntimeVersion,
+    //                     message: this.sideNav.translateService.instant(PortalResources.topBar_newVersion),
+    //                     iconClass: 'fa fa-info link',
+    //                     learnMoreLink: 'https://go.microsoft.com/fwlink/?linkid=829530',
+    //                     clickCallback: () => {
+    //                         this.openSettings();
+    //                     }
+    //                 });
+    //             }
+    //             if (result.slotsResponse) {
+    //                 let slotsStorageSetting = appSettings.properties[Constants.slotsSecretStorageSettingsName];
+    //                 if (!!slotsStorageSetting) {
+    //                     slotsStorageSetting = slotsStorageSetting.toLowerCase();
+    //                 }
+    //                 const numSlots = result.slotsResponse.length;
+    //                 if (numSlots > 0 && slotsStorageSetting !== Constants.slotsSecretStorageSettingsValue.toLowerCase()) {
+    //                     notifications.push({
+    //                         id: NotificationIds.slotsHostId,
+    //                         message: this.sideNav.translateService.instant(PortalResources.topBar_slotsHostId),
+    //                         iconClass: 'fa fa-exclamation-triangle warning',
+    //                         learnMoreLink: '',
+    //                         clickCallback: null
+    //                     });
+    //                 }
+    //             }
 
-                if (!this._functionApp.isAlwaysOn) {
-                    notifications.push({
-                        id: NotificationIds.alwaysOn,
-                        message: this.sideNav.translateService.instant(PortalResources.topBar_alwaysOn),
-                        iconClass: 'fa fa-exclamation-triangle warning',
-                        learnMoreLink: 'https://go.microsoft.com/fwlink/?linkid=830855',
-                        clickCallback: null
-                    });
-                }
-            }
+    //         }
 
-            if (result.appSettingResponse) {
-                const appSettings: ArmObj<any> = result.appSettingResponse.json();
-                const extensionVersion = appSettings.properties[Constants.runtimeVersionAppSettingName];
-                let isLatestFunctionRuntime = null;
-                if (extensionVersion) {
-                    if (extensionVersion === 'beta') {
-                        isLatestFunctionRuntime = true;
-                        notifications.push({
-                            id: NotificationIds.runtimeV2,
-                            message: this.sideNav.translateService.instant(PortalResources.topBar_runtimeV2),
-                            iconClass: 'fa fa-exclamation-triangle warning',
-                            learnMoreLink: '',
-                            clickCallback: () => {
-                                this.openSettings();
-                            }
-                        });
-                    } else {
-                        isLatestFunctionRuntime = !FunctionsVersionInfoHelper.needToUpdateRuntime(this.sideNav.configService.FunctionsVersionInfo, extensionVersion);
-                        this.sideNav.aiService.trackEvent('/values/runtime_version', { runtime: extensionVersion, appName: this.resourceId });
-                    }
-                }
-
-                if (!isLatestFunctionRuntime) {
-                    notifications.push({
-                        id: NotificationIds.newRuntimeVersion,
-                        message: this.sideNav.translateService.instant(PortalResources.topBar_newVersion),
-                        iconClass: 'fa fa-info link',
-                        learnMoreLink: 'https://go.microsoft.com/fwlink/?linkid=829530',
-                        clickCallback: () => {
-                            this.openSettings();
-                        }
-                    });
-                }
-                if (result.slotsResponse) {
-                    let slotsStorageSetting = appSettings.properties[Constants.slotsSecretStorageSettingsName];
-                    if (!!slotsStorageSetting) {
-                        slotsStorageSetting = slotsStorageSetting.toLowerCase();
-                    }
-                    const numSlots = result.slotsResponse.length;
-                    if (numSlots > 0 && slotsStorageSetting !== Constants.slotsSecretStorageSettingsValue.toLowerCase()) {
-                        notifications.push({
-                            id: NotificationIds.slotsHostId,
-                            message: this.sideNav.translateService.instant(PortalResources.topBar_slotsHostId),
-                            iconClass: 'fa fa-exclamation-triangle warning',
-                            learnMoreLink: '',
-                            clickCallback: null
-                        });
-                    }
-                }
-
-            }
-
-            this.sideNav.globalStateService.setTopBarNotifications(notifications);
-        }
-    }
+    //         this.sideNav.globalStateService.setTopBarNotifications(notifications);
+    //     }
+    // }
 }
 
 /*

--- a/AzureFunctions.AngularClient/src/app/tree-view/app-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/app-node.ts
@@ -1,7 +1,5 @@
 import { DashboardType } from 'app/tree-view/models/dashboard-type';
-// import { TreeUpdateEvent } from './../shared/models/broadcast-event';
 import { BroadcastService } from 'app/shared/services/broadcast.service';
-// import { Subscription as RxSubscription } from 'rxjs/Subscription';
 import { Subject } from 'rxjs/Subject';
 import { FunctionsService } from './../shared/services/functions-service';
 import { LogCategories } from 'app/shared/models/constants';
@@ -9,23 +7,9 @@ import { LogService } from './../shared/services/log.service';
 import { CacheService } from './../shared/services/cache.service';
 import { ScenarioService } from './../shared/services/scenario/scenario.service';
 import { SiteTabIds, ScenarioIds } from './../shared/models/constants';
-// import { SiteService } from './../shared/services/slots.service';
 import { Observable } from 'rxjs/Observable';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
-import 'rxjs/add/operator/catch';
-import 'rxjs/add/operator/concatMap';
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/mergeMap';
-import 'rxjs/add/operator/share';
-import 'rxjs/add/operator/take';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/observable/timer';
-import 'rxjs/add/observable/zip';
-
 import { PortalResources } from './../shared/models/portal-resources';
-// import { ErrorIds } from './../shared/models/error-ids';
-// import { TopBarNotification } from './../top-bar/top-bar-models';
 import { ArmObj } from './../shared/models/arm/arm-obj';
 import { SiteDescriptor } from './../shared/resourceDescriptors';
 import { AppsNode } from './apps-node';
@@ -37,11 +21,6 @@ import { FunctionsNode } from './functions-node';
 import { ProxiesNode } from './proxies-node';
 import { FunctionApp } from '../shared/function-app';
 import { Subscription } from 'app/shared/models/subscription';
-// import { Constants, NotificationIds } from '../shared/models/constants';
-// import { BroadcastEvent } from '../shared/models/broadcast-event';
-// import { ErrorEvent, ErrorType } from '../shared/models/error-event';
-// import { FunctionsVersionInfoHelper } from '../../../../common/models/functions-version-info';
-// import { ArmUtil } from 'app/shared/Utilities/arm-utils';
 
 export class AppNode extends TreeNode
     implements Disposable, Removable, CustomSelection, Collection, Refreshable, CanBlockNavChange {
@@ -67,7 +46,6 @@ export class AppNode extends TreeNode
     public iconClass = 'tree-node-svg-icon';
     public iconUrl = 'image/functions.svg';
 
-    // private _treeUpdateSubscription: RxSubscription;
     private _ngUnsubscribe = new Subject();
 
     private _functionsService: FunctionsService;
@@ -108,26 +86,6 @@ export class AppNode extends TreeNode
 
         this.subscription = sub && sub.displayName;
         this.subscriptionId = sub && sub.subscriptionId;
-    }
-
-    public handleSelection(): Observable<any> {
-        // if (!this._treeUpdateSubscription) {
-        //     this._treeUpdateSubscription = this._broadcastService.getEvents<TreeUpdateEvent>(BroadcastEvent.TreeUpdate)
-        //         .takeUntil(this._ngUnsubscribe)
-        //         .subscribe(event => {
-        //             if (event.dashboardType === DashboardType.FunctionDashboard) {
-
-        //                 const functionsNode = <FunctionsNode>this.children.find(c => c.dashboardType === DashboardType.FunctionsDashboard);
-        //                 if (event.operation === 'delete') {
-        //                     functionsNode.removeChild(event.resourceId);
-        //                 } else if(event.operation === 'update'){
-        //                     functionsNode.updateChild(event.resourceId, event.data);
-        //                 }
-        //             }
-        //         });
-        // }
-
-        return Observable.of({});
     }
 
     public loadChildren() {
@@ -214,20 +172,6 @@ export class AppNode extends TreeNode
     }
 
     public handleDeselection(newSelectedNode?: TreeNode) {
-        // Ensures that we're only disposing if you're selecting a node that's not a child of the
-        // the current app node.
-        // if (newSelectedNode) {
-
-        //     // Tests whether you've selected a child node or newselectedNode is not a slot node
-        //     if (newSelectedNode.resourceId !== this.resourceId
-        //         && newSelectedNode.resourceId.startsWith(this.resourceId + '/')
-        //         && !SiteService.isSlot(newSelectedNode.resourceId)) {
-        //         return;
-        //     } else if (newSelectedNode.resourceId === this.resourceId && newSelectedNode === this) {
-        //         // Tests whether you're navigating to this node from a child node
-        //         return;
-        //     }
-        // }
 
         this.inSelectedTree = false;
         this.children.forEach(c => c.inSelectedTree = false);
@@ -251,127 +195,6 @@ export class AppNode extends TreeNode
         this.openTabId = SiteTabIds.functionRuntime;
         this.select(true /* force */);
     }
-
-    // private _setupBackgroundTasks() {
-
-    //     return this._functionApp.initKeysAndWarmupMainSite()
-    //         .catch(() => Observable.of(null))
-    //         .map(() => {
-
-    //             if (!this._pollingTask) {
-
-    //                 this._pollingTask = Observable.timer(1, 60000)
-    //                     .concatMap(() => {
-    //                         const val = Observable.zip(
-    //                             this._functionApp.getHostErrors().catch(() => Observable.of([])),
-    //                             this.sideNav.cacheService.getArm(`${this.resourceId}/config/web`, true),
-    //                             this.sideNav.cacheService.postArm(`${this.resourceId}/config/appsettings/list`, true),
-    //                             this.sideNav.slotsService.getSlotsList(`${this.resourceId}`),
-    //                             this._functionApp.pingScmSite(),
-    //                             (e: string[], c: Response, a: Response, s: ArmObj<Site>[]) => ({ errors: e, configResponse: c, appSettingResponse: a, slotsResponse: s }));
-    //                         return val;
-    //                     })
-    //                     .catch(() => Observable.of({}))
-    //                     .subscribe((result: { errors: string[], configResponse: Response, appSettingResponse: Response, slotsResponse: ArmObj<Site>[] }) => {
-    //                         this._handlePollingTaskResult(result);
-    //                     });
-    //             }
-    //         });
-    // }
-
-    // private _handlePollingTaskResult(result: { errors: string[], configResponse: Response, appSettingResponse: Response, slotsResponse: ArmObj<Site>[] }) {
-    //     if (result) {
-
-    //         const notifications: TopBarNotification[] = [];
-
-    //         if (result.errors) {
-
-    //             this.sideNav.broadcastService.broadcast<string>(BroadcastEvent.ClearError, ErrorIds.generalHostErrorFromHost);
-    //             // Give clearing a chance to run
-    //             setTimeout(() => {
-    //                 result.errors.forEach(e => {
-    //                     this.sideNav.broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
-    //                         message: this.sideNav.translateService.instant(PortalResources.functionDev_hostErrorMessage, { error: e }),
-    //                         details: this.sideNav.translateService.instant(PortalResources.functionDev_hostErrorMessage, { error: e }),
-    //                         errorId: ErrorIds.generalHostErrorFromHost,
-    //                         errorType: ErrorType.RuntimeError,
-    //                         resourceId: this._functionApp.site.id
-    //                     });
-    //                     this.sideNav.aiService.trackEvent('/errors/host', { error: e, app: this.resourceId });
-    //                 });
-    //             });
-    //         }
-
-    //         if (result.configResponse) {
-    //             const config = result.configResponse.json();
-    //             this._functionApp.isAlwaysOn = config.properties.alwaysOn === true || this._functionApp.site.properties.sku === 'Dynamic';
-
-    //             if (!this._functionApp.isAlwaysOn) {
-    //                 notifications.push({
-    //                     id: NotificationIds.alwaysOn,
-    //                     message: this.sideNav.translateService.instant(PortalResources.topBar_alwaysOn),
-    //                     iconClass: 'fa fa-exclamation-triangle warning',
-    //                     learnMoreLink: 'https://go.microsoft.com/fwlink/?linkid=830855',
-    //                     clickCallback: null
-    //                 });
-    //             }
-    //         }
-
-    //         if (result.appSettingResponse) {
-    //             const appSettings: ArmObj<any> = result.appSettingResponse.json();
-    //             const extensionVersion = appSettings.properties[Constants.runtimeVersionAppSettingName];
-    //             let isLatestFunctionRuntime = null;
-    //             if (extensionVersion) {
-    //                 if (extensionVersion === 'beta') {
-    //                     isLatestFunctionRuntime = true;
-    //                     notifications.push({
-    //                         id: NotificationIds.runtimeV2,
-    //                         message: this.sideNav.translateService.instant(PortalResources.topBar_runtimeV2),
-    //                         iconClass: 'fa fa-exclamation-triangle warning',
-    //                         learnMoreLink: '',
-    //                         clickCallback: () => {
-    //                             this.openSettings();
-    //                         }
-    //                     });
-    //                 } else {
-    //                     isLatestFunctionRuntime = !FunctionsVersionInfoHelper.needToUpdateRuntime(this.sideNav.configService.FunctionsVersionInfo, extensionVersion);
-    //                     this.sideNav.aiService.trackEvent('/values/runtime_version', { runtime: extensionVersion, appName: this.resourceId });
-    //                 }
-    //             }
-
-    //             if (!isLatestFunctionRuntime) {
-    //                 notifications.push({
-    //                     id: NotificationIds.newRuntimeVersion,
-    //                     message: this.sideNav.translateService.instant(PortalResources.topBar_newVersion),
-    //                     iconClass: 'fa fa-info link',
-    //                     learnMoreLink: 'https://go.microsoft.com/fwlink/?linkid=829530',
-    //                     clickCallback: () => {
-    //                         this.openSettings();
-    //                     }
-    //                 });
-    //             }
-    //             if (result.slotsResponse) {
-    //                 let slotsStorageSetting = appSettings.properties[Constants.slotsSecretStorageSettingsName];
-    //                 if (!!slotsStorageSetting) {
-    //                     slotsStorageSetting = slotsStorageSetting.toLowerCase();
-    //                 }
-    //                 const numSlots = result.slotsResponse.length;
-    //                 if (numSlots > 0 && slotsStorageSetting !== Constants.slotsSecretStorageSettingsValue.toLowerCase()) {
-    //                     notifications.push({
-    //                         id: NotificationIds.slotsHostId,
-    //                         message: this.sideNav.translateService.instant(PortalResources.topBar_slotsHostId),
-    //                         iconClass: 'fa fa-exclamation-triangle warning',
-    //                         learnMoreLink: '',
-    //                         clickCallback: null
-    //                     });
-    //                 }
-    //             }
-
-    //         }
-
-    //         this.sideNav.globalStateService.setTopBarNotifications(notifications);
-    //     }
-    // }
 }
 
 /*

--- a/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
@@ -1,10 +1,8 @@
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
-import { ReplaySubject } from 'rxjs/ReplaySubject';
-
 import { ErrorIds } from './../shared/models/error-ids';
 import { PortalResources } from './../shared/models/portal-resources';
-import { Arm } from './../shared/models/constants';
+import { Arm, LogCategories } from './../shared/models/constants';
 import { Subscription } from './../shared/models/subscription';
 import { ArmObj, ArmArrayResult } from './../shared/models/arm/arm-obj';
 import { TreeNode, MutableCollection, Disposable, Refreshable } from './tree-node';
@@ -15,6 +13,13 @@ import { AppNode } from './app-node';
 import { BroadcastEvent } from '../shared/models/broadcast-event';
 import { ErrorEvent, ErrorType } from '../shared/models/error-event';
 import { ArmUtil } from 'app/shared/Utilities/arm-utils';
+import { BroadcastService } from 'app/shared/services/broadcast.service';
+
+interface SearchInfo {
+    searchTerm: string;
+    subscriptions: Subscription[];
+}
+
 
 export class AppsNode extends TreeNode implements MutableCollection, Disposable, Refreshable {
     public title = this.sideNav.translateService.instant(PortalResources.functionApps);
@@ -22,15 +27,13 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
     public supportsRefresh = true;
 
     public resourceId = '/apps';
-    public childrenStream = new ReplaySubject<AppNode[]>(1);
     public isExpanded = true;
     private _exactAppSearchExp = '\"(.+)\"';
-    private _subscriptions: Subscription[];
 
-    private _searchObs: Observable<{
-        term: string;
-        children: TreeNode[];
-    }>;
+    private _searchTerm: string;
+    private _subscriptions: Subscription[];
+    private _searchInfo = new Subject<SearchInfo>();
+    private _broadcastService: BroadcastService;
 
     constructor(
         sideNav: SideNavComponent,
@@ -43,57 +46,124 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
 
         this.newDashboardType = sideNav.configService.isStandalone() ? DashboardType.createApp : null;
 
+        this._broadcastService = sideNav.injector.get(BroadcastService);
+
         this.iconClass = 'tree-node-collection-icon';
         this.iconUrl = 'image/BulletList.svg';
         this.showExpandIcon = false;
-        this.childrenStream.subscribe(children => {
-            this.children = children;
-        });
 
-        this._getSearchStream()
-            .subscribe((result: { term: string, children: TreeNode[] }) => {
+        // Always listening for list update
+        this._broadcastService.getEvents<AppNode[]>(BroadcastEvent.UpdateAppsList)
+            .subscribe(children => {
+                this.children = children ? children : [];
+            })
 
-                if (!result) {
-                    this.isLoading = false;
+        // Always listening for subscription changes
+        this._subscriptionsStream
+            .subscribe(subs => {
+                this._subscriptions = subs;
+
+                if (!this._initialized()) {
                     return;
                 }
 
-                const regex = new RegExp(this._exactAppSearchExp, 'i');
-                const exactSearchResult = regex.exec(result.term);
+                this._searchInfo.next({
+                    searchTerm: this._searchTerm,
+                    subscriptions: subs
+                });
+            });
 
-                if (exactSearchResult && exactSearchResult.length > 1) {
-                    const filteredChildren = result.children.filter(c => {
-                        if (c.title.toLowerCase() === exactSearchResult[1].toLowerCase()) {
-                            c.select();
-                            return true;
-                        }
+        // Always listening for search term changes
+        this._searchTermStream
+            .distinctUntilChanged()
+            .debounceTime(500)
+            .subscribe(term => {
+                this._searchTerm = term;
 
-                        return false;
-                    });
-
-                    // Purposely don't update the stream with the filtered list of children.
-                    // This is because we only want the exact matching to affect the tree view,
-                    // not any other listeners.
-                    this.childrenStream.next(<AppNode[]>result.children);
-                    this.children = filteredChildren;
-
-                    // Scoping to an app will cause the currently focused item in the tree to be
-                    // recreated.  In that case, we'll just refocus on the root node.  It's probably
-                    // not ideal but simple for us to do.
-                    this.treeView.setFocus(this);
+                if (!this._initialized()) {
+                    return;
                 }
 
-                this.isLoading = false;
+                this._searchInfo.next({
+                    searchTerm: this._searchTerm,
+                    subscriptions: this._subscriptions
+                });
+            });
+
+        this._searchInfo
+            .switchMap(result => {
+
+                this._broadcastService.broadcastEvent<AppNode[]>(BroadcastEvent.UpdateAppsList, null);
+                // this.childrenStream.next([]);
+
+                this.isLoading = true;
+                this.supportsRefresh = false;
+
+                this._subscriptions = result.subscriptions;
+
+                return this._doSearch(<AppNode[]>this.children, result.searchTerm, result.subscriptions, 0, null);
+            })
+            .do(() => {
+                this.supportsRefresh = true;
+            }, err => {
+                this.sideNav.logService.error(LogCategories.SideNav, '/search-error', err);
+            })
+            .retry()
+            .subscribe((result: { term: string, children: TreeNode[] }) => {
+
+                try {
+                    if (!result) {
+                        this.isLoading = false;
+                        return;
+                    }
+
+                    const regex = new RegExp(this._exactAppSearchExp, 'i');
+                    const exactSearchResult = regex.exec(result.term);
+
+                    if (exactSearchResult && exactSearchResult.length > 1) {
+                        this.supportsRefresh = false;
+
+                        const filteredChildren = result.children.filter(c => {
+                            if (c.title.toLowerCase() === exactSearchResult[1].toLowerCase()) {
+                                c.select();
+                                return true;
+                            }
+
+                            return false;
+                        });
+
+                        // Purposely don't update the stream with the filtered list of children.
+                        // This is because we only want the exact matching to affect the tree view,
+                        // not any other listeners.
+                        // this.childrenStream.next(<AppNode[]>result.children);
+                        this._broadcastService.broadcastEvent<AppNode[]>(BroadcastEvent.UpdateAppsList, result.children as AppNode[]);
+                        this.children = filteredChildren;
+
+                        // Scoping to an app will cause the currently focused item in the tree to be
+                        // recreated.  In that case, we'll just refocus on the root node.  It's probably
+                        // not ideal but simple for us to do.
+                        this.treeView.setFocus(this);
+                    } else{
+                        this.supportsRefresh = true;
+                    }
+
+                    this.isLoading = false;
+
+                } catch (err) {
+                    this.isLoading = false;
+                    this.sideNav.logService.error(LogCategories.SideNav, '/parse-search', err);
+                }
+
             });
     }
 
     public handleSelection(): Observable<any> {
         this.inSelectedTree = true;
         this.supportsRefresh = true;
-        return super.handleSelection();
+        return Observable.of(null);
     }
 
-    public dispose() {
+    public handleDeselection() {
 
         // For now, we're just hiding the refresh icon if you're not currently on the apps node.  The only reason
         // is because we're not properly handling the restoration of the selection properly if you're currently
@@ -106,49 +176,20 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
     }
 
     public handleRefresh(): Observable<any> {
-        this.childrenStream.next([]);
         this.sideNav.cacheService.clearArmIdCachePrefix(`/resources`);
 
-        return this._getSearchStream().first();
+        this.isLoading = true;
+
+        this._searchInfo.next({
+            searchTerm: this._searchTerm,
+            subscriptions: this._subscriptions
+        })
+
+        return Observable.of(null);
     }
 
-    private _getSearchStream() {
-        return this._searchTermStream
-            .debounceTime(400)
-            .distinctUntilChanged()
-            .switchMap((searchTerm) => {
-                return this._subscriptionsStream.distinctUntilChanged()
-                    .map(subscriptions => {
-                        return {
-                            searchTerm: searchTerm,
-                            subscriptions: subscriptions
-                        };
-                    });
-            })
-            .switchMap(result => {
-
-                if (!result.subscriptions || result.subscriptions.length === 0) {
-                    return Observable.of(null);
-                }
-
-                this.childrenStream.next([]);
-
-                this.isLoading = true;
-                this.supportsRefresh = false;
-
-                this._subscriptions = result.subscriptions;
-
-                if (!this._searchObs) {
-                    this._searchObs = this._doSearch(<AppNode[]>this.children, result.searchTerm, result.subscriptions, 0, null);
-                }
-
-                return this._searchObs;
-            })
-            .do(() => {
-                this._searchObs = null;
-                this.supportsRefresh = true;
-            })
-            .share();
+    private _initialized(){
+        return this._subscriptions && this._subscriptions.length > 0 && this._searchTerm !== undefined;
     }
 
     private _doSearch(
@@ -220,7 +261,7 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
                 // Only update children if we're not doing an exact match.  For exact matches, we
                 // wait until everything is done loading and then show the final result
                 if (!exactSearch) {
-                    this.childrenStream.next(children);
+                    this._broadcastService.broadcastEvent<AppNode[]>(BroadcastEvent.UpdateAppsList, children);
                 }
 
                 if (result.nextLink || (subsIndex + Arm.MaxSubscriptionBatchSize < subscriptions.length)) {
@@ -252,7 +293,7 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
         });
 
         this._removeHelper(removeIndex, callRemoveOnChild);
-        this.childrenStream.next(<AppNode[]>this.children);
+        this._broadcastService.broadcastEvent<AppNode[]>(BroadcastEvent.UpdateAppsList, this.children as AppNode[]);
         this.sideNav.cacheService.clearArmIdCachePrefix(`/resources`);
     }
 

--- a/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
@@ -94,7 +94,6 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
             .switchMap(result => {
 
                 this._broadcastService.broadcastEvent<AppNode[]>(BroadcastEvent.UpdateAppsList, null);
-                // this.childrenStream.next([]);
 
                 this.isLoading = true;
                 this.supportsRefresh = false;
@@ -135,7 +134,6 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
                         // Purposely don't update the stream with the filtered list of children.
                         // This is because we only want the exact matching to affect the tree view,
                         // not any other listeners.
-                        // this.childrenStream.next(<AppNode[]>result.children);
                         this._broadcastService.broadcastEvent<AppNode[]>(BroadcastEvent.UpdateAppsList, result.children as AppNode[]);
                         this.children = filteredChildren;
 

--- a/AzureFunctions.AngularClient/src/app/tree-view/base-functions-proxies-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/base-functions-proxies-node.ts
@@ -1,13 +1,13 @@
-import { AppNode } from './app-node';
+import { BroadcastService } from './../shared/services/broadcast.service';
+import { FunctionAppContext, FunctionsService } from './../shared/services/functions-service';
+import { LogCategories } from './../shared/models/constants';
+import { LogService } from './../shared/services/log.service';
 import { DashboardType } from 'app/tree-view/models/dashboard-type';
 import { EditModeHelper } from './../shared/Utilities/edit-mode.helper';
 import { AuthzService } from './../shared/services/authz.service';
 import { Observable } from 'rxjs/Observable';
 import { SideNavComponent } from './../side-nav/side-nav.component';
-import { FunctionApp } from './../shared/function-app';
 import { TreeNode } from './tree-node';
-import { reachableInternalLoadBalancerApp } from 'app/shared/Utilities/internal-load-balancer';
-
 
 interface ErrorTitles {
     noAccessTitle: string;
@@ -23,13 +23,21 @@ interface WorkingTitles {
 
 export abstract class BaseFunctionsProxiesNode extends TreeNode {
 
+    protected _logService: LogService;
+    protected _functionsService: FunctionsService;
+    protected _broadcastService: BroadcastService;
+
     constructor(
         sideNav: SideNavComponent,
         resourceId: string,
-        public functionApp: FunctionApp,
+        protected _context: FunctionAppContext,
         parentNode: TreeNode,
         createResourceId?: string) {
         super(sideNav, resourceId, parentNode, createResourceId);
+
+        this._logService = sideNav.injector.get(LogService);
+        this._functionsService = sideNav.injector.get(FunctionsService);
+        this._broadcastService = sideNav.injector.get(BroadcastService);
     }
 
     abstract loadChildren(): Observable<any>;
@@ -38,13 +46,14 @@ export abstract class BaseFunctionsProxiesNode extends TreeNode {
 
     protected abstract _updateTreeForNonUsableState(title: string);
 
-    public baseLoadChildren(workingTitles: WorkingTitles, errorTitles: ErrorTitles) {
-        if (this.functionApp.site.properties.state === 'Running') {
+    public baseLoadChildren(workingTitles: WorkingTitles, errorTitles: ErrorTitles): Observable<any> {
+        if (this._context.site.properties.state === 'Running') {
+            this.isLoading = true;
             return Observable.zip(
-                this.sideNav.authZService.hasPermission(this.functionApp.site.id, [AuthzService.writeScope]),
-                this.sideNav.authZService.hasReadOnlyLock(this.functionApp.site.id),
-                reachableInternalLoadBalancerApp(this.functionApp, this.sideNav.cacheService),
-                this.functionApp.getFunctionAppEditMode().map(EditModeHelper.isReadOnly),
+                this.sideNav.authZService.hasPermission(this._context.site.id, [AuthzService.writeScope]),
+                this.sideNav.authZService.hasReadOnlyLock(this._context.site.id),
+                this._functionsService.reachableInternalLoadBalancerApp(this._context, this.sideNav.cacheService),
+                this._functionsService.getFunctionAppEditMode(this._context).map(EditModeHelper.isReadOnly),
                 (p, l, r, isReadOnly) => ({ hasWritePermission: p, hasReadOnlyLock: l, reachable: r, isReadOnly: isReadOnly }))
                 .switchMap(r => {
                     if (r.hasWritePermission && !r.hasReadOnlyLock && r.reachable && !r.isReadOnly) {
@@ -62,6 +71,12 @@ export abstract class BaseFunctionsProxiesNode extends TreeNode {
                         this.disabledReason = this.sideNav.translateService.instant('You have read only access. Functions require write access to view');
                         return this._updateTreeForNonUsableState(errorTitles.readOnlyTitle);
                     }
+                })
+                .do(() => {
+                    this.isLoading = false;
+                }, err => {
+                    this._logService.error(LogCategories.SideNav, '/base-function-proxies-node/load-children', err);
+                    this.isLoading = false;
                 });
         } else {
             this.disabledReason = this.sideNav.translateService.instant('All functions are stopped. Start your app to view your functions.')
@@ -70,11 +85,7 @@ export abstract class BaseFunctionsProxiesNode extends TreeNode {
     }
 
     public handleSelection(): Observable<any> {
-        if (!this.disabled) {
-            this.parent.inSelectedTree = true;
-            return (<AppNode>this.parent).initialize();
-        }
-
+        this.parent.inSelectedTree = true;
         return Observable.of({});
     }
 }

--- a/AzureFunctions.AngularClient/src/app/tree-view/function-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/function-node.ts
@@ -187,7 +187,6 @@ export class FunctionManageNode extends FunctionEditBaseNode implements Removabl
 
     constructor(
         sideNav: SideNavComponent,
-        // private _functionsNode: FunctionsNode,
         functionInfo: FunctionInfo,
         parentNode: TreeNode) {
 

--- a/AzureFunctions.AngularClient/src/app/tree-view/functions-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/functions-node.ts
@@ -151,7 +151,6 @@ export class FunctionsNode extends BaseFunctionsProxiesNode implements MutableCo
                 .map(fcs => {
                     const fcNodes = <FunctionNode[]>[];
                     fcs.forEach(fc => {
-                        // fc.functionApp = this.functionApp;
                         fcNodes.push(new FunctionNode(this.sideNav, fc, this));
                     });
 

--- a/AzureFunctions.AngularClient/src/app/tree-view/functions-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/functions-node.ts
@@ -1,3 +1,9 @@
+import { Subject } from 'rxjs/Subject';
+import { BroadcastEvent } from 'app/shared/models/broadcast-event';
+import { TreeUpdateEvent } from './../shared/models/broadcast-event';
+import { CacheService } from 'app/shared/services/cache.service';
+import { FunctionDescriptor } from 'app/shared/resourceDescriptors';
+import { FunctionAppContext } from './../shared/services/functions-service';
 import { EditModeHelper } from './../shared/Utilities/edit-mode.helper';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
@@ -11,7 +17,6 @@ import { DashboardType } from './models/dashboard-type';
 import { PortalResources } from '../shared/models/portal-resources';
 import { FunctionInfo } from '../shared/models/function-info';
 import { FunctionNode } from './function-node';
-import { FunctionApp } from '../shared/function-app';
 import { Action } from '../shared/models/binding';
 import { BaseFunctionsProxiesNode } from 'app/tree-view/base-functions-proxies-node';
 
@@ -21,21 +26,26 @@ export class FunctionsNode extends BaseFunctionsProxiesNode implements MutableCo
     public newDashboardType = DashboardType.CreateFunctionAutoDetectDashboard;
     public action: Action;
 
+    private _cacheService: CacheService;
+    private _ngUnsubscribe = new Subject();
+
     constructor(
         sideNav: SideNavComponent,
-        public functionApp: FunctionApp,
+        context: FunctionAppContext,
         parentNode: TreeNode) {
         super(sideNav,
-            functionApp.site.id + '/functions',
-            functionApp,
+            context.site.id + '/functions',
+            context,
             parentNode,
-            functionApp.site.id + '/functions/new/function');
+            context.site.id + '/functions/new/function');
+
+        this._cacheService = sideNav.injector.get(CacheService);
 
         this.iconClass = 'tree-node-collection-icon';
         this.iconUrl = 'image/BulletList.svg';
         this.nodeClass += ' collection-node';
 
-        functionApp.getFunctionAppEditMode()
+        this._functionsService.getFunctionAppEditMode(context)
             .map(EditModeHelper.isReadOnly)
             .subscribe(isReadOnly => {
                 if (isReadOnly) {
@@ -46,6 +56,24 @@ export class FunctionsNode extends BaseFunctionsProxiesNode implements MutableCo
                     this.newDashboardType = DashboardType.CreateFunctionAutoDetectDashboard;
                 }
             });
+    }
+
+    public handleSelection(): Observable<any> {
+        this._broadcastService.getEvents<TreeUpdateEvent>(BroadcastEvent.TreeUpdate)
+            .takeUntil(this._ngUnsubscribe)
+            .subscribe(event => {
+                if (event.operation === 'removeChild') {
+                    this.removeChild(event.resourceId);
+                } else if (event.operation === 'update') {
+                    this.updateChild(event.resourceId, event.data);
+                }
+            });
+
+        return Observable.of({});
+    }
+
+    public handleDeselection(newSelectedNode?: TreeNode) {
+        this._ngUnsubscribe.next();
     }
 
     public loadChildren() {
@@ -67,21 +95,30 @@ export class FunctionsNode extends BaseFunctionsProxiesNode implements MutableCo
     }
 
     public addChild(functionInfo: FunctionInfo) {
-        functionInfo.functionApp = this.functionApp;
-        this.sideNav.cacheService.clearCachePrefix(this.functionApp.getScmUrl());
+        this._cacheService.clearCachePrefix(functionInfo.context.urlTemplates.functionsUrl);
 
-        const newNode = new FunctionNode(this.sideNav, this, functionInfo, this);
+        const newNode = new FunctionNode(this.sideNav, functionInfo, this);
         this._addChildAlphabetically(newNode);
         newNode.select();
     }
 
-    public removeChild(functionInfo: FunctionInfo, callRemoveOnChild?: boolean) {
+    public removeChild(resourceId: string, callRemoveOnChild?: boolean) {
 
-        const removeIndex = this.children.findIndex((childNode: FunctionNode) => {
-            return childNode.functionInfo.name === functionInfo.name;
-        });
+        const descriptor = new FunctionDescriptor(resourceId);
+        resourceId = descriptor.getTrimmedResourceId();
 
-        this._removeHelper(removeIndex, callRemoveOnChild);
+        const removeIndex = this.children.findIndex(c => c.resourceId.toLowerCase() === resourceId.toLowerCase());
+        this._removeHelper(removeIndex);
+    }
+
+    public updateChild(resourceId: string, disabled: boolean) {
+        const descriptor = new FunctionDescriptor(resourceId);
+        resourceId = descriptor.getTrimmedResourceId();
+
+        const child = <FunctionNode>this.children.find(c => c.resourceId.toLowerCase() === resourceId.toLowerCase());
+        if (child) {
+            child.functionInfo.config.disabled = disabled;
+        }
     }
 
     public openCreateDashboard(dashboardType: DashboardType, action?: Action) {
@@ -90,17 +127,13 @@ export class FunctionsNode extends BaseFunctionsProxiesNode implements MutableCo
         this.openCreateNew();
     }
 
-    public dispose(newSelectedNode?: TreeNode) {
-        this.parent.dispose(newSelectedNode);
-    }
-
     protected _updateTreeForNonUsableState(title: string) {
         this.disabled = true;
         this.newDashboardType = null;
         this.children = [];
         this.title = title;
         this.showExpandIcon = false;
-        this.sideNav.cacheService.clearCachePrefix(`${this.functionApp.getScmUrl()}/api/functions`);
+        this.sideNav.cacheService.clearCachePrefix(`${this._context.scmUrl}/api/functions`);
         return Observable.of(null);
     }
 
@@ -114,12 +147,12 @@ export class FunctionsNode extends BaseFunctionsProxiesNode implements MutableCo
         }
 
         if (!this.children || this.children.length === 0) {
-            return this.functionApp.getFunctions()
+            return this._functionsService.getFunctions(this._context)
                 .map(fcs => {
                     const fcNodes = <FunctionNode[]>[];
                     fcs.forEach(fc => {
-                        fc.functionApp = this.functionApp;
-                        fcNodes.push(new FunctionNode(this.sideNav, this, fc, this))
+                        // fc.functionApp = this.functionApp;
+                        fcNodes.push(new FunctionNode(this.sideNav, fc, this));
                     });
 
                     this.children = fcNodes;

--- a/AzureFunctions.AngularClient/src/app/tree-view/proxies-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/proxies-node.ts
@@ -1,13 +1,8 @@
 import { FunctionDescriptor } from './../shared/resourceDescriptors';
 import { FunctionAppContext } from './../shared/services/functions-service';
 import { ApiProxy } from './../shared/models/api-proxy';
-// import { BaseFunctionsProxiesNode } from 'app/tree-view/base-functions-proxies-node';
 import { PortalResources } from './../shared/models/portal-resources';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/switchMap';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/observable/zip';
 import { BaseFunctionsProxiesNode } from 'app/tree-view/base-functions-proxies-node';
 import { TreeNode } from './tree-node';
 import { SideNavComponent } from '../side-nav/side-nav.component';
@@ -53,9 +48,6 @@ export class ProxiesNode extends BaseFunctionsProxiesNode{
     }
 
     public addChild(proxy: ApiProxy) {
-        // functionInfo.functionApp = this.functionApp;
-        // this.sideNav.cacheService.clearCachePrefix(this.functionApp.getScmUrl());
-
         const newNode = new ProxyNode(this.sideNav, proxy, this._context.site, this);
         this._addChildAlphabetically(newNode);
         newNode.select();
@@ -68,10 +60,6 @@ export class ProxiesNode extends BaseFunctionsProxiesNode{
 
         const removeIndex = this.children.findIndex(c => c.resourceId.toLowerCase() === resourceId.toLowerCase());
         this._removeHelper(removeIndex);
-    }
-
-    public handleDeselection(newSelectedNode?: TreeNode) {
-        // this.parent.dispose(newSelectedNode);
     }
 
     protected _updateTreeForNonUsableState(title: string) {

--- a/AzureFunctions.AngularClient/src/app/tree-view/proxies-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/proxies-node.ts
@@ -1,33 +1,33 @@
-import { BaseFunctionsProxiesNode } from 'app/tree-view/base-functions-proxies-node';
+import { FunctionDescriptor } from './../shared/resourceDescriptors';
+import { FunctionAppContext } from './../shared/services/functions-service';
+import { ApiProxy } from './../shared/models/api-proxy';
+// import { BaseFunctionsProxiesNode } from 'app/tree-view/base-functions-proxies-node';
 import { PortalResources } from './../shared/models/portal-resources';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/zip';
-
-import { TreeNode, MutableCollection, Disposable, CustomSelection, Collection } from './tree-node';
+import { BaseFunctionsProxiesNode } from 'app/tree-view/base-functions-proxies-node';
+import { TreeNode } from './tree-node';
 import { SideNavComponent } from '../side-nav/side-nav.component';
 import { DashboardType } from './models/dashboard-type';
-import { ApiProxy } from '../shared/models/api-proxy';
 import { ProxyNode } from './proxy-node';
-import { FunctionApp } from '../shared/function-app';
 
-export class ProxiesNode extends BaseFunctionsProxiesNode implements MutableCollection, Disposable, CustomSelection, Collection {
+export class ProxiesNode extends BaseFunctionsProxiesNode{
     public title = this.sideNav.translateService.instant(PortalResources.appFunctionSettings_apiProxies);
     public dashboardType = DashboardType.ProxiesDashboard;
     public newDashboardType = DashboardType.CreateProxyDashboard;
 
     constructor(
         sideNav: SideNavComponent,
-        public functionApp: FunctionApp,
+        context: FunctionAppContext,
         parentNode: TreeNode) {
-
         super(sideNav,
-            functionApp.site.id + '/proxies',
-            functionApp,
+            context.site.id + '/proxies',
+            context,
             parentNode,
-            functionApp.site.id + '/proxies/new/proxy');
+            context.site.id + '/proxies/new/proxy');
 
         this.nodeClass += ' collection-node';
         this.iconClass = 'tree-node-collection-icon';
@@ -52,26 +52,26 @@ export class ProxiesNode extends BaseFunctionsProxiesNode implements MutableColl
             });
     }
 
-    public addChild(functionInfo: ApiProxy) {
-        functionInfo.functionApp = this.functionApp;
-        this.sideNav.cacheService.clearCachePrefix(this.functionApp.getScmUrl());
+    public addChild(proxy: ApiProxy) {
+        // functionInfo.functionApp = this.functionApp;
+        // this.sideNav.cacheService.clearCachePrefix(this.functionApp.getScmUrl());
 
-        const newNode = new ProxyNode(this.sideNav, functionInfo, this);
+        const newNode = new ProxyNode(this.sideNav, proxy, this._context.site, this);
         this._addChildAlphabetically(newNode);
         newNode.select();
     }
 
-    public removeChild(functionInfo: ApiProxy, callRemoveOnChild?: boolean) {
+    public removeChild(resourceId: string, callRemoveOnChild?: boolean) {
 
-        const removeIndex = this.children.findIndex((childNode: ProxyNode) => {
-            return childNode.proxy.name === functionInfo.name;
-        });
+        const descriptor = new FunctionDescriptor(resourceId);
+        resourceId = descriptor.getTrimmedResourceId();
 
-        this._removeHelper(removeIndex, callRemoveOnChild);
+        const removeIndex = this.children.findIndex(c => c.resourceId.toLowerCase() === resourceId.toLowerCase());
+        this._removeHelper(removeIndex);
     }
 
-    public dispose(newSelectedNode?: TreeNode) {
-        this.parent.dispose(newSelectedNode);
+    public handleDeselection(newSelectedNode?: TreeNode) {
+        // this.parent.dispose(newSelectedNode);
     }
 
     protected _updateTreeForNonUsableState(title: string) {
@@ -80,7 +80,7 @@ export class ProxiesNode extends BaseFunctionsProxiesNode implements MutableColl
         this.children = [];
         this.title = title;
         this.showExpandIcon = false;
-        this.sideNav.cacheService.clearCachePrefix(`${this.functionApp.getScmUrl()}/api/functions`);
+        this.sideNav.cacheService.clearCachePrefix(`${this._context.scmUrl}/api/functions`);
         return Observable.of(null);
     }
 
@@ -95,12 +95,11 @@ export class ProxiesNode extends BaseFunctionsProxiesNode implements MutableColl
         }
 
         if (!this.children || this.children.length === 0) {
-            return this.functionApp.getApiProxies()
+            return this._functionsService.getApiProxies(this._context)
                 .map(proxies => {
                     const fcNodes = <ProxyNode[]>[];
                     proxies.forEach(proxy => {
-                        proxy.functionApp = this.functionApp;
-                        fcNodes.push(new ProxyNode(this.sideNav, proxy, this));
+                        fcNodes.push(new ProxyNode(this.sideNav, proxy, this._context.site, this));
                     });
 
                     this.children = fcNodes;

--- a/AzureFunctions.AngularClient/src/app/tree-view/proxy-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/proxy-node.ts
@@ -1,27 +1,37 @@
+import { ProxiesNode } from './proxies-node';
+import { BroadcastEvent } from 'app/shared/models/broadcast-event';
+import { TreeUpdateEvent } from './../shared/models/broadcast-event';
+import { Subject } from 'rxjs/Subject';
+import { BroadcastService } from './../shared/services/broadcast.service';
+import { ArmObj } from './../shared/models/arm/arm-obj';
+import { Site } from './../shared/models/arm/site';
+import { FunctionNode } from './function-node';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 
-import { AppNode } from './app-node';
-import { FunctionDescriptor } from './../shared/resourceDescriptors';
 import { TreeNode, CanBlockNavChange, Disposable, CustomSelection } from './tree-node';
 import { SideNavComponent } from '../side-nav/side-nav.component';
 import { DashboardType } from './models/dashboard-type';
-import { PortalResources } from '../shared/models/portal-resources';
 import { ApiProxy } from '../shared/models/api-proxy';
 
 export class ProxyNode extends TreeNode implements CanBlockNavChange, Disposable, CustomSelection {
     public title = 'Proxy';
     public dashboardType = DashboardType.ProxyDashboard;
     public showExpandIcon = false;
+    private _broadcastService: BroadcastService;
+    private _ngUnsubscribe = new Subject();
 
     constructor(
         sideNav: SideNavComponent,
         public proxy: ApiProxy,
+        site: ArmObj<Site>,
         parentNode: TreeNode) {
 
         super(sideNav,
-            proxy.functionApp.site.id + '/proxies/' + proxy.name,
+            site.id + '/proxies/' + proxy.name,
             parentNode);
+
+        this._broadcastService = sideNav.injector.get(BroadcastService);
 
         this.title = proxy.name;
         this.iconClass = 'tree-node-svg-icon';
@@ -29,148 +39,28 @@ export class ProxyNode extends TreeNode implements CanBlockNavChange, Disposable
     }
 
     public handleSelection(): Observable<any> {
-        if (!this.disabled) {
-            return (<AppNode>this.parent.parent).initialize();
-        }
+        this._broadcastService.getEvents<TreeUpdateEvent>(BroadcastEvent.TreeUpdate)
+            .takeUntil(this._ngUnsubscribe)
+            .subscribe(event => {
+                if (event.operation === 'remove') {
+                    (<ProxiesNode>this.parent).removeChild(event.resourceId);
+                    this.handleDeselection();
+                }
+            });
 
         return Observable.of({});
     }
 
-    //public loadChildren(){
-    //    this.children = [
-    //        //new FunctionIntegrateNode(this.sideNav, this.functionInfo, this),
-    //        //new FunctionManageNode(this.sideNav, this._functionsNode, this.functionInfo, this),
-    //        //new FunctionMonitorNode(this.sideNav, this.functionInfo, this)
-    //    ]
-
-    //    return Observable.of(null);
-    //}
+    public handleDeselection(newSelectedNode?: TreeNode) {
+        this._ngUnsubscribe.next();
+        this.sideNav.broadcastService.clearAllDirtyStates();
+    }
 
     public getViewData(): any {
         return this.proxy;
     }
 
     public shouldBlockNavChange(): boolean {
-        return ProxyNode.blockNavChangeHelper(this);
-    }
-
-    public dispose(newSelectedNode?: TreeNode) {
-        this.sideNav.broadcastService.clearAllDirtyStates();
-        this.parent.dispose(newSelectedNode);
-    }
-
-    public static blockNavChangeHelper(currentNode: TreeNode) {
-        var canSwitchFunction = true;
-        if (currentNode.sideNav.broadcastService.getDirtyState('function')
-            || currentNode.sideNav.broadcastService.getDirtyState('function_integrate')
-            || currentNode.sideNav.broadcastService.getDirtyState('api-proxy')) {
-
-            let descriptor = new FunctionDescriptor(currentNode.resourceId);
-
-            canSwitchFunction = confirm(currentNode.sideNav.translateService.instant(
-                PortalResources.sideBar_changeMade,
-                {
-                    name: descriptor.functionName
-                }));
-        }
-
-        return !canSwitchFunction;
+        return FunctionNode.blockNavChangeHelper(this);
     }
 }
-
-//export class FunctionEditBaseNode extends TreeNode implements CanBlockNavChange, Disposable, CustomSelection{
-//    public dashboardType = DashboardType.function;
-//    public showExpandIcon = false;
-
-//    constructor(
-//        sideNav : SideNavComponent,
-//        public functionInfo : FunctionInfo,
-//        resourceId : string,
-//        public parentNode : TreeNode){
-
-//        super(sideNav, resourceId, parentNode);
-//    }
-
-//    public handleSelection() : Observable<any>{
-//        if(!this.disabled){
-//            return (<AppNode>this.parent.parent.parent).initialize();
-//        }
-
-//        return Observable.of({});
-//    }
-
-//    public getViewData() : any{
-//        return this.functionInfo;
-//    }
-
-//    public shouldBlockNavChange() : boolean{
-//        return ProxyNode.blockNavChangeHelper(this);
-//    }
-
-//    public dispose(newSelectedNode? : TreeNode){
-//        this.parentNode.dispose(newSelectedNode);
-//    }
-//}
-
-//export class FunctionIntegrateNode extends FunctionEditBaseNode{
-//    public title = "Integrate";
-
-//    constructor(
-//        sideNav : SideNavComponent,
-//        functionInfo : FunctionInfo,
-//        parentNode : TreeNode){
-
-//        super(sideNav,
-//            functionInfo,
-//            functionInfo.functionApp.site.id + "/functions/" + functionInfo.name + "/integrate",
-//            parentNode);
-
-//        this.iconClass = "fa fa-flash tree-node-function-icon";
-//    }
-//}
-
-//export class FunctionManageNode extends FunctionEditBaseNode implements Removable{
-//    public title = "Manage";
-
-//    constructor(
-//        sideNav : SideNavComponent,
-//        private _functionsNode : FunctionsNode,
-//        functionInfo : FunctionInfo,
-//        parentNode : TreeNode){
-
-//        super(sideNav,
-//            functionInfo,
-//            functionInfo.functionApp.site.id + "/functions/" + functionInfo.name + "/manage",
-//            parentNode);
-
-//        this.iconClass = "fa fa-cog tree-node-function-icon";
-//    }
-
-//    public remove(){
-//        this._functionsNode.removeChild(this.functionInfo, false);
-
-//        let defaultHostName = this._functionsNode.functionApp.site.properties.defaultHostName;
-//        let scmHostName = this._functionsNode.functionApp.site.properties.hostNameSslStates.find(s => s.hostType === 1).name;
-
-//        this.sideNav.cacheService.clearCachePrefix(`https://${defaultHostName}`);
-//        this.sideNav.cacheService.clearCachePrefix(`https://${scmHostName}`);
-
-//    }
-// }
-
-// export class FunctionMonitorNode extends FunctionEditBaseNode{
-//    public title = "Monitor";
-
-//    constructor(
-//        sideNav : SideNavComponent,
-//        functionInfo : FunctionInfo,
-//        parentNode : TreeNode){
-
-//        super(sideNav,
-//            functionInfo,
-//            functionInfo.functionApp.site.id + "/functions/" + functionInfo.name + "/monitor",
-//            parentNode);
-
-//        this.iconClass = "fa fa-search tree-node-function-icon";
-//    }
-// }

--- a/AzureFunctions.AngularClient/src/app/tree-view/slots-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/slots-node.ts
@@ -1,3 +1,5 @@
+import { LogCategories } from './../shared/models/constants';
+import { LogService } from './../shared/services/log.service';
 import { SlotNode } from './app-node';
 import { TreeNode } from './tree-node';
 import { DashboardType } from './models/dashboard-type';
@@ -11,6 +13,7 @@ export class SlotsNode extends TreeNode {
     public dashboardType = DashboardType.SlotsDashboard;
     public newDashboardType = DashboardType.CreateSlotDashboard;
     public title = this.sideNav.translateService.instant(PortalResources.appFunctionSettings_slotsOptinSettings);
+    private _logService: LogService;
 
     constructor(
         sideNav: SideNavComponent,
@@ -25,16 +28,22 @@ export class SlotsNode extends TreeNode {
         this.nodeClass += ' collection-node';
         this.iconClass = 'tree-node-collection-icon';
         this.iconUrl = 'image/BulletList.svg';
+        this._logService = sideNav.injector.get(LogService);
     }
 
     public loadChildren() {
+        this.isLoading = true;
         return this.sideNav.slotsService.getSlotsList(this._siteArmCacheObj.id)
             .do(slots => {
+                this.isLoading = false;
                 this.children = slots.map(s => new SlotNode(
                     this.sideNav,
                     s,
                     this,
                     this._subscriptions));
+            }, err =>{
+                this._logService.error(LogCategories.SideNav, '/slots-node-loadchildren', err);
+                this.isLoading = false;
             });
     }
 
@@ -52,9 +61,5 @@ export class SlotsNode extends TreeNode {
 
         this._removeHelper(removeIndex, callRemoveOnChild);
         this.sideNav.cacheService.clearArmIdCachePrefix('/slots');
-    }
-
-    public dispose(newSelectedNode?: TreeNode) {
-        this.parent.dispose(newSelectedNode);
     }
 }

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
@@ -1,19 +1,19 @@
 import { DomEvents, KeyCodes } from './../shared/models/constants';
 import { TreeViewComponent } from './tree-view.component';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/do';
-import 'rxjs/add/observable/of';
-
 import { Disposable } from './tree-node';
 import { SideNavComponent } from '../side-nav/side-nav.component';
 import { DashboardType } from './models/dashboard-type';
+import 'rxjs/add/operator/do';
+import 'rxjs/add/observable/of';
+
 
 export interface CustomSelection {
     handleSelection();
 }
 
 export interface Disposable {
-    dispose(newSelectedNode?: TreeNode);
+    handleDeselection(newSelectedNode?: TreeNode);
 }
 
 export interface Removable {
@@ -94,8 +94,8 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
     }
 
     // Virtual
-    public handleSelection(): Observable<any> {
-        this.isLoading = false;
+    public handleSelection(data?: any): Observable<any> {
+        // this.isLoading = false;
         return Observable.of(null);
     }
 
@@ -107,7 +107,7 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
             }
         }
 
-        this.isLoading = true;
+        // this.isLoading = true;
         this.handleRefresh()
             .do(null, e => {
                 this.sideNav.aiService.trackException(e, '/errors/tree-node/refresh');
@@ -123,7 +123,7 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
                     })
                     .subscribe(() => { });
 
-                this.isLoading = false;
+                // this.isLoading = false;
             });
 
         this.treeView.setFocus(this);
@@ -140,7 +140,7 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
     public toggle(event) {
 
         if (!this.isExpanded) {
-            this.isLoading = true;
+            // this.isLoading = true;
             this.isExpanded = true;
 
             this._loadAndExpandChildrenIfSingle();
@@ -159,7 +159,6 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
                 this.sideNav.aiService.trackException(e, '/errors/tree-node/expand-single/load-children');
             })
             .subscribe(() => {
-                this.isLoading = false;
                 if (this.children && this.children.length > 0) {
                     const matchingChild = this.children.find(c => {
                         return this.sideNav.initialResourceId && this.sideNav.initialResourceId.toLowerCase().startsWith(`${this.resourceId}/${c.title}`.toLowerCase());
@@ -208,7 +207,7 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
         return Observable.of(null);
     }
 
-    public dispose(_?: TreeNode) {
+    public handleDeselection(_?: TreeNode) {
     }
 
     public remove() {

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-node.ts
@@ -95,7 +95,6 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
 
     // Virtual
     public handleSelection(data?: any): Observable<any> {
-        // this.isLoading = false;
         return Observable.of(null);
     }
 
@@ -107,7 +106,6 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
             }
         }
 
-        // this.isLoading = true;
         this.handleRefresh()
             .do(null, e => {
                 this.sideNav.aiService.trackException(e, '/errors/tree-node/refresh');
@@ -122,8 +120,6 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
                         this.sideNav.aiService.trackException(e, '/errors/tree-node/refresh/update-view');
                     })
                     .subscribe(() => { });
-
-                // this.isLoading = false;
             });
 
         this.treeView.setFocus(this);
@@ -140,7 +136,6 @@ export class TreeNode implements Disposable, Removable, CanBlockNavChange, Custo
     public toggle(event) {
 
         if (!this.isExpanded) {
-            // this.isLoading = true;
             this.isExpanded = true;
 
             this._loadAndExpandChildrenIfSingle();

--- a/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.html
+++ b/AzureFunctions.AngularClient/src/app/tree-view/tree-view.component.html
@@ -26,6 +26,8 @@
 
   {{node.title}}
 
+  <span *ngIf="node.isLoading !== undefined" [log-message]="node.title + ' isLoading=' + node.isLoading" log-category="SideNav"></span>
+
   <i *ngIf="node.isLoading" class="fa fa-refresh fa-spin fa-fw margin-bottom"></i>
 
   <!-- Optional menu icons that show up on right side of each node -->

--- a/AzureFunctions.AngularClient/src/app/try-landing/try-landing.component.ts
+++ b/AzureFunctions.AngularClient/src/app/try-landing/try-landing.component.ts
@@ -1,21 +1,14 @@
 import { Router } from '@angular/router';
-import { SiteService } from 'app/shared/services/slots.service';
-import { Component, ViewChild, OnInit, OnDestroy } from '@angular/core';
-import { Http } from '@angular/http';
+import { Component, ViewChild, OnInit, OnDestroy, Injector } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import { TranslateService } from '@ngx-translate/core';
-
-import { ConfigService } from './../shared/services/config.service';
 import { ArmTryService } from './../shared/services/arm-try.service';
-import { CacheService } from './../shared/services/cache.service';
-import { AuthzService } from './../shared/services/authz.service';
-import { LanguageService } from './../shared/services/language.service';
 import { ArmService } from './../shared/services/arm.service';
 import { FunctionApp } from './../shared/function-app';
 import { Site } from './../shared/models/arm/site';
 import { ArmObj } from './../shared/models/arm/arm-obj';
 import { ErrorIds } from './../shared/models/error-ids';
-import { FunctionsService } from '../shared/services/functions.service';
+import { TryFunctionsService } from '../shared/services/try-functions.service';
 import { BroadcastService } from '../shared/services/broadcast.service';
 import { UserService } from '../shared/services/user.service';
 import { BroadcastEvent } from '../shared/models/broadcast-event'
@@ -47,20 +40,15 @@ export class TryLandingComponent implements OnInit, OnDestroy {
     private _ngUnsubscribe = new Subject();
 
     constructor(
-        private _httpService: Http,
-        private _functionsService: FunctionsService,
+        private _tryFunctionsService: TryFunctionsService,
         private _broadcastService: BroadcastService,
         private _globalStateService: GlobalStateService,
         private _userService: UserService,
         private _translateService: TranslateService,
         private _aiService: AiService,
         private _armService: ArmService,
-        private _cacheService: CacheService,
-        private _languageService: LanguageService,
-        private _authZService: AuthzService,
-        private _configService: ConfigService,
-        private _slotsService: SiteService,
-        private _router: Router) {
+        private _router: Router,
+        private _injector: Injector) {
     }
 
     ngOnInit() {
@@ -68,47 +56,47 @@ export class TryLandingComponent implements OnInit, OnDestroy {
         // possibly related to https://github.com/angular/angular/issues/6782
         // and strangely the clearbusystate doesnt get called.
         // this.setBusyState();
-        this.selectedFunction = this._functionsService.selectedFunction || 'HttpTrigger';
-        this.selectedLanguage = this._functionsService.selectedLanguage || 'CSharp';
+        this.selectedFunction = this._tryFunctionsService.selectedFunction || 'HttpTrigger';
+        this.selectedLanguage = this._tryFunctionsService.selectedLanguage || 'CSharp';
 
         this._globalStateService.setBusyState();
 
         this._userService.getStartupInfo()
-        .takeUntil(this._ngUnsubscribe)
-        .switchMap(info =>{
-            return this._functionsService.getTemplates();
-        })
-        .subscribe(templates =>{
-            this._globalStateService.clearBusyState();
+            .takeUntil(this._ngUnsubscribe)
+            .switchMap(info => {
+                return this._tryFunctionsService.getTemplates();
+            })
+            .subscribe(templates => {
+                this._globalStateService.clearBusyState();
 
-            if (this._globalStateService.TryAppServiceToken) {
-                const selectedTemplate: FunctionTemplate = templates.find((t) => {
-                    return t.id === this.selectedFunction + '-' + this.selectedLanguage;
-                });
+                if (this._globalStateService.TryAppServiceToken) {
+                    const selectedTemplate: FunctionTemplate = templates.find((t) => {
+                        return t.id === this.selectedFunction + '-' + this.selectedLanguage;
+                    });
 
-                if (selectedTemplate) {
-                    this.setBusyState();
-                    this._functionsService.createTrialResource(selectedTemplate,
-                        this._functionsService.selectedProvider, this._functionsService.selectedFunctionName)
-                        .subscribe((resource) => {
-                            this.clearBusyState();
-                            this.createFunctioninResource(resource, selectedTemplate, this._functionsService.selectedFunctionName);
-                        },
-                        error => {
-                            if (error.status === 400) {
-                                // If there is already a free resource assigned ,
-                                // we'll get a HTTP 400 ..so lets get it.
-                                this._functionsService.getTrialResource(this._functionsService.selectedProvider)
-                                    .subscribe((resource) => {
-                                        this.createFunctioninResource(resource, selectedTemplate, this._functionsService.selectedFunctionName);
-                                    });
-                            } else {
+                    if (selectedTemplate) {
+                        this.setBusyState();
+                        this._tryFunctionsService.createTrialResource(selectedTemplate,
+                            this._tryFunctionsService.selectedProvider, this._tryFunctionsService.selectedFunctionName)
+                            .subscribe((resource) => {
                                 this.clearBusyState();
-                            }
-                        });
+                                this.createFunctioninResource(resource, selectedTemplate, this._tryFunctionsService.selectedFunctionName);
+                            },
+                            error => {
+                                if (error.status === 400) {
+                                    // If there is already a free resource assigned ,
+                                    // we'll get a HTTP 400 ..so lets get it.
+                                    this._tryFunctionsService.getTrialResource(this._tryFunctionsService.selectedProvider)
+                                        .subscribe((resource) => {
+                                            this.createFunctioninResource(resource, selectedTemplate, this._tryFunctionsService.selectedFunctionName);
+                                        });
+                                } else {
+                                    this.clearBusyState();
+                                }
+                            });
+                    }
                 }
-            }
-        });
+            });
 
         const result = {
             name: this._translateService.instant(PortalResources.sideBar_newFunction),
@@ -122,13 +110,14 @@ export class TryLandingComponent implements OnInit, OnDestroy {
             test_data: null,
             script_root_path_href: null,
             config_href: null,
-            functionApp: null
+            functionApp: null,
+            context: null
         };
 
         this.functionsInfo.push(result);
     }
 
-    ngOnDestroy(){
+    ngOnDestroy() {
         this._ngUnsubscribe.next();
     }
 
@@ -145,7 +134,7 @@ export class TryLandingComponent implements OnInit, OnDestroy {
     }
 
     handleLoginClick(provider: string) {
-        this._functionsService.getTemplates().subscribe((templates) => {
+        this._tryFunctionsService.getTemplates().subscribe((templates) => {
             const selectedTemplate: FunctionTemplate = templates.find((t) => {
                 return t.id === this.selectedFunction + '-' + this.selectedLanguage;
             });
@@ -162,7 +151,7 @@ export class TryLandingComponent implements OnInit, OnDestroy {
                         this.setBusyState();
                         // login
                         // get trial account
-                        this._functionsService.createTrialResource(selectedTemplate, provider, functionName)
+                        this._tryFunctionsService.createTrialResource(selectedTemplate, provider, functionName)
                             .subscribe((resource) => {
                                 this.clearBusyState();
                                 this.createFunctioninResource(resource, selectedTemplate, functionName);
@@ -178,7 +167,7 @@ export class TryLandingComponent implements OnInit, OnDestroy {
                                     }
                                     this.clearBusyState();
                                 } else if (error.status === 400) {
-                                    this._functionsService.getTrialResource(provider)
+                                    this._tryFunctionsService.getTrialResource(provider)
                                         .subscribe((resource) => {
                                             this.createFunctioninResource(resource, selectedTemplate, functionName);
                                         }
@@ -213,7 +202,7 @@ export class TryLandingComponent implements OnInit, OnDestroy {
     createFunctioninResource(resource: UIResource, selectedTemplate: FunctionTemplate, functionName: string) {
         const scmUrl = resource.gitUrl.substring(0, resource.gitUrl.lastIndexOf('/'));
         const encryptedCreds = btoa(scmUrl.substring(8, scmUrl.indexOf('@')));
-        // TODO: find a better way to handle this
+
         const tryfunctionContainer = <ArmObj<Site>>{
             id: resource.csmId,
             name: resource.csmId.substring(resource.csmId.lastIndexOf('/') + 1, resource.csmId.length),
@@ -241,20 +230,8 @@ export class TryLandingComponent implements OnInit, OnDestroy {
             tryScmCred: encryptedCreds
         };
 
-        this._functionApp = new FunctionApp(
-            tryfunctionContainer,
-            this._httpService,
-            this._userService,
-            this._globalStateService,
-            this._translateService,
-            this._broadcastService,
-            this._armService,
-            this._cacheService,
-            this._languageService,
-            this._authZService,
-            this._aiService,
-            this._configService,
-            this._slotsService);
+        this._tryFunctionsService.functionContainer = tryfunctionContainer;
+        this._functionApp = new FunctionApp(tryfunctionContainer, this._injector);
 
         (<ArmTryService>this._armService).tryFunctionApp = this._functionApp;
 
@@ -267,7 +244,7 @@ export class TryLandingComponent implements OnInit, OnDestroy {
                 this._aiService.trackEvent('new-function', { template: selectedTemplate.id, result: 'success', first: 'true' });
                 this._broadcastService.broadcast(BroadcastEvent.FunctionAdded, res);
                 const navId = this._functionApp.site.id.slice(1, this._functionApp.site.id.length).toLowerCase().replace('/providers/microsoft.web', '');
-                this._router.navigate([`/resources/${navId}}/functions/${res.name}`], { queryParams: Url.getQueryStringObj()});
+                this._router.navigate([`/resources/${navId}}/functions/${res.name}`], { queryParams: Url.getQueryStringObj() });
             },
             e => {
                 this.clearBusyState();

--- a/AzureFunctions.AngularClient/src/app/try-now/try-now.component.ts
+++ b/AzureFunctions.AngularClient/src/app/try-now/try-now.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { UIResource } from '../shared/models/ui-resource';
 import { BroadcastService } from '../shared/services/broadcast.service';
 import { BroadcastEvent } from '../shared/models/broadcast-event';
-import { FunctionsService } from '../shared/services/functions.service';
+import { TryFunctionsService } from '../shared/services/try-functions.service';
 import { TranslateService } from '@ngx-translate/core';
 import { PortalResources } from '../shared/models/portal-resources';
 import { GlobalStateService } from '../shared/services/global-state.service';
@@ -22,7 +22,7 @@ export class TryNowComponent implements OnInit {
     public timerText: string;
     public discoverMoreUri: string;
 
-    constructor(private _functionsService: FunctionsService,
+    constructor(private _functionsService: TryFunctionsService,
         private _broadcastService: BroadcastService,
         private _globalStateService: GlobalStateService,
         private _translateService: TranslateService,


### PR DESCRIPTION
In order to make the tree (hopefully) less buggy, I made a few major changes.  This PR contains the majority of work which lays the groundwork for tree changes.

**1. Tree nodes are dumber.** - Previously we were doing a ton of work on the app-node.ts in order to read Function errors and notifications.  There was also a lot of super-confusing dispose logic that was necessary to manage the background task for each app and all of the functions under it.  Now, I've pushed all of the background task work into ONLY the Function dev, integrate, monitor, and manage experiences.  This makes disposing a lot safer since those components already have lifecycle management that we can utilize.

**2. Use broadcast service to communicate between tree and dashboard** - Instead of referencing a tree node directly from the dashboard, you can now broadcast a message to it.  The issue with referencing a node directly is if the tree gets refreshed, then your node reference becomes invalid.

**3. Start bringing the FunctionsService back** - The FunctionApp object was a hack that got us into a multi-app world faster, but it's proven to have some issues because it cannot be disposed easily and recreated easily.  So instead of passing a huge FunctionApp object, we will now pass a small FunctionAppContext object, which contains the site ARM object, the scm/main urls, the url templates, and the master key.  So the first thing you need always do is call getAppContext(siteResourceId).  Then you just pass that around to any other method on the service.

**Remaining work:**
Part 2 (which I'll work on in a future sprint) will be a lot smaller and will involve migrating the remaining dashboards to using the broadcast service instead of referencing the tree nodes directly.

For the FunctionsService, @patricklee2 will be helping to move the remainder FunctionApp code into the new FunctionsService.