### PR TITLE
Add read/write mode and warning for VS generated functions

### DIFF
--- a/AzureFunctions.AngularClient/src/app/edit-mode-warning/edit-mode-warning.component.html
+++ b/AzureFunctions.AngularClient/src/app/edit-mode-warning/edit-mode-warning.component.html
@@ -26,9 +26,16 @@
   </div>
 </div>
 
-<div *ngIf="ReadOnlyVSGenerated">
+<div *ngIf="readOnlyVSGenerated">
   <br />
   <div class="alert alert-warning alert-dismissible" role="alert">
     {{ 'readOnlyGeneratedBy' | translate }} <a *ngIf="context" class="link" href="https://go.microsoft.com/fwlink/?linkid=856288" target="_blank">{{ 'topBar_learnMore' | translate }}</a>.
+  </div>
+</div>
+
+<div *ngIf="readWriteVSGenerated">
+  <br />
+  <div class="alert alert-warning alert-dismissible" role="alert">
+    {{ 'readWriteGeneratedBy' | translate }} <span *ngIf="context" class="link" (click)="onFunctionAppSettingsClicked()">{{ 'appFunctionSettings_functionAppSettings' | translate }}</span>.
   </div>
 </div>

--- a/AzureFunctions.AngularClient/src/app/edit-mode-warning/edit-mode-warning.component.ts
+++ b/AzureFunctions.AngularClient/src/app/edit-mode-warning/edit-mode-warning.component.ts
@@ -19,7 +19,8 @@ export class EditModeWarningComponent implements OnInit {
   public readOnlySourceControlled = false;
   public readWriteSourceControlled = false;
   public readOnlySlots = false;
-  public ReadOnlyVSGenerated = false;
+  public readOnlyVSGenerated = false;
+  public readWriteVSGenerated = false;
 
   constructor(private _functionsService: FunctionsService, private _broadcastService: BroadcastService) { }
 
@@ -37,7 +38,9 @@ export class EditModeWarningComponent implements OnInit {
           } else if (editMode === FunctionAppEditMode.ReadOnlySlots) {
             this.readOnlySlots = true;
           } else if (editMode === FunctionAppEditMode.ReadOnlyVSGenerated) {
-            this.ReadOnlyVSGenerated = true;
+            this.readOnlyVSGenerated = true;
+          } else if (editMode === FunctionAppEditMode.ReadWriteVSGenerated) {
+            this.readWriteVSGenerated = true;
           }
         });
     }

--- a/AzureFunctions.AngularClient/src/app/shared/models/function-app-edit-mode.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/function-app-edit-mode.ts
@@ -4,5 +4,6 @@ export enum FunctionAppEditMode {
     ReadWrite,
     ReadOnly,
     ReadOnlySlots,
-    ReadOnlyVSGenerated
+    ReadOnlyVSGenerated,
+    ReadWriteVSGenerated
 }

--- a/AzureFunctions.AngularClient/src/app/shared/services/functions-service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/functions-service.ts
@@ -202,26 +202,36 @@ export class FunctionsService {
     }
 
     getFunctionAppEditMode(context: FunctionAppContext): Observable<FunctionAppEditMode> {
-        // The we have 2 settings to check here. There is the SourceControl setting which comes from /config/web
-        // and there is FUNCTION_APP_EDIT_MODE which comes from app settings.
+        // 4 settings to check here, SourceControl, Visual Studio generated, Slots, FUNCTION_APP_EDIT_MODE
         // editMode (true -> readWrite, false -> readOnly)
         // Table
-        // |Slots | SourceControl | AppSettingValue | EditMode                      |
-        // |------|---------------|-----------------|-------------------------------|
-        // | No   | true          | readWrite       | ReadWriteSourceControlled     |
-        // | No   | true          | readOnly        | ReadOnlySourceControlled      |
-        // | No   | true          | undefined       | ReadOnlySourceControlled      |
-        // | No   | false         | readWrite       | ReadWrite                     |
-        // | No   | false         | readOnly        | ReadOnly                      |
-        // | No   | false         | undefined       | ReadWrite                     |
-
-        // | Yes  | true          | readWrite       | ReadWriteSourceControlled     |
-        // | Yes  | true          | readOnly        | ReadOnlySourceControlled      |
-        // | Yes  | true          | undefined       | ReadOnlySourceControlled      |
-        // | Yes  | false         | readWrite       | ReadWrite                     |
-        // | Yes  | false         | readOnly        | ReadOnly                      |
-        // | Yes  | false         | undefined       | ReadOnlySlots                 |
-        // |______|_______________|_________________|_______________________________|
+        // | SourceControl | VS    | Slots | AppSettingValue | EditMode                  |
+        // |---------------|-------|-------|-----------------|---------------------------|
+        // | true          | true  | Yes   | readWrite       | ReadWriteSourceControlled |
+        // | true          | true  | Yes   | readOnly        | ReadOnlySourceControlled  |
+        // | true          | true  | Yes   | undefined       | ReadOnlySourceControlled  |
+        // | true          | true  | No    | readWrite       | ReadWriteSourceControlled |
+        // | true          | true  | No    | readOnly        | ReadOnlySourceControlled  |
+        // | true          | true  | No    | undefined       | ReadOnlySourceControlled  |
+        // | true          | false | Yes   | readWrite       | ReadWriteSourceControlled |
+        // | true          | false | Yes   | readOnly        | ReadOnlySourceControlled  |
+        // | true          | false | Yes   | undefined       | ReadOnlySourceControlled  |
+        // | true          | false | No    | readWrite       | ReadWriteSourceControlled |
+        // | true          | false | No    | readOnly        | ReadOnlySourceControlled  |
+        // | true          | false | No    | undefined       | ReadOnlySourceControlled  |
+        // | false         | true  | Yes   | readWrite       | ReadWriteVSGenerated      |
+        // | false         | true  | Yes   | readOnly        | ReadOnlyVSGenerated       |
+        // | false         | true  | Yes   | undefined       | ReadOnlyVSGenerated       |
+        // | false         | true  | No    | readWrite       | ReadWriteVSGenerated      |
+        // | false         | true  | No    | readOnly        | ReadOnlyVSGenerated       |
+        // | false         | true  | No    | undefined       | ReadOnlyVSGenerated       |
+        // | false         | false | Yes   | readWrite       | ReadWrite                 |
+        // | false         | false | Yes   | readOnly        | ReadOnly                  |
+        // | false         | false | Yes   | undefined       | ReadOnlySlots             |
+        // | false         | false | No    | readWrite       | ReadWrite                 |
+        // | false         | false | No    | readOnly        | ReadOnly                  |
+        // | false         | false | No    | undefined       | ReadWrite                 |
+        // |_______________|_______|_______|_________________|___________________________|
 
         return Observable.zip(
             this._checkIfSourceControlEnabled(context.site),
@@ -239,17 +249,50 @@ export class FunctionsService {
                 let editModeSettingString: string = appSettings.properties[Constants.functionAppEditModeSettingName] || '';
                 editModeSettingString = editModeSettingString.toLocaleLowerCase();
                 const vsCreatedFunc = result.functions.find((fc: any) => !!fc.config.generatedBy);
-                if (vsCreatedFunc) {
-                    return FunctionAppEditMode.ReadOnlyVSGenerated;
-                }
+                const hasSlots = result.hasSlots;
+
+                const resolveReadOnlyMode = () => {
+                    if (sourceControlled) {
+                        return FunctionAppEditMode.ReadOnlySourceControlled;
+                    } else if (vsCreatedFunc) {
+                        return FunctionAppEditMode.ReadOnlyVSGenerated;
+                    } else if (hasSlots) {
+                        return FunctionAppEditMode.ReadOnly;
+                    } else {
+                        return FunctionAppEditMode.ReadOnly;
+                    };
+                };
+
+                const resolveReadWriteMode = () => {
+                    if (sourceControlled) {
+                        return FunctionAppEditMode.ReadWriteSourceControlled;
+                    } else if (vsCreatedFunc) {
+                        return FunctionAppEditMode.ReadWriteVSGenerated;
+                    } else if (hasSlots) {
+                        return FunctionAppEditMode.ReadWrite;
+                    } else {
+                        return FunctionAppEditMode.ReadWrite;
+                    };
+                };
+
+                const resolveUndefined = () => {
+                    if (sourceControlled) {
+                        return FunctionAppEditMode.ReadOnlySourceControlled;
+                    } else if (vsCreatedFunc) {
+                        return FunctionAppEditMode.ReadOnlyVSGenerated;
+                    } else if (hasSlots) {
+                        return FunctionAppEditMode.ReadOnlySlots;
+                    } else {
+                        return FunctionAppEditMode.ReadWrite;
+                    };
+                };
+
                 if (editModeSettingString === Constants.ReadWriteMode) {
-                    return sourceControlled ? FunctionAppEditMode.ReadWriteSourceControlled : FunctionAppEditMode.ReadWrite;
+                    return resolveReadWriteMode();
                 } else if (editModeSettingString === Constants.ReadOnlyMode) {
-                    return sourceControlled ? FunctionAppEditMode.ReadOnlySourceControlled : FunctionAppEditMode.ReadOnly;
-                } else if (sourceControlled) {
-                    return FunctionAppEditMode.ReadOnlySourceControlled;
+                    return resolveReadOnlyMode();
                 } else {
-                    return result.hasSlots ? FunctionAppEditMode.ReadOnlySlots : FunctionAppEditMode.ReadWrite;
+                    return resolveUndefined();
                 }
             })
             .catch(() => Observable.of(FunctionAppEditMode.ReadWrite));

--- a/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/Resources.resx
@@ -1993,6 +1993,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
   <data name="readOnlyGeneratedBy" xml:space="preserve">
     <value>Your app is currently in read-only mode because you have published a generated function.json. Changes made to function.json will not be honored by the Functions runtime. </value>
   </data>
+  <data name="readWriteGeneratedBy" xml:space="preserve">
+    <value>Your app is currently in read\write mode because you've set the edit mode to read\write despite having a generated function.json. Any changes you make may get overwritten with your next deployment. To change edit mode visit </value>
+  </data>
   <data name="copypre_copy" xml:space="preserve">
     <value>Copy</value>
   </data>


### PR DESCRIPTION
Add read/write mode and warning for VS generated functions
resolves #1913 
![image](https://user-images.githubusercontent.com/31744877/32523474-45c9aab4-c3d0-11e7-9158-6293e1f648a3.png)
