### PR TITLE
Some fixes for Standalone Function portal

### DIFF
--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -180,6 +180,7 @@ export class ScenarioIds {
 
     public static readonly createApp = 'createApp';
     public static readonly filterAppNodeChildren = 'FilterAppNodeChildren';
+    public static readonly headerOnTopOfSideNav = 'headerOnTopOfSideNav';
 }
 
 export class ServerFarmSku {

--- a/AzureFunctions.AngularClient/src/app/shared/services/scenario/stand-alone.environment.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/scenario/stand-alone.environment.ts
@@ -63,6 +63,14 @@ export class StandaloneEnvironment extends Environment {
                 return this._filterAppNodeChildren(input);
             }
         };
+
+        this.scenarioChecks[ScenarioIds.headerOnTopOfSideNav] = {
+            id: ScenarioIds.headerOnTopOfSideNav,
+            runCheck: (input: ScenarioCheckInput) => {
+                return { status: 'enabled' };
+            }
+        };
+
     }
 
     public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.html
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.html
@@ -1,4 +1,4 @@
-<div class="sidenav" [class.sidenav-try]="tryFunctionApp">
+<div class="sidenav" [class.sidenav-try]="tryFunctionApp" [class.header-on-top-of-sidenav]="headerOnTopOfSideNav">
 
     <div id="sidenav-menu" *ngIf="!tryFunctionApp">
 

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.scss
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.scss
@@ -11,7 +11,9 @@
     z-index: 100;
     border-right: $border;
 }
-
+.header-on-top-of-sidenav {
+    position: absolute;
+}
 .create-refresh-sub {
     padding-left: 10px;
     background-color: #e1efff;

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
@@ -408,9 +408,7 @@ export class SideNavComponent implements AfterViewInit {
     private _updateSubDisplayText(displayText: string) {
         setTimeout(() => {
             this.subscriptionsDisplayText = '';
-            setTimeout(() => {
-                this.subscriptionsDisplayText = displayText;
-            }, 0);
+            this.subscriptionsDisplayText = displayText;
         });
     }
 

--- a/AzureFunctions.AngularClient/src/app/site/create-app/create-app.component.html
+++ b/AzureFunctions.AngularClient/src/app/site/create-app/create-app.component.html
@@ -12,7 +12,7 @@
   <div class="createapp-wrapper">
       <label class="createapp-label">{{ '_name' | translate }}</label>
       <div class="createapp-control-container">
-        <textbox class="name-textbox"
+        <textbox
           [control]="group?.controls['name']"
           [placeholder]="Resources.enterName | translate"></textbox>
       </div>

--- a/AzureFunctions.AngularClient/src/app/site/create-app/create-app.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/create-app/create-app.component.ts
@@ -2,6 +2,7 @@ import { UserService } from './../../shared/services/user.service';
 import { Links, RuntimeImage } from './../../shared/models/constants';
 import { Component, OnInit, OnDestroy, Input, Injector } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
+import { CustomFormControl } from './../../controls/click-to-edit/click-to-edit.component';
 import { TranslateService } from '@ngx-translate/core';
 import { Subject } from 'rxjs/Subject';
 import { ErrorIds } from './../../shared/models/error-ids';
@@ -82,7 +83,7 @@ export class CreateAppComponent implements OnInit, OnDestroy {
             required.validate.bind(required),
             siteNameValidator.validate.bind(siteNameValidator)],
           subscription: defaultSubId,
-          runtimeImage: RuntimeImage.v1
+          runtimeImage: RuntimeImage.v2
         });
       });
 
@@ -129,7 +130,13 @@ export class CreateAppComponent implements OnInit, OnDestroy {
   }
 
   create() {
-    const name = this.group.controls['name'].value;
+    const nameControl = <CustomFormControl>this.group.controls['name'];
+    const name = nameControl.value;
+    if (!name) {
+      nameControl._msRunValidation = true;
+      nameControl.updateValueAndValidity();
+      return;
+    }
 
     const id = `/subscriptions/${this.group.controls['subscription'].value}/resourceGroups/StandaloneResourceGroup/providers/Microsoft.Web/sites/${name}`;
 

--- a/AzureFunctions.AngularClient/src/app/subscription/create-subscription/create-subscription.component.scss
+++ b/AzureFunctions.AngularClient/src/app/subscription/create-subscription/create-subscription.component.scss
@@ -15,8 +15,6 @@ h2{
 .textbox-sub {
     border: 2px solid $border-color;
     width: 300px;
-    padding-left: 5px;
-    margin-right: 10px;
 }
 
 .choose {

--- a/AzureFunctions.AngularClient/src/app/top-bar/top-bar.component.scss
+++ b/AzureFunctions.AngularClient/src/app/top-bar/top-bar.component.scss
@@ -16,7 +16,6 @@
 .logo-standalone{
     @extend .logo;
     font-size: 18px;
-    margin-left: 265px;
 }
 
 .function-information {


### PR DESCRIPTION
1. workaround for error thrown after creating subscription  "ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked" 
2. Name and Subscription field in Create app resized.
![image](https://user-images.githubusercontent.com/20177468/32533485-d8321c44-c405-11e7-8449-4ac2f5ad6ebf.png)
3. Creating subscription with empty display name is not allowed. 
![image](https://user-images.githubusercontent.com/20177468/32533532-1640440c-c406-11e7-8451-1630fe0a402a.png)

4.Creating app with empty name is not allowed.
![image](https://user-images.githubusercontent.com/20177468/32533522-06a6ec08-c406-11e7-8b0d-c11c33cd326a.png)
5. Header is now on top of sidenav and dashboard
![image](https://user-images.githubusercontent.com/20177468/32533550-2be06c42-c406-11e7-82c7-989d461ac69f.png)
