### PR TITLE
Update PopOverComponent to support left/right positioning.

### DIFF
--- a/AzureFunctions.AngularClient/src/app/pop-over/pop-over.component.html
+++ b/AzureFunctions.AngularClient/src/app/pop-over/pop-over.component.html
@@ -2,8 +2,7 @@
     tabindex="-1">
     <span *ngIf="message"
         class="pop-over-common pop-over-links"
-        [class.pop-over]="position!=='bottom'"
-        [class.pop-over-bottom]="position==='bottom'"
+        [ngClass]="'pop-over-' + position"
         [class.pop-over-visible]="show"
         [innerHtml]="message" tabindex="-1"></span>
 

--- a/AzureFunctions.AngularClient/src/app/pop-over/pop-over.component.scss
+++ b/AzureFunctions.AngularClient/src/app/pop-over/pop-over.component.scss
@@ -19,42 +19,78 @@
     display: none;
     font-size: 12px;
     font-family: 'Helvetica',sans-serif;
-    left: -142px;
     padding: 5px 10px;
     position: absolute;
     width: 300px;
     z-index: 110;
     line-height: 1.3;
     text-align: center;
+
+    &:before{
+      display: block;
+      position: absolute;
+      content: '';
+    }
+
+    &.pop-over-top, &.pop-over-bottom {
+      left: -142px;
+
+      &:before {
+        border-right: 7px solid transparent;
+        border-left: 7px solid transparent; 
+        left: 50%;
+        margin-left: -7px;
+      }
+    }
+    
+    &.pop-over-left, &.pop-over-right {
+      top: -5px;
+
+      &:before {
+        border-bottom: 7px solid transparent;
+        border-top: 7px solid transparent; 
+        top: 12px;
+        margin-top: -7px;
+      }
+    }
   }
 
- .pop-over-common:before {
-    border-right: 7px solid transparent;
-    border-left: 7px solid transparent; 
-    content: '';
-    display: block;
-    left: 50%;
-    margin-left: -7px;
-    position: absolute;
-  }
-
-  .pop-over {
+  .pop-over-top {
     bottom: 24px;
     white-space: initial;
-  }
 
-  .pop-over:before {
-    border-top: 7px solid rgba(0, 0, 0, 0.85);
-    bottom: -6px;
+    &:before {
+      border-top: 7px solid rgba(0, 0, 0, 0.85);
+      bottom: -6px;
+    }
   }
 
   .pop-over-bottom {
     top: 24px;
-  }  
 
-  .pop-over-bottom:before {
-    border-bottom: 7px solid rgba(0, 0, 0, 0.85); 
-    top: -6px;
+    &:before {
+      border-bottom: 7px solid rgba(0, 0, 0, 0.85); 
+      top: -6px;
+    }
+  }
+
+  .pop-over-left {
+    right: 19px;
+    white-space: initial;
+
+    &:before {
+      border-left: 7px solid rgba(0, 0, 0, 0.85);
+      right: -6px;
+    }
+  }
+
+  .pop-over-right {
+    left: 19px;
+
+    &:before {
+      border-right: 7px solid rgba(0, 0, 0, 0.85); 
+      left: -6px;
+    }
   }
 
   .pop-over-visible{

--- a/AzureFunctions.AngularClient/src/app/pop-over/pop-over.component.ts
+++ b/AzureFunctions.AngularClient/src/app/pop-over/pop-over.component.ts
@@ -13,7 +13,7 @@ export class PopOverComponent {
     @Input() isInputError: boolean;
     @Input() isInputWarning: boolean;
     @Input() popOverClass = 'pop-over-container';
-    @Input() position: string;
+    @Input() position: 'top' | 'bottom' | 'left' | 'right' = 'top';
     @Input() isShiftTabPressed: boolean;
 
     public show: boolean;

--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.html
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.html
@@ -7,7 +7,7 @@
 
     <div *ngIf="netFrameworkSupported" class="setting-wrapper">
       <label class="setting-label">{{ 'netFrameWorkVersionLabel' | translate }}
-        <pop-over [message]="('netFrameWorkVersionLabelHelp' | translate)">
+        <pop-over [message]="('netFrameWorkVersionLabelHelp' | translate)" position="right">
             <span class="glyphicon glyphicon-info-sign button-title"></span>
         </pop-over>
       </label>
@@ -22,7 +22,7 @@
 
     <div *ngIf="phpSupported" class="setting-wrapper">
       <label class="setting-label">{{ 'phpVersionLabel' | translate }}
-        <pop-over [message]="('phpVersionLabelHelp' | translate)">
+        <pop-over [message]="('phpVersionLabelHelp' | translate)" position="right">
             <span class="glyphicon glyphicon-info-sign button-title"></span>
         </pop-over>
       </label>
@@ -38,7 +38,7 @@
     <div *ngIf="pythonSupported" class="setting-wrapper">
       <info-box [infoText]="('pythonInfoText' | translate)" [infoLink]="FwLinks.pythonLearnMore"></info-box>
       <label class="setting-label">{{ 'pythonVersionLabel' | translate }}
-        <pop-over [message]="('pythonVersionLabelHelp' | translate)">
+        <pop-over [message]="('pythonVersionLabelHelp' | translate)" position="right">
             <span class="glyphicon glyphicon-info-sign button-title"></span>
         </pop-over>
       </label>
@@ -53,7 +53,7 @@
 
     <div *ngIf="javaSupported" class="setting-wrapper">
       <label class="setting-label">{{ 'javaVersionLabel' | translate }}
-        <pop-over [message]="('javaVersionLabelHelp' | translate)">
+        <pop-over [message]="('javaVersionLabelHelp' | translate)" position="right">
             <span class="glyphicon glyphicon-info-sign button-title"></span>
         </pop-over>
       </label>
@@ -69,7 +69,7 @@
 
     <div *ngIf="javaSupported" class="setting-wrapper">
       <label class="setting-label">{{ 'javaMinorVersionLabel' | translate }}
-        <pop-over [message]="('javaMinorVersionLabelHelp' | translate)">
+        <pop-over [message]="('javaMinorVersionLabelHelp' | translate)" position="right">
             <span class="glyphicon glyphicon-info-sign button-title"></span>
         </pop-over>
       </label>
@@ -84,7 +84,7 @@
 
     <div *ngIf="javaSupported" class="setting-wrapper">
       <label class="setting-label">{{ 'javaWebContainerLabel' | translate }}
-        <pop-over [message]="('javaWebContainerLabelHelp' | translate)">
+        <pop-over [message]="('javaWebContainerLabelHelp' | translate)" position="right">
             <span class="glyphicon glyphicon-info-sign button-title"></span>
         </pop-over>
       </label>
@@ -99,7 +99,7 @@
 
     <div *ngIf="platform64BitSupported" class="setting-wrapper">
       <label class="setting-label">{{ 'use32BitWorkerProcessLabel' | translate }}
-        <pop-over [message]="('use32BitWorkerProcessLabelHelp' | translate)">
+        <pop-over [message]="('use32BitWorkerProcessLabelHelp' | translate)" position="right">
             <span class="glyphicon glyphicon-info-sign button-title"></span>
         </pop-over>
       </label>
@@ -123,7 +123,7 @@
 
     <div *ngIf="webSocketsSupported" class="setting-wrapper">
       <label class="setting-label">{{ 'webSocketsEnabledLabel' | translate }}
-        <pop-over [message]="('webSocketsEnabledLabelHelp' | translate)">
+        <pop-over [message]="('webSocketsEnabledLabelHelp' | translate)" position="right">
             <span class="glyphicon glyphicon-info-sign button-title"></span>
         </pop-over>
       </label>
@@ -138,7 +138,7 @@
 
     <div *ngIf="alwaysOnSupported" class="setting-wrapper">
       <label class="setting-label">{{ 'alwaysOnLabel' | translate }}
-        <pop-over [message]="('alwaysOnLabelHelp' | translate)">
+        <pop-over [message]="('alwaysOnLabelHelp' | translate)" position="right">
             <span class="glyphicon glyphicon-info-sign button-title"></span>
         </pop-over>
       </label>
@@ -272,7 +272,7 @@
 
       <div class="setting-wrapper">
         <label class="setting-label">{{ 'linuxFxVersionLabel' | translate }}
-          <pop-over [message]="('linuxFxVersionLabelHelp' | translate)">
+          <pop-over [message]="('linuxFxVersionLabelHelp' | translate)" position="right">
               <span class="glyphicon glyphicon-info-sign button-title"></span>
           </pop-over>
         </label>
@@ -287,7 +287,7 @@
 
       <div class="setting-wrapper last">
         <label class="setting-label">{{ 'appCommandLineLabel' | translate }}
-          <pop-over [message]="('appCommandLineLabelHelp' | translate)">
+          <pop-over [message]="('appCommandLineLabelHelp' | translate)" position="right">
               <span class="glyphicon glyphicon-info-sign button-title"></span>
           </pop-over>
         </label>


### PR DESCRIPTION
This allows us to set the popovers in General Settings to open to the right instead of above/below, so we avoid the situation where the popover extends beyond the left boundary of the iframe.

Before:
![image](https://user-images.githubusercontent.com/5387224/32883462-56bfa11e-ca6c-11e7-9276-9e8eaaf6bb82.png)

After:
![image](https://user-images.githubusercontent.com/5387224/32883527-809c4686-ca6c-11e7-95fb-c918a091619f.png)
