### PR TITLE
Accessibility and styling updates for MultiDropDownComponent

### DIFF
--- a/AzureFunctions.AngularClient/src/app/multi-drop-down/multi-drop-down.component.html
+++ b/AzureFunctions.AngularClient/src/app/multi-drop-down/multi-drop-down.component.html
@@ -1,11 +1,58 @@
-<div class="multi-select-container">
-  <input type="text" [value]="displayText" readonly (click)="click()" (keydown)="onKeyPress($event)" />
-  <span class="multi-select-arrow" (click)="click()"></span>
-  <div class="multi-select-content" *ngIf="opened" #itemListContainer>
-    <ul>
-      <li *ngFor="let option of options" (click)="handleChecked(option)" [class.focused]="option.isFocused">
-        <input type="checkbox" [checked]="option.isSelected"/>{{option.displayLabel}}
-      </li>
-    </ul>
+<div
+  class="multi-select-container"
+  (keydown)="onKeyDown($event)"
+  (mousedown)=onMouseDown($event)>
+
+  <div
+    role="combobox"
+    [class.focused]="hasFocus && focusedIndex === -1"
+    [attr.aria-label]="ariaLabel"
+    [attr.aria-expanded]="opened"
+    [attr.aria-owns]="!opened ? null : id + '-list'"
+    aria-haspopup="listbox"
+    (click)="onComboBoxClick($event)"
+    #comboBox>
+
+    <input
+      type="text"
+      role="textbox"
+      aria-multiline="false"
+      [attr.aria-controls]="!opened ? null : id + '-list'"
+      [attr.aria-activedescendant]="(!opened || focusedIndex === -1) ? null : id + '-opt' + focusedIndex"
+      readonly
+      aria-readonly="true"
+      [value]="displayText"
+      (focus)="onFocus()"
+      (blur)="onBlur()"
+      #displayInput/>
+    
+    <span
+      class="multi-select-arrow"
+      role="presentation"
+      #toggleArrow>
+    </span>
+
   </div>
+
+  <ul
+    role="listbox"
+    class="multi-select-content"
+    [class.hidden]="!opened"
+    [class.focused]="hasFocus && focusedIndex !== -1"
+    [id]="id + '-list'"
+    aria-multiselectable="true"
+    #listBox>
+
+    <li
+      *ngFor="let option of options; let optionIndex=index"
+      role="option"
+      [id]="id + '-opt' + optionIndex"
+      [attr.aria-selected]="option.isSelected"
+      [class.focused]="optionIndex === focusedIndex"
+      (click)="onOptionClick(optionIndex)">
+      <span>{{option.displayLabel}}</span>
+    </li>
+
+  </ul>
+
 </div>

--- a/AzureFunctions.AngularClient/src/app/multi-drop-down/multi-drop-down.component.scss
+++ b/AzureFunctions.AngularClient/src/app/multi-drop-down/multi-drop-down.component.scss
@@ -4,72 +4,150 @@
     position : relative;
     cursor: pointer;
 
-    input{
+    *{
         cursor: pointer;
-    }
-
-    >input[type=text]{
-        width: 100%;
-        margin-right: 1px;  // Not sure why, but you need at least a 1px margin or the layout gets crazy
-        // cursor: pointer;
     }
 }
 
-.multi-select-content{
+[role=combobox]{
     border: $border;
+    outline: 1px transparent solid;
+    
+    &.focused{
+        border: 1px solid $primary-color;
+        outline: $border-focus;
+    }
+
+    >input[type=text][role=textbox]{
+        width: 100%;
+        border: none;
+        height: 27px;
+    }
+}
+
+ul[role=listbox]{
+    list-style: none;
     position: absolute;
     width: 100%;
+    top: 30px;
+    padding: 0px;
+    margin-bottom: 0px;
+    border: $border;
+    outline: 1px transparent solid;
     background-color: $body-bg-color;
     max-height: 300px;
     overflow-y: auto;
     z-index: 1000;
+    
+    &.focused{
+        border: 1px solid $primary-color;
+        outline: $border-focus;
+    }
 
-    ul{
-        list-style: none;
-        padding: 0px;
+    //https://bootsnipp.com/snippets/ZkMKE
+    li[role=option]{
+        overflow-x: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        
+        padding-left: 20px;
 
-        input{
-            vertical-align: middle;
-            margin: 0px 5px 2px 5px;
+        &.inline {
+            margin-top: 0;
         }
 
-        li{
-            overflow-x: hidden;
-            white-space: nowrap;
-            text-overflow: ellipsis;
+        span{
+            display: inline-block;
+            position: relative;
+            height: 25px;
+            padding-top: 5px;
+            padding-left: 5px;
+
+            &::before{
+                content: "";
+                display: inline-block;
+                position: absolute;
+                width: 13px;
+                height: 13px;
+                top: 6px;
+                left: 0;
+                margin-left: -15px;
+                border: $border;
+                border-radius: 3px;
+                background-color: $body-bg-color;
+                -webkit-transition: border 0.15s ease-in-out, color 0.15s ease-in-out;
+                -o-transition: border 0.15s ease-in-out, color 0.15s ease-in-out;
+                transition: border 0.15s ease-in-out, color 0.15s ease-in-out;
+            }
+            &::after{
+                display: inline-block;
+                position: absolute;
+                width: 9px;
+                height: 9px;
+                top: 6px;
+                left: 0;
+                margin-left: -15px;
+                padding-left: 1px;
+                padding-top: 0px;
+                font-size: 11px;
+                color: $default-text-color;
+            }
         }
 
-        li:hover{
-            background-color: darken($border-color, 10%);
+        &[aria-selected="true"]{
+            span{
+                &::after {
+                    font-family: 'FontAwesome';
+                    content: "\f00c";
+                }
+            }
         }
 
-        li.focused{
+        &:hover{
+            background-color: $grey-color;
+        }
+
+        &.focused{
             outline: $border-focus;
         }
     }
 }
 
-:host-context(#app-root[theme=dark]) .multi-select-content{
+:host-context(#app-root[theme=dark]) ul[role=listbox]{
     background-color: $chrome-color-dark;
+
+    li[role=option] {
+
+        &:hover {
+            background-color: $grey-color-dark;
+        }
+
+        span::before {
+            background-color: $body-bg-color-dark;
+        }
+
+        span::after {
+            color: $default-text-color-dark;
+        }
+    }
 }
 
 .multi-select-arrow {
     display: block;
     font-size: 0;
-    height: 25px;
+    height: 27px;
     margin: 0;
     overflow: hidden;
     padding: 0;
     position: absolute;
     right: 0;
     top: 0;
-    width: 25px;
+    width: 27px;
     zoom: 1;
 }
 
 .multi-select-arrow:before {
-    border-color: #dedede;
-    border-style: solid;
+    border: $border;
     border-width: 0 2px 2px 0;
     box-sizing: border-box;
     content: "";

--- a/AzureFunctions.AngularClient/src/sass/common/_variables.scss
+++ b/AzureFunctions.AngularClient/src/sass/common/_variables.scss
@@ -79,6 +79,7 @@ $background-color-opaque: #ccc;
 $background-color-disabled: rgba(127, 127, 127, 0.5);
 
 $grey-color: #f5f5f5;
+$grey-color-dark: #3d3d3d;
 
 $command-color-hover: #f1f1f8;
 $heading-text-color: #252525;


### PR DESCRIPTION
(Fixes #1738)

I closed the related PR (Accessibility updates for MultiDropDownComponent #1751) because I decided to use aria-activedescendant to handle moving the "focus".

Updates:
- Control collapses if display text or arrow are clicked.
- Control does not lose track of focus when an option is clicked.
- Navigation to top or bottom of list using "Home" and "End" keys is supported.
- The selected state for a given option is indicated by styles instead of using checkbox elements.
- The "Select all" option is automatically selected if all other options are set to selected.
- Aria attributes have been added.

Below are the old vs. updated styles (both Light and Dark theme) for the following scenarios:
- Component is collapsed and has focus
- Component is expanded and display box has focus
- Component is expanded and "South Central US" option has focus
  - "Select All" option has hover
  - "West US" option is not selected

![multidropdown-light](https://user-images.githubusercontent.com/5387224/33403242-6ea4dd00-d514-11e7-95b6-4e302ad78c3a.png)

![multidropdown-dark](https://user-images.githubusercontent.com/5387224/33403251-76a6a452-d514-11e7-8391-56d213e3ab31.png)

