### PR TITLE
Updating styling for SlideToggleComponent (fixes #1798)

### DIFF
--- a/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.html
+++ b/AzureFunctions.AngularClient/src/app/apps-list/apps-list.component.html
@@ -39,14 +39,14 @@
 
   <tr *ngFor="let item of table.items">
     <ng-container *ngIf="item.type === 'row' && table.groupedBy === 'none'">
-      <td><a (click)="clickRow(item)">{{item.title}}</a></td>
+      <td><a class="link" (click)="clickRow(item)" [activate-with-keys]>{{item.title}}</a></td>
       <td>{{item.subscription}}</td>
       <td>{{item.resourceGroup}}</td>
       <td>{{item.location}}</td>
     </ng-container>
 
     <ng-container *ngIf="item.type === 'row' && table.groupedBy !== 'none'">
-      <td class='tabbed'><a (click)="clickRow(item)">{{item.title}}</a></td>
+      <td class='tabbed'><a class="link" (click)="clickRow(item)" [activate-with-keys]>{{item.title}}</a></td>
       <td>{{item.subscription}}</td>
       <td>{{item.resourceGroup}}</td>
       <td>{{item.location}}</td>

--- a/AzureFunctions.AngularClient/src/app/controls/activate-with-keys/activate-with-keys.directive.ts
+++ b/AzureFunctions.AngularClient/src/app/controls/activate-with-keys/activate-with-keys.directive.ts
@@ -1,0 +1,51 @@
+import { Input, ElementRef, Directive, OnInit, OnDestroy } from '@angular/core';
+import { KeyCodes } from './../../shared/models/constants';
+
+@Directive({
+    selector: '[activate-with-keys]',
+})
+export class ActivateWithKeysDirective implements OnInit, OnDestroy {
+
+    constructor(private _elementRef: ElementRef) {
+    }
+
+    private _keyCodes:Array<number> = [KeyCodes.enter];
+
+    @Input('activate-with-keys') set keyCodes(keys: Array<'enter' | 'space'>) {
+        this._keyCodes = [];
+        keys.forEach(key => {
+            switch (key) {
+                case 'enter':
+                    this._keyCodes.push(KeyCodes.enter);
+                    break;
+                case 'space':
+                    this._keyCodes.push(KeyCodes.space);
+                    break;
+                default:
+                    break;
+            }
+        })
+    }
+
+    private _keyPressFunc = (event: KeyboardEvent) => { this._keyPressListener(event); };
+
+    private _keyPressListener(event: KeyboardEvent) {
+        if (this._keyCodes && this._keyCodes.findIndex(k => k === event.keyCode) !== -1) {
+            if (this._elementRef && this._elementRef.nativeElement) {
+                (this._elementRef.nativeElement as HTMLElement).click();
+            }
+        }
+    }
+
+    ngOnInit() {
+        if (this._elementRef && this._elementRef.nativeElement) {
+            this._elementRef.nativeElement.addEventListener('keypress', this._keyPressFunc, true);
+        }
+    }
+
+    ngOnDestroy() {
+        if (this._elementRef && this._elementRef.nativeElement) {
+            this._elementRef.nativeElement.removeEventListener('keypress', this._keyPressFunc, true);
+        }
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/controls/slide-toggle/slide-toggle.component.html
+++ b/AzureFunctions.AngularClient/src/app/controls/slide-toggle/slide-toggle.component.html
@@ -1,17 +1,21 @@
-<a #toggleContainer
-    class="toggle-container clickable"
-    [attr.role]="role"
-    [attr.aria-label]="ariaLabel"
-    [attr.aria-checked]="ariaChecked"
-    [attr.aria-pressed]="ariaPressed"
-    (mousedown)="onMousedown($event)"
-    (mouseup)="onMouseup($event)"
-    (click)="onClick($event)"
-    (keydown)="onKeyPress($event)">
-    <div role="presentation" class="toggle">
-        <span class="slider round" [class.on]="on"></span>
-    </div>
-    <span role="presentation" class="state-label">
+<div #toggleContainer
+    class="toggle-container">
+    <button
+        [id]="id + '-toggle'"
+        class="toggle"
+        [class.on]="on"
+        [attr.role]="role"
+        [attr.aria-label]="ariaLabel"
+        [attr.aria-checked]="ariaChecked"
+        [attr.aria-pressed]="ariaPressed"
+        [attr.aria-disabled]="disabled"
+        [disabled]="disabled"
+        (click)="onClick($event)">
+        <span class="toggle-thumb"></span>
+    </button>
+    <label
+        [for]="id + '-toggle'"
+        class="state-label">
         {{ displayLabel }}
-    </span>
-</a>
+    </label>
+</div>

--- a/AzureFunctions.AngularClient/src/app/controls/slide-toggle/slide-toggle.component.scss
+++ b/AzureFunctions.AngularClient/src/app/controls/slide-toggle/slide-toggle.component.scss
@@ -1,74 +1,142 @@
 @import '../../../sass/common/variables';
 
-/*Overwrite bootstrap*/ 
-a.toggle-container {
-  color: inherit;
+.toggle-container {
+  position: relative;
+  display: inline-flex;
+  vertical-align: middle;
+  color: inherit !important;
   text-decoration: none !important;
   outline: none !important;
 }
 
-div.toggle {
+.toggle {
   position: relative;
-  display: inline-block;
-  width: 50px;
-  height: 14px;
-  vertical-align: middle;
-  margin-bottom: 0px !important;
-  font-weight: normal !important;
-  cursor: pointer;
+  font-size: 20px;
+  line-height: 1em;
+  width: 2.2em;
+  height: 1em;
+  transition: all 0.1s ease;
+  outline: transparent;
+  border-radius: 1em;
+  border-color: $default-text-color;
+  border-width: 1px;
+  border-style: solid;
+  background: $body-bg-color;
+
+  .toggle-thumb {
+    position: absolute;
+    left: 0.2em;
+    top: 0.18em;
+    width: 0.5em;
+    height: 0.5em;
+    transition: all 0.1s ease;
+    border-radius: 0.5em;
+    border-color: transparent;
+    border-width: 0.28em;
+    border-style: solid;
+    background-color: $default-text-color;
+  }
+  
+  &:not(:disabled):hover {
+    background: darken($body-bg-color, 5%);
+  }
 }
 
-.slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: $background-color-opaque;
-  border: 1px solid $background-color-opaque;
-  -webkit-transition: .4s;
-  transition: .4s;
+.toggle:focus {
+  outline: $border-focus;
+  outline-offset: 1px;
 }
 
-.slider:before {
-  position: absolute;
-  content: "";
-  height: 20px;
-  width: 20px;
-  left: -4px;
-  bottom: -3px;
-  background-color: $disabled-color;
-  -webkit-transition: .4s;
-  transition: .4s;
+.toggle+label {
+  margin-left: 5px;
+  margin-right: 5px;
+  margin-bottom: 0px;
+  line-height: 1.67em;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  user-select: none;
 }
 
-.slider.on:before {
-  -webkit-transform: translateX(36px);
-  -ms-transform: translateX(36px);
-  transform: translateX(36px);
-  background-color: $primary-color;
+.toggle.on {
+  border-color: transparent;
+  background: $primary-color;
+
+  .toggle-thumb {
+    left: 1.4em;
+    background-color: $body-bg-color;
+  }
+  
+  &:not(:disabled):hover {
+    background: darken($primary-color, 5%);
+  }
 }
 
-:focus {
-  outline: none;
+.toggle:disabled {
+  border-color: $disabled-color;
+
+  .toggle-thumb {
+    background-color: $disabled-color;
+  }
 }
 
-.toggle-container:focus .slider {
-  box-shadow: 0 0 1px $border-focus-color;
-  border: 1px dashed $border-focus-color;
+.toggle:disabled+label {
+  color: $disabled-color;
 }
 
-/* Rounded sliders */
-.slider.round {
-  border-radius: 34px;
+.toggle.on:disabled {
+  background: $disabled-color;
+
+  .toggle-thumb {
+    background-color: $body-bg-color;
+  }
 }
 
-.slider.round:before {
-  border-radius: 50%;
-}
+:host-context(#app-root[theme=dark]){
 
-.state-label {
-    vertical-align: middle;
-    padding-left: 5px;
+  .toggle {
+    border-color: $default-text-color-dark;
+    background: $body-bg-color-dark;
+
+    .toggle-thumb {
+      background-color: $default-text-color-dark;
+    }
+    
+    &:not(:disabled):hover {
+      background: lighten($body-bg-color-dark, 10%);
+    }
+  }
+
+  .toggle.on {
+    border-color: transparent;
+    background: $primary-color-dark;
+
+    .toggle-thumb {
+      background-color: $body-bg-color-dark;
+    }
+    
+    &:not(:disabled):hover {
+      background: lighten($primary-color-dark, 10%);
+    }
+  }
+
+  .toggle:disabled {
+    border-color: $disabled-color-dark;
+    background: $body-bg-color-dark;
+
+    .toggle-thumb {
+      background-color: $disabled-color-dark;
+    }
+  }
+
+  .toggle:disabled.on {
+    background: $disabled-color-dark;
+
+    .toggle-thumb {
+      background-color: $body-bg-color-dark;
+    }
+  }
+
+  .toggle:disabled+label {
+    color: $disabled-color-dark;
+  }
 }

--- a/AzureFunctions.AngularClient/src/app/controls/slide-toggle/slide-toggle.component.ts
+++ b/AzureFunctions.AngularClient/src/app/controls/slide-toggle/slide-toggle.component.ts
@@ -1,4 +1,4 @@
-import { Dom } from './../../shared/Utilities/dom';
+import { Guid } from './../../shared/Utilities/Guid';
 import { KeyCodes } from './../../shared/models/constants';
 import { PortalResources } from './../../shared/models/portal-resources';
 import { Component, OnChanges, SimpleChanges, Input, Output, ViewChild, ElementRef } from '@angular/core';
@@ -65,11 +65,15 @@ export class SlideToggleComponent implements OnChanges {
     public ariaPressed: boolean = null;
     public displayLabel: string;
 
+    @Input() id: string;
+
     private _initialized: boolean = false;
 
     @ViewChild('toggleContainer') toggleContainer: ElementRef;
 
-    constructor(private _translateService: TranslateService) { }
+    constructor(private _translateService: TranslateService) {
+        this.id = Guid.newGuid();
+    }
 
     ngOnChanges(changes: SimpleChanges) {
         // These properties will only be set once, in the first execution of ngOnChanges().
@@ -77,10 +81,8 @@ export class SlideToggleComponent implements OnChanges {
         this.displayLabelFormat = this.displayLabelFormat || 'stateName';
         this.ariaLabelFormat = this.ariaLabelFormat || 'name';
 
-        if (!this.disabled) {
-            if (!this._initialized || !!changes['on']) {
-                this._updateLabelAndAriaAttributes();
-            }
+        if (!this._initialized || !!changes['on']) {
+            this._updateLabelAndAriaAttributes();
         }
 
         this._initialized = true;
@@ -188,68 +190,8 @@ export class SlideToggleComponent implements OnChanges {
         return stateNames;
     }
 
-    // We want the control to appear to be a single element, so we redirect focus/events to the #toggleContainer element
-    // If a mouse event occurs on inner element of component, we stop the original event. We then simuulate the behavior on #toggleContainer.
-
-    onMousedown(event: MouseEvent) {
-        if (event.target !== this.toggleContainer.nativeElement) {
-            event.preventDefault();
-            event.stopImmediatePropagation();
-            event.stopPropagation();
-
-            // simulate mousedown
-            let newEvent: MouseEvent;
-            if (typeof (Event) === 'function') {
-                // This isn't IE, so we can use MouseEvent()
-                newEvent = new MouseEvent(event.type, { bubbles: event.bubbles, cancelable: event.cancelable });
-            } else {
-                // This is IE, so we have to use document.createEvent() and .initEvent()
-                newEvent = document.createEvent('MouseEvents');
-                newEvent.initEvent(event.type, event.bubbles, event.cancelable);
-            }
-            (<HTMLElement>this.toggleContainer.nativeElement).dispatchEvent(newEvent);
-
-            // move focus
-            setTimeout(() => {
-                if (!newEvent || !newEvent.defaultPrevented) {
-                    Dom.setFocus(<HTMLElement>this.toggleContainer.nativeElement);
-                }
-            }, 0);
-        }
-    }
-
-    onMouseup(event: MouseEvent) {
-        if (event.target !== this.toggleContainer.nativeElement) {
-            event.preventDefault();
-            event.stopImmediatePropagation();
-            event.stopPropagation();
-
-            // simulate mouseup
-            let newEvent: MouseEvent;
-            if (typeof (Event) === 'function') {
-                // This isn't IE, so we can use MouseEvent()
-                newEvent = new MouseEvent(event.type, { bubbles: event.bubbles, cancelable: event.cancelable });
-            } else {
-                // This is IE, so we have to use document.createEvent() and .initEvent()
-                newEvent = document.createEvent('MouseEvents');
-                newEvent.initEvent(event.type, event.bubbles, event.cancelable);
-            }
-            (<HTMLElement>this.toggleContainer.nativeElement).dispatchEvent(newEvent);
-        }
-    }
-
     onClick(event: MouseEvent) {
-        if (event.target !== this.toggleContainer.nativeElement) {
-            event.preventDefault();
-            event.stopImmediatePropagation();
-            event.stopPropagation();
-
-            // trigger click action
-            (<HTMLElement>this.toggleContainer.nativeElement).click();
-        }
-        else {
-            this._toggle();
-        }
+        this._toggle();
     }
 
     onKeyPress(event: KeyboardEvent) {

--- a/AzureFunctions.AngularClient/src/app/controls/tbl/tbl-th/tbl-th.component.ts
+++ b/AzureFunctions.AngularClient/src/app/controls/tbl/tbl-th/tbl-th.component.ts
@@ -4,7 +4,7 @@ import { Component, OnInit, Input, ElementRef } from '@angular/core';
 @Component({
   selector: 'tbl-th',
   template: `
-    <div class="sortable" (click)="sort()">
+    <div class="sortable" (click)="onClick()" [activate-with-keys]>
       <ng-content class="sortable"></ng-content>
       <i class="fa chevron"
           [class.fa-chevron-up]="table.sortedColName === name && table.sortAscending"
@@ -32,6 +32,13 @@ export class TblThComponent implements OnInit {
 
       element.parentElement.parentElement.classList.add('header-row');
     }
+  }
+
+  onClick() {
+    // Wait one cycle to allow tabindex on focused element to get set to -1
+    setTimeout(() => {
+      this.sort();
+    });
   }
 
   sort() {

--- a/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
+++ b/AzureFunctions.AngularClient/src/app/controls/tbl/tbl.component.ts
@@ -54,7 +54,7 @@ export class TblComponent implements OnInit, OnChanges, AfterContentChecked {
   ngOnInit() {
   }
 
-  ngAfterContentChecked(){
+  ngAfterContentChecked() {
     this.headers.forEach(h => h.table = this);
   }
 
@@ -98,7 +98,14 @@ export class TblComponent implements OnInit, OnChanges, AfterContentChecked {
 
       if (rowIndex >= 0 && cellIndex >= 0) {
         this._clearFocusOnCell(rows, this._focusedRowIndex, this._focusedCellIndex);
-        this._setFocusOnCell(rows, rowIndex, cellIndex);
+        if (e.target === cell || document.activeElement === cell) {
+          this._setFocusOnCell(rows, rowIndex, cellIndex);
+        }
+        else if (cell.contains(document.activeElement)) {
+          Dom.setFocusable(document.activeElement as HTMLElement);
+          this._focusedRowIndex = rowIndex;
+          this._focusedCellIndex = cellIndex;
+        }
       }
     }
   }

--- a/AzureFunctions.AngularClient/src/app/functions-list/functions-list.component.html
+++ b/AzureFunctions.AngularClient/src/app/functions-list/functions-list.component.html
@@ -29,7 +29,7 @@
         </tr>
 
         <tr *ngFor="let item of table.items">
-            <td><span class="link" (click)="clickRow(item)">{{item.functionName}}</span></td>
+            <td><a class="link" (click)="clickRow(item)" [activate-with-keys]>{{item.functionName}}</a></td>
             <td>
                 <div *ngIf="runtimeVersion === 'V1'" [fnWriteAccess]="functionApp">
                     <slide-toggle

--- a/AzureFunctions.AngularClient/src/app/functions-list/functions-list.component.html
+++ b/AzureFunctions.AngularClient/src/app/functions-list/functions-list.component.html
@@ -50,14 +50,15 @@
                     </slide-toggle>
                 </div>
             </td>
-            <td class="icon-cell">
+            <td>
                 <div [fnWriteAccess]="functionApp">
-                    <span role="button"
-                        class="icon-small"
-                        load-image="image/delete.svg"
-                        [attr.aria-label]="'functionManage_delete' | translate:{name: item.functionName}"
-                        (click)="clickDelete(item)">
-                    </span>
+                    <button class="icon-small" (click)="clickDelete(item)">
+                        <span
+                            role="presentation"
+                            [attr.aria-label]="'functionManage_delete' | translate:{name: item.functionName}"
+                            load-image="image/delete.svg">
+                        </span>
+                    </button>
                 </div>
             </td>
         </tr>

--- a/AzureFunctions.AngularClient/src/app/functions-list/functions-list.component.scss
+++ b/AzureFunctions.AngularClient/src/app/functions-list/functions-list.component.scss
@@ -22,23 +22,27 @@ h2{
     margin-bottom: 15px;
 }
 
-td.icon-cell{
-    &:hover{
-        background-color: $item-selected-color;
+.icon-small {
+    height: 18px;
+    width: 18px;
+
+    border: none;
+    background: transparent;
+    padding: 0;
+    display: block;
+    margin: auto;
+
+    &:hover>* {
+        filter: brightness(150%);
+        -webkit-filter: brightness(150%);
     }
 }
 
-.icon-small{
-    height: 18px;
-    width: 18px;
-    vertical-align: middle;
-    margin-left: 7px;
-}
-
-:host-context(#app-root[theme=dark]){
-    td.icon-cell{
-        &:hover{
-            background-color: $item-selected-color-dark;
+:host-context(#app-root[theme=dark]) {
+    .icon-small {
+        &:hover>* {
+            filter: brightness(50%);
+            -webkit-filter: brightness(50%);
         }
     }
 }

--- a/AzureFunctions.AngularClient/src/app/logic-apps/logic-apps.component.html
+++ b/AzureFunctions.AngularClient/src/app/logic-apps/logic-apps.component.html
@@ -44,13 +44,13 @@
 
     <tr *ngFor="let item of table.items">
       <ng-container *ngIf="item.type === 'row' && table.groupedBy === 'none'">
-        <td><a (click)="clickRow(item)">{{item.title}}</a></td>
+        <td><a class="link" (click)="clickRow(item)" [activate-with-keys]>{{item.title}}</a></td>
         <td>{{item.resourceGroup}}</td>
         <td>{{item.location}}</td>
       </ng-container>
 
       <ng-container *ngIf="item.type === 'row' && table.groupedBy !== 'none'">
-        <td class='tabbed'><a (click)="clickRow(item)">{{item.title}}</a></td>
+        <td class='tabbed'><a class="link" (click)="clickRow(item)" [activate-with-keys]>{{item.title}}</a></td>
         <td>{{item.resourceGroup}}</td>
         <td>{{item.location}}</td>
       </ng-container>

--- a/AzureFunctions.AngularClient/src/app/proxies-list/proxies-list.component.html
+++ b/AzureFunctions.AngularClient/src/app/proxies-list/proxies-list.component.html
@@ -9,7 +9,7 @@
   </tr>
 
   <tr *ngFor="let item of table.items">
-    <td><span class="link" (click)="clickRow(item)">{{item.name}}</span></td>
+    <td><a class="link" (click)="clickRow(item)" [activate-with-keys]>{{item.name}}</a></td>
     <td>{{item.url}}</td>
   </tr>
 

--- a/AzureFunctions.AngularClient/src/app/shared/Utilities/dom.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/Utilities/dom.ts
@@ -16,8 +16,12 @@ export class Dom {
     // This isn't comprehensive but is good enough for our current scenarios.  To get more context, checkout these links:
     // https://stackoverflow.com/questions/7208161/focus-next-element-in-tab-index
     // https://stackoverflow.com/questions/7668525/is-there-a-jquery-selector-to-get-all-elements-that-can-get-focus
+    public static getTabbableControls(element: HTMLElement): NodeList {
+        return element.querySelectorAll('input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), object:not([disabled]), a:not([disabled]), area:not([disabled]), .link, div.sortable, [tabindex="0"]');
+    }
+
     public static getTabbableControl(element: HTMLElement, excludedClassList?: string[]): HTMLElement {
-        const controls = element.querySelectorAll('input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), object:not([disabled]), a:not([disabled]), area:not([disabled]), .link, div.sortable, [tabindex="0"]');
+        const controls = this.getTabbableControls(element);
 
         if (controls.length !== 0) {
             if (!excludedClassList || excludedClassList.length === 0) {

--- a/AzureFunctions.AngularClient/src/app/shared/shared.module.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/shared.module.ts
@@ -57,6 +57,8 @@ import { TableCellComponent } from './../controls/table-cell/table-cell.componen
 import { TableRowComponent } from './../controls/table-row/table-row.component';
 import { TableRootComponent } from './../controls/table-root/table-root.component';
 import { DeletedItemsFilter } from './../controls/table-root/deleted-items-filter.pipe';
+import { ActivateWithKeysDirective } from './../controls/activate-with-keys/activate-with-keys.directive';
+
 
 export function ArmServiceFactory(
     http: Http,
@@ -106,7 +108,8 @@ export function AiServiceFactory() {
         TableCellComponent,
         TableRowComponent,
         TableRootComponent,
-        DeletedItemsFilter
+        DeletedItemsFilter,
+        ActivateWithKeysDirective
     ],
     exports: [
         CommonModule,
@@ -142,7 +145,8 @@ export function AiServiceFactory() {
         TableCellComponent,
         TableRowComponent,
         TableRootComponent,
-        DeletedItemsFilter
+        DeletedItemsFilter,
+        ActivateWithKeysDirective
     ],
     imports: [
         FormsModule,

--- a/AzureFunctions.AngularClient/src/app/slots-list/slots-list.component.html
+++ b/AzureFunctions.AngularClient/src/app/slots-list/slots-list.component.html
@@ -16,7 +16,7 @@
     </tr>
 
     <tr *ngFor="let item of table.items">
-      <td><span class="link" (click)="clickRow(item)">{{item.name}}</span></td>
+      <td><a class="link" (click)="clickRow(item)" [activate-with-keys]>{{item.name}}</a></td>
       <td>{{item.status}}</td>
       <td>{{item.serverFarm}}</td>
     </tr>


### PR DESCRIPTION
Changes:

- Updated styles for SlideToggleComponent (fixes #1798)
  - This is supposed to match https://developer.microsoft.com/en-us/fabric#/components/toggle, but there are some deviations. For colors, I used the closest-matching colors from our existing color scheme. Similarly, for :hover and :focus styling, I kept things consistent with our existing conventions.

![toggle](https://user-images.githubusercontent.com/5387224/33696004-0e276d48-dab5-11e7-91e1-2fd701727868.PNG)

- Fixed issue in TblComponent that was causing click() to be called twice when "Enter" was pressed on a button element.

- Fixed issue in TblComponent where clicking inside a cell would always move focus to the first tab-able element in the cell, event if the element that was click on was tab-able.

- Minor accessibility and styling updates for icon buttons. (The icon buttons inside the table in FunctionsListComponent were not keyboard accessible.)