### PR TITLE
Fix tree from resetting on updates to startupinfo

### DIFF
--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
@@ -416,10 +416,6 @@ export class SideNavComponent implements AfterViewInit {
     }
 
     private _updateSubscriptions(info: StartupInfo) {
-        // Need to set an initial value to force the tree to render with an initial list first.
-        // Otherwise the tree won't load in batches of objects for long lists until the entire
-        // observable sequence has completed.
-
         const savedSubs = <StoredSubscriptions>this.localStorageService.getItem(LocalStorageKeys.savedSubsKey);
         const savedSelectedSubscriptionIds = savedSubs ? savedSubs.subscriptions : [];
         let descriptor: SiteDescriptor | null;

--- a/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
+++ b/AzureFunctions.AngularClient/src/app/side-nav/side-nav.component.ts
@@ -1,5 +1,5 @@
 import { LogService } from './../shared/services/log.service';
-import { Router, ActivatedRoute} from '@angular/router';
+import { Router, ActivatedRoute } from '@angular/router';
 import { BroadcastEvent } from 'app/shared/models/broadcast-event';
 import { StoredSubscriptions } from './../shared/models/localStorage/local-storage';
 import { Dom } from './../shared/Utilities/dom';
@@ -61,7 +61,7 @@ export class SideNavComponent implements AfterViewInit {
     public searchTerm = '';
     public hasValue = false;
     public tryFunctionApp: FunctionApp;
-    public headerOnTopOfSideNav =  false;
+    public headerOnTopOfSideNav = false;
     public noPaddingOnSideNav = false;
 
     public selectedNode: TreeNode;
@@ -101,8 +101,8 @@ export class SideNavComponent implements AfterViewInit {
         public route: ActivatedRoute,
         private _scenarioService: ScenarioService) {
 
-        this.headerOnTopOfSideNav =  this._scenarioService.checkScenario(ScenarioIds.headerOnTopOfSideNav).status === 'enabled';
-        this.noPaddingOnSideNav =  this._scenarioService.checkScenario(ScenarioIds.noPaddingOnSideNav).status === 'enabled';
+        this.headerOnTopOfSideNav = this._scenarioService.checkScenario(ScenarioIds.headerOnTopOfSideNav).status === 'enabled';
+        this.noPaddingOnSideNav = this._scenarioService.checkScenario(ScenarioIds.noPaddingOnSideNav).status === 'enabled';
         userService.getStartupInfo().subscribe(info => {
 
             const sitenameIncoming = !!info.resourceId ? SiteDescriptor.getSiteDescriptor(info.resourceId).site.toLocaleLowerCase() : null;
@@ -155,7 +155,8 @@ export class SideNavComponent implements AfterViewInit {
                 } else {
                     this._searchTermStream.next('');
                 }
-            } else {
+            } else if (!this.searchTerm) {
+                // Ensure that we don't override existing search term if we get a startupInfo update
                 this._searchTermStream.next('');
             }
         });
@@ -279,21 +280,21 @@ export class SideNavComponent implements AfterViewInit {
 
     navidateToNewSub() {
         const navId = 'subs/new/subscription';
-        this.router.navigate([navId], { relativeTo: this.route, queryParams: Url.getQueryStringObj() });        
+        this.router.navigate([navId], { relativeTo: this.route, queryParams: Url.getQueryStringObj() });
     }
 
     refreshSubs() {
         this.cacheService.getArm('/subscriptions', true).subscribe(r => {
             this.userService.getStartupInfo()
-            .first()
-            .subscribe((info) => {
-                const subs: Subscription[] = r.json().value;
-                if (!SubUtil.subsChanged(info.subscriptions, subs)) {
-                    return;
-                }
-                info.subscriptions = subs;
-                this.userService.updateStartupInfo(info);
-            });
+                .first()
+                .subscribe((info) => {
+                    const subs: Subscription[] = r.json().value;
+                    if (!SubUtil.subsChanged(info.subscriptions, subs)) {
+                        return;
+                    }
+                    info.subscriptions = subs;
+                    this.userService.updateStartupInfo(info);
+                });
         });
     }
 
@@ -418,7 +419,6 @@ export class SideNavComponent implements AfterViewInit {
         // Need to set an initial value to force the tree to render with an initial list first.
         // Otherwise the tree won't load in batches of objects for long lists until the entire
         // observable sequence has completed.
-        this._subscriptionsStream.next([]);
 
         const savedSubs = <StoredSubscriptions>this.localStorageService.getItem(LocalStorageKeys.savedSubsKey);
         const savedSelectedSubscriptionIds = savedSubs ? savedSubs.subscriptions : [];

--- a/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/apps-node.ts
@@ -50,7 +50,7 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
 
         super(sideNav, null, rootNode, '/apps/new/app');
 
-        this.newDashboardType =  null;
+        this.newDashboardType = null;
         this._userService = sideNav.injector.get(UserService);
         this._scenarioService = sideNav.injector.get(ScenarioService);
 
@@ -162,7 +162,7 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
                         // recreated.  In that case, we'll just refocus on the root node.  It's probably
                         // not ideal but simple for us to do.
                         this.treeView.setFocus(this);
-                    } else{
+                    } else {
                         this.supportsRefresh = true;
                     }
 
@@ -207,7 +207,7 @@ export class AppsNode extends TreeNode implements MutableCollection, Disposable,
         return Observable.of(null);
     }
 
-    private _initialized(){
+    private _initialized() {
         return this._subscriptions && this._subscriptions.length > 0 && this._searchTerm !== undefined;
     }
 


### PR DESCRIPTION
Any updates to the startupInfo object is causing 2 issues at the moment in the side nav.

**1. The list of subscriptions gets cleared out** - This is an artifact of how the tree used to work and is no longer necessary after tree simplification.  Combining this with Ahmed's change to [revert AppsNode back to previous logic should fix this.](https://github.com/Azure/azure-functions-ux/commit/36ce372fbff73b6a237c1677a239df5386134928)

**2. The search term was getting cleared out** - This is a regression from fixing #1563.  I fixed this to make sure we only clear out the search term stream only if it wasn't already set.  We still need to clear out the search term on init which is why it's there in the first place.  @hartra344 - Can you verify that I didn't regress the fix that I made for this please?

