### PR TITLE
add close label for screen readers

### DIFF
--- a/AzureFunctions.AngularClient/src/app/download-function-app-content/download-function-app-content.component.html
+++ b/AzureFunctions.AngularClient/src/app/download-function-app-content/download-function-app-content.component.html
@@ -3,7 +3,13 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h3>{{'downloadFunctionAppContent' | translate}}</h3>
-                <button type="button" class="close" (click)="closeModal()">&times;</button>
+                <button 
+                    type="button" 
+                    class="close" 
+                    (click)="closeModal()" 
+                    [attr.aria-label]="'close' | translate">
+                    &times;
+                </button>
             </div>
 
             <div class="modal-body">


### PR DESCRIPTION
using a screen reader to close button will say 'close'

tested on edge and chrome with windows narrator
fixes http://vstfrd:8080/Azure/RD/_workitems?id=10622615&_a=edit&triage=true  
  