### PR TITLE
Add check box label in download app for screen readers

### DIFF
--- a/AzureFunctions.AngularClient/src/app/download-function-app-content/download-function-app-content.component.html
+++ b/AzureFunctions.AngularClient/src/app/download-function-app-content/download-function-app-content.component.html
@@ -26,8 +26,11 @@
                      [cs-input]="{}"
                      cs-enabledByDefault="true"
                      id="app-settings-checkbox">
-                    <input type="checkbox" [(ngModel)]="includeAppSettings" />
-                    <label>{{ 'downloadFunctionAppContent_includeAppSettings' | translate }}</label>
+                    <input
+                        type="checkbox" 
+                        aria-labelledby="includeAppSettingsLabel"
+                        [(ngModel)]="includeAppSettings"/>
+                    <label id="includeAppSettingsLabel">{{ 'downloadFunctionAppContent_includeAppSettings' | translate }}</label>
                     <pop-over [position]="'bottom'" [message]="'downloadFunctionAppContent_includeAppSettingsHelp' | translate">
                         <span class="glyphicon glyphicon-info-sign button-title"></span>
                     </pop-over>


### PR DESCRIPTION
Screen readers will read label while on checkbox.

Tested on chrome / edge with windows narrator

fixes http://vstfrd:8080/Azure/RD/_workitems?id=10622642&_a=edit&triage=true