### PR TITLE
Check typeof appInsight before accessing it

### DIFF
--- a/AzureFunctions.AngularClient/src/app/shared/services/ai.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/ai.service.ts
@@ -190,7 +190,7 @@ export class AiService implements IAppInsights {
      */
     trackException(exception: Error, handledAt?: string, properties?: { [name: string]: string; }, measurements?: { [name: string]: number; }, _?: SeverityLevel) {
         console.error(exception);
-        if (appInsights && appInsights.trackException) {
+        if (typeof appInsights !== 'undefined' && appInsights.trackException) {
             return appInsights.trackException(exception, handledAt, properties, measurements);
         }
     }


### PR DESCRIPTION
most adblocker and tracker blockers will block App Insights script from loading, which would make `appInsight` undefined reference. 