### PR TITLE
Making sure selected option in DropDownComponent matches the selected option in the native select element (fixes #2060)

### DIFF
--- a/AzureFunctions.AngularClient/src/app/drop-down/drop-down.component.html
+++ b/AzureFunctions.AngularClient/src/app/drop-down/drop-down.component.html
@@ -14,13 +14,25 @@
         class="drop-down-select"
         [disabled]="disabled">
 
-        <option selected disabled hidden style='display: none' value=''></option>
+        <option *ngIf="!selectedElement" selected disabled hidden style='display: none' value=''></option>
 
-        <optgroup *ngFor="let group of (optionsGrouped ? _options : [])" [label]="group.displayLabel">
-            <option *ngFor="let option of group.dropDownElements" [value]="option.id">{{option.displayLabel}}</option>
+        <optgroup
+            *ngFor="let group of (optionsGrouped ? _options : [])"
+            [label]="group.displayLabel">
+            <option
+                *ngFor="let option of group.dropDownElements"
+                [value]="option.id"
+                [selected]="selectedElement === option">
+                {{option.displayLabel}}
+            </option>
         </optgroup>
 
-        <option *ngFor="let option of (!optionsGrouped ? _options : [])" [value]="option.id">{{option.displayLabel}}</option>
+        <option
+            *ngFor="let option of (!optionsGrouped ? _options : [])"
+            [value]="option.id"
+            [selected]="selectedElement === option">
+            {{option.displayLabel}}
+        </option>
 
     </select>
 
@@ -37,13 +49,25 @@
         [formControl]="control"
         #selectInput>
 
-        <option selected disabled hidden style='display: none' value=''></option>
+        <option *ngIf="!selectedElement" selected disabled hidden style='display: none' value=''></option>
 
-        <optgroup *ngFor="let group of (optionsGrouped ? _options : [])" [label]="group.displayLabel">
-            <option *ngFor="let option of group.dropDownElements" [value]="option.value">{{option.displayLabel}}</option>
+        <optgroup
+            *ngFor="let group of (optionsGrouped ? _options : [])"
+            [label]="group.displayLabel">
+            <option
+                *ngFor="let option of group.dropDownElements"
+                [value]="option.value"
+                [selected]="selectedElement === option">
+                {{option.displayLabel}}
+            </option>
         </optgroup>
 
-        <option *ngFor="let option of (!optionsGrouped ? _options : [])" [value]="option.value">{{option.displayLabel}}</option>
+        <option
+            *ngFor="let option of (!optionsGrouped ? _options : [])"
+            [value]="option.value"
+            [selected]="selectedElement === option">
+            {{option.displayLabel}}
+        </option>
 
     </select>
 

--- a/AzureFunctions.AngularClient/src/app/drop-down/drop-down.component.ts
+++ b/AzureFunctions.AngularClient/src/app/drop-down/drop-down.component.ts
@@ -125,8 +125,11 @@ export class DropDownComponent<T> implements OnInit, OnChanges {
             } else {
                 this.onSelectValue(selectedOptionValue);
             }
+        } else {
+            if (this.selectedElement) {
+                delete this.selectedElement;
+            }
         }
-
     }
 
     @Input() set resetOnChange(_) {


### PR DESCRIPTION
It looks like we can't completely get rid of the empty/disabled drop-down option mentioned in (#2060). It will still appear (in Edge) for drop down elements that don't have any option pre-selected.