### PR TITLE
Fixes #2228, Fixes #2230 - Proxy save not working and master key missing

### DIFF
--- a/AzureFunctions.AngularClient/src/app/api/api-details/api-details.component.ts
+++ b/AzureFunctions.AngularClient/src/app/api/api-details/api-details.component.ts
@@ -257,13 +257,15 @@ export class ApiDetailsComponent extends NavigableComponent implements OnDestroy
     }
 
     rrOverriedValueChanges(value: any) {
-        if (this.rrComponent) {
-            this._rrOverrideValue = value;
-            this.rrOverrideValid = this.rrComponent.valid;
-            if (this.rrComponent.dirty) {
-                this._broadcastService.setDirtyState('api-proxy');
-                this.complexForm.markAsDirty();
+        setTimeout(() => {
+            if (this.rrComponent) {
+                this._rrOverrideValue = value;
+                this.rrOverrideValid = this.rrComponent.valid;
+                if (this.rrComponent.dirty) {
+                    this._broadcastService.setDirtyState('api-proxy');
+                    this.complexForm.markAsDirty();
+                }
             }
-        }
+        });
     }
 }


### PR DESCRIPTION
For the proxy save issue, it looks like the order/timing of how the request/response child component is being loaded has changed. A simple low-risk (albeit hacky) solution is to just add a setTimeout when we try to reference it.

For the master key missing issue, it looks like after @ahmelsayed updated the FunctionAppService, he forgot to add back in any references to master key requests. I added it back it and it seems to be working now.