### PR TITLE
Adding abstract class ConfigTableBaseComponent (fixes #1860)

### DIFF
--- a/AzureFunctions.AngularClient/src/app/site/site-config/app-settings/app-settings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/app-settings/app-settings.component.ts
@@ -2,7 +2,7 @@ import { LogCategories } from './../../../shared/models/constants';
 import { Response } from '@angular/http';
 import { BroadcastService } from 'app/shared/services/broadcast.service';
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
-import { FormArray, FormBuilder, FormGroup, Validators, ValidatorFn } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators, ValidatorFn } from '@angular/forms';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { Subscription as RxSubscription } from 'rxjs/Subscription';
@@ -14,7 +14,7 @@ import { SaveOrValidationResult } from './../site-config.component';
 import { LogService } from './../../../shared/services/log.service';
 import { PortalResources } from './../../../shared/models/portal-resources';
 import { BusyStateScopeManager } from './../../../busy-state/busy-state-scope-manager';
-import { CustomFormControl, CustomFormGroup } from './../../../controls/click-to-edit/click-to-edit.component';
+import { CustomFormGroup } from './../../../controls/click-to-edit/click-to-edit.component';
 import { ArmObj, ArmObjMap } from './../../../shared/models/arm/arm-obj';
 import { CacheService } from './../../../shared/services/cache.service';
 import { AuthzService } from './../../../shared/services/authz.service';
@@ -24,14 +24,15 @@ import { RequiredValidator } from 'app/shared/validators/requiredValidator';
 import { LinuxAppSettingNameValidator } from 'app/shared/validators/linuxAppSettingNameValidator';
 import { ArmUtil } from 'app/shared/Utilities/arm-utils';
 
+import { ConfigTableBaseComponent }  from '../config-table-base-component';
+
 @Component({
   selector: 'app-settings',
   templateUrl: './app-settings.component.html',
   styleUrls: ['./../site-config.component.scss']
 })
-export class AppSettingsComponent implements OnChanges, OnDestroy {
+export class AppSettingsComponent extends ConfigTableBaseComponent implements OnChanges, OnDestroy {
   public Resources = PortalResources;
-  public groupArray: FormArray;
 
   private _resourceIdStream: Subject<string>;
   private _resourceIdSubscription: RxSubscription;
@@ -55,9 +56,6 @@ export class AppSettingsComponent implements OnChanges, OnDestroy {
   public loadingFailureMessage: string;
   public loadingMessage: string;
 
-  public newItem: CustomFormGroup;
-  public originalItemsDeleted: number;
-
   @Input() mainForm: FormGroup;
 
   @Input() resourceId: string;
@@ -71,12 +69,11 @@ export class AppSettingsComponent implements OnChanges, OnDestroy {
     private _authZService: AuthzService,
     broadcastService: BroadcastService
   ) {
+    super();
+
     this._busyManager = new BusyStateScopeManager(broadcastService, 'site-tabs');
 
     this._resetPermissionsAndLoadingState();
-
-    this.newItem = null;
-    this.originalItemsDeleted = 0;
 
     this._resourceIdStream = new Subject<string>();
     this._resourceIdSubscription = this._resourceIdStream
@@ -87,8 +84,7 @@ export class AppSettingsComponent implements OnChanges, OnDestroy {
         this._appSettingsArm = null;
         this._slotConfigNamesArm = null;
         this.groupArray = null;
-        this.newItem = null;
-        this.originalItemsDeleted = 0;
+        this._resetNewAndDeleted();
         this._resetPermissionsAndLoadingState();
         this._slotConfigNamesArmPath =
           `${new ArmSiteDescriptor(this.resourceId).getSiteOnlyResourceId()}/config/slotConfigNames`;
@@ -174,8 +170,7 @@ export class AppSettingsComponent implements OnChanges, OnDestroy {
   private _setupForm(appSettingsArm: ArmObj<any>, slotConfigNamesArm: ArmObj<SlotConfigNames>) {
     if (!!appSettingsArm && !!slotConfigNamesArm) {
       if (!this._saveError || !this.groupArray) {
-        this.newItem = null;
-        this.originalItemsDeleted = 0;
+        this._resetNewAndDeleted();
         this.groupArray = this._fb.array([]);
 
         this._requiredValidator = new RequiredValidator(this._translateService);
@@ -214,7 +209,7 @@ export class AppSettingsComponent implements OnChanges, OnDestroy {
           }
         }
 
-        this._validateAllControls(this.groupArray.controls as CustomFormGroup[]);
+        this._validateAllControls();
       }
 
       if (this.mainForm.contains('appSettings')) {
@@ -223,8 +218,7 @@ export class AppSettingsComponent implements OnChanges, OnDestroy {
         this.mainForm.addControl('appSettings', this.groupArray);
       }
     } else {
-      this.newItem = null;
-      this.originalItemsDeleted = 0;
+      this._resetNewAndDeleted();
       this.groupArray = null;
       if (this.mainForm.contains('appSettings')) {
         this.mainForm.removeControl('appSettings');
@@ -235,36 +229,14 @@ export class AppSettingsComponent implements OnChanges, OnDestroy {
   }
 
   validate(): SaveOrValidationResult {
-    const groups = this.groupArray.controls;
+    this._purgePristineNewItems();
 
-    // Purge any added entries that were never modified
-    for (let i = groups.length - 1; i >= 0; i--) {
-      const group = groups[i] as CustomFormGroup;
-      if (group.msStartInEditMode && group.pristine) {
-        groups.splice(i, 1);
-        if (group === this.newItem) {
-          this.newItem = null;
-        }
-      }
-    }
-
-    this._validateAllControls(groups as CustomFormGroup[]);
+    this._validateAllControls();
 
     return {
       success: this.groupArray.valid,
       error: this.groupArray.valid ? null : this._validationFailureMessage()
     };
-  }
-
-  private _validateAllControls(groups: CustomFormGroup[]) {
-    groups.forEach(group => {
-      const controls = (<FormGroup>group).controls;
-      for (const controlName in controls) {
-        const control = <CustomFormControl>controls[controlName];
-        control._msRunValidation = true;
-        control.updateValueAndValidity();
-      }
-    });
   }
 
   getConfigForSave(): ArmObjMap {
@@ -355,66 +327,8 @@ export class AppSettingsComponent implements OnChanges, OnDestroy {
     return this._translateService.instant(PortalResources.configUpdateFailureInvalidInput, { configGroupName: configGroupName });
   }
 
-  deleteItem(group: FormGroup) {
-    const groups = this.groupArray;
-    const index = groups.controls.indexOf(group);
-    if (index >= 0) {
-      if ((group as CustomFormGroup).msExistenceState === 'original') {
-        this._deleteOriginalItem(groups, group);
-      } else {
-        this._deleteAddedItem(groups, group, index);
-      }
-    }
-  }
-
-  private _deleteOriginalItem(groups: FormArray, group: FormGroup) {
-    // Keep the deleted group around with its state set to dirty.
-    // This keeps the overall state of this.groupArray and this.mainForm dirty.
-    group.markAsDirty();
-
-    // Set the group.msExistenceState to 'deleted' so we know to ignore it when validating and saving.
-    (group as CustomFormGroup).msExistenceState = 'deleted';
-
-    // Force the deleted group to have a valid state by clear all validators on the controls and then running validation.
-    for (const key in group.controls) {
-      const control = group.controls[key];
-      control.clearAsyncValidators();
-      control.clearValidators();
-      control.updateValueAndValidity();
-    }
-
-    this.originalItemsDeleted++;
-
-    groups.updateValueAndValidity();
-  }
-
-  private _deleteAddedItem(groups: FormArray, group: FormGroup, index: number) {
-    // Remove group from groups
-    groups.removeAt(index);
-    if (group === this.newItem) {
-      this.newItem = null;
-    }
-
-    // If group was dirty, then groups is also dirty.
-    // If all the remaining controls in groups are pristine, mark groups as pristine.
-    if (!group.pristine) {
-      let pristine = true;
-      for (const control of groups.controls) {
-        pristine = pristine && control.pristine;
-      }
-
-      if (pristine) {
-        groups.markAsPristine();
-      }
-    }
-
-    groups.updateValueAndValidity();
-  }
-
-  addItem() {
-    const groups = this.groupArray;
-
-    this.newItem = this._fb.group({
+  protected _createNewItem(): CustomFormGroup {
+    const newItem = this._fb.group({
       name: [
         null,
         Validators.compose(this._validatorFns)],
@@ -422,8 +336,6 @@ export class AppSettingsComponent implements OnChanges, OnDestroy {
       isSlotSetting: [false]
     }) as CustomFormGroup;
 
-    this.newItem.msExistenceState = 'new';
-    this.newItem.msStartInEditMode = true;
-    groups.push(this.newItem);
+    return newItem;
   }
 }

--- a/AzureFunctions.AngularClient/src/app/site/site-config/config-table-base-component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/config-table-base-component.ts
@@ -1,0 +1,114 @@
+import { FormArray, FormGroup } from '@angular/forms';
+import { CustomFormControl, CustomFormGroup } from './../../controls/click-to-edit/click-to-edit.component';
+
+export abstract class ConfigTableBaseComponent {
+    public groupArray: FormArray;
+
+    public newItem: CustomFormGroup;
+    public originalItemsDeleted: number;
+
+    constructor() {
+        this._resetNewAndDeleted();
+    }
+
+    protected _resetNewAndDeleted() {
+        this.newItem = null;
+        this.originalItemsDeleted = 0;
+    }
+
+    protected _purgePristineNewItems() {
+        const groups = this.groupArray.controls;
+
+        // Purge any added entries that were never modified
+        for (let i = groups.length - 1; i >= 0; i--) {
+            const group = groups[i] as CustomFormGroup;
+            if (group.msStartInEditMode && group.pristine) {
+                groups.splice(i, 1);
+                if (group === this.newItem) {
+                    this.newItem = null;
+                }
+            }
+        }
+    }
+
+    protected _validateAllControls() {
+        const groups = this.groupArray.controls;
+
+        groups.forEach(group => {
+            const controls = (<FormGroup>group).controls;
+            for (const controlName in controls) {
+                const control = <CustomFormControl>controls[controlName];
+                control._msRunValidation = true;
+                control.updateValueAndValidity();
+            }
+        });
+    }
+
+    deleteItem(group: FormGroup) {
+        const groups = this.groupArray;
+        const index = groups.controls.indexOf(group);
+        if (index >= 0) {
+            if ((group as CustomFormGroup).msExistenceState === 'original') {
+                this._deleteOriginalItem(groups, group);
+            } else {
+                this._deleteAddedItem(groups, group, index);
+            }
+        }
+    }
+
+    protected _deleteOriginalItem(groups: FormArray, group: FormGroup) {
+        // Keep the deleted group around with its state set to dirty.
+        // This keeps the overall state of this.groupArray and this.mainForm dirty.
+        group.markAsDirty();
+
+        // Set the group.msExistenceState to 'deleted' so we know to ignore it when validating and saving.
+        (group as CustomFormGroup).msExistenceState = 'deleted';
+
+        // Force the deleted group to have a valid state by clear all validators on the controls and then running validation.
+        for (const key in group.controls) {
+            const control = group.controls[key];
+            control.clearAsyncValidators();
+            control.clearValidators();
+            control.updateValueAndValidity();
+        }
+
+        this.originalItemsDeleted++;
+
+        groups.updateValueAndValidity();
+    }
+
+    protected _deleteAddedItem(groups: FormArray, group: FormGroup, index: number) {
+        // Remove group from groups
+        groups.removeAt(index);
+        if (group === this.newItem) {
+            this.newItem = null;
+        }
+
+        // If group was dirty, then groups is also dirty.
+        // If all the remaining controls in groups are pristine, mark groups as pristine.
+        if (!group.pristine) {
+            let pristine = true;
+            for (const control of groups.controls) {
+                pristine = pristine && control.pristine;
+            }
+
+            if (pristine) {
+                groups.markAsPristine();
+            }
+        }
+
+        groups.updateValueAndValidity();
+    }
+
+    addItem() {
+        const groups = this.groupArray;
+
+        this.newItem = this._createNewItem();
+        this.newItem.msExistenceState = 'new';
+        this.newItem.msStartInEditMode = true;
+
+        groups.push(this.newItem);
+    }
+
+    protected abstract _createNewItem(): CustomFormGroup;
+}

--- a/AzureFunctions.AngularClient/src/app/site/site-config/default-documents/default-documents.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/default-documents/default-documents.component.ts
@@ -1,7 +1,7 @@
 import { LogCategories } from './../../../shared/models/constants';
 import { BroadcastService } from './../../../shared/services/broadcast.service';
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
-import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { Subscription as RxSubscription } from 'rxjs/Subscription';
@@ -12,21 +12,22 @@ import { SaveOrValidationResult } from './../site-config.component';
 import { LogService } from './../../../shared/services/log.service';
 import { PortalResources } from './../../../shared/models/portal-resources';
 import { BusyStateScopeManager } from './../../../busy-state/busy-state-scope-manager';
-import { CustomFormControl, CustomFormGroup } from './../../../controls/click-to-edit/click-to-edit.component';
+import { CustomFormGroup } from './../../../controls/click-to-edit/click-to-edit.component';
 import { ArmObj } from './../../../shared/models/arm/arm-obj';
 import { CacheService } from './../../../shared/services/cache.service';
 import { AuthzService } from './../../../shared/services/authz.service';
 import { UniqueValidator } from 'app/shared/validators/uniqueValidator';
 import { RequiredValidator } from 'app/shared/validators/requiredValidator';
 
+import { ConfigTableBaseComponent }  from '../config-table-base-component';
+
 @Component({
     selector: 'default-documents',
     templateUrl: './default-documents.component.html',
     styleUrls: ['./../site-config.component.scss']
 })
-export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
+export class DefaultDocumentsComponent extends ConfigTableBaseComponent implements OnChanges, OnDestroy {
     public Resources = PortalResources;
-    public groupArray: FormArray;
 
     private _resourceIdStream: Subject<string>;
     private _resourceIdSubscription: RxSubscription;
@@ -47,9 +48,6 @@ export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
     public loadingFailureMessage: string;
     public loadingMessage: string;
 
-    public newItem: CustomFormGroup;
-    public originalItemsDeleted: number;
-
     @Input() mainForm: FormGroup;
 
     @Input() resourceId: string;
@@ -62,12 +60,11 @@ export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
         private _authZService: AuthzService,
         broadcastService: BroadcastService
     ) {
+        super();
+
         this._busyManager = new BusyStateScopeManager(broadcastService, 'site-tabs');
 
         this._resetPermissionsAndLoadingState();
-
-        this.newItem = null;
-        this.originalItemsDeleted = 0;
 
         this._resourceIdStream = new Subject<string>();
         this._resourceIdSubscription = this._resourceIdStream
@@ -77,8 +74,7 @@ export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
                 this._saveError = null;
                 this._webConfigArm = null;
                 this.groupArray = null;
-                this.newItem = null;
-                this.originalItemsDeleted = 0;
+                this._resetNewAndDeleted();
                 this._resetPermissionsAndLoadingState();
                 return Observable.zip(
                     this._authZService.hasPermission(this.resourceId, [AuthzService.writeScope]),
@@ -152,8 +148,7 @@ export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
     private _setupForm(webConfigArm: ArmObj<SiteConfig>) {
         if (!!webConfigArm) {
             if (!this._saveError || !this.groupArray) {
-                this.newItem = null;
-                this.originalItemsDeleted = 0;
+                this._resetNewAndDeleted();
                 this.groupArray = this._fb.array([]);
 
                 this._requiredValidator = new RequiredValidator(this._translateService);
@@ -177,7 +172,7 @@ export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
                     });
                 }
 
-                this._validateAllControls(this.groupArray.controls as CustomFormGroup[]);
+                this._validateAllControls();
             }
 
             if (this.mainForm.contains('defaultDocs')) {
@@ -186,8 +181,7 @@ export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
                 this.mainForm.addControl('defaultDocs', this.groupArray);
             }
         } else {
-            this.newItem = null;
-            this.originalItemsDeleted = 0;
+            this._resetNewAndDeleted();
             this.groupArray = null;
             if (this.mainForm.contains('defaultDocs')) {
                 this.mainForm.removeControl('defaultDocs');
@@ -198,36 +192,14 @@ export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
     }
 
     validate(): SaveOrValidationResult {
-        const groups = this.groupArray.controls;
+        this._purgePristineNewItems();
 
-        // Purge any added entries that were never modified
-        for (let i = groups.length - 1; i >= 0; i--) {
-            const group = groups[i] as CustomFormGroup;
-            if (group.msStartInEditMode && group.pristine) {
-                groups.splice(i, 1);
-                if (group === this.newItem) {
-                    this.newItem = null;
-                }
-            }
-        }
-
-        this._validateAllControls(groups as CustomFormGroup[]);
+        this._validateAllControls();
 
         return {
             success: this.groupArray.valid,
             error: this.groupArray.valid ? null : this._validationFailureMessage()
         };
-    }
-
-    private _validateAllControls(groups: CustomFormGroup[]) {
-        groups.forEach(group => {
-            const controls = (<FormGroup>group).controls;
-            for (const controlName in controls) {
-                const control = <CustomFormControl>controls[controlName];
-                control._msRunValidation = true;
-                control.updateValueAndValidity();
-            }
-        });
     }
 
     save(): Observable<SaveOrValidationResult> {
@@ -280,66 +252,8 @@ export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
         return this._translateService.instant(PortalResources.configUpdateFailureInvalidInput, { configGroupName: configGroupName });
     }
 
-    deleteItem(group: FormGroup) {
-        const groups = this.groupArray;
-        const index = groups.controls.indexOf(group);
-        if (index >= 0) {
-            if ((group as CustomFormGroup).msExistenceState === 'original') {
-                this._deleteOriginalItem(groups, group);
-            } else {
-                this._deleteAddedItem(groups, group, index);
-            }
-        }
-    }
-
-    private _deleteOriginalItem(groups: FormArray, group: FormGroup) {
-        // Keep the deleted group around with its state set to dirty.
-        // This keeps the overall state of this.groupArray and this.mainForm dirty.
-        group.markAsDirty();
-
-        // Set the group.msExistenceState to 'deleted' so we know to ignore it when validating and saving.
-        (group as CustomFormGroup).msExistenceState = 'deleted';
-
-        // Force the deleted group to have a valid state by clear all validators on the controls and then running validation.
-        for (const key in group.controls) {
-            const control = group.controls[key];
-            control.clearAsyncValidators();
-            control.clearValidators();
-            control.updateValueAndValidity();
-        }
-
-        this.originalItemsDeleted++;
-
-        groups.updateValueAndValidity();
-    }
-
-    private _deleteAddedItem(groups: FormArray, group: FormGroup, index: number) {
-        // Remove group from groups
-        groups.removeAt(index);
-        if (group === this.newItem) {
-            this.newItem = null;
-        }
-
-        // If group was dirty, then groups is also dirty.
-        // If all the remaining controls in groups are pristine, mark groups as pristine.
-        if (!group.pristine) {
-            let pristine = true;
-            for (const control of groups.controls) {
-                pristine = pristine && control.pristine;
-            }
-
-            if (pristine) {
-                groups.markAsPristine();
-            }
-        }
-
-        groups.updateValueAndValidity();
-    }
-
-    addItem() {
-        const groups = this.groupArray;
-
-        this.newItem = this._fb.group({
+    protected _createNewItem(): CustomFormGroup {
+        const newItem = this._fb.group({
             name: [
                 null,
                 Validators.compose([
@@ -348,8 +262,6 @@ export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
             value: [null]
         }) as CustomFormGroup;
 
-        this.newItem.msExistenceState = 'new';
-        this.newItem.msStartInEditMode = true;
-        groups.push(this.newItem);
+        return newItem;
     }
 }

--- a/AzureFunctions.AngularClient/src/app/site/site-config/virtual-directories/virtual-directories.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/virtual-directories/virtual-directories.component.ts
@@ -1,7 +1,7 @@
 import { LogCategories } from './../../../shared/models/constants';
 import { BroadcastService } from './../../../shared/services/broadcast.service';
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
-import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { Subscription as RxSubscription } from 'rxjs/Subscription';
@@ -13,12 +13,14 @@ import { SaveOrValidationResult } from './../site-config.component';
 import { LogService } from './../../../shared/services/log.service';
 import { PortalResources } from './../../../shared/models/portal-resources';
 import { BusyStateScopeManager } from './../../../busy-state/busy-state-scope-manager';
-import { CustomFormControl, CustomFormGroup } from './../../../controls/click-to-edit/click-to-edit.component';
+import { CustomFormGroup } from './../../../controls/click-to-edit/click-to-edit.component';
 import { ArmObj } from './../../../shared/models/arm/arm-obj';
 import { CacheService } from './../../../shared/services/cache.service';
 import { AuthzService } from './../../../shared/services/authz.service';
 import { UniqueValidator } from 'app/shared/validators/uniqueValidator';
 import { RequiredValidator } from 'app/shared/validators/requiredValidator';
+
+import { ConfigTableBaseComponent }  from '../config-table-base-component';
 
 // TODO: [andimarc] extend FunctionAppContextComponent
 @Component({
@@ -26,9 +28,8 @@ import { RequiredValidator } from 'app/shared/validators/requiredValidator';
     templateUrl: './virtual-directories.component.html',
     styleUrls: ['./../site-config.component.scss']
 })
-export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
+export class VirtualDirectoriesComponent extends ConfigTableBaseComponent implements OnChanges, OnDestroy {
     public Resources = PortalResources;
-    public groupArray: FormArray;
 
     private _resourceIdStream: Subject<string>;
     private _resourceIdSubscription: RxSubscription;
@@ -49,9 +50,6 @@ export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
     public loadingFailureMessage: string;
     public loadingMessage: string;
 
-    public newItem: CustomFormGroup;
-    public originalItemsDeleted: number;
-
     @Input() mainForm: FormGroup;
 
     @Input() resourceId: string;
@@ -64,12 +62,11 @@ export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
         private _authZService: AuthzService,
         broadcastService: BroadcastService
     ) {
+        super();
+
         this._busyManager = new BusyStateScopeManager(broadcastService, 'site-tabs');
 
         this._resetPermissionsAndLoadingState();
-
-        this.newItem = null;
-        this.originalItemsDeleted = 0;
 
         this._resourceIdStream = new Subject<string>();
         this._resourceIdSubscription = this._resourceIdStream
@@ -79,8 +76,7 @@ export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
                 this._saveError = null;
                 this._webConfigArm = null;
                 this.groupArray = null;
-                this.newItem = null;
-                this.originalItemsDeleted = 0;
+                this._resetNewAndDeleted();
                 this._resetPermissionsAndLoadingState();
                 return Observable.zip(
                     this._authZService.hasPermission(this.resourceId, [AuthzService.writeScope]),
@@ -155,8 +151,7 @@ export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
     private _setupForm(webConfigArm: ArmObj<SiteConfig>) {
         if (!!webConfigArm) {
             if (!this._saveError || !this.groupArray) {
-                this.newItem = null;
-                this.originalItemsDeleted = 0;
+                this._resetNewAndDeleted();
                 this.groupArray = this._fb.array([]);
 
                 this._requiredValidator = new RequiredValidator(this._translateService);
@@ -185,7 +180,7 @@ export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
                     });
                 }
 
-                this._validateAllControls(this.groupArray.controls as CustomFormGroup[]);
+                this._validateAllControls();
             }
 
             if (this.mainForm.contains('virtualDirectories')) {
@@ -194,8 +189,7 @@ export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
                 this.mainForm.addControl('virtualDirectories', this.groupArray);
             }
         } else {
-            this.newItem = null;
-            this.originalItemsDeleted = 0;
+            this._resetNewAndDeleted();
             this.groupArray = null;
             if (this.mainForm.contains('virtualDirectories')) {
                 this.mainForm.removeControl('virtualDirectories');
@@ -243,36 +237,14 @@ export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
     }
 
     validate(): SaveOrValidationResult {
-        const groups = this.groupArray.controls;
+        this._purgePristineNewItems();
 
-        // Purge any added entries that were never modified
-        for (let i = groups.length - 1; i >= 0; i--) {
-            const group = groups[i] as CustomFormGroup;
-            if (group.msStartInEditMode && group.pristine) {
-                groups.splice(i, 1);
-                if (group === this.newItem) {
-                    this.newItem = null;
-                }
-            }
-        }
-
-        this._validateAllControls(groups as CustomFormGroup[]);
+        this._validateAllControls();
 
         return {
             success: this.groupArray.valid,
             error: this.groupArray.valid ? null : this._validationFailureMessage()
         };
-    }
-
-    private _validateAllControls(groups: CustomFormGroup[]) {
-        groups.forEach(group => {
-            const controls = (<FormGroup>group).controls;
-            for (const controlName in controls) {
-                const control = <CustomFormControl>controls[controlName];
-                control._msRunValidation = true;
-                control.updateValueAndValidity();
-            }
-        });
     }
 
     save(): Observable<SaveOrValidationResult> {
@@ -359,66 +331,8 @@ export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
         return this._translateService.instant(PortalResources.configUpdateFailureInvalidInput, { configGroupName: configGroupName });
     }
 
-    deleteItem(group: FormGroup) {
-        const groups = this.groupArray;
-        const index = groups.controls.indexOf(group);
-        if (index >= 0) {
-            if ((group as CustomFormGroup).msExistenceState === 'original') {
-                this._deleteOriginalItem(groups, group);
-            } else {
-                this._deleteAddedItem(groups, group, index);
-            }
-        }
-    }
-
-    private _deleteOriginalItem(groups: FormArray, group: FormGroup) {
-        // Keep the deleted group around with its state set to dirty.
-        // This keeps the overall state of this.groupArray and this.mainForm dirty.
-        group.markAsDirty();
-
-        // Set the group.msExistenceState to 'deleted' so we know to ignore it when validating and saving.
-        (group as CustomFormGroup).msExistenceState = 'deleted';
-
-        // Force the deleted group to have a valid state by clear all validators on the controls and then running validation.
-        for (const key in group.controls) {
-            const control = group.controls[key];
-            control.clearAsyncValidators();
-            control.clearValidators();
-            control.updateValueAndValidity();
-        }
-
-        this.originalItemsDeleted++;
-
-        groups.updateValueAndValidity();
-    }
-
-    private _deleteAddedItem(groups: FormArray, group: FormGroup, index: number) {
-        // Remove group from groups
-        groups.removeAt(index);
-        if (group === this.newItem) {
-            this.newItem = null;
-        }
-
-        // If group was dirty, then groups is also dirty.
-        // If all the remaining controls in groups are pristine, mark groups as pristine.
-        if (!group.pristine) {
-            let pristine = true;
-            for (const control of groups.controls) {
-                pristine = pristine && control.pristine;
-            }
-
-            if (pristine) {
-                groups.markAsPristine();
-            }
-        }
-
-        groups.updateValueAndValidity();
-    }
-
-    addItem() {
-        const groups = this.groupArray;
-
-        this.newItem = this._fb.group({
+    protected _createNewItem(): CustomFormGroup {
+        const newItem = this._fb.group({
             virtualPath: [
                 null,
                 Validators.compose([
@@ -430,8 +344,6 @@ export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
             isApplication: [false]
         }) as CustomFormGroup;
 
-        this.newItem.msExistenceState = 'new';
-        this.newItem.msStartInEditMode = true;
-        groups.push(this.newItem);
+        return newItem;
     }
 }


### PR DESCRIPTION
Moving common logic from the following components into a new base class "ConfigTableBaseComponent":
- AppSettingsComponent
- ConnectionStringsComponent
- DefaultDocumentsComponent
- HandlerMappingsComponent
- VirtualDirectoriesComponent