### PR TITLE
Fixes #2243 - Update URL rewrite rules so that API calls only match if path starts with /api and not just contains 'api/'

### DIFF
--- a/AzureFunctions/Web.config
+++ b/AzureFunctions/Web.config
@@ -64,7 +64,7 @@
           <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" redirectType="Permanent" />
         </rule>
         <rule name="ignoreApiRoutes" stopProcessing="true">
-          <match url="api/.*" negate="false" />
+          <match url="^api/.*" negate="false" />
           <action type="None" />
         </rule>
         <rule name="ignoreFavicon" stopProcessing="true">


### PR DESCRIPTION
Our current ASP.Net rewrite rules are matching the **"api/"** string in deep links like "https://functions.azure.com/feature/subscriptions/{sub}/resourcegroups/{rg}/providers/microsoft.web/sites/myapi/settings" and are allowing them to passthrough to our API controller instead of rewriting them to "https://functions.azure.com/".  Since we are a single page app, it's important for all requests that aren't API requests or for static content, to be rewritten to the root app so that Angular routing can do its own magic to load the proper UI components.  Since there aren't any API's that match the full path of the URL, we get a 404.