### PR TITLE
Adding telemetry for AppSettings and creating base FeatureComponent

### DIFF
--- a/AzureFunctions.AngularClient/src/app/shared/components/errorable-component.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/components/errorable-component.ts
@@ -5,7 +5,7 @@ import { BroadcastEvent } from '../models/broadcast-event';
 
 export abstract class ErrorableComponent {
 
-    constructor(_componentName: string, protected _broadcastService: BroadcastService) { }
+    constructor(protected componentName: string, protected _broadcastService: BroadcastService) { }
 
     showComponentError(error: ErrorEvent) {
         this._broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, error);

--- a/AzureFunctions.AngularClient/src/app/shared/components/feature-component.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/components/feature-component.ts
@@ -1,3 +1,4 @@
+import { LogService } from './../services/log.service';
 import { TelemetryService } from './../services/telemetry.service';
 import { BroadcastService } from 'app/shared/services/broadcast.service';
 import { Injector } from '@angular/core/src/core';
@@ -6,6 +7,7 @@ import { Subject } from 'rxjs/Subject';
 import { OnDestroy } from '@angular/core/src/metadata/lifecycle_hooks';
 import { ErrorableComponent } from './errorable-component';
 import { Input } from '@angular/core';
+import { LogCategories } from 'app/shared/models/constants';
 
 export abstract class FeatureComponent<T> extends ErrorableComponent implements OnDestroy {
     @Input() featureName: string;
@@ -18,6 +20,8 @@ export abstract class FeatureComponent<T> extends ErrorableComponent implements 
         super(componentName, injector.get(BroadcastService));
 
         this._telemetryService = injector.get(TelemetryService);
+        const logService = injector.get(LogService);
+
         const preCheckEvents = this._inputEvents
             .takeUntil(this._ngUnsubscribe)
             .do(input => {
@@ -32,6 +36,8 @@ export abstract class FeatureComponent<T> extends ErrorableComponent implements 
             .takeUntil(this._ngUnsubscribe)
             .subscribe(r => {
                 this._telemetryService.featureLoadingComplete(this.featureName, this.componentName);
+            }, err => {
+                logService.error(LogCategories.featureLoading, '/load-failure', err);
             });
     }
 

--- a/AzureFunctions.AngularClient/src/app/shared/components/feature-component.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/components/feature-component.ts
@@ -11,6 +11,7 @@ import { LogCategories } from 'app/shared/models/constants';
 
 export abstract class FeatureComponent<T> extends ErrorableComponent implements OnDestroy {
     @Input() featureName: string;
+    isParentComponent = false;
 
     private _inputEvents = new Subject<T>();
     private _ngUnsubscribe = new Subject();
@@ -29,7 +30,7 @@ export abstract class FeatureComponent<T> extends ErrorableComponent implements 
                     throw Error('featureName is not defined');
                 }
 
-                this._telemetryService.featureLoading(this.featureName, this.componentName);
+                this._telemetryService.featureLoading(this.isParentComponent, this.featureName, this.componentName);
             });
 
         this.setup(preCheckEvents)

--- a/AzureFunctions.AngularClient/src/app/shared/components/feature-component.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/components/feature-component.ts
@@ -1,0 +1,47 @@
+import { TelemetryService } from './../services/telemetry.service';
+import { BroadcastService } from 'app/shared/services/broadcast.service';
+import { Injector } from '@angular/core/src/core';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import { OnDestroy } from '@angular/core/src/metadata/lifecycle_hooks';
+import { ErrorableComponent } from './errorable-component';
+import { Input } from '@angular/core';
+
+export abstract class FeatureComponent<T> extends ErrorableComponent implements OnDestroy {
+    @Input() featureName: string;
+
+    private _inputEvents = new Subject<T>();
+    private _ngUnsubscribe = new Subject();
+    private _telemetryService: TelemetryService;
+
+    constructor(componentName: string, injector: Injector) {
+        super(componentName, injector.get(BroadcastService));
+
+        this._telemetryService = injector.get(TelemetryService);
+        const preCheckEvents = this._inputEvents
+            .takeUntil(this._ngUnsubscribe)
+            .do(input => {
+                if (!this.featureName) {
+                    throw Error('featureName is not defined');
+                }
+
+                this._telemetryService.featureLoading(this.featureName, this.componentName);
+            });
+
+        this.setup(preCheckEvents)
+            .takeUntil(this._ngUnsubscribe)
+            .subscribe(r => {
+                this._telemetryService.featureLoadingComplete(this.featureName, this.componentName);
+            });
+    }
+
+    protected setInput(input: T) {
+        this._inputEvents.next(input);
+    }
+
+    protected abstract setup(inputEvents: Observable<T>): Observable<any>;
+
+    ngOnDestroy(): void {
+        this._ngUnsubscribe.next();
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/shared/models/arm/arm-obj.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/arm/arm-obj.ts
@@ -1,3 +1,5 @@
+export type ResourceId = string;
+
 export interface ArmObj<T> {
     id: string;
     name: string;
@@ -9,16 +11,16 @@ export interface ArmObj<T> {
 }
 
 export interface ArmObjMap {
-    objects: { [key: string]: ArmObj<any> },
-    error?: string
+    objects: { [key: string]: ArmObj<any> };
+    error?: string;
 }
 
 export interface ArmArrayResult<T> {
-    value : ArmObj<T>[];
-    nextLink : string;
+    value: ArmObj<T>[];
+    nextLink: string;
 }
 
-export interface Identity{
+export interface Identity {
     principalId: string;
     tenantId: string;
     type: string;

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -237,6 +237,7 @@ export class LogCategories {
     public static readonly binding = 'Binding';
     public static readonly functionNew = 'FunctionNew';
     public static readonly cicd = 'CICD';
+    public static readonly telemetry = 'Telemetry';
 }
 
 export class KeyCodes {

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -238,6 +238,7 @@ export class LogCategories {
     public static readonly functionNew = 'FunctionNew';
     public static readonly cicd = 'CICD';
     public static readonly telemetry = 'Telemetry';
+    public static readonly featureLoading = 'FeatureLoading';
 }
 
 export class KeyCodes {

--- a/AzureFunctions.AngularClient/src/app/shared/services/log.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/log.service.ts
@@ -83,18 +83,18 @@ export class LogService {
         }
     }
 
-    public log(level: LogLevel, category: string, data: any, id?: string){
-        if(!id && (level === LogLevel.error || level === LogLevel.warning)){
+    public log(level: LogLevel, category: string, data: any, id?: string) {
+        if (!id && (level === LogLevel.error || level === LogLevel.warning)) {
             throw Error('Error and Warning log levels require an id');
         }
 
-        if(level === LogLevel.error){
+        if (level === LogLevel.error) {
             this.error(category, id, data);
-        } else if(level === LogLevel.warning){
+        } else if (level === LogLevel.warning) {
             this.warn(category, id, data);
-        } else if(level === LogLevel.debug){
+        } else if (level === LogLevel.debug) {
             this.debug(category, data);
-        } else{
+        } else {
             this.verbose(category, data);
         }
     }
@@ -102,7 +102,9 @@ export class LogService {
     private _shouldLog(category: string, logLevel: LogLevel) {
 
         if (logLevel <= this._logLevel) {
-            if (this._categories.length > 0 && this._categories.find(c => c.toLowerCase() === category.toLowerCase())) {
+            if (logLevel === LogLevel.error || logLevel === LogLevel.warning) {
+                return true;
+            } else if (this._categories.length > 0 && this._categories.find(c => c.toLowerCase() === category.toLowerCase())) {
                 return true;
             } else if (this._categories.length === 0) {
                 return true;
@@ -114,7 +116,7 @@ export class LogService {
         return false;
     }
 
-    private _getTime(){
+    private _getTime() {
         const now = new Date();
         return now.toISOString();
     }

--- a/AzureFunctions.AngularClient/src/app/shared/services/telemetry.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/telemetry.service.ts
@@ -1,0 +1,77 @@
+import { LogService } from 'app/shared/services/log.service';
+import { PortalService } from './portal.service';
+import { Observable } from 'rxjs/Observable';
+import { Injectable } from '@angular/core';
+import { LogCategories } from 'app/shared/models/constants';
+
+interface ComponentMap {
+    [key: string]: string;
+}
+
+@Injectable()
+export class TelemetryService {
+
+    private _featureMap: { [key: string]: ComponentMap } = {};
+
+    private readonly _loadingIdFormat = '/feature/{0}/loading';
+    private readonly _debouceTimeMs = 250;
+
+    constructor(
+        private _portalService: PortalService,
+        private _logService: LogService) {
+    }
+
+    public featureLoading(featureName: string, componentName: string) {
+        if (!this._featureMap[featureName]) {
+            this._featureMap[featureName] = {};
+
+            this._logService.verbose(LogCategories.telemetry, `Feature loading started. feature: ${featureName}`);
+
+            this._portalService.sendTimerEvent({
+                timerId: this._loadingIdFormat.format(featureName),
+                timerAction: 'start'
+            });
+        }
+
+        this._logService.verbose(
+            LogCategories.telemetry,
+            `Loading feature: ${featureName}, component: ${componentName}`);
+
+        this._featureMap[featureName][componentName] = componentName;
+    }
+
+    public featureLoadingComplete(featureName: string, componentName: string) {
+        if (!this._featureMap[featureName] || !this._featureMap[featureName][componentName]) {
+            return;
+        }
+
+        delete this._featureMap[featureName][componentName];
+
+        this._logService.verbose(
+            LogCategories.telemetry,
+            `Component is done loading.  feature: ${featureName}, component: ${componentName}`);
+
+        if (Object.keys(this._featureMap[featureName]).length === 0) {
+
+            this._logService.verbose(
+                LogCategories.telemetry,
+                `All components should be complete for: ${featureName}.  Debouncing for ${this._debouceTimeMs}ms`);
+
+            // "Debouncing" any straggling signals
+            Observable.timer(this._debouceTimeMs)
+                .subscribe(() => {
+                    if (this._featureMap[featureName] && Object.keys(this._featureMap[featureName]).length === 0) {
+
+                        this._logService.verbose(LogCategories.telemetry, `Completing load for feature: ${featureName}`);
+                        delete this._featureMap[featureName];
+                        this._portalService.sendTimerEvent({
+                            timerId: this._loadingIdFormat.format(featureName),
+                            timerAction: 'stop'
+                        });
+                    } else {
+                        this._logService.verbose(LogCategories.telemetry, `New loading signals detected for feature: ${featureName}`);
+                    }
+                });
+        }
+    }
+}

--- a/AzureFunctions.AngularClient/src/app/shared/services/telemetry.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/telemetry.service.ts
@@ -57,7 +57,10 @@ export class TelemetryService {
                 LogCategories.telemetry,
                 `All components should be complete for: ${featureName}.  Debouncing for ${this._debouceTimeMs}ms`);
 
-            // "Debouncing" any straggling signals
+            // "Debouncing" any straggling signals.  We need to do this it's possible that on completion of
+            // a parent component, new child components may be created from the result of conditional statements
+            // becoming true.  In that case, the child components will start to emit feature loading events, so we
+            // need to wait for things to settle down.
             Observable.timer(this._debouceTimeMs)
                 .subscribe(() => {
                     if (this._featureMap[featureName] && Object.keys(this._featureMap[featureName]).length === 0) {

--- a/AzureFunctions.AngularClient/src/app/shared/shared.module.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/shared.module.ts
@@ -1,3 +1,4 @@
+import { TelemetryService } from './services/telemetry.service';
 import { PortalService } from 'app/shared/services/portal.service';
 import { Injector } from '@angular/core';
 import { TabComponent } from './../controls/tabs/tab/tab.component';
@@ -200,6 +201,7 @@ export class SharedModule {
                 GlobalStateService,
                 EmbeddedService,
                 SiteService,
+                TelemetryService,
                 { provide: AiService, useFactory: AiServiceFactory },
                 { provide: ErrorHandler, useClass: GlobalErrorHandler }
             ]

--- a/AzureFunctions.AngularClient/src/app/site/site-config/app-settings/app-settings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/app-settings/app-settings.component.ts
@@ -28,35 +28,28 @@ import { LogCategories } from 'app/shared/models/constants';
   styleUrls: ['./../site-config.component.scss']
 })
 export class AppSettingsComponent extends FeatureComponent<ResourceId> implements OnChanges, OnDestroy {
+  @Input() mainForm: FormGroup;
+  @Input() resourceId: ResourceId;
+
   public Resources = PortalResources;
   public groupArray: FormArray;
-
   public hasWritePermissions: boolean;
   public permissionsMessage: string;
   public showPermissionsMessage: boolean;
+  public loadingFailureMessage: string;
+  public loadingMessage: string;
+  public newItem: CustomFormGroup;
+  public originalItemsDeleted: number;
 
   private _busyManager: BusyStateScopeManager;
-
   private _saveError: string;
-
   private _validatorFns: ValidatorFn[];
   private _requiredValidator: RequiredValidator;
   private _uniqueAppSettingValidator: UniqueValidator;
   private _linuxAppSettingNameValidator: LinuxAppSettingNameValidator;
   private _isLinux: boolean;
-
   private _appSettingsArm: ArmObj<any>;
   private _slotConfigNamesArm: ArmObj<SlotConfigNames>;
-
-  public loadingFailureMessage: string;
-  public loadingMessage: string;
-
-  public newItem: CustomFormGroup;
-  public originalItemsDeleted: number;
-
-  @Input() mainForm: FormGroup;
-
-  @Input() resourceId: string;
   private _slotConfigNamesArmPath: string;
 
   constructor(
@@ -151,6 +144,7 @@ export class AppSettingsComponent extends FeatureComponent<ResourceId> implement
   }
 
   ngOnDestroy(): void {
+    super.ngOnDestroy();
     this._busyManager.clearBusy();
   }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/connection-strings/connection-strings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/connection-strings/connection-strings.component.ts
@@ -29,7 +29,7 @@ import { RequiredValidator } from 'app/shared/validators/requiredValidator';
 })
 export class ConnectionStringsComponent extends FeatureComponent<ResourceId> implements OnChanges, OnDestroy {
     @Input() mainForm: FormGroup;
-    @Input() resourceId: string;
+    @Input() resourceId: ResourceId;
 
     public Resources = PortalResources;
     public groupArray: FormArray;
@@ -127,6 +127,7 @@ export class ConnectionStringsComponent extends FeatureComponent<ResourceId> imp
     }
 
     ngOnDestroy(): void {
+        super.ngOnDestroy();
         this._busyManager.clearBusy();
     }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/default-documents/default-documents.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/default-documents/default-documents.component.ts
@@ -24,7 +24,7 @@ import { RequiredValidator } from 'app/shared/validators/requiredValidator';
 })
 export class DefaultDocumentsComponent extends FeatureComponent<ResourceId> implements OnChanges, OnDestroy {
     @Input() mainForm: FormGroup;
-    @Input() resourceId: string;
+    @Input() resourceId: ResourceId;
 
     public Resources = PortalResources;
     public groupArray: FormArray;
@@ -112,6 +112,7 @@ export class DefaultDocumentsComponent extends FeatureComponent<ResourceId> impl
     }
 
     ngOnDestroy(): void {
+        super.ngOnDestroy();
         this._busyManager.clearBusy();
     }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/default-documents/default-documents.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/default-documents/default-documents.component.ts
@@ -1,19 +1,17 @@
+import { FeatureComponent } from 'app/shared/components/feature-component';
 import { LogCategories } from './../../../shared/models/constants';
 import { BroadcastService } from './../../../shared/services/broadcast.service';
-import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, SimpleChanges, Injector } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
-import { Subscription as RxSubscription } from 'rxjs/Subscription';
 import { TranslateService } from '@ngx-translate/core';
-
-import { SiteConfig } from './../../../shared/models/arm/site-config'
+import { SiteConfig } from './../../../shared/models/arm/site-config';
 import { SaveOrValidationResult } from './../site-config.component';
 import { LogService } from './../../../shared/services/log.service';
 import { PortalResources } from './../../../shared/models/portal-resources';
 import { BusyStateScopeManager } from './../../../busy-state/busy-state-scope-manager';
 import { CustomFormControl, CustomFormGroup } from './../../../controls/click-to-edit/click-to-edit.component';
-import { ArmObj } from './../../../shared/models/arm/arm-obj';
+import { ArmObj, ResourceId } from './../../../shared/models/arm/arm-obj';
 import { CacheService } from './../../../shared/services/cache.service';
 import { AuthzService } from './../../../shared/services/authz.service';
 import { UniqueValidator } from 'app/shared/validators/uniqueValidator';
@@ -24,35 +22,26 @@ import { RequiredValidator } from 'app/shared/validators/requiredValidator';
     templateUrl: './default-documents.component.html',
     styleUrls: ['./../site-config.component.scss']
 })
-export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
+export class DefaultDocumentsComponent extends FeatureComponent<ResourceId> implements OnChanges, OnDestroy {
+    @Input() mainForm: FormGroup;
+    @Input() resourceId: string;
+
     public Resources = PortalResources;
     public groupArray: FormArray;
-
-    private _resourceIdStream: Subject<string>;
-    private _resourceIdSubscription: RxSubscription;
     public hasWritePermissions: boolean;
     public permissionsMessage: string;
     public showPermissionsMessage: boolean;
     public showReadOnlySettingsMessage: string;
-
-    private _busyManager: BusyStateScopeManager;
-
-    private _saveError: string;
-
-    private _requiredValidator: RequiredValidator;
-    private _uniqueDocumentValidator: UniqueValidator;
-
-    private _webConfigArm: ArmObj<SiteConfig>;
-
     public loadingFailureMessage: string;
     public loadingMessage: string;
-
     public newItem: CustomFormGroup;
     public originalItemsDeleted: number;
 
-    @Input() mainForm: FormGroup;
-
-    @Input() resourceId: string;
+    private _busyManager: BusyStateScopeManager;
+    private _saveError: string;
+    private _requiredValidator: RequiredValidator;
+    private _uniqueDocumentValidator: UniqueValidator;
+    private _webConfigArm: ArmObj<SiteConfig>;
 
     constructor(
         private _cacheService: CacheService,
@@ -60,17 +49,20 @@ export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
         private _translateService: TranslateService,
         private _logService: LogService,
         private _authZService: AuthzService,
-        broadcastService: BroadcastService
+        broadcastService: BroadcastService,
+        injector: Injector
     ) {
+        super('DefaultDocumentComponent', injector);
         this._busyManager = new BusyStateScopeManager(broadcastService, 'site-tabs');
 
         this._resetPermissionsAndLoadingState();
 
         this.newItem = null;
         this.originalItemsDeleted = 0;
+    }
 
-        this._resourceIdStream = new Subject<string>();
-        this._resourceIdSubscription = this._resourceIdStream
+    protected setup(inputEvents: Observable<ResourceId>) {
+        return inputEvents
             .distinctUntilChanged()
             .switchMap(() => {
                 this._busyManager.setBusy();
@@ -101,7 +93,7 @@ export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
                 this._busyManager.clearBusy();
             })
             .retry()
-            .subscribe(r => {
+            .do(r => {
                 this._webConfigArm = r.webConfigResponse.json();
                 this._setupForm(this._webConfigArm);
                 this.loadingMessage = null;
@@ -112,7 +104,7 @@ export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
 
     ngOnChanges(changes: SimpleChanges) {
         if (changes['resourceId']) {
-            this._resourceIdStream.next(this.resourceId);
+            this.setInput(this.resourceId);
         }
         if (changes['mainForm'] && !changes['resourceId']) {
             this._setupForm(this._webConfigArm);
@@ -120,10 +112,6 @@ export class DefaultDocumentsComponent implements OnChanges, OnDestroy {
     }
 
     ngOnDestroy(): void {
-        if (this._resourceIdSubscription) {
-            this._resourceIdSubscription.unsubscribe();
-            this._resourceIdSubscription = null;
-        }
         this._busyManager.clearBusy();
     }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
@@ -31,7 +31,7 @@ import { ArmUtil } from 'app/shared/Utilities/arm-utils';
 })
 export class GeneralSettingsComponent extends FeatureComponent<ResourceId> implements OnChanges, OnDestroy {
     @Input() mainForm: FormGroup;
-    @Input() resourceId: string;
+    @Input() resourceId: ResourceId;
 
     public Resources = PortalResources;
     public group: FormGroup;
@@ -183,6 +183,7 @@ export class GeneralSettingsComponent extends FeatureComponent<ResourceId> imple
     }
 
     ngOnDestroy(): void {
+        super.ngOnDestroy();
         this._busyManager.clearBusy();
     }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
@@ -1,11 +1,9 @@
+import { FeatureComponent } from 'app/shared/components/feature-component';
 import { Links, LogCategories } from './../../../shared/models/constants';
 import { PortalService } from './../../../shared/services/portal.service';
-import { BroadcastService } from './../../../shared/services/broadcast.service';
-import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, SimpleChanges, Injector } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
-import { Subscription as RxSubscription } from 'rxjs/Subscription';
 import { TranslateService } from '@ngx-translate/core';
 import { SaveOrValidationResult } from '../site-config.component';
 import { Site } from 'app/shared/models/arm/site';
@@ -18,7 +16,7 @@ import { LogService } from './../../../shared/services/log.service';
 import { PortalResources } from './../../../shared/models/portal-resources';
 import { BusyStateScopeManager } from './../../../busy-state/busy-state-scope-manager';
 import { CustomFormControl } from './../../../controls/click-to-edit/click-to-edit.component';
-import { ArmObj, ArmArrayResult } from './../../../shared/models/arm/arm-obj';
+import { ArmObj, ArmArrayResult, ResourceId } from './../../../shared/models/arm/arm-obj';
 import { CacheService } from './../../../shared/services/cache.service';
 import { AuthzService } from './../../../shared/services/authz.service';
 import { ArmSiteDescriptor } from 'app/shared/resourceDescriptors';
@@ -26,36 +24,26 @@ import { ArmSiteDescriptor } from 'app/shared/resourceDescriptors';
 import { JavaWebContainerProperties } from './models/java-webcontainer-properties';
 import { ArmUtil } from 'app/shared/Utilities/arm-utils';
 
-
-// TODO: [andimarc] update to extend FunctionAppContextComponent
 @Component({
     selector: 'general-settings',
     templateUrl: './general-settings.component.html',
     styleUrls: ['./../site-config.component.scss']
 })
-export class GeneralSettingsComponent implements OnChanges, OnDestroy {
+export class GeneralSettingsComponent extends FeatureComponent<ResourceId> implements OnChanges, OnDestroy {
+    @Input() mainForm: FormGroup;
+    @Input() resourceId: string;
+
     public Resources = PortalResources;
     public group: FormGroup;
-
-    private _resourceIdStream: Subject<string>;
-    private _resourceIdSubscription: RxSubscription;
     public hasWritePermissions: boolean;
     public permissionsMessage: string;
     public showPermissionsMessage: boolean;
     public showReadOnlySettingsMessage: string;
-
-    private _busyManager: BusyStateScopeManager;
-
-    private _saveError: string;
-
-    private _webConfigArm: ArmObj<SiteConfig>;
     public siteArm: ArmObj<Site>;
     public loadingFailureMessage: string;
     public loadingMessage: string;
-
-    private _sku: string;
-
     public FwLinks = Links;
+    public isProductionSlot: boolean;
 
     public clientAffinityEnabledOptions: SelectOption<boolean>[];
     public use32BitWorkerProcessOptions: SelectOption<boolean>[];
@@ -64,15 +52,6 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
     public managedPipelineModeOptions: SelectOption<number>[];
     public remoteDebuggingEnabledOptions: SelectOption<boolean>[];
     public remoteDebuggingVersionOptions: SelectOption<string>[];
-
-    private _emptyJavaWebContainerProperties: JavaWebContainerProperties = { container: '-', containerMajorVersion: '', containerMinorVersion: '' };
-
-    public versionOptionsMap: { [key: string]: DropDownElement<string>[] };
-    private _versionOptionsMapClean: { [key: string]: DropDownElement<string>[] };
-    private _javaMinorVersionOptionsMap: { [key: string]: DropDownElement<string>[] };
-    private _javaMinorToMajorVersionsMap: { [key: string]: string };
-
-    private _selectedJavaVersion: string;
 
     public netFrameworkSupported = false;
     public phpSupported = false;
@@ -91,17 +70,22 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
 
     public linuxRuntimeSupported = false;
     public linuxFxVersionOptions: DropDownGroupElement<string>[];
+    public versionOptionsMap: { [key: string]: DropDownElement<string>[] };
+
+    private _busyManager: BusyStateScopeManager;
+    private _saveError: string;
+    private _webConfigArm: ArmObj<SiteConfig>;
+    private _sku: string;
+
+    private _emptyJavaWebContainerProperties: JavaWebContainerProperties = { container: '-', containerMajorVersion: '', containerMinorVersion: '' };
+    private _versionOptionsMapClean: { [key: string]: DropDownElement<string>[] };
+    private _javaMinorVersionOptionsMap: { [key: string]: DropDownElement<string>[] };
+    private _javaMinorToMajorVersionsMap: { [key: string]: string };
+
+    private _selectedJavaVersion: string;
     private _linuxFxVersionOptionsClean: DropDownGroupElement<string>[];
-
-
-    @Input() mainForm: FormGroup;
-
-    @Input() resourceId: string;
-
     private _slotsConfigArmPath: string;
     private _slotsConfigArm: ArmArrayResult<Site>;
-    public isProductionSlot: boolean;
-
     private _ignoreChildEvents = true;
 
     constructor(
@@ -111,18 +95,21 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
         private _logService: LogService,
         private _authZService: AuthzService,
         private _portalService: PortalService,
-        broadcastService: BroadcastService
+        injector: Injector
     ) {
-        this._busyManager = new BusyStateScopeManager(broadcastService, 'site-tabs');
+        super('GeneralSettingsComponent', injector);
+
+        this._busyManager = new BusyStateScopeManager(this._broadcastService, 'site-tabs');
 
         this._resetSlotsInfo();
 
         this._resetPermissionsAndLoadingState();
 
         this._generateRadioOptions();
+    }
 
-        this._resourceIdStream = new Subject<string>();
-        this._resourceIdSubscription = this._resourceIdStream
+    protected setup(inputEvents: Observable<ResourceId>) {
+        return inputEvents
             .distinctUntilChanged()
             .switchMap(() => {
                 this._busyManager.setBusy();
@@ -167,7 +154,7 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
                 this._busyManager.clearBusy();
             })
             .retry()
-            .subscribe(r => {
+            .do(r => {
                 this.siteArm = r.siteConfigResponse.json();
                 this._webConfigArm = r.webConfigResponse.json();
                 this._slotsConfigArm = r.slotsConfigResponse.json();
@@ -188,7 +175,7 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
 
     ngOnChanges(changes: SimpleChanges) {
         if (changes['resourceId']) {
-            this._resourceIdStream.next(this.resourceId);
+            this.setInput(this.resourceId);
         }
         if (changes['mainForm'] && !changes['resourceId']) {
             this._setupForm(this._webConfigArm, this.siteArm, this._slotsConfigArm);
@@ -196,10 +183,6 @@ export class GeneralSettingsComponent implements OnChanges, OnDestroy {
     }
 
     ngOnDestroy(): void {
-        if (this._resourceIdSubscription) {
-            this._resourceIdSubscription.unsubscribe();
-            this._resourceIdSubscription = null;
-        }
         this._busyManager.clearBusy();
     }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/handler-mappings/handler-mappings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/handler-mappings/handler-mappings.component.ts
@@ -110,6 +110,7 @@ export class HandlerMappingsComponent extends FeatureComponent<ResourceId> imple
     }
 
     ngOnDestroy(): void {
+        super.ngOnDestroy();
         this._busyManager.clearBusy();
     }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/handler-mappings/handler-mappings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/handler-mappings/handler-mappings.component.ts
@@ -1,19 +1,18 @@
+import { Injector } from '@angular/core';
+import { FeatureComponent } from 'app/shared/components/feature-component';
 import { LogCategories } from './../../../shared/models/constants';
 import { BroadcastService } from './../../../shared/services/broadcast.service';
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup } from '@angular/forms';
 import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
-import { Subscription as RxSubscription } from 'rxjs/Subscription';
 import { TranslateService } from '@ngx-translate/core';
-
 import { SiteConfig } from './../../../shared/models/arm/site-config';
 import { SaveOrValidationResult } from './../site-config.component';
 import { LogService } from './../../../shared/services/log.service';
 import { PortalResources } from './../../../shared/models/portal-resources';
 import { BusyStateScopeManager } from './../../../busy-state/busy-state-scope-manager';
 import { CustomFormControl, CustomFormGroup } from './../../../controls/click-to-edit/click-to-edit.component';
-import { ArmObj } from './../../../shared/models/arm/arm-obj';
+import { ArmObj, ResourceId } from './../../../shared/models/arm/arm-obj';
 import { CacheService } from './../../../shared/services/cache.service';
 import { AuthzService } from './../../../shared/services/authz.service';
 import { RequiredValidator } from 'app/shared/validators/requiredValidator';
@@ -23,34 +22,25 @@ import { RequiredValidator } from 'app/shared/validators/requiredValidator';
     templateUrl: './handler-mappings.component.html',
     styleUrls: ['./../site-config.component.scss']
 })
-export class HandlerMappingsComponent implements OnChanges, OnDestroy {
+export class HandlerMappingsComponent extends FeatureComponent<ResourceId> implements OnChanges, OnDestroy {
+    @Input() mainForm: FormGroup;
+    @Input() resourceId: ResourceId;
+
     public Resources = PortalResources;
     public groupArray: FormArray;
-
-    private _resourceIdStream: Subject<string>;
-    private _resourceIdSubscription: RxSubscription;
     public hasWritePermissions: boolean;
     public permissionsMessage: string;
     public showPermissionsMessage: boolean;
     public showReadOnlySettingsMessage: string;
-
-    private _busyManager: BusyStateScopeManager;
-
-    private _saveError: string;
-
-    private _requiredValidator: RequiredValidator;
-
-    private _webConfigArm: ArmObj<SiteConfig>;
-
     public loadingFailureMessage: string;
     public loadingMessage: string;
-
     public newItem: CustomFormGroup;
     public originalItemsDeleted: number;
 
-    @Input() mainForm: FormGroup;
-
-    @Input() resourceId: string;
+    private _busyManager: BusyStateScopeManager;
+    private _saveError: string;
+    private _requiredValidator: RequiredValidator;
+    private _webConfigArm: ArmObj<SiteConfig>;
 
     constructor(
         private _cacheService: CacheService,
@@ -58,18 +48,20 @@ export class HandlerMappingsComponent implements OnChanges, OnDestroy {
         private _translateService: TranslateService,
         private _logService: LogService,
         private _authZService: AuthzService,
-        broadcastService: BroadcastService
+        broadcastService: BroadcastService,
+        injector: Injector
     ) {
+        super('HandlerMappingsComponent', injector);
         this._busyManager = new BusyStateScopeManager(broadcastService, 'site-tabs');
 
         this._resetPermissionsAndLoadingState();
 
         this.newItem = null;
         this.originalItemsDeleted = 0;
+    }
 
-        this._resourceIdStream = new Subject<string>();
-        this._resourceIdSubscription = this._resourceIdStream
-            .distinctUntilChanged()
+    protected setup(inputEvents: Observable<ResourceId>) {
+        return inputEvents.distinctUntilChanged()
             .switchMap(() => {
                 this._busyManager.setBusy();
                 this._saveError = null;
@@ -99,7 +91,7 @@ export class HandlerMappingsComponent implements OnChanges, OnDestroy {
                 this._busyManager.clearBusy();
             })
             .retry()
-            .subscribe(r => {
+            .do(r => {
                 this._webConfigArm = r.webConfigResponse.json();
                 this._setupForm(this._webConfigArm);
                 this.loadingMessage = null;
@@ -110,7 +102,7 @@ export class HandlerMappingsComponent implements OnChanges, OnDestroy {
 
     ngOnChanges(changes: SimpleChanges) {
         if (changes['resourceId']) {
-            this._resourceIdStream.next(this.resourceId);
+            this.setInput(this.resourceId);
         }
         if (changes['mainForm'] && !changes['resourceId']) {
             this._setupForm(this._webConfigArm);
@@ -118,10 +110,6 @@ export class HandlerMappingsComponent implements OnChanges, OnDestroy {
     }
 
     ngOnDestroy(): void {
-        if (this._resourceIdSubscription) {
-            this._resourceIdSubscription.unsubscribe();
-            this._resourceIdSubscription = null;
-        }
         this._busyManager.clearBusy();
     }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.html
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.html
@@ -19,16 +19,37 @@
   [is-dirty]="mainForm.dirty"
   [is-dirty-message]="dirtyMessage">
 
-  <general-settings [mainForm]="mainForm" [resourceId]="resourceId"></general-settings>
+  <general-settings
+    [mainForm]="mainForm"
+    [resourceId]="resourceId"
+    [featureName]="featureName"></general-settings>
 
-  <app-settings [mainForm]="mainForm" [resourceId]="resourceId"></app-settings>
+  <app-settings
+    [mainForm]="mainForm"
+    [resourceId]="resourceId"
+    [featureName]="featureName"></app-settings>
 
-  <connection-strings [mainForm]="mainForm" [resourceId]="resourceId"></connection-strings>
+  <connection-strings
+    [mainForm]="mainForm"
+    [resourceId]="resourceId"
+    [featureName]="featureName"></connection-strings>
 
-  <default-documents *ngIf="defaultDocumentsSupported" [mainForm]="mainForm" [resourceId]="resourceId"></default-documents>
+  <default-documents
+    *ngIf="defaultDocumentsSupported"
+    [mainForm]="mainForm"
+    [resourceId]="resourceId"
+    [featureName]="featureName"></default-documents>
 
-  <handler-mappings *ngIf="handlerMappingsSupported" [mainForm]="mainForm" [resourceId]="resourceId"></handler-mappings>
+  <handler-mappings
+    *ngIf="handlerMappingsSupported"
+    [mainForm]="mainForm"
+    [resourceId]="resourceId"
+    [featureName]="featureName"></handler-mappings>
 
-  <virtual-directories *ngIf="virtualDirectoriesSupported" [mainForm]="mainForm" [resourceId]="resourceId"></virtual-directories>
+  <virtual-directories
+    *ngIf="virtualDirectoriesSupported"
+    [mainForm]="mainForm"
+    [resourceId]="resourceId"
+    [featureName]="featureName"></virtual-directories>
 
 </div>

--- a/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.ts
@@ -74,6 +74,7 @@ export class SiteConfigComponent extends FeatureComponent<TreeViewInfo<SiteData>
 
         // For ibiza scenarios, this needs to match the deep link feature name used to load this in ibiza menu
         this.featureName = 'settings';
+        this.isParentComponent = true;
         this._busyManager = new BusyStateScopeManager(this._broadcastService, 'site-tabs');
     }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.ts
@@ -5,10 +5,8 @@ import { Site } from './../../shared/models/arm/site';
 import { ArmObj, ArmObjMap } from './../../shared/models/arm/arm-obj';
 import { Component, Input, OnDestroy, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
-// import { Subject } from 'rxjs/Subject';
 import { Subscription as RxSubscription } from 'rxjs/Subscription';
 import { TranslateService } from '@ngx-translate/core';
-
 import { PortalResources } from './../../shared/models/portal-resources';
 import { BusyStateScopeManager } from './../../busy-state/busy-state-scope-manager';
 import { TreeViewInfo, SiteData } from './../../tree-view/models/tree-view-info';
@@ -74,7 +72,7 @@ export class SiteConfigComponent extends FeatureComponent<TreeViewInfo<SiteData>
     ) {
         super('SiteConfigComponent', injector);
 
-        // For ibiza scenario's, this needs to match the deep link feature name used to load this in ibiza menu
+        // For ibiza scenarios, this needs to match the deep link feature name used to load this in ibiza menu
         this.featureName = 'settings';
         this._busyManager = new BusyStateScopeManager(this._broadcastService, 'site-tabs');
     }
@@ -140,6 +138,8 @@ export class SiteConfigComponent extends FeatureComponent<TreeViewInfo<SiteData>
     }
 
     ngOnDestroy(): void {
+        super.ngOnDestroy();
+
         if (this._valueSubscription) {
             this._valueSubscription.unsubscribe();
             this._valueSubscription = null;

--- a/AzureFunctions.AngularClient/src/app/site/site-config/virtual-directories/virtual-directories.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/virtual-directories/virtual-directories.component.ts
@@ -26,7 +26,7 @@ import { RequiredValidator } from 'app/shared/validators/requiredValidator';
 })
 export class VirtualDirectoriesComponent extends FeatureComponent<ResourceId> implements OnChanges, OnDestroy {
     @Input() mainForm: FormGroup;
-    @Input() resourceId: string;
+    @Input() resourceId: ResourceId;
 
     public Resources = PortalResources;
     public groupArray: FormArray;
@@ -116,6 +116,7 @@ export class VirtualDirectoriesComponent extends FeatureComponent<ResourceId> im
     }
 
     ngOnDestroy(): void {
+        super.ngOnDestroy();
         this._busyManager.clearBusy();
     }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/virtual-directories/virtual-directories.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/virtual-directories/virtual-directories.component.ts
@@ -1,60 +1,49 @@
+import { Injector } from '@angular/core';
+import { FeatureComponent } from 'app/shared/components/feature-component';
 import { LogCategories } from './../../../shared/models/constants';
 import { BroadcastService } from './../../../shared/services/broadcast.service';
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
-import { Subscription as RxSubscription } from 'rxjs/Subscription';
 import { TranslateService } from '@ngx-translate/core';
-
 import { VirtualApplication, VirtualDirectory } from './../../../shared/models/arm/virtual-application';
-import { SiteConfig } from './../../../shared/models/arm/site-config'
+import { SiteConfig } from './../../../shared/models/arm/site-config';
 import { SaveOrValidationResult } from './../site-config.component';
 import { LogService } from './../../../shared/services/log.service';
 import { PortalResources } from './../../../shared/models/portal-resources';
 import { BusyStateScopeManager } from './../../../busy-state/busy-state-scope-manager';
 import { CustomFormControl, CustomFormGroup } from './../../../controls/click-to-edit/click-to-edit.component';
-import { ArmObj } from './../../../shared/models/arm/arm-obj';
+import { ArmObj, ResourceId } from './../../../shared/models/arm/arm-obj';
 import { CacheService } from './../../../shared/services/cache.service';
 import { AuthzService } from './../../../shared/services/authz.service';
 import { UniqueValidator } from 'app/shared/validators/uniqueValidator';
 import { RequiredValidator } from 'app/shared/validators/requiredValidator';
 
-// TODO: [andimarc] extend FunctionAppContextComponent
 @Component({
     selector: 'virtual-directories',
     templateUrl: './virtual-directories.component.html',
     styleUrls: ['./../site-config.component.scss']
 })
-export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
+export class VirtualDirectoriesComponent extends FeatureComponent<ResourceId> implements OnChanges, OnDestroy {
+    @Input() mainForm: FormGroup;
+    @Input() resourceId: string;
+
     public Resources = PortalResources;
     public groupArray: FormArray;
-
-    private _resourceIdStream: Subject<string>;
-    private _resourceIdSubscription: RxSubscription;
     public hasWritePermissions: boolean;
     public permissionsMessage: string;
     public showPermissionsMessage: boolean;
     public showReadOnlySettingsMessage: string;
-
-    private _busyManager: BusyStateScopeManager;
-
-    private _saveError: string;
-
-    private _requiredValidator: RequiredValidator;
-    private _uniqueValidator: UniqueValidator;
-
-    private _webConfigArm: ArmObj<SiteConfig>;
-
     public loadingFailureMessage: string;
     public loadingMessage: string;
-
     public newItem: CustomFormGroup;
     public originalItemsDeleted: number;
 
-    @Input() mainForm: FormGroup;
-
-    @Input() resourceId: string;
+    private _busyManager: BusyStateScopeManager;
+    private _saveError: string;
+    private _requiredValidator: RequiredValidator;
+    private _uniqueValidator: UniqueValidator;
+    private _webConfigArm: ArmObj<SiteConfig>;
 
     constructor(
         private _cacheService: CacheService,
@@ -62,17 +51,20 @@ export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
         private _translateService: TranslateService,
         private _logService: LogService,
         private _authZService: AuthzService,
-        broadcastService: BroadcastService
+        broadcastService: BroadcastService,
+        injector: Injector
     ) {
+        super('VirtualDirectoriesComponent', injector);
         this._busyManager = new BusyStateScopeManager(broadcastService, 'site-tabs');
 
         this._resetPermissionsAndLoadingState();
 
         this.newItem = null;
         this.originalItemsDeleted = 0;
+    }
 
-        this._resourceIdStream = new Subject<string>();
-        this._resourceIdSubscription = this._resourceIdStream
+    protected setup(inputEvents: Observable<ResourceId>) {
+        return inputEvents
             .distinctUntilChanged()
             .switchMap(() => {
                 this._busyManager.setBusy();
@@ -105,7 +97,7 @@ export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
                 this._busyManager.clearBusy();
             })
             .retry()
-            .subscribe(r => {
+            .do(r => {
                 this._webConfigArm = r.webConfigResponse.json();
                 this._setupForm(this._webConfigArm);
                 this.loadingMessage = null;
@@ -116,7 +108,7 @@ export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
 
     ngOnChanges(changes: SimpleChanges) {
         if (changes['resourceId']) {
-            this._resourceIdStream.next(this.resourceId);
+            this.setInput(this.resourceId);
         }
         if (changes['mainForm'] && !changes['resourceId']) {
             this._setupForm(this._webConfigArm);
@@ -124,10 +116,6 @@ export class VirtualDirectoriesComponent implements OnChanges, OnDestroy {
     }
 
     ngOnDestroy(): void {
-        if (this._resourceIdSubscription) {
-            this._resourceIdSubscription.unsubscribe();
-            this._resourceIdSubscription = null;
-        }
         this._busyManager.clearBusy();
     }
 


### PR DESCRIPTION
I created a new base component called FeatureComponent which takes care of logging completion timer telemetry for us.  Typically when you build a "feature", it's a collection of individual components.  Since your UI may not be done loading until several of those child components are done loading, it's difficult to know when we're really "done".

When building a component within a feature, you just need to inherit from FeatureComponent and set the featureName property.  Each FeatureComponent will log completion for that component to the TelemetryService, which keeps track of all FeatureComponents with the same name.  Once all FeatureComponents are done loading, it'll log the telemetry completion in Ibiza.

Eventually I'm thinking that I could actually merge this class in with the base ErrorableComponent so that all components inheriting from FunctionAppContextComponent and NavigableComponent will also get this benefit, but I haven't done it yet because I'm kind of in a rush to get telemetry working for App Settings and that would be kind of a big change.