### PR TITLE
Added timer to track when a feature's first constructor gets called

### DIFF
--- a/AzureFunctions.AngularClient/src/app/shared/components/feature-component.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/components/feature-component.ts
@@ -30,6 +30,10 @@ export abstract class FeatureComponent<T> extends ErrorableComponent implements 
                     throw Error('featureName is not defined');
                 }
 
+                if (this.isParentComponent) {
+                    this._telemetryService.featureConstructComplete(this.featureName);
+                }
+
                 this._telemetryService.featureLoading(this.isParentComponent, this.featureName, this.componentName);
             });
 

--- a/AzureFunctions.AngularClient/src/app/shared/services/telemetry.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/telemetry.service.ts
@@ -19,12 +19,21 @@ export class TelemetryService {
     // feature properly defines a parent component
     private _registeredParentFeatures: { [key: string]: string } = {};
 
+    private readonly _constructIdFormat = '/feature/{0}/construct';
     private readonly _loadingIdFormat = '/feature/{0}/loading';
     private readonly _debouceTimeMs = 250;
 
     constructor(
         private _portalService: PortalService,
         private _logService: LogService) {
+    }
+
+    public featureConstructComplete(featureName: string) {
+        // For now, this will only be started for Ibiza menu scenario's.
+        this._portalService.sendTimerEvent({
+            timerId: this._constructIdFormat.format(featureName),
+            timerAction: 'stop'
+        });
     }
 
     public featureLoading(isParentComponent: boolean, featureName: string, componentName: string) {


### PR DESCRIPTION
As discussed, I added a new timer to complete the trace for '/feature/{name}/construct'.