### PR TITLE
Fixes #2267 - Updating conditional http client to handle complex error types being thrown

### DIFF
--- a/AzureFunctions.AngularClient/src/app/api/api-new/api-new.component.ts
+++ b/AzureFunctions.AngularClient/src/app/api/api-new/api-new.component.ts
@@ -106,8 +106,7 @@ export class ApiNewComponent extends NavigableComponent {
                 }
                 if (res.proxies.isSuccessful) {
                     this.apiProxies = res.proxies.result;
-                } else if (res.proxies.error.errorId === errorIds.proxyJsonNotFound ||
-                    res.proxies.error.message === errorIds.proxyJsonNotFound) {
+                } else if (res.proxies.error.errorId === errorIds.proxyJsonNotFound) {
                     this.apiProxies = [];
                 } else {
                     this.showComponentError({

--- a/AzureFunctions.AngularClient/src/app/shared/models/error-ids.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/error-ids.ts
@@ -14,6 +14,7 @@ export namespace errorIds {
         export const scopeLocked = '/errors/arm/scopelocked';
     }
 
+    export const unknown = 'errors/unknown-error';
     export const functionNotFound = '/errors/functionNotFound';
     export const unableToRetrieveFileContent = '/errors/UnableToRetrieveFileContent';
     export const deserializingKudusFunctionList = '/errors/deserializingKudusFunctionList';

--- a/AzureFunctions.AngularClient/src/app/shared/services/function-app.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/function-app.service.ts
@@ -120,8 +120,11 @@ export class FunctionAppService {
         return client.execute({ resourceId: context.site.id }, t => Observable.zip(
             this._cacheService.get(context.urlTemplates.proxiesJsonUrl, false, this.headers(t))
                 .catch(err => err.status === 404
-                    ? Observable.throw(errorIds.proxyJsonNotFound)
-                    : Observable.throw(err)),
+                    ? Observable.throw({
+                        errorId: errorIds.proxyJsonNotFound,
+                        message: '',
+                        result: null
+                    }) : Observable.throw(err)),
             this._cacheService.get('assets/schemas/proxies.json', false, this.portalHeaders(t)),
             (p, s) => ({ proxies: p, schema: s.json() })
         ).map(r => {


### PR DESCRIPTION
As discussed offline, if a user throws a string in conditional http client, then we'll treat that as the message with an "unknown-error" errorId.  If they want to be explicit about the error, then they need to specify an HttpError type.