### PR TITLE
add role link to revoke renew

### DIFF
--- a/AzureFunctions.AngularClient/src/app/function-keys/function-keys.component.html
+++ b/AzureFunctions.AngularClient/src/app/function-keys/function-keys.component.html
@@ -45,21 +45,26 @@
                                 <i class="fa fa-copy"></i> {{'functionKeys_copy' | translate}}
                             </span>
                         </pop-over>
-                        <a class="operation" 
+                        <a class="operation"
+                            role="link"
                             (click)="renewKey(key)"
                             (keydown)="keyDown($event, 'renewKey', key)"
                             tabindex="0"
                             id="renewKeyAction"
                             aria-labelledby="keyNameLabel renewKeyAction">
-                                <i class="fa fa-refresh"></i> {{'functionKeys_renew' | translate}}</a>
-                        <a class="operation" 
+                            <i class="fa fa-refresh"></i>
+                            {{'functionKeys_renew' | translate}}
+                        </a>
+                        <a class="operation"
+                            role="link"
                             *ngIf="key.name !== '_master'"
                             (click)="revokeKey(key)"
                             (keydown)="keyDown($event, 'revokeKey', key)"
                             tabindex="0"
                             id="revokeKeyAction"
                             aria-labelledby="keyNameLabel revokeKeyAction">
-                                <i class="fa fa-times"></i> {{'functionKeys_revoke' | translate}}
+                            <i class="fa fa-times"></i>
+                            {{'functionKeys_revoke' | translate}}
                         </a>
                     </div>
                 </td>


### PR DESCRIPTION
Add role=link to renew/revoke in manage blade
reader now reads "(keyname) renew, link" and " (keyname) revoke, link"

tested in chrome and edge with narrator
original bug only occurred in edge

fixes http://vstfrd:8080/Azure/RD/_workitems?id=10654586&triage=true&_a=edit