### PR TITLE
Updating site-config to do permission/lock checks after initial load

### DIFF
--- a/AzureFunctions.AngularClient/src/app/shared/components/feature-component.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/components/feature-component.ts
@@ -1,4 +1,5 @@
-import { LogService } from './../services/log.service';
+import { LogService } from 'app/shared/services/log.service';
+import { BusyStateName } from './../../busy-state/busy-state.component';
 import { TelemetryService } from './../services/telemetry.service';
 import { BroadcastService } from 'app/shared/services/broadcast.service';
 import { Injector } from '@angular/core/src/core';
@@ -8,46 +9,120 @@ import { OnDestroy } from '@angular/core/src/metadata/lifecycle_hooks';
 import { ErrorableComponent } from './errorable-component';
 import { Input } from '@angular/core';
 import { LogCategories } from 'app/shared/models/constants';
+import { BusyStateScopeManager } from 'app/busy-state/busy-state-scope-manager';
 
 export abstract class FeatureComponent<T> extends ErrorableComponent implements OnDestroy {
+    // The name of the feature this component is apart of.  Telemetry will
+    // be collected for all features with the same name.
     @Input() featureName: string;
+
+    // Specifies if this is the main parent component for the entire feature.
+    // There should only be one parent component per feature
     isParentComponent = false;
 
     private _inputEvents = new Subject<T>();
     private _ngUnsubscribe = new Subject();
-    private _telemetryService: TelemetryService;
+    private _busyManager: BusyStateScopeManager;
+    private _busyClearedEarly = false;
 
-    constructor(componentName: string, injector: Injector) {
+    private __logService: LogService;
+    private __telemetryService: TelemetryService;
+
+    constructor(
+        componentName: string,
+        injector: Injector,
+        busyComponentName?: BusyStateName) {
+
         super(componentName, injector.get(BroadcastService));
 
-        this._telemetryService = injector.get(TelemetryService);
-        const logService = injector.get(LogService);
+        this.__telemetryService = injector.get(TelemetryService);
+        this.__logService = injector.get(LogService);
+        if (busyComponentName) {
+            this._busyManager = new BusyStateScopeManager(this._broadcastService, busyComponentName);
+        }
 
         const preCheckEvents = this._inputEvents
             .takeUntil(this._ngUnsubscribe)
             .do(input => {
+
                 if (!this.featureName) {
                     throw Error('featureName is not defined');
                 }
 
                 if (this.isParentComponent) {
-                    this._telemetryService.featureConstructComplete(this.featureName);
+                    this.__telemetryService.featureConstructComplete(this.featureName);
                 }
 
-                this._telemetryService.featureLoading(this.isParentComponent, this.featureName, this.componentName);
+                if (this._busyManager) {
+                    this.__telemetryService.featureLoading(
+                        this.isParentComponent,
+                        this.featureName,
+                        this.componentName);
+
+                    this.__logService.verbose(
+                        LogCategories.featureComponent,
+                        `New input received, setting busy componentName: ${this.componentName}`);
+
+                    this.setBusy();
+                }
             });
 
         this.setup(preCheckEvents)
             .takeUntil(this._ngUnsubscribe)
             .subscribe(r => {
-                this._telemetryService.featureLoadingComplete(this.featureName, this.componentName);
+                if (!this._busyClearedEarly && this._busyManager) {
+                    this.__logService.verbose(
+                        LogCategories.featureComponent,
+                        `Clearing busy normally componentName: ${this.componentName}`);
+
+                    this.__telemetryService.featureLoadingComplete(this.featureName, this.componentName);
+                    this.clearBusy();
+                }
             }, err => {
-                logService.error(LogCategories.featureLoading, '/load-failure', err);
+                this.__logService.error(LogCategories.featureComponent, '/load-failure', err);
+                this.clearBusy();
             });
     }
 
     protected setInput(input: T) {
         this._inputEvents.next(input);
+    }
+
+    protected setBusy() {
+        if (!this._busyManager) {
+            throw Error(`No busy manager defined, component: ${this.componentName}`);
+        }
+
+        this.__logService.verbose(
+            LogCategories.featureComponent,
+            `Setting busy componentName: ${this.componentName}`);
+
+        this._busyManager.setBusy();
+    }
+
+    // Use this to clear the busy state before the initial setup observable has
+    // completed loading.  This is useful if the main parts of your UI are ready
+    // to be used, but you still want to load some stuff in the background.
+    protected clearBusyEarly() {
+        this._busyClearedEarly = true;
+        this.__telemetryService.featureLoadingComplete(this.featureName, this.componentName);
+        this.__logService.verbose(
+            LogCategories.featureComponent,
+            `Clearing busy early componentName: ${this.componentName}`);
+
+        this.clearBusy();
+    }
+
+    protected clearBusy() {
+        if (!this._busyManager) {
+            throw Error(`No busy manager defined, component: ${this.componentName}`);
+        }
+
+        this.__logService.verbose(
+            LogCategories.featureComponent,
+            `Clearing busy componentName: ${this.componentName}`);
+
+        this._busyManager.clearBusy();
     }
 
     protected abstract setup(inputEvents: Observable<T>): Observable<any>;

--- a/AzureFunctions.AngularClient/src/app/shared/conditional-http-client.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/conditional-http-client.ts
@@ -125,7 +125,7 @@ export class ConditionalHttpClient {
         if (body && body.error) {
             mesg = body.error.message;
 
-            if (response.status === 401) {
+            if (response.status === 401 || response.status === 403) {
                 errorId = errorIds.armErrors.noAccess;
             } else if (response.status === 409 && body.error.code === 'ScopeLocked') {
                 errorId = errorIds.armErrors.scopeLocked;

--- a/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/constants.ts
@@ -240,7 +240,7 @@ export class LogCategories {
     public static readonly functionNew = 'FunctionNew';
     public static readonly cicd = 'CICD';
     public static readonly telemetry = 'Telemetry';
-    public static readonly featureLoading = 'FeatureLoading';
+    public static readonly featureComponent = 'FeatureComponent';
 }
 
 export class KeyCodes {

--- a/AzureFunctions.AngularClient/src/app/shared/services/authz.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/authz.service.ts
@@ -46,6 +46,9 @@ export class AuthzService {
         return this._getLocks(resourceId)
             .map(locks => {
                 return !!locks.find(l => l.properties.level === 'ReadOnly');
+            })
+            .catch(e => {
+                return Observable.of(false);
             });
     }
 

--- a/AzureFunctions.AngularClient/src/app/shared/services/site.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/site.service.ts
@@ -1,3 +1,7 @@
+import { ConnectionString } from './../models/arm/connection-strings';
+import { AvailableStack } from './../models/arm/stacks';
+import { SiteConfig } from './../models/arm/site-config';
+import { ArmArrayResult } from './../models/arm/arm-obj';
 import { Injectable, Injector } from '@angular/core';
 import { ConditionalHttpClient } from 'app/shared/conditional-http-client';
 import { UserService } from 'app/shared/services/user.service';
@@ -25,22 +29,48 @@ export class SiteService {
 
     getSite(resourceId: string): Result<ArmObj<Site>> {
         const getSite = this._cacheService.getArm(resourceId).map(r => r.json());
-        return this._client.execute({ resourceId: resourceId}, t => getSite);
+        return this._client.execute({ resourceId: resourceId }, t => getSite);
     }
 
-    getAppSettings(resourceId: string): Result<ArmObj<{[key: string]: string}>> {
+    getSlots(resourceId: string): Result<ArmArrayResult<Site>> {
+        const siteDescriptor = new ArmSiteDescriptor(resourceId);
+        const slotsId = `${siteDescriptor.getSiteOnlyResourceId()}/slots`;
+        const getSlots = this._cacheService.getArm(slotsId).map(r => r.json());
 
-        const getAppSettings = this._cacheService.postArm(`${resourceId}/config/appSettings/list`, true)
+        return this._client.execute({ resourceId: resourceId }, t => getSlots);
+    }
+
+    getSiteConfig(resourceId: string, force?: boolean): Result<ArmObj<SiteConfig>> {
+        const getSiteConfig = this._cacheService.getArm(`${resourceId}/config/web`, force).map(r => r.json());
+        return this._client.execute({ resourceId: resourceId }, t => getSiteConfig);
+    }
+
+    getAppSettings(resourceId: string, force?: boolean): Result<ArmObj<{ [key: string]: string }>> {
+
+        const getAppSettings = this._cacheService.postArm(`${resourceId}/config/appSettings/list`, force)
             .map(r => r.json());
 
         return this._client.execute({ resourceId: resourceId }, t => getAppSettings);
     }
 
-    getSlotConfigNames(resourceId: string): Result<ArmObj<SlotConfigNames>> {
-        const slotsConfigNamesId = `${new ArmSiteDescriptor(resourceId).getSiteOnlyResourceId()}/config/slotConfigNames`;
-        const getSlotConfigNames = this._cacheService.getArm(slotsConfigNamesId, true)
+    getConnectionStrings(resourceId: string, force?: boolean): Result<ArmObj<ConnectionString>> {
+
+        const getConnectionStrings = this._cacheService.postArm(`${resourceId}/config/connectionstrings/list`, force)
             .map(r => r.json());
 
-        return this._client.execute( { resourceId: resourceId }, t => getSlotConfigNames);
+        return this._client.execute({ resourceId: resourceId }, t => getConnectionStrings);
+    }
+
+    getSlotConfigNames(resourceId: string, force?: boolean): Result<ArmObj<SlotConfigNames>> {
+        const slotsConfigNamesId = `${new ArmSiteDescriptor(resourceId).getSiteOnlyResourceId()}/config/slotConfigNames`;
+        const getSlotConfigNames = this._cacheService.getArm(slotsConfigNamesId, force)
+            .map(r => r.json());
+
+        return this._client.execute({ resourceId: resourceId }, t => getSlotConfigNames);
+    }
+
+    getAvailableStacks(): Result<ArmArrayResult<AvailableStack>> {
+        const getAvailableStacks = this._cacheService.getArm('/providers/Microsoft.Web/availablestacks').map(r => r.json());
+        return this._client.execute({ resourceId: null }, t => getAvailableStacks);
     }
 }

--- a/AzureFunctions.AngularClient/src/app/shared/services/site.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/site.service.ts
@@ -1,4 +1,4 @@
-import { ConnectionString } from './../models/arm/connection-strings';
+import { ConnectionStrings } from './../models/arm/connection-strings';
 import { AvailableStack } from './../models/arm/stacks';
 import { SiteConfig } from './../models/arm/site-config';
 import { ArmArrayResult } from './../models/arm/arm-obj';
@@ -53,7 +53,7 @@ export class SiteService {
         return this._client.execute({ resourceId: resourceId }, t => getAppSettings);
     }
 
-    getConnectionStrings(resourceId: string, force?: boolean): Result<ArmObj<ConnectionString>> {
+    getConnectionStrings(resourceId: string, force?: boolean): Result<ArmObj<ConnectionStrings>> {
 
         const getConnectionStrings = this._cacheService.postArm(`${resourceId}/config/connectionstrings/list`, force)
             .map(r => r.json());

--- a/AzureFunctions.AngularClient/src/app/shared/services/telemetry.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/telemetry.service.ts
@@ -37,6 +37,11 @@ export class TelemetryService {
     }
 
     public featureLoading(isParentComponent: boolean, featureName: string, componentName: string) {
+        // If the inputs on a parent component have changed, then we should reset timers
+        if (isParentComponent && this._featureMap[featureName]) {
+            delete this._featureMap[featureName];
+        }
+
         if (!this._featureMap[featureName]) {
 
             if (isParentComponent) {

--- a/AzureFunctions.AngularClient/src/app/site/site-config/connection-strings/connection-strings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/connection-strings/connection-strings.component.ts
@@ -125,7 +125,6 @@ export class ConnectionStringsComponent extends FeatureComponent<ResourceId> imp
 
     ngOnDestroy(): void {
         super.ngOnDestroy();
-        // this._busyManager.clearBusy();
         this.clearBusy();
     }
 

--- a/AzureFunctions.AngularClient/src/app/site/site-config/connection-strings/connection-strings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/connection-strings/connection-strings.component.ts
@@ -9,7 +9,7 @@ import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Observable } from 'rxjs/Observable';
 import { TranslateService } from '@ngx-translate/core';
 import { SlotConfigNames } from './../../../shared/models/arm/slot-config-names';
-import { ConnectionStringType, ConnectionString } from './../../../shared/models/arm/connection-strings';
+import { ConnectionStringType, ConnectionStrings } from './../../../shared/models/arm/connection-strings';
 import { EnumEx } from './../../../shared/Utilities/enumEx';
 import { SaveOrValidationResult } from './../site-config.component';
 import { PortalResources } from './../../../shared/models/portal-resources';
@@ -45,7 +45,7 @@ export class ConnectionStringsComponent extends FeatureComponent<ResourceId> imp
     private _saveError: string;
     private _requiredValidator: RequiredValidator;
     private _uniqueCsValidator: UniqueValidator;
-    private _connectionStringsArm: ArmObj<ConnectionString>;
+    private _connectionStringsArm: ArmObj<ConnectionStrings>;
     private _slotConfigNamesArm: ArmObj<SlotConfigNames>;
     private _slotConfigNamesArmPath: string;
 
@@ -148,7 +148,7 @@ export class ConnectionStringsComponent extends FeatureComponent<ResourceId> imp
         this.hasWritePermissions = writePermission && !readOnlyLock;
     }
 
-    private _setupForm(connectionStringsArm: ArmObj<ConnectionString>, slotConfigNamesArm: ArmObj<SlotConfigNames>) {
+    private _setupForm(connectionStringsArm: ArmObj<ConnectionStrings>, slotConfigNamesArm: ArmObj<SlotConfigNames>) {
         if (!!connectionStringsArm && !!slotConfigNamesArm) {
             if (!this._saveError || !this.groupArray) {
                 this.newItem = null;

--- a/AzureFunctions.AngularClient/src/app/site/site-config/default-documents/default-documents.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/default-documents/default-documents.component.ts
@@ -1,5 +1,5 @@
+import { SiteService } from 'app/shared/services/site.service';
 import { FeatureComponent } from 'app/shared/components/feature-component';
-import { LogCategories } from './../../../shared/models/constants';
 import { BroadcastService } from './../../../shared/services/broadcast.service';
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges, Injector } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
@@ -7,9 +7,7 @@ import { Observable } from 'rxjs/Observable';
 import { TranslateService } from '@ngx-translate/core';
 import { SiteConfig } from './../../../shared/models/arm/site-config';
 import { SaveOrValidationResult } from './../site-config.component';
-import { LogService } from './../../../shared/services/log.service';
 import { PortalResources } from './../../../shared/models/portal-resources';
-import { BusyStateScopeManager } from './../../../busy-state/busy-state-scope-manager';
 import { CustomFormControl, CustomFormGroup } from './../../../controls/click-to-edit/click-to-edit.component';
 import { ArmObj, ResourceId } from './../../../shared/models/arm/arm-obj';
 import { CacheService } from './../../../shared/services/cache.service';
@@ -37,7 +35,6 @@ export class DefaultDocumentsComponent extends FeatureComponent<ResourceId> impl
     public newItem: CustomFormGroup;
     public originalItemsDeleted: number;
 
-    private _busyManager: BusyStateScopeManager;
     private _saveError: string;
     private _requiredValidator: RequiredValidator;
     private _uniqueDocumentValidator: UniqueValidator;
@@ -47,13 +44,12 @@ export class DefaultDocumentsComponent extends FeatureComponent<ResourceId> impl
         private _cacheService: CacheService,
         private _fb: FormBuilder,
         private _translateService: TranslateService,
-        private _logService: LogService,
         private _authZService: AuthzService,
+        private _siteService: SiteService,
         broadcastService: BroadcastService,
         injector: Injector
     ) {
-        super('DefaultDocumentComponent', injector);
-        this._busyManager = new BusyStateScopeManager(broadcastService, 'site-tabs');
+        super('DefaultDocumentComponent', injector, 'site-tabs');
 
         this._resetPermissionsAndLoadingState();
 
@@ -65,40 +61,24 @@ export class DefaultDocumentsComponent extends FeatureComponent<ResourceId> impl
         return inputEvents
             .distinctUntilChanged()
             .switchMap(() => {
-                this._busyManager.setBusy();
                 this._saveError = null;
                 this._webConfigArm = null;
                 this.groupArray = null;
                 this.newItem = null;
                 this.originalItemsDeleted = 0;
                 this._resetPermissionsAndLoadingState();
+
                 return Observable.zip(
+                    this._siteService.getSiteConfig(this.resourceId, true),
                     this._authZService.hasPermission(this.resourceId, [AuthzService.writeScope]),
-                    this._authZService.hasReadOnlyLock(this.resourceId),
-                    (wp, rl) => ({ writePermission: wp, readOnlyLock: rl }));
+                    this._authZService.hasReadOnlyLock(this.resourceId));
             })
-            .mergeMap(p => {
-                this._setPermissions(p.writePermission, p.readOnlyLock);
-                return Observable.zip(
-                    Observable.of(this.hasWritePermissions),
-                    this._cacheService.postArm(`${this.resourceId}/config/web`, true),
-                    (h, w) => ({ hasWritePermissions: h, webConfigResponse: w }));
-            })
-            .do(null, error => {
-                this._logService.error(LogCategories.defaultDocuments, '/default-documents', error);
-                this._setupForm(null);
-                this.loadingFailureMessage = this._translateService.instant(PortalResources.configLoadFailure);
-                this.loadingMessage = null;
-                this.showPermissionsMessage = true;
-                this._busyManager.clearBusy();
-            })
-            .retry()
-            .do(r => {
-                this._webConfigArm = r.webConfigResponse.json();
+            .do(results => {
+                this._webConfigArm = results[0].result;
+                this._setPermissions(results[1], results[2]);
                 this._setupForm(this._webConfigArm);
                 this.loadingMessage = null;
                 this.showPermissionsMessage = true;
-                this._busyManager.clearBusy();
             });
     }
 
@@ -113,7 +93,7 @@ export class DefaultDocumentsComponent extends FeatureComponent<ResourceId> impl
 
     ngOnDestroy(): void {
         super.ngOnDestroy();
-        this._busyManager.clearBusy();
+        this.clearBusy();
     }
 
     private _resetPermissionsAndLoadingState() {

--- a/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/general-settings/general-settings.component.ts
@@ -133,21 +133,41 @@ export class GeneralSettingsComponent extends FeatureComponent<ResourceId> imple
                 const hasWritePermission = results[4];
                 const hasReadonlyLock = results[5];
 
-                this.siteArm = siteResult.result;
-                this._webConfigArm = configResult.result;
+                if (!siteResult.isSuccessful
+                    || !slotsResult.isSuccessful
+                    || !configResult.isSuccessful
+                    || !stacksResult.isSuccessful) {
 
-                this._setPermissions(hasWritePermission, hasReadonlyLock);
+                    if (!siteResult.isSuccessful) {
+                        this._logService.error(LogCategories.generalSettings, '/general-settings', siteResult.error.result);
+                    } else if (!slotsResult.isSuccessful) {
+                        this._logService.error(LogCategories.generalSettings, '/general-settings', slotsResult.error.result);
+                    } else if (!configResult.isSuccessful) {
+                        this._logService.error(LogCategories.generalSettings, '/general-settings', configResult.error.result);
+                    } else {
+                        this._logService.error(LogCategories.generalSettings, '/general-settings', stacksResult.error.result);
+                    }
 
-                if (!this._dropDownOptionsMapClean) {
-                    this._parseAvailableStacks(stacksResult.result);
-                    this._parseSlotsConfig(slotsResult.result);
+                    this._setupForm(null, null);
+                    this.loadingFailureMessage = this._translateService.instant(PortalResources.configLoadFailure);
+
+                } else {
+                    this.siteArm = siteResult.result;
+                    this._webConfigArm = configResult.result;
+
+                    this._setPermissions(hasWritePermission, hasReadonlyLock);
+
+                    if (!this._dropDownOptionsMapClean) {
+                        this._parseAvailableStacks(stacksResult.result);
+                        this._parseSlotsConfig(slotsResult.result);
+                    }
+                    if (!this._linuxFxVersionOptionsClean) {
+                        this._parseLinuxBuiltInStacks(LinuxConstants.builtInStacks);
+                    }
+
+                    this._processSupportedControls(this.siteArm, this._webConfigArm);
+                    this._setupForm(this._webConfigArm, this.siteArm);
                 }
-                if (!this._linuxFxVersionOptionsClean) {
-                    this._parseLinuxBuiltInStacks(LinuxConstants.builtInStacks);
-                }
-
-                this._processSupportedControls(this.siteArm, this._webConfigArm);
-                this._setupForm(this._webConfigArm, this.siteArm);
 
                 this.loadingMessage = null;
                 this.showPermissionsMessage = true;

--- a/AzureFunctions.AngularClient/src/app/site/site-config/handler-mappings/handler-mappings.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/handler-mappings/handler-mappings.component.ts
@@ -1,3 +1,5 @@
+import { LogService } from './../../../shared/services/log.service';
+import { LogCategories } from './../../../shared/models/constants';
 import { SiteService } from './../../../shared/services/site.service';
 import { Injector } from '@angular/core';
 import { FeatureComponent } from 'app/shared/components/feature-component';
@@ -43,6 +45,7 @@ export class HandlerMappingsComponent extends FeatureComponent<ResourceId> imple
         private _cacheService: CacheService,
         private _fb: FormBuilder,
         private _translateService: TranslateService,
+        private _logService: LogService,
         private _authZService: AuthzService,
         broadcastService: BroadcastService,
         private _siteService: SiteService,
@@ -71,9 +74,16 @@ export class HandlerMappingsComponent extends FeatureComponent<ResourceId> imple
                     this._authZService.hasReadOnlyLock(this.resourceId));
             })
             .do(results => {
-                this._webConfigArm = results[0].result;
-                this._setPermissions(results[1], results[2]);
-                this._setupForm(this._webConfigArm);
+                if (!results[0].isSuccessful) {
+                    this._logService.error(LogCategories.handlerMappings, '/handler-mappings', results[0].error.result);
+                    this._setupForm(null);
+                    this.loadingFailureMessage = this._translateService.instant(PortalResources.configLoadFailure);
+                } else {
+                    this._webConfigArm = results[0].result;
+                    this._setPermissions(results[1], results[2]);
+                    this._setupForm(this._webConfigArm);
+                }
+
                 this.loadingMessage = null;
                 this.showPermissionsMessage = true;
             });

--- a/AzureFunctions.AngularClient/src/app/site/site-config/virtual-directories/virtual-directories.component.ts
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/virtual-directories/virtual-directories.component.ts
@@ -1,3 +1,5 @@
+import { LogService } from './../../../shared/services/log.service';
+import { LogCategories } from './../../../shared/models/constants';
 import { SiteService } from 'app/shared/services/site.service';
 import { Injector } from '@angular/core';
 import { FeatureComponent } from 'app/shared/components/feature-component';
@@ -46,6 +48,7 @@ export class VirtualDirectoriesComponent extends FeatureComponent<ResourceId> im
         private _cacheService: CacheService,
         private _fb: FormBuilder,
         private _translateService: TranslateService,
+        private _logService: LogService,
         private _authZService: AuthzService,
         private _siteService: SiteService,
         broadcastService: BroadcastService,
@@ -75,17 +78,19 @@ export class VirtualDirectoriesComponent extends FeatureComponent<ResourceId> im
                     this._authZService.hasReadOnlyLock(this.resourceId));
             })
             .do(results => {
-                this._webConfigArm = results[0].result;
-                this._setPermissions(results[1], results[2]);
-                this._setupForm(this._webConfigArm);
+
+                if (!results[0].isSuccessful) {
+                    this._logService.error(LogCategories.virtualDirectories, '/virtual-directories', results[0].error.result);
+                    this._setupForm(null);
+                    this.loadingFailureMessage = this._translateService.instant(PortalResources.configLoadFailure);
+                } else {
+                    this._webConfigArm = results[0].result;
+                    this._setPermissions(results[1], results[2]);
+                    this._setupForm(this._webConfigArm);
+                }
+
                 this.loadingMessage = null;
                 this.showPermissionsMessage = true;
-
-                return Observable.zip(
-                    Observable.of(this.hasWritePermissions),
-                    this._cacheService.postArm(`${this.resourceId}/config/web`, true),
-                    (h, w) => ({ hasWritePermissions: h, webConfigResponse: w })
-                );
             });
     }
 


### PR DESCRIPTION
In order to get this to work properly, I had to update FeatureComponent to support clearing the busy state before the input observable completed.  To do this, I did:

1. Moved the BusyStateManager to the base FeatureComponent so that you can just call this.setbusy() or this.clearBusy() from the component.
2. Automatically set the busy state when we get a new input, and automatically clear it when the component has finished loading.  This means that for most components, you no longer need to explicitly call setBusy or clearBusy during initialization.
3. Added another base function called this.clearBusyEarly() which will clear the busy state early before the setup observable has completed.  This is useful if a developer wants to enable their UI early, but still want to run other async setup code in the background.  It's preferred to call this instead of clearBusy() during initialization because it will ensure that clearbusy doesn't get called twice, which can cause race condition errors with clearing the busy state if the input changes.