### PR TITLE
 add labels to actions in manage blade

### DIFF
--- a/AzureFunctions.AngularClient/src/app/function-keys/function-keys.component.html
+++ b/AzureFunctions.AngularClient/src/app/function-keys/function-keys.component.html
@@ -1,7 +1,6 @@
-<div class="wrapper" *ngIf="!disabled" role="region" aria-labelledby="keys1 keys2">
+<div class="wrapper" *ngIf="!disabled" role="region">
     <busy-state name="function-keys"></busy-state>
-    <label *ngIf="functionInfo" id="keys1" class="title"> {{'functionKeys_title' | translate}} </label>
-    <label *ngIf="!functionInfo" id="keys2" class="title"> {{'adminKeys_title' | translate}} </label>
+    <label id="{{ tableId }}" class="title">{{ (functionInfo ? 'functionKeys_title' : 'adminKeys_title') | translate }}</label>
     <table class="table-function">
         <thead>
             <tr class="not-clickable">
@@ -11,27 +10,29 @@
             </tr>
         </thead>
         <tbody>
-            <tr class="not-clickable" *ngFor="let key of keys">
-                <td><label id="keyNameLabel">{{key.name}}</label></td>
+            <tr class="not-clickable" *ngFor="let key of keys; let i = index;">
+                <td><label id="{{ keyNameIdPrefix + i }}">{{key.name}}</label></td>
                 <td>
                     <a *ngIf="key.show"
+                        id="clickToHide"
                         role="button"
                         (click)="key.show=!key.show" 
                         (keydown)="keyDown($event, 'showKey', key)"
                         class="operation" 
                         tabindex="0"
                         [attr.aria-expanded]="key.show"
-                        [attr.aria-label]="clickToHide">
+                        [attr.aria-labelledby]="keyActionLabelledByPrefix + i + ' clickToHide'">
                         {{'functionKeys_clickToHide' | translate}}
                     </a>
                     <a *ngIf="!key.show"
+                        id="clickToShow"
                         role="button"
                         (click)="key.show=!key.show" 
                         (keydown)="keyDown($event, 'showKey', key)"
                         class="operation" 
                         tabindex="0"
                         [attr.aria-expanded]="key.show"
-                        [attr.aria-label]="clickToShow">
+                        [attr.aria-labelledby]="keyActionLabelledByPrefix + i + ' clickToShow'">
                         {{'functionKeys_clickToShow' | translate}}
                     </a>
                     <span *ngIf="key.show" [attr.aria-label]="key.value" tabindex="0">{{ key.value }}</span>
@@ -51,7 +52,7 @@
                             (keydown)="keyDown($event, 'renewKey', key)"
                             tabindex="0"
                             id="renewKeyAction"
-                            aria-labelledby="keyNameLabel renewKeyAction">
+                            [attr.aria-labelledby]="keyActionLabelledByPrefix + i + ' renewKeyAction'">
                             <i class="fa fa-refresh"></i>
                             {{'functionKeys_renew' | translate}}
                         </a>
@@ -62,7 +63,7 @@
                             (keydown)="keyDown($event, 'revokeKey', key)"
                             tabindex="0"
                             id="revokeKeyAction"
-                            aria-labelledby="keyNameLabel revokeKeyAction">
+                            [attr.aria-labelledby]="keyActionLabelledByPrefix + i + ' revokeKeyAction'">
                             <i class="fa fa-times"></i>
                             {{'functionKeys_revoke' | translate}}
                         </a>

--- a/AzureFunctions.AngularClient/src/app/function-keys/function-keys.component.ts
+++ b/AzureFunctions.AngularClient/src/app/function-keys/function-keys.component.ts
@@ -45,6 +45,10 @@ export class FunctionKeysComponent extends FunctionAppContextComponent implement
     private refreshSubject: ReplaySubject<void>;
     private functionInfo: FunctionInfo;
 
+    public tableId: string;
+    public keyNameIdPrefix: string;
+    public keyActionLabelledByPrefix: string;
+
     constructor(
         broadcastService: BroadcastService,
         private _translateService: TranslateService,
@@ -73,9 +77,11 @@ export class FunctionKeysComponent extends FunctionAppContextComponent implement
                     return this._functionAppService.getHostKeys(viewInfo.context);
                 } else if (viewInfo.functionInfo.isSuccessful) {
                     this.functionInfo = viewInfo.functionInfo.result;
+
                     return this._functionAppService.getFunctionKeys(viewInfo.context, viewInfo.functionInfo.result)
                 } else {
                     this.functionInfo = null;
+
                     return Observable.of({
                         isSuccessful: true,
                         result: { keys: [], links: [] },
@@ -84,6 +90,10 @@ export class FunctionKeysComponent extends FunctionAppContextComponent implement
                 }
             })
             .subscribe(keysResult => {
+                this.tableId = this.functionInfo ? 'functionKeys' : 'hostKeys';
+                this.keyNameIdPrefix = `keyNameLabel-${this.tableId}-`;
+                this.keyActionLabelledByPrefix = `${this.tableId} ${this.keyNameIdPrefix}`;
+
                 this.resetState();
                 if (keysResult.isSuccessful) {
                     const keys = keysResult.result;


### PR DESCRIPTION
add labels to actions in manage blade

actions in manage blade will read "table name, key name, action, link/button"
tested in chrome and edge with screen reader

fixes http://vstfrd:8080/Azure/RD/_workitems?id=10654901&triage=true&_a=edit