### PR TITLE
Updating to app settings blade to keep command bar at top of blade when scrolling. (fixes #2281)

### DIFF
--- a/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.html
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.html
@@ -15,41 +15,46 @@
 
 <div
   *ngIf="!!mainForm"
-  id="site-config-wrapper"
-  [is-dirty]="mainForm.dirty"
-  [is-dirty-message]="dirtyMessage">
+  class="site-config-wrapper">
 
-  <general-settings
-    [mainForm]="mainForm"
-    [resourceId]="resourceId"
-    [featureName]="featureName"></general-settings>
+  <div
+    class="site-config-container"
+    [is-dirty]="mainForm.dirty"
+    [is-dirty-message]="dirtyMessage">
 
-  <app-settings
-    [mainForm]="mainForm"
-    [resourceId]="resourceId"
-    [featureName]="featureName"></app-settings>
+    <general-settings
+      [mainForm]="mainForm"
+      [resourceId]="resourceId"
+      [featureName]="featureName"></general-settings>
 
-  <connection-strings
-    [mainForm]="mainForm"
-    [resourceId]="resourceId"
-    [featureName]="featureName"></connection-strings>
+    <app-settings
+      [mainForm]="mainForm"
+      [resourceId]="resourceId"
+      [featureName]="featureName"></app-settings>
 
-  <default-documents
-    *ngIf="defaultDocumentsSupported"
-    [mainForm]="mainForm"
-    [resourceId]="resourceId"
-    [featureName]="featureName"></default-documents>
+    <connection-strings
+      [mainForm]="mainForm"
+      [resourceId]="resourceId"
+      [featureName]="featureName"></connection-strings>
 
-  <handler-mappings
-    *ngIf="handlerMappingsSupported"
-    [mainForm]="mainForm"
-    [resourceId]="resourceId"
-    [featureName]="featureName"></handler-mappings>
+    <default-documents
+      *ngIf="defaultDocumentsSupported"
+      [mainForm]="mainForm"
+      [resourceId]="resourceId"
+      [featureName]="featureName"></default-documents>
 
-  <virtual-directories
-    *ngIf="virtualDirectoriesSupported"
-    [mainForm]="mainForm"
-    [resourceId]="resourceId"
-    [featureName]="featureName"></virtual-directories>
+    <handler-mappings
+      *ngIf="handlerMappingsSupported"
+      [mainForm]="mainForm"
+      [resourceId]="resourceId"
+      [featureName]="featureName"></handler-mappings>
+
+    <virtual-directories
+      *ngIf="virtualDirectoriesSupported"
+      [mainForm]="mainForm"
+      [resourceId]="resourceId"
+      [featureName]="featureName"></virtual-directories>
+
+  </div>
 
 </div>

--- a/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.scss
+++ b/AzureFunctions.AngularClient/src/app/site/site-config/site-config.component.scss
@@ -1,6 +1,11 @@
 @import '../../../sass/common/variables';
 
-#site-config-wrapper{
+.site-config-wrapper{
+    height: calc(100% - 42px);
+    overflow-y: auto;
+}
+
+.site-config-container{
     padding: 5px 20px;
 }
 


### PR DESCRIPTION
This only addresses the blade scenario. For the app settings tab in the functions portal, the command bar will still move with the rest of the content when scrolling.