### PR TITLE
Fixes #2367: Updating the warning message shown in the banner when slots

### DIFF
--- a/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/Resources.resx
@@ -896,7 +896,7 @@
     <value>'AlwaysOn' is not enabled. Your app may not function properly</value>
   </data>
   <data name="topBar_slotsHostId" xml:space="preserve">
-    <value>Value for id has been explicitly set in host.json, which may cause unexpected behavior when using deployment slots</value>
+    <value>The 'AzureWebJobsSecretStorageType' setting should be set to 'blob',not having this setting will cause unexpected behavior when using deployment slots</value>
   </data>
   <data name="topBar_releaseNotes" xml:space="preserve">
     <value>Azure Functions release notes.</value>


### PR DESCRIPTION
is enable but missing the expected storage