### PR TITLE
Clean up the proxy UI headers/query grid

### DIFF
--- a/AzureFunctions.AngularClient/src/app/api/request-respose-override/request-respose-override.component.html
+++ b/AzureFunctions.AngularClient/src/app/api/request-respose-override/request-respose-override.component.html
@@ -26,7 +26,6 @@
             <pair-list *ngIf="paramsOptions"
                         [options]="paramsOptions"
                         addButtonLabel="{{ 'httpRun_addParameter' | translate}}"
-                        emptyLabel="{{ 'httpRun_noQuery' | translate }}"
                         (valueChanges)="paramsValueChanges($event)">
             </pair-list>
         </div>
@@ -39,7 +38,6 @@
             <pair-list *ngIf="headerOptions"
                         [options]="headerOptions"
                         addButtonLabel="{{ 'httpRun_addHeader' | translate}}"
-                        emptyLabel="{{ 'httpRun_noHeaders' | translate }}"
                         (valueChanges)="headerValueChanges($event)">
             </pair-list>
         </div>
@@ -75,7 +73,6 @@
             <pair-list *ngIf="responseHeaderOptions"
                         [options]="responseHeaderOptions"
                         addButtonLabel="{{ 'httpRun_addHeader' | translate}}"
-                        emptyLabel="{{ 'httpRun_noHeaders' | translate }}"
                         (valueChanges)="responseHeaderValueChanges($event)">
 
             </pair-list>

--- a/AzureFunctions.AngularClient/src/app/controls/pair-list/pair-list.component.html
+++ b/AzureFunctions.AngularClient/src/app/controls/pair-list/pair-list.component.html
@@ -1,10 +1,10 @@
 <form [formGroup]="form">
 
-    <div *ngIf="!title" style="padding-top:8px">
+    <div *ngIf="title" style="padding-top:8px">
         {{ title }}
     </div>
 
-    <div *ngIf="form.value.items.length === 0" class="text-label" style="font-style:italic">
+    <div *ngIf="form.value.items.length === 0 && emptyLabel" class="text-label" style="font-style:italic">
         {{ emptyLabel }}
     </div>
 


### PR DESCRIPTION
Clean up the proxy UI headers/query grid. Was going through the WI to close and realized this should have been done in the previous CR.

![image](https://user-images.githubusercontent.com/493476/37679339-d61e9c0c-2c3d-11e8-8bc1-4502c484221f.png)

Verified it continues to work in the run-http UI as intended..

