### PR TITLE
Handle errors in proxies.json gracefully

### DIFF
--- a/AzureFunctions.AngularClient/src/app/proxies-list/proxies-list.component.html
+++ b/AzureFunctions.AngularClient/src/app/proxies-list/proxies-list.component.html
@@ -1,7 +1,11 @@
 <command-bar>
-  <command displayText="{{ 'apiProxy_new' | translate }}" 
+  <command *ngIf="!requiresAdvancedEditor" displayText="{{ 'apiProxy_new' | translate }}" 
     iconUrl="image/add.svg" 
     (click)="onNewProxyClick()"></command>
+
+    <command *ngIf="requiresAdvancedEditor" displayText="{{ 'functionIntegrate_advancedEditor' | translate }}"
+        (click)="openAdvancedEditor()"
+        iconUrl="image/open-external.svg"></command>
 </command-bar>
 
 <div class="browse-container">
@@ -20,7 +24,7 @@
       <td>{{item.url}}</td>
     </tr>
 
-    <tr *ngIf="table.items.length === 0 || isLoading">    
+    <tr *ngIf="table.items.length === 0 || isLoading">
       <td *ngIf="isLoading" colspan="2">{{'functionMonitor_loading' | translate}}</td>
       <td *ngIf="!isLoading && table.items.length === 0" colspan="2">{{'noResults' | translate}}</td>
     </tr>

--- a/AzureFunctions.AngularClient/src/app/shared/models/error-ids.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/error-ids.ts
@@ -36,8 +36,6 @@ export namespace errorIds {
     export const unableToCreateSwaggerKey = '/errors/unableToCreateSwaggerKey';
     export const unableToDeleteFunctionKey = '/errors/unableToDeleteFunctionKey';
     export const unableToRenewFunctionKey = '/errors/unableToRenewFunctionKey';
-    export const proxyWithSameNameAlreadyExists = '/errors/proxyWithSameNameAlreadyExists';
-    export const proxySchemaValidationFails = '/errors/proxySchemaValidationFails';
     export const errorParsingConfig = '/errors/errorParsingConfig';
     export const generalFunctionErrorFromHost = '/errors/generalFunctionErrorFromHost';
     export const generalHostErrorFromHost = '/errors/generalHostErrorFromHost';
@@ -65,7 +63,11 @@ export namespace errorIds {
     export const failedToUnInstallFunctionRuntimeExtension = '/errors/failedToUnInstallFunctionRuntimeExtension';
     export const timeoutInstallingFunctionRuntimeExtension = '/errors/timeoutInstallingFunctionRuntimeExtension';
     export const extensionAlreadyInstalledWithDifferentVersion = '/errors/extensionAlreadyInstalledWithDifferentVersion';
+    export const proxyWithSameNameAlreadyExists = '/errors/proxyWithSameNameAlreadyExists';
+    export const proxySchemaValidationFails = '/errors/proxySchemaValidationFails';
     export const proxyJsonNotFound = '/errors/proxyJsonNotFound';
+    export const proxyJsonNotValid = '/errors/proxyJsonNotValid';
+    export const proxySchemaNotValid = '/errors/proxySchemaNotValid';
     export const embeddedEditorLoadError = '/errors/embedded/editor-load';
     export const embeddedEditorSaveError = '/errors/embedded/editor-save';
     export const embeddedDeleteError = '/errors/embedded/delete';

--- a/AzureFunctions.AngularClient/src/app/shared/models/portal-resources.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/models/portal-resources.ts
@@ -950,4 +950,6 @@
     public static diagnostics_errorsAndWarnings: string = "diagnostics_errorsAndWarnings";
     public static diagnostics_file: string = "diagnostics_file";
     public static diagnostics_line: string = "diagnostics_line";
+    public static proxyJsonInvalid: string = "proxyJsonInvalid";
+    public static schemaJsonInvalid: string = "schemaJsonInvalid";
 }

--- a/AzureFunctions.AngularClient/src/app/shared/services/function-app.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/function-app.service.ts
@@ -123,28 +123,66 @@ export class FunctionAppService {
     }
 
     getApiProxies(context: FunctionAppContext): Result<ApiProxy[]> {
-        const client = this.getClient(context);
-        return client.execute({ resourceId: context.site.id }, t => Observable.zip(
-            this._cacheService.get(context.urlTemplates.proxiesJsonUrl, false, this.headers(t))
-                .catch(err => err.status === 404
-                    ? Observable.throw({
-                        errorId: errorIds.proxyJsonNotFound,
-                        message: '',
-                        result: null
-                    }) : Observable.throw(err)),
-            this._cacheService.get('assets/schemas/proxies.json', false, this.portalHeaders(t)),
-            (p, s) => ({ proxies: p, schema: s.json() })
-        ).map(r => {
-            const proxies = r.proxies.json();
-            if (proxies.proxies) {
-                const validateResult = jsonschema.validate(proxies, r.schema).toString();
-                if (validateResult) {
-                    // TODO: [alrod] handle error
-                    return ApiProxy.fromJson({});
-                }
+        return this
+            .getClient(context)
+            .execute(
+                /*input*/ { resourceId: context.site.id },
+                /*query*/ token => Observable
+                    .zip(
+                        this.retrieveProxies(context, token),
+                        this._cacheService.get('assets/schemas/proxies.json', false, this.portalHeaders(token)),
+                        (p, s) => ({ proxies: p, schema: s }))
+                    .flatMap(response => this.validateAndGetProxies(response.proxies, response.schema)));
+    }
+
+    private retrieveProxies(context: FunctionAppContext, token: string) : Observable<any> {
+        return this._cacheService
+            .get(context.urlTemplates.proxiesJsonUrl, false, this.headers(token))
+            .catch(err => err.status === 404
+                ? Observable.throw({
+                    errorId: errorIds.proxyJsonNotFound,
+                    message: '',
+                    result: null
+                })
+                : Observable.throw(err));
+    }
+
+    private validateAndGetProxies(proxiesResponse: any, schemaResponse: any) : Observable<ApiProxy[]>
+    {
+        let proxiesJson, schemaJson;
+
+        try {
+            proxiesJson = proxiesResponse.json();
+        } catch (exception) {
+            return Observable.throw({
+                errorId: errorIds.proxyJsonNotValid,
+                message: this._translateService.instant(PortalResources.proxyJsonInvalid).format(exception.message),
+                result: null
+            });
+        }
+
+        try {
+            schemaJson = schemaResponse.json();
+        } catch (exception) {
+            return Observable.throw({
+                errorId: errorIds.proxySchemaNotValid,
+                message: this._translateService.instant(PortalResources.schemaJsonInvalid).format(exception.message),
+                result: null
+            });
+        }
+
+        if (proxiesJson.proxies) {
+            const validateResult = jsonschema.validate(proxiesJson, schemaJson);
+            if (!validateResult.valid) {
+                return Observable.throw({
+                    errorId: errorIds.proxySchemaValidationFails,
+                    message: this._translateService.instant(PortalResources.error_schemaValidationProxies).format(validateResult.toString()),
+                    result: null
+                });
             }
-            return ApiProxy.fromJson(proxies);
-        }));
+        }
+        
+        return Observable.of(ApiProxy.fromJson(proxiesJson));
     }
 
     saveApiProxy(context: FunctionAppContext, jsonString: string): Result<Response> {

--- a/AzureFunctions.AngularClient/src/app/shared/services/function-app.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/function-app.service.ts
@@ -171,7 +171,7 @@ export class FunctionAppService {
             });
         }
 
-        if (proxiesJson.proxies) {
+        if (proxiesJson) {
             const validateResult = jsonschema.validate(proxiesJson, schemaJson);
             if (!validateResult.valid) {
                 return Observable.throw({

--- a/AzureFunctions.AngularClient/src/app/shared/services/function-app.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/function-app.service.ts
@@ -126,8 +126,8 @@ export class FunctionAppService {
         return this
             .getClient(context)
             .execute(
-                /*input*/ { resourceId: context.site.id },
-                /*query*/ token => Observable
+                { resourceId: context.site.id }, /*input*/ 
+                token => Observable /*query*/ 
                     .zip(
                         this.retrieveProxies(context, token),
                         this._cacheService.get('assets/schemas/proxies.json', false, this.portalHeaders(token)),

--- a/AzureFunctions.AngularClient/src/app/tree-view/proxies-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/proxies-node.ts
@@ -111,7 +111,7 @@ export class ProxiesNode extends BaseFunctionsProxiesNode {
                         this._broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
                             errorId: response.error.errorId,
                             message: response.error.message,
-                            resourceId: ""
+                            resourceId: this._context.site.id
                         })
                     }
 

--- a/AzureFunctions.AngularClient/src/app/tree-view/proxies-node.ts
+++ b/AzureFunctions.AngularClient/src/app/tree-view/proxies-node.ts
@@ -8,11 +8,14 @@ import { TreeNode } from './tree-node';
 import { SideNavComponent } from '../side-nav/side-nav.component';
 import { DashboardType } from './models/dashboard-type';
 import { ProxyNode } from './proxy-node';
+import { BroadcastEvent } from './../shared/models/broadcast-event';
+import { ErrorEvent } from './../shared/models/error-event';
 
 export class ProxiesNode extends BaseFunctionsProxiesNode {
     public title = this.sideNav.translateService.instant(PortalResources.appFunctionSettings_apiProxies);
     public dashboardType = DashboardType.ProxiesDashboard;
     public newDashboardType = DashboardType.CreateProxyDashboard;
+    public requiresAdvancedEditor: boolean = false;
 
     constructor(
         sideNav: SideNavComponent,
@@ -67,6 +70,10 @@ export class ProxiesNode extends BaseFunctionsProxiesNode {
         this.openCreateNew();
     }
 
+    public getProxyAdvancedEditorUrl() {
+        return `${this._context.scmUrl}/dev/wwwroot/proxies.json`;
+    }
+
     protected _updateTreeForNonUsableState(title: string) {
         this.disabled = true;
         this.newDashboardType = null;
@@ -88,13 +95,24 @@ export class ProxiesNode extends BaseFunctionsProxiesNode {
         }
 
         if (!this.children || this.children.length === 0) {
-            return this._functionAppService.getApiProxies(this._context)
-                .map(proxies => {
+            return this._functionAppService
+                .getApiProxies(this._context)
+                .map(response => {
                     const fcNodes = <ProxyNode[]>[];
-                    if (proxies.isSuccessful) {
-                        proxies.result.forEach(proxy => {
+                    if (response.isSuccessful) {
+                        this.requiresAdvancedEditor = false;
+
+                        response.result.forEach(proxy => {
                             fcNodes.push(new ProxyNode(this.sideNav, proxy, this._context.site, this));
                         });
+                    } else {
+                        this.requiresAdvancedEditor = true;
+
+                        this._broadcastService.broadcast<ErrorEvent>(BroadcastEvent.Error, {
+                            errorId: response.error.errorId,
+                            message: response.error.message,
+                            resourceId: ""
+                        })
                     }
 
                     this.children = fcNodes;

--- a/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/Resources.resx
@@ -2243,7 +2243,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <value>Policy</value>
   </data>
   <data name="error_schemaValidationProxies" xml:space="preserve">
-    <value>proxies.json schema validation error</value>
+    <value>The proxies.json schema validation failed. Error: '{0}'.</value>
   </data>
   <data name="functionAppSettings_dailyUsageQuotaHelp" xml:space="preserve">
     <value>On a Consumption plan, you can limit platform usage by setting a daily usage quota, in gigabytes-seconds. Once the daily usage quota is reached, the Function App is stopped until the next day at 0:00 AM UTC.</value>
@@ -2973,5 +2973,11 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
   </data>
   <data name="diagnostics_line" xml:space="preserve">
     <value>Line</value>
+  </data>
+  <data name="proxyJsonInvalid" xml:space="preserve">
+    <value>The proxies.json is not valid. Error: '{0}'.</value>
+  </data>
+  <data name="schemaJsonInvalid" xml:space="preserve">
+    <value>The proxies schema is not valid. Error: '{0}'.</value>
   </data>
 </root>


### PR DESCRIPTION
If proxies.json files contains errors (malformed json), show the error to the user with a link to the advanced editor. In the current scenario the UI does not display the error and allows the user to create a new proxy. Unfortunately the creation of new proxy just hangs as there is already a malformed proxies.json file.

**In case of**
![image](https://user-images.githubusercontent.com/493476/37743168-044ee13e-2d26-11e8-83a8-96698c71270a.png)

**Before**
![image](https://user-images.githubusercontent.com/493476/37743277-8f6daaca-2d26-11e8-90e6-d1fde09040da.png)

**After**
![image](https://user-images.githubusercontent.com/493476/37743521-b14b830a-2d27-11e8-8316-338b4d31e77d.png)

![image](https://user-images.githubusercontent.com/493476/37743496-97c29b44-2d27-11e8-9932-a2e5d7ca8ca0.png)
