### PR TITLE
HOTFIX: Fixing iframe signature that we send to Ibiza

### DIFF
--- a/AzureFunctions.AngularClient/src/app/shared/services/portal.service.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/services/portal.service.ts
@@ -359,13 +359,13 @@ export class PortalService {
     }
 
     private postMessage(verb: string, data: string) {
-        if (PortalService.inIFrame()) {
+        if (Url.getParameterByName(null, 'appsvc.bladetype') === 'appblade') {
             window.parent.postMessage(<Data>{
                 signature: this.portalSignature,
                 kind: verb,
                 data: data
             }, this.shellSrc);
-
+        } else {
             window.parent.postMessage(<Data>{
                 signature: this.portalSignatureFrameBlade,
                 kind: verb,


### PR DESCRIPTION
Making sure we send the appropriate postMessage signature for the type of blade that we've been opened from.