### PR TITLE
Fixes: #2166 - Updating site tabs so that every tab has its own busy component

### DIFF
--- a/client/src/app/busy-state/busy-state.component.ts
+++ b/client/src/app/busy-state/busy-state.component.ts
@@ -10,9 +10,18 @@ import { Guid } from './../shared/Utilities/Guid';
 export type BusyStateName =
     'global'
     | 'dashboard'
-    | 'site-tabs'
     | 'try-functions'
-    | 'function-keys';
+    | 'function-keys'
+    | 'site-summary'
+    | 'site-manage'
+    | 'site-config'
+    | 'site-function-settings'
+    | 'site-api-definition'
+    | 'site-continuous-deployment'
+    | 'logic-apps'
+    | 'scale-up'
+    | 'deployment-slots-config'
+    | 'standalone-config';
 
 @Component({
     selector: 'busy-state',

--- a/client/src/app/ibiza-feature/app-settings-shell/app-settings-shell.component.html
+++ b/client/src/app/ibiza-feature/app-settings-shell/app-settings-shell.component.html
@@ -1,2 +1,2 @@
-<busy-state name="site-tabs" cssClass="ibiza-feature"></busy-state>
+<busy-state name="site-config" cssClass="ibiza-feature"></busy-state>
 <site-config *ngIf="viewInfo" [viewInfoInput]='viewInfo'></site-config>

--- a/client/src/app/ibiza-feature/deployment-shell/deployment-shell.component.html
+++ b/client/src/app/ibiza-feature/deployment-shell/deployment-shell.component.html
@@ -1,2 +1,2 @@
-<busy-state name="site-tabs" cssClass="ibiza-feature"></busy-state>
+<busy-state name="site-continuous-deployment" cssClass="ibiza-feature"></busy-state>
 <app-deployment-center *ngIf="viewInfo" [viewInfoInput]='viewInfo'></app-deployment-center>

--- a/client/src/app/ibiza-feature/deployment-slots-shell/deployment-slots-shell.component.html
+++ b/client/src/app/ibiza-feature/deployment-slots-shell/deployment-slots-shell.component.html
@@ -1,2 +1,2 @@
-<busy-state name="site-tabs" cssClass="ibiza-feature"></busy-state>
+<busy-state name="deployment-slots-config" cssClass="ibiza-feature"></busy-state>
 <deployment-slots *ngIf="viewInfo" [viewInfoInput]='viewInfo' [swapMode]='swapMode'></deployment-slots>

--- a/client/src/app/logic-apps/logic-apps.component.ts
+++ b/client/src/app/logic-apps/logic-apps.component.ts
@@ -1,7 +1,7 @@
 import { ArmSiteDescriptor } from 'app/shared/resourceDescriptors';
 import { FunctionAppService } from 'app/shared/services/function-app.service';
 import { FunctionAppContextComponent } from 'app/shared/components/function-app-context-component';
-import { LogCategories } from './../shared/models/constants';
+import { LogCategories, SiteTabIds } from './../shared/models/constants';
 import { LogService } from './../shared/services/log.service';
 import { ArmService } from 'app/shared/services/arm.service';
 import { BusyStateScopeManager } from './../busy-state/busy-state-scope-manager';
@@ -79,7 +79,7 @@ export class LogicAppsComponent extends FunctionAppContextComponent {
         broadcastService: BroadcastService) {
         super('logic-apps', _functionAppService, broadcastService);
 
-        this._busyManager = new BusyStateScopeManager(broadcastService, 'site-tabs');
+        this._busyManager = new BusyStateScopeManager(broadcastService, SiteTabIds.logicApps);
     }
 
     setup(): RxSubscription {

--- a/client/src/app/shared/components/feature-component.ts
+++ b/client/src/app/shared/components/feature-component.ts
@@ -140,6 +140,7 @@ export abstract class FeatureComponent<T> extends ErrorableComponent implements 
     ngOnDestroy(): void {
         this.ngUnsubscribe.next();
         if (this.__busyManager) {
+            this.__logService.debug(LogCategories.featureComponent, `In destroy.  Clearing busy for componentName: ${this.componentName}`);
             this.__busyManager.clearBusy();
         }
     }

--- a/client/src/app/shared/models/constants.ts
+++ b/client/src/app/shared/models/constants.ts
@@ -61,19 +61,18 @@ export class TabCommunicationVerbs {
 }
 
 export class SiteTabIds {
-    public static readonly overview = 'overview';
-    public static readonly monitor = 'monitor';
-    public static readonly features = 'platformFeatures';
-    public static readonly functionRuntime = 'functionRuntimeSettings';
-    public static readonly apiDefinition = 'apiDefinition';
-    public static readonly config = 'config';
-    public static readonly applicationSettings = 'appSettings';
-    public static readonly continuousDeployment = 'continuousDeployment';
-    public static readonly logicApps = 'logicApps';
-    public static readonly deploymentSlotsConfig = 'deploymentSlotsConfig';
-    public static readonly deploymentSlotsSwap = 'deploymentSlotsSwap';
-    public static readonly deploymentSlotsCreate = 'deploymentSlotsCreate';
-    public static readonly scaleUp = 'scaleUp';
+    public static readonly overview = 'site-summary';
+    public static readonly platformFeatures = 'site-manage';
+    public static readonly functionRuntime = 'site-function-settings';
+    public static readonly apiDefinition = 'site-api-definition';
+    public static readonly standaloneConfig = 'standalone-config';
+    public static readonly applicationSettings = 'site-config';
+    public static readonly continuousDeployment = 'site-continuous-deployment';
+    public static readonly logicApps = 'logic-apps';
+    public static readonly deploymentSlotsConfig = 'deployment-slots-config';
+    public static readonly deploymentSlotsSwap = 'deployment-slots-swap';
+    public static readonly deploymentSlotsCreate = 'deployment-slots-create';
+    public static readonly scaleUp = 'scale-up';
 }
 
 export class Arm {

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-complete/step-complete.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-complete/step-complete.component.ts
@@ -10,7 +10,7 @@ import { ArmObj } from 'app/shared/models/arm/arm-obj';
 import { Site } from 'app/shared/models/arm/site';
 import { PublishingCredentials } from 'app/shared/models/publishing-credentials';
 import { LogService } from 'app/shared/services/log.service';
-import { LogCategories } from 'app/shared/models/constants';
+import { LogCategories, SiteTabIds } from 'app/shared/models/constants';
 import { summaryItem } from 'app/site/deployment-center/Models/summary-item';
 import { sourceControlProvider } from 'app/site/deployment-center/deployment-center-setup/wizard-logic/deployment-center-setup-models';
 import { TranslateService } from '@ngx-translate/core';
@@ -37,7 +37,7 @@ export class StepCompleteComponent implements OnInit {
         private _logService: LogService,
         private _translateService: TranslateService
     ) {
-        this._busyManager = new BusyStateScopeManager(_broadcastService, 'site-tabs');
+        this._busyManager = new BusyStateScopeManager(_broadcastService, SiteTabIds.continuousDeployment);
 
         this.wizard.resourceIdStream$
             .takeUntil(this._ngUnsubscribe$)

--- a/client/src/app/site/deployment-center/deployment-center.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center.component.ts
@@ -18,7 +18,7 @@ import { BroadcastService } from 'app/shared/services/broadcast.service';
 import { BroadcastEvent } from 'app/shared/models/broadcast-event';
 import { OnDestroy } from '@angular/core/src/metadata/lifecycle_hooks';
 import { TreeViewInfo, SiteData } from 'app/tree-view/models/tree-view-info';
-import { LogCategories } from 'app/shared/models/constants';
+import { LogCategories, SiteTabIds } from 'app/shared/models/constants';
 import { LogService } from 'app/shared/services/log.service';
 
 @Component({
@@ -52,7 +52,7 @@ export class DeploymentCenterComponent implements OnDestroy {
         private _logService: LogService,
         broadcastService: BroadcastService
     ) {
-        this._busyManager = new BusyStateScopeManager(broadcastService, 'site-tabs');
+        this._busyManager = new BusyStateScopeManager(broadcastService, SiteTabIds.continuousDeployment);
 
         this.viewInfoStream
             .takeUntil(this._ngUnsubscribe$)

--- a/client/src/app/site/deployment-center/provider-dashboards/kudu-dashboard/kudu-dashboard.component.ts
+++ b/client/src/app/site/deployment-center/provider-dashboards/kudu-dashboard/kudu-dashboard.component.ts
@@ -14,7 +14,7 @@ import { BusyStateScopeManager } from 'app/busy-state/busy-state-scope-manager';
 import { BroadcastService } from 'app/shared/services/broadcast.service';
 import { BroadcastEvent } from 'app/shared/models/broadcast-event';
 import { LogService } from 'app/shared/services/log.service';
-import { LogCategories } from 'app/shared/models/constants';
+import { LogCategories, SiteTabIds } from 'app/shared/models/constants';
 class KuduTableItem implements TableItem {
     public type: 'row' | 'group';
     public time: string;
@@ -57,7 +57,7 @@ export class KuduDashboardComponent implements OnChanges, OnDestroy {
         private _broadcastService: BroadcastService,
         private _logService: LogService
     ) {
-        this._busyManager = new BusyStateScopeManager(_broadcastService, 'site-tabs');
+        this._busyManager = new BusyStateScopeManager(_broadcastService, SiteTabIds.continuousDeployment);
         this._tableItems = [];
         this.viewInfoStream$ = new Subject<string>();
         this._viewInfoSubscription$ = this.viewInfoStream$
@@ -93,29 +93,29 @@ export class KuduDashboardComponent implements OnChanges, OnDestroy {
                 );
             })
             .subscribe(
-            r => {
-                this._busyManager.clearBusy();
-                this._forceLoad = false;
-                this.deploymentObject = {
-                    site: r.site,
-                    siteConfig: r.siteConfig,
-                    sourceControls: r.sourceControl,
-                    publishingCredentials: r.pubCreds,
-                    deployments: r.deployments,
-                    publishingUser: r.publishingUser
-                };
-                this._populateTable();
+                r => {
+                    this._busyManager.clearBusy();
+                    this._forceLoad = false;
+                    this.deploymentObject = {
+                        site: r.site,
+                        siteConfig: r.siteConfig,
+                        sourceControls: r.sourceControl,
+                        publishingCredentials: r.pubCreds,
+                        deployments: r.deployments,
+                        publishingUser: r.publishingUser
+                    };
+                    this._populateTable();
 
-                this._writePermission = r.writePermission;
-                this._readOnlyLock = r.readOnlyLock;
-                this.hasWritePermissions = r.writePermission && !r.readOnlyLock;
-            },
-            err => {
-                this._busyManager.clearBusy();
-                this._forceLoad = false;
-                this.deploymentObject = null;
-                this._logService.error(LogCategories.cicd, '/deployment-center-initial-load', err);
-            }
+                    this._writePermission = r.writePermission;
+                    this._readOnlyLock = r.readOnlyLock;
+                    this.hasWritePermissions = r.writePermission && !r.readOnlyLock;
+                },
+                err => {
+                    this._busyManager.clearBusy();
+                    this._forceLoad = false;
+                    this.deploymentObject = null;
+                    this._logService.error(LogCategories.cicd, '/deployment-center-initial-load', err);
+                }
             );
 
         //refresh automatically every 5 seconds

--- a/client/src/app/site/deployment-center/provider-dashboards/vso-Dashboard/vso-dashboard.component.ts
+++ b/client/src/app/site/deployment-center/provider-dashboards/vso-Dashboard/vso-dashboard.component.ts
@@ -11,7 +11,7 @@ import { SimpleChanges, OnDestroy } from '@angular/core/src/metadata/lifecycle_h
 import { Deployment, DeploymentData } from '../../Models/deployment-data';
 import { Component, Input, OnChanges, ViewChild } from '@angular/core';
 import * as moment from 'moment-mini-ts';
-import { LogCategories } from 'app/shared/models/constants';
+import { LogCategories, SiteTabIds } from 'app/shared/models/constants';
 import { LogService } from 'app/shared/services/log.service';
 import { BusyStateScopeManager } from '../../../../busy-state/busy-state-scope-manager';
 import { ArmService } from '../../../../shared/services/arm.service';
@@ -47,7 +47,7 @@ export class VsoDashboardComponent implements OnChanges, OnDestroy {
         private _translateService: TranslateService,
         private _broadcastService: BroadcastService
     ) {
-        this._busyManager = new BusyStateScopeManager(_broadcastService, 'site-tabs');
+        this._busyManager = new BusyStateScopeManager(_broadcastService, SiteTabIds.continuousDeployment);
         this.viewInfoStream$ = new Subject<string>();
         this.viewInfoStream$
             .takeUntil(this._ngUnsubscribe$)

--- a/client/src/app/site/deployment-slots/add-slot/add-slot.component.ts
+++ b/client/src/app/site/deployment-slots/add-slot/add-slot.component.ts
@@ -1,4 +1,4 @@
-import { LogCategories } from 'app/shared/models/constants';
+import { LogCategories, SiteTabIds } from 'app/shared/models/constants';
 import { LogService } from 'app/shared/services/log.service';
 import { Component, Injector, Input, OnDestroy, Output } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
@@ -64,7 +64,7 @@ export class AddSlotComponent extends FeatureComponent<ResourceId> implements On
         private _authZService: AuthzService,
         private _injector: Injector
     ) {
-        super('AddSlotComponent', _injector, 'site-tabs');
+        super('AddSlotComponent', _injector, SiteTabIds.deploymentSlotsConfig);
 
         // TODO [andimarc]
         // For ibiza scenarios, this needs to match the deep link feature name used to load this in ibiza menu

--- a/client/src/app/site/deployment-slots/deployment-slots.component.ts
+++ b/client/src/app/site/deployment-slots/deployment-slots.component.ts
@@ -8,7 +8,7 @@ import { FeatureComponent } from 'app/shared/components/feature-component';
 import { ArmObj, ResourceId } from 'app/shared/models/arm/arm-obj';
 import { Site } from 'app/shared/models/arm/site';
 import { SiteConfig } from 'app/shared/models/arm/site-config';
-import { Links, LogCategories } from 'app/shared/models/constants';
+import { Links, LogCategories, SiteTabIds } from 'app/shared/models/constants';
 import { PortalResources } from 'app/shared/models/portal-resources';
 import { RoutingRule } from 'app/shared/models/arm/routing-rule';
 import { ArmSiteDescriptor } from 'app/shared/resourceDescriptors';
@@ -85,7 +85,7 @@ export class DeploymentSlotsComponent extends FeatureComponent<TreeViewInfo<Site
         private _translateService: TranslateService,
         injector: Injector) {
 
-        super('SlotsComponent', injector, 'site-tabs');
+        super('SlotsComponent', injector, SiteTabIds.deploymentSlotsConfig);
 
         // TODO [andimarc]
         // For ibiza scenarios, this needs to match the deep link feature name used to load this in ibiza menu

--- a/client/src/app/site/deployment-slots/swap-slots/swap-slots.component.ts
+++ b/client/src/app/site/deployment-slots/swap-slots/swap-slots.component.ts
@@ -8,7 +8,7 @@ import { FeatureComponent } from 'app/shared/components/feature-component';
 import { ArmObj, ResourceId, ArmArrayResult } from 'app/shared/models/arm/arm-obj';
 import { Site } from 'app/shared/models/arm/site';
 import { SlotsDiff } from 'app/shared/models/arm/slots-diff';
-import { LogCategories } from 'app/shared/models/constants';
+import { LogCategories, SiteTabIds } from 'app/shared/models/constants';
 import { DropDownElement } from 'app/shared/models/drop-down-element';
 import { PortalResources } from 'app/shared/models/portal-resources';
 import { ArmSiteDescriptor } from 'app/shared/resourceDescriptors';
@@ -88,7 +88,7 @@ export class SwapSlotsComponent extends FeatureComponent<ResourceId> implements 
         private _translateService: TranslateService,
         injector: Injector
     ) {
-        super('SwapSlotsComponent', injector, 'site-tabs');
+        super('SwapSlotsComponent', injector, SiteTabIds.deploymentSlotsConfig);
 
         this.close = new Subject<boolean>();
 

--- a/client/src/app/site/function-runtime/function-runtime.component.ts
+++ b/client/src/app/site/function-runtime/function-runtime.component.ts
@@ -89,7 +89,7 @@ export class FunctionRuntimeComponent extends FunctionAppContextComponent {
         private _languageService: LanguageService) {
         super('function-runtime', _functionAppService, broadcastService, () => this._busyManager.setBusy());
 
-        this._busyManager = new BusyStateScopeManager(broadcastService, 'site-tabs');
+        this._busyManager = new BusyStateScopeManager(broadcastService, SiteTabIds.functionRuntime);
 
         this.functionStatusOptions = [
             {

--- a/client/src/app/site/site-config-standalone/site-config-standalone.component.ts
+++ b/client/src/app/site/site-config-standalone/site-config-standalone.component.ts
@@ -51,7 +51,7 @@ export class SiteConfigStandaloneComponent implements OnDestroy {
         private _aiService: AiService,
         private _broadcastService: BroadcastService,
     ) {
-        this._busyManager = new BusyStateScopeManager(_broadcastService, 'site-tabs');
+        this._busyManager = new BusyStateScopeManager(_broadcastService, SiteTabIds.standaloneConfig);
 
         this.viewInfoStream = new Subject<TreeViewInfo<SiteData>>();
         this._viewInfoSubscription = this.viewInfoStream
@@ -136,7 +136,7 @@ export class SiteConfigStandaloneComponent implements OnDestroy {
             connectionStrings: connectionStrings
         });
 
-        this._broadcastService.clearDirtyState(SiteTabIds.config);
+        this._broadcastService.clearDirtyState(SiteTabIds.standaloneConfig);
 
         if (this._valueSubscription) {
             this._valueSubscription.unsubscribe();
@@ -145,7 +145,8 @@ export class SiteConfigStandaloneComponent implements OnDestroy {
         this._valueSubscription = this.mainForm.valueChanges.subscribe(() => {
             // There isn't a callback for dirty state on a form, so this is a workaround.
             if (this.mainForm.dirty) {
-                this._broadcastService.setDirtyState(SiteTabIds.config);
+                this._broadcastService.clearDirtyState(SiteTabIds.standaloneConfig);
+                this._broadcastService.setDirtyState(SiteTabIds.standaloneConfig);
             }
         });
     }
@@ -177,7 +178,7 @@ export class SiteConfigStandaloneComponent implements OnDestroy {
             this._valueSubscription.unsubscribe();
             this._valueSubscription = null;
         }
-        this._broadcastService.clearDirtyState(SiteTabIds.config);
+        this._broadcastService.clearDirtyState(SiteTabIds.standaloneConfig);
     }
 
     save() {

--- a/client/src/app/site/site-config/app-settings/app-settings.component.ts
+++ b/client/src/app/site/site-config/app-settings/app-settings.component.ts
@@ -1,3 +1,4 @@
+import { SiteTabIds } from './../../../shared/models/constants';
 import { ConfigSaveComponent, ArmSaveConfigs } from 'app/shared/components/config-save-component';
 import { Component, Injector, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, Validators, ValidatorFn } from '@angular/forms';
@@ -51,7 +52,7 @@ export class AppSettingsComponent extends ConfigSaveComponent implements OnChang
     private _siteService: SiteService,
     injector: Injector
   ) {
-    super('AppSettingsComponent', injector, ['ApplicationSettings', 'SlotConfigNames'], 'site-tabs');
+    super('AppSettingsComponent', injector, ['ApplicationSettings', 'SlotConfigNames'], SiteTabIds.applicationSettings);
 
     this._resetPermissionsAndLoadingState();
 

--- a/client/src/app/site/site-config/connection-strings/connection-strings.component.ts
+++ b/client/src/app/site/site-config/connection-strings/connection-strings.component.ts
@@ -1,6 +1,6 @@
 import { ConfigSaveComponent, ArmSaveConfigs } from 'app/shared/components/config-save-component';
 import { LogService } from 'app/shared/services/log.service';
-import { LogCategories } from './../../../shared/models/constants';
+import { LogCategories, SiteTabIds } from './../../../shared/models/constants';
 import { errorIds } from 'app/shared/models/error-ids';
 import { Component, Injector, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
@@ -49,7 +49,7 @@ export class ConnectionStringsComponent extends ConfigSaveComponent implements O
         private _logService: LogService,
         injector: Injector
     ) {
-        super('ConnectionStringsComponent', injector, ['ConnectionStrings', 'SlotConfigNames'], 'site-tabs');
+        super('ConnectionStringsComponent', injector, ['ConnectionStrings', 'SlotConfigNames'], SiteTabIds.applicationSettings);
 
         this._resetPermissionsAndLoadingState();
 

--- a/client/src/app/site/site-config/default-documents/default-documents.component.ts
+++ b/client/src/app/site/site-config/default-documents/default-documents.component.ts
@@ -1,5 +1,5 @@
 import { ConfigSaveComponent, ArmSaveConfigs } from 'app/shared/components/config-save-component';
-import { LogCategories } from './../../../shared/models/constants';
+import { LogCategories, SiteTabIds } from './../../../shared/models/constants';
 import { LogService } from './../../../shared/services/log.service';
 import { SiteService } from 'app/shared/services/site.service';
 import { Component, Injector, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
@@ -45,7 +45,7 @@ export class DefaultDocumentsComponent extends ConfigSaveComponent implements On
         private _siteService: SiteService,
         injector: Injector
     ) {
-        super('DefaultDocumentComponent', injector, ['SiteConfig'], 'site-tabs');
+        super('DefaultDocumentComponent', injector, ['SiteConfig'], SiteTabIds.applicationSettings);
 
         this._resetPermissionsAndLoadingState();
 

--- a/client/src/app/site/site-config/general-settings/general-settings.component.ts
+++ b/client/src/app/site/site-config/general-settings/general-settings.component.ts
@@ -1,5 +1,5 @@
 import { ConfigSaveComponent, ArmSaveConfigs } from 'app/shared/components/config-save-component';
-import { Links, LogCategories } from './../../../shared/models/constants';
+import { Links, LogCategories, SiteTabIds } from './../../../shared/models/constants';
 import { PortalService } from './../../../shared/services/portal.service';
 import { Component, Injector, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
@@ -89,7 +89,7 @@ export class GeneralSettingsComponent extends ConfigSaveComponent implements OnC
         private _siteService: SiteService,
         injector: Injector
     ) {
-        super('GeneralSettingsComponent', injector, ['Site', 'SiteConfig'], 'site-tabs');
+        super('GeneralSettingsComponent', injector, ['Site', 'SiteConfig'], SiteTabIds.applicationSettings);
 
         this._resetSlotsInfo();
 

--- a/client/src/app/site/site-config/handler-mappings/handler-mappings.component.ts
+++ b/client/src/app/site/site-config/handler-mappings/handler-mappings.component.ts
@@ -1,6 +1,6 @@
 import { ConfigSaveComponent, ArmSaveConfigs } from 'app/shared/components/config-save-component';
 import { LogService } from './../../../shared/services/log.service';
-import { LogCategories } from './../../../shared/models/constants';
+import { LogCategories, SiteTabIds } from './../../../shared/models/constants';
 import { SiteService } from './../../../shared/services/site.service';
 import { Component, Injector, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup } from '@angular/forms';
@@ -44,7 +44,7 @@ export class HandlerMappingsComponent extends ConfigSaveComponent implements OnC
         private _siteService: SiteService,
         injector: Injector
     ) {
-        super('HandlerMappingsComponent', injector, ['SiteConfig'], 'site-tabs');
+        super('HandlerMappingsComponent', injector, ['SiteConfig'], SiteTabIds.applicationSettings);
 
         this._resetPermissionsAndLoadingState();
 

--- a/client/src/app/site/site-config/site-config.component.ts
+++ b/client/src/app/site/site-config/site-config.component.ts
@@ -69,7 +69,7 @@ export class SiteConfigComponent extends FeatureComponent<TreeViewInfo<SiteData>
         private _siteService: SiteService,
         injector: Injector
     ) {
-        super('SiteConfigComponent', injector, 'site-tabs');
+        super('site-config', injector, SiteTabIds.applicationSettings);
 
         // For ibiza scenarios, this needs to match the deep link feature name used to load this in ibiza menu
         this.featureName = 'settings';

--- a/client/src/app/site/site-config/virtual-directories/virtual-directories.component.ts
+++ b/client/src/app/site/site-config/virtual-directories/virtual-directories.component.ts
@@ -1,6 +1,6 @@
 import { ConfigSaveComponent, ArmSaveConfigs } from 'app/shared/components/config-save-component';
 import { LogService } from './../../../shared/services/log.service';
-import { LogCategories } from './../../../shared/models/constants';
+import { LogCategories, SiteTabIds } from './../../../shared/models/constants';
 import { SiteService } from 'app/shared/services/site.service';
 import { Component, Injector, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
@@ -46,7 +46,7 @@ export class VirtualDirectoriesComponent extends ConfigSaveComponent implements 
         private _siteService: SiteService,
         injector: Injector
     ) {
-        super('VirtualDirectoriesComponent', injector, ['SiteConfig'], 'site-tabs');
+        super('VirtualDirectoriesComponent', injector, ['SiteConfig'], SiteTabIds.applicationSettings);
 
         this._resetPermissionsAndLoadingState();
 

--- a/client/src/app/site/site-dashboard/site-dashboard.component.ts
+++ b/client/src/app/site/site-dashboard/site-dashboard.component.ts
@@ -89,11 +89,11 @@ export class SiteDashboardComponent extends NavigableComponent implements OnDest
             this.tabInfos = [this._getTabInfo(SiteTabIds.overview, true /* active */, null)];
 
             if (this._scenarioService.checkScenario(ScenarioIds.addSiteConfigTab).status === 'enabled') {
-                this.tabInfos.push(this._getTabInfo(SiteTabIds.config, false /* active */, null));
+                this.tabInfos.push(this._getTabInfo(SiteTabIds.standaloneConfig, false /* active */, null));
             }
 
             if (this._scenarioService.checkScenario(ScenarioIds.addSiteFeaturesTab).status === 'enabled') {
-                this.tabInfos.push(this._getTabInfo(SiteTabIds.features, false /* active */, null));
+                this.tabInfos.push(this._getTabInfo(SiteTabIds.platformFeatures, false /* active */, null));
             }
         }
 
@@ -282,7 +282,7 @@ export class SiteDashboardComponent extends NavigableComponent implements OnDest
                 info.closeable = false;
                 break;
 
-            case SiteTabIds.features:
+            case SiteTabIds.platformFeatures:
                 info.title = this._translateService.instant(PortalResources.tab_features);
                 info.componentFactory = SiteManageComponent;
                 info.closeable = false;
@@ -300,7 +300,7 @@ export class SiteDashboardComponent extends NavigableComponent implements OnDest
                 info.componentFactory = SwaggerDefinitionComponent;
                 break;
 
-            case SiteTabIds.config:
+            case SiteTabIds.standaloneConfig:
                 info.title = this._translateService.instant(PortalResources.tab_configuration);
                 info.componentFactory = SiteConfigStandaloneComponent;
                 info.closeable = false;

--- a/client/src/app/site/site-dashboard/site-tab/site-tab.component.ts
+++ b/client/src/app/site/site-dashboard/site-tab/site-tab.component.ts
@@ -6,14 +6,14 @@ import { Component, OnChanges, Input, Type, ViewChild, ComponentFactoryResolver,
     selector: 'site-tab',
     template: `
       <div *ngIf="initialized">
-        <busy-state name="site-tabs" cssClass="busy-site-tabs"></busy-state>
         <div [hidden]="!active"
           [id]="'site-tab-content-' + id"
           [attr.aria-label]="title"
           [attr.aria-label]="title"
           role="tabpanel">
 
-            <ng-template *ngIf="componentFactory" dynamic-loader></ng-template>
+          <busy-state [name]="id" cssClass="busy-site-tabs"></busy-state>
+          <ng-template *ngIf="componentFactory" dynamic-loader></ng-template>
         </div>
     </div>`
 })
@@ -54,6 +54,7 @@ export class SiteTabComponent implements OnChanges {
         // we're currently the active tab
         if (this.componentFactory
             && this.componentInput
+            && Object.keys(this.componentInput).length > 0
             && this.active) {
 
             this.initialized = true;

--- a/client/src/app/site/site-manage/site-manage.component.html
+++ b/client/src/app/site/site-manage/site-manage.component.html
@@ -1,3 +1,4 @@
+<busy-state name="site-manage" cssClass="busy-site-tabs"></busy-state>
 <div id="site-manage-container">
 <div id="site-manage-search-container">
     <input id="site-manage-search"

--- a/client/src/app/site/site-manage/site-manage.component.ts
+++ b/client/src/app/site/site-manage/site-manage.component.ts
@@ -55,9 +55,9 @@ export class SiteManageComponent extends FeatureComponent<TreeViewInfo<SiteData>
         private _scenarioService: ScenarioService,
         injector: Injector
     ) {
-        super('site-manage', injector, 'site-tabs');
+        super('site-manage', injector, SiteTabIds.platformFeatures);
 
-        this.featureName = 'site-manage';
+        this.featureName = this.componentName;
         this.isParentComponent = true;
     }
 

--- a/client/src/app/site/site-summary/site-summary.component.ts
+++ b/client/src/app/site/site-summary/site-summary.component.ts
@@ -1,6 +1,6 @@
 import { SiteService } from './../../shared/services/site.service';
 import { Injector } from '@angular/core';
-import { ScenarioIds, AvailabilityStates, KeyCodes, LogCategories } from './../../shared/models/constants';
+import { ScenarioIds, AvailabilityStates, KeyCodes, LogCategories, SiteTabIds } from './../../shared/models/constants';
 import { ScenarioService } from './../../shared/services/scenario/scenario.service';
 import { UserService } from './../../shared/services/user.service';
 import { Component, OnDestroy, Input } from '@angular/core';
@@ -78,9 +78,9 @@ export class SiteSummaryComponent extends FeatureComponent<TreeViewInfo<SiteData
         private _siteService: SiteService,
         injector: Injector) {
 
-        super('site-summary', injector, 'site-tabs');
+        super('site-summary', injector, SiteTabIds.overview);
 
-        this.featureName = 'site-summary';
+        this.featureName = this.componentName;
         this.isParentComponent = true;
 
         this.isStandalone = _configService.isStandalone();
@@ -184,6 +184,7 @@ export class SiteSummaryComponent extends FeatureComponent<TreeViewInfo<SiteData
     }
 
     ngOnDestroy() {
+        super.ngOnDestroy();
         this._cleanupBlob();
     }
 
@@ -278,15 +279,15 @@ export class SiteSummaryComponent extends FeatureComponent<TreeViewInfo<SiteData
                         true,
                         this.ts.instant(PortalResources.siteSummary_resetProfileNotifySuccess));
                 },
-                e => {
-                    this.clearBusy();
-                    this._portalService.stopNotification(
-                        notificationId,
-                        false,
-                        this.ts.instant(PortalResources.siteSummary_resetProfileNotifyFail));
+                    e => {
+                        this.clearBusy();
+                        this._portalService.stopNotification(
+                            notificationId,
+                            false,
+                            this.ts.instant(PortalResources.siteSummary_resetProfileNotifyFail));
 
-                    this._aiService.trackException(e, '/errors/site-summary/reset-profile');
-                });
+                        this._aiService.trackException(e, '/errors/site-summary/reset-profile');
+                    });
         }
     }
 
@@ -317,15 +318,15 @@ export class SiteSummaryComponent extends FeatureComponent<TreeViewInfo<SiteData
                         true,
                         this.ts.instant(PortalResources.siteSummary_restartNotifySuccess).format(site.name));
                 },
-                e => {
-                    this.clearBusy();
-                    this._portalService.stopNotification(
-                        notificationId,
-                        false,
-                        this.ts.instant(PortalResources.siteSummary_restartNotifyFail).format(site.name));
+                    e => {
+                        this.clearBusy();
+                        this._portalService.stopNotification(
+                            notificationId,
+                            false,
+                            this.ts.instant(PortalResources.siteSummary_restartNotifyFail).format(site.name));
 
-                    this._aiService.trackException(e, '/errors/site-summary/restart-app');
-                }, () => this.clearBusy());
+                        this._aiService.trackException(e, '/errors/site-summary/restart-app');
+                    }, () => this.clearBusy());
         }
     }
 
@@ -430,20 +431,20 @@ export class SiteSummaryComponent extends FeatureComponent<TreeViewInfo<SiteData
 
                 appNode.refresh();
             },
-            e => {
-                this.clearBusy();
-                const notifyFail = stop
-                    ? this.ts.instant(PortalResources.siteSummary_stopNotifyFail).format(site.name)
-                    : this.ts.instant(PortalResources.siteSummary_startNotifyFail).format(site.name);
+                e => {
+                    this.clearBusy();
+                    const notifyFail = stop
+                        ? this.ts.instant(PortalResources.siteSummary_stopNotifyFail).format(site.name)
+                        : this.ts.instant(PortalResources.siteSummary_startNotifyFail).format(site.name);
 
-                this._portalService.stopNotification(
-                    notificationId,
-                    false,
-                    notifyFail);
+                    this._portalService.stopNotification(
+                        notificationId,
+                        false,
+                        notifyFail);
 
-                this._aiService.trackException(e, '/errors/site-summary/stop-start');
-            },
-            () => this.clearBusy());
+                    this._aiService.trackException(e, '/errors/site-summary/stop-start');
+                },
+                () => this.clearBusy());
     }
 
     openSwapBlade() {

--- a/client/src/app/site/spec-picker/spec-picker-shell/spec-picker-shell.component.html
+++ b/client/src/app/site/spec-picker/spec-picker-shell/spec-picker-shell.component.html
@@ -1,2 +1,2 @@
-<busy-state name="site-tabs" cssClass="ibiza-feature"></busy-state>
+<busy-state name="scale-up" cssClass="ibiza-feature"></busy-state>
 <spec-picker *ngIf="viewInfo" [viewInfoInput]="viewInfo" isOpenedFromMenu="true"></spec-picker>

--- a/client/src/app/site/spec-picker/spec-picker.component.ts
+++ b/client/src/app/site/spec-picker/spec-picker.component.ts
@@ -11,6 +11,7 @@ import { PriceSpec } from './price-spec-manager/price-spec';
 import { PriceSpecGroup } from './price-spec-manager/price-spec-group';
 import { ResourceId } from '../../shared/models/arm/arm-obj';
 import { PortalResources } from '../../shared/models/portal-resources';
+import { SiteTabIds } from '../../shared/models/constants';
 
 interface StatusMessage {
   message: string;
@@ -63,7 +64,7 @@ export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPicke
     private _ts: TranslateService,
     private _portalService: PortalService,
     private _injector: Injector) {
-    super('SpecPickerComponent', _injector, 'site-tabs');
+    super('SpecPickerComponent', _injector, SiteTabIds.scaleUp);
 
     this.isParentComponent = true;
     this.featureName = 'SpecPickerComponent';

--- a/client/src/app/site/swagger-definition/swagger-definition.component.ts
+++ b/client/src/app/site/swagger-definition/swagger-definition.component.ts
@@ -1,5 +1,5 @@
 import { ScenarioService } from './../../shared/services/scenario/scenario.service';
-import { KeyCodes, Constants, ScenarioIds } from './../../shared/models/constants';
+import { KeyCodes, Constants, ScenarioIds, SiteTabIds } from './../../shared/models/constants';
 import { BusyStateScopeManager } from './../../busy-state/busy-state-scope-manager';
 import { Component, OnDestroy, ViewChild } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
@@ -63,7 +63,7 @@ export class SwaggerDefinitionComponent extends FunctionAppContextComponent impl
     ) {
         super('swagger-definition', _functionAppService, broadcastService, () => this._busyManager.setBusy());
 
-        this._busyManager = new BusyStateScopeManager(broadcastService, 'site-tabs');
+        this._busyManager = new BusyStateScopeManager(broadcastService, SiteTabIds.apiDefinition);
         this.swaggerStatusOptions = [
             {
                 displayLabel: this._translateService.instant(PortalResources.swaggerDefinition_internal),


### PR DESCRIPTION
Updating all site tabs so that each tab will get its own busy state.  This means that if one tab is loading, it's completely independent from the other tabs.  It's a little more work on the tab owner because they need to make sure they pass in a unique ID for their busy component, but it makes a pretty big difference from a usability perspective so it's worth it.

