### PR TITLE
[SpecPicker] Adding individual banner to each group.  Also several other bug fixes

### DIFF
--- a/client/src/app/busy-state/busy-state.component.scss
+++ b/client/src/app/busy-state/busy-state.component.scss
@@ -4,7 +4,7 @@
     height: 100%;
     width: 100%;
     position: absolute;
-    background-color: rgba(255, 255, 255, 0.40);
+    background-color: $translucent-shield-color;
     z-index: 15;
 }
 

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -961,6 +961,8 @@
     public static pricing_noWritePermissionsOnPlan: string = "pricing_noWritePermissionsOnPlan";
     public static pricing_noWritePermissionsOnPlanFormat: string = "pricing_noWritePermissionsOnPlanFormat";
     public static pricing_planReadonlyLockFormat: string = "pricing_planReadonlyLockFormat";
+    public static pricing_planUpdateTitle: string = "pricing_planUpdateTitle";
+    public static pricing_planUpdateDesc: string = "pricing_planUpdateDesc";
     public static pricing_planUpdateSuccessFormat: string = "pricing_planUpdateSuccessFormat";
     public static pricing_planUpdateFailFormat: string = "pricing_planUpdateFailFormat";
     public static pricing_includedFeatures: string = "pricing_includedFeatures";
@@ -972,6 +974,9 @@
     public static pricing_windowsContainers: string = "pricing_windowsContainers";
     public static pricing_emptyIsolatedGroup: string = "pricing_emptyIsolatedGroup";
     public static pricing_pv2NotAvailable: string = "pricing_pv2NotAvailable";
+    public static pricing_scaleUp: string = "pricing_scaleUp";
+    public static pricing_pricePerHour: string = "pricing_pricePerHour";
+    public static pricing_scaleUpDescription: string = "pricing_scaleUpDescription";
     public static proxyJsonInvalid: string = "proxyJsonInvalid";
     public static schemaJsonInvalid: string = "schemaJsonInvalid";
     public static vstsBuildServerTitle: string = "vstsBuildServerTitle";
@@ -984,6 +989,7 @@
     public static webAppFramework: string = "webAppFramework";
     public static selectFramework: string = "selectFramework";
     public static workingDirectory: string = "workingDirectory";
+    public static clearDirtyConfirmation: string = "clearDirtyConfirmation";
     public static taskRunner: string = "taskRunner";
     public static pythonFramework: string = "pythonFramework";
     public static pythonVersion: string = "pythonVersion";

--- a/client/src/app/site/site-manage/site-manage.component.ts
+++ b/client/src/app/site/site-manage/site-manage.component.ts
@@ -554,9 +554,9 @@ export class SiteManageComponent extends FeatureComponent<TreeViewInfo<SiteData>
 
             Url.getParameterByName(null, 'appsvc.feature.scale') === 'true' ?
                 new DisableableTabFeature(
-                    this._translateService.instant('Scale up'),
-                    this._translateService.instant('Scale up'),
-                    this._translateService.instant('Choose a different pricing tier to add more resources for your plan'),
+                    this._translateService.instant(PortalResources.pricing_scaleUp),
+                    this._translateService.instant(PortalResources.pricing_scaleUp),
+                    this._translateService.instant(PortalResources.pricing_scaleUpDescription),
                     'image/scale-up.svg',
                     SiteTabIds.scaleUp,
                     this._broadcastService,

--- a/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
@@ -1,4 +1,4 @@
-import { PriceSpec } from './price-spec';
+import { PriceSpec, PriceSpecInput } from './price-spec';
 import { FreePlanPriceSpec } from './free-plan-price-spec';
 import { SharedPlanPriceSpec } from './shared-plan-price-spec';
 import { BasicSmallPlanPriceSpec, BasicMediumPlanPriceSpec, BasicLargePlanPriceSpec, } from './basic-plan-price-spec';
@@ -18,6 +18,7 @@ export abstract class PriceSpecGroup {
     abstract emptyMessage: string;
     abstract emptyInfoLink: string;
 
+    bannerMessage: string;
     selectedSpec: PriceSpec = null;
     isExpanded = false;
 
@@ -26,6 +27,8 @@ export abstract class PriceSpecGroup {
     constructor(protected injector: Injector) {
         this.ts = injector.get(TranslateService);
     }
+
+    abstract initialize(input: PriceSpecInput);
 }
 
 export class DevSpecGroup extends PriceSpecGroup {
@@ -49,6 +52,15 @@ export class DevSpecGroup extends PriceSpecGroup {
         super(injector);
     }
 
+    initialize(input: PriceSpecInput) {
+        if (input.specPickerInput.data) {
+            if (input.specPickerInput.data.isLinux) {
+                this.bannerMessage = this.ts.instant(PortalResources.pricing_linuxTrial);
+            } else if (input.specPickerInput.data.isXenon) {
+                this.bannerMessage = this.ts.instant(PortalResources.pricing_windowsContainers);
+            }
+        }
+    }
 }
 
 export class ProdSpecGroup extends PriceSpecGroup {
@@ -74,6 +86,16 @@ export class ProdSpecGroup extends PriceSpecGroup {
     constructor(injector: Injector) {
         super(injector);
     }
+
+    initialize(input: PriceSpecInput) {
+        if (input.specPickerInput.data) {
+            if (input.specPickerInput.data.isLinux) {
+                this.bannerMessage = this.ts.instant(PortalResources.pricing_linuxTrial);
+            } else if (input.specPickerInput.data.isXenon) {
+                this.bannerMessage = this.ts.instant(PortalResources.pricing_windowsContainers);
+            }
+        }
+    }
 }
 
 export class IsolatedSpecGroup extends PriceSpecGroup {
@@ -93,5 +115,11 @@ export class IsolatedSpecGroup extends PriceSpecGroup {
 
     constructor(injector: Injector) {
         super(injector);
+    }
+
+    initialize(input: PriceSpecInput) {
+        if (input.specPickerInput.data && input.specPickerInput.data.isLinux) {
+            this.bannerMessage = this.ts.instant(PortalResources.pricing_linuxAseDiscount);
+        }
     }
 }

--- a/client/src/app/site/spec-picker/price-spec-manager/price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/price-spec.ts
@@ -89,7 +89,7 @@ export abstract class PriceSpec {
 
                     if (isDreamspark) {
                         this.state = 'disabled';
-                        this.disabledMessage = PortalResources.pricing_subscriptionNotAllowed;
+                        this.disabledMessage = this._ts.instant(PortalResources.pricing_subscriptionNotAllowed);
                         this.disabledInfoLink = `https://account.windowsazure.com/Subscriptions/Statement?subscriptionId=${subscriptionId}&isRdfeId=true&launchOption=upgrade`;
                     }
                 });

--- a/client/src/app/site/spec-picker/spec-list/spec-list.component.ts
+++ b/client/src/app/site/spec-picker/spec-list/spec-list.component.ts
@@ -11,7 +11,7 @@ import { PriceSpec } from '../price-spec-manager/price-spec';
 })
 export class SpecListComponent implements OnChanges {
   @Input() specGroup: PriceSpecGroup;
-  @Input() isRecommendedList: boolean;  // Specs that show up in top row
+  @Input() isExpanded: boolean = false;
   @Output() onSelectedSpec = new Subject<PriceSpec>();
 
   specs: PriceSpec[];
@@ -19,12 +19,10 @@ export class SpecListComponent implements OnChanges {
   constructor() { }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes['specGroup']) {
-      if (this.isRecommendedList) {
-        this.specs = this.specGroup.specs.slice(0, 4);
-      } else if (this.specGroup.specs.length > 4) {
-        this.specs = this.specGroup.specs.slice(4, this.specGroup.specs.length);
-      }
+    if (this.specGroup) {
+      this.specs = this.isExpanded
+        ? this.specGroup.specs
+        : this.specs = this.specGroup.specs.slice(0, 4);
     }
   }
 

--- a/client/src/app/site/spec-picker/spec-picker.component.html
+++ b/client/src/app/site/spec-picker/spec-picker.component.html
@@ -14,7 +14,7 @@
   </nav>
 
   <section>
-    <info-box *ngIf="infoMessage" [infoText]="infoMessage" typeClass="info"></info-box>
+    <info-box *ngIf="specManager.selectedSpecGroup.bannerMessage" [infoText]="specManager.selectedSpecGroup.bannerMessage" typeClass="info"></info-box>
   </section>
 
   <section *ngIf="specManager.selectedSpecGroup.specs.length === 0" class="empty-group">
@@ -28,13 +28,7 @@
   <section class="centered">
     <spec-list
       [specGroup]="specManager.selectedSpecGroup"
-      [isRecommendedList]="true"
-      (onSelectedSpec)="selectSpec($event)"></spec-list>
-
-    <spec-list
-      *ngIf="specManager.selectedSpecGroup.isExpanded"
-      [specGroup]="specManager.selectedSpecGroup"
-      [isRecommendedList]="false"
+      [isExpanded]="specManager.selectedSpecGroup.isExpanded"
       (onSelectedSpec)="selectSpec($event)"></spec-list>
 
     <div class="spec-expander" *ngIf=" specManager.selectedSpecGroup.specs.length > 4">

--- a/client/src/app/site/spec-picker/spec-picker.component.scss
+++ b/client/src/app/site/spec-picker/spec-picker.component.scss
@@ -9,7 +9,7 @@ $center-column-max-width: calc(#{$spec-card-max-width}*4 - 40px);
 
     #spec-picker-shield{
         position: fixed;
-        background-color: rgba(0, 0, 0, 0.25);
+        background-color: $translucent-shield-color;
         z-index: 10;
         bottom: 0px;
         top: 42px;
@@ -112,15 +112,16 @@ $center-column-max-width: calc(#{$spec-card-max-width}*4 - 40px);
 
         &.selected{
             outline-color: $border-selection-color;
-            outline-width: 2px;
+            outline-width: 3px;
             outline-style: solid;
-            outline-offset: 1px;
+            outline-offset: 2px;
         }
 
         .top-features{
             position: absolute;
-            left: 70px;
+            left: 65px;
             top: 50%;
+            padding-right: 10px;
             transform: translateY(-50%);
         }
 

--- a/client/src/sass/common/_variables.scss
+++ b/client/src/sass/common/_variables.scss
@@ -81,6 +81,7 @@ $alt1-color-faded: lighten($alt1-color, 35%);
 
 $background-color-opaque: #ccc;
 $background-color-disabled: rgba(127, 127, 127, 0.5);
+$translucent-shield-color: rgba(255, 255, 255, 0.40);
 
 $grey-color: #f5f5f5;
 $grey-color-dark: #3d3d3d;

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -3016,6 +3016,12 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
   <data name="pricing_planReadonlyLockFormat" xml:space="preserve">
     <value>The plan '{0}' has a read only lock on it and cannot be updated</value>
   </data>
+  <data name="pricing_planUpdateTitle" xml:space="preserve">
+    <value>Updating App Service Plan</value>
+  </data>
+  <data name="pricing_planUpdateDesc" xml:space="preserve">
+    <value>Updating the plan {0}</value>
+  </data>
   <data name="pricing_planUpdateSuccessFormat" xml:space="preserve">
     <value>The plan '{0}' was updated successfully!</value>
   </data>
@@ -3048,6 +3054,15 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
   </data>
   <data name="pricing_pv2NotAvailable" xml:space="preserve">
     <value>Premium V2 is not supported for this scale unit. Please consider redeploying or cloning your app.</value>
+  </data>
+  <data name="pricing_scaleUp" xml:space="preserve">
+    <value>Scale up</value>
+  </data>
+  <data name="pricing_pricePerHour" xml:space="preserve">
+    <value>{0} {1}/Hour (Estimated)</value>
+  </data>
+  <data name="pricing_scaleUpDescription" xml:space="preserve">
+    <value>Choose a different pricing tier to add more resources for your plan</value>
   </data>
   <data name="proxyJsonInvalid" xml:space="preserve">
     <value>The proxies.json is not valid. Error: '{0}'.</value>
@@ -3087,6 +3102,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
   </data>
   <data name="workingDirectory" xml:space="preserve">
     <value>Working Directory</value>
+  </data>
+  <data name="clearDirtyConfirmation" xml:space="preserve">
+    <value>There is an operation in progress.  Are you sure you would like leave?</value>
   </data>
   <data name="taskRunner" xml:space="preserve">
     <value>Task Runner</value>


### PR DESCRIPTION
1. Each group can have its own banner now.  This means that you can show a different discount message when you switch between Dev/Test and Isolated groups.
2. I now use Ibiza notifications for update status
3. I made sure to disable isolated sku's for dreamspark
4. Fixed flex box wrap issues when window gets too small
5. And a few other small issues.