### PR TITLE
Fixes #2480 - Add accessibility support to spec picker

### DIFF
--- a/client/src/app/controls/flex-list/flex-list.directive.ts
+++ b/client/src/app/controls/flex-list/flex-list.directive.ts
@@ -1,0 +1,268 @@
+import { Output } from '@angular/core';
+// import { FlexItemDirective } from './flex-item.directive';
+import { Directive, AfterViewInit, ElementRef, OnDestroy } from '@angular/core';
+import { KeyCodes } from 'app/shared/models/constants';
+import { Dom } from '../../shared/Utilities/dom';
+import { Subject } from 'rxjs/Subject';
+
+@Directive({
+    selector: '[flex-list]',
+})
+export class FlexListDirective implements AfterViewInit, OnDestroy {
+
+    @Output() onEnterKeyPressed = new Subject<HTMLElement>();
+
+    private _nativeElement: HTMLElement;
+
+    constructor(elementRef: ElementRef) {
+        this._nativeElement = elementRef.nativeElement;
+
+        this._nativeElement.addEventListener('keydown', this._onKeyDown.bind(this), true);
+        this._nativeElement.addEventListener('click', this._onClick.bind(this), true);
+
+    }
+
+    ngAfterViewInit() {
+        this._initFirstChildAsFocusable();
+    }
+
+    ngOnDestroy() {
+        this._nativeElement.removeEventListener('keydown', this._onKeyDown.bind(this), true);
+        this._nativeElement.removeEventListener('click', this._onClick.bind(this), true);
+    }
+
+    private _initFirstChildAsFocusable() {
+        if (this._nativeElement.children.length > 0) {
+            (<HTMLElement>this._nativeElement.children[0]).tabIndex = 0;
+        }
+    }
+
+    private _onClick(event: MouseEvent) {
+        const child = this._findFlexItemElement(event.srcElement);
+        if (child) {
+            // Reset all focusable elements
+            for (let i = 0; i < this._nativeElement.children.length; i++) {
+                (<HTMLElement>this._nativeElement.children[i]).tabIndex = -1;
+            }
+
+            (<HTMLElement>child).tabIndex = 0;
+        }
+    }
+
+    private _findFlexItemElement(element: Element) {
+        do {
+            if (element.parentElement === this._nativeElement) {
+                return element;
+            }
+
+            element = element.parentElement;
+        } while (element.parentElement !== document.documentElement);
+
+        return null;
+    }
+
+    private _onKeyDown(event: KeyboardEvent) {
+        if (event.keyCode !== KeyCodes.arrowDown
+            && event.keyCode !== KeyCodes.arrowUp
+            && event.keyCode !== KeyCodes.arrowLeft
+            && event.keyCode !== KeyCodes.arrowRight
+            && event.keyCode !== KeyCodes.enter) {
+
+            return;
+        }
+
+        const children = this._nativeElement.children;
+        let focusedIndex = this._getFocusedChildIndex();
+        if (focusedIndex < 0) {
+            this._initFirstChildAsFocusable();
+            return;
+        }
+
+        if (event.keyCode === KeyCodes.enter) {
+            this.onEnterKeyPressed.next(<HTMLElement>event.srcElement);
+
+        } else if (event.keyCode === KeyCodes.arrowDown) {
+            const nextIndex = this._findNextVerticleChildDown(children, focusedIndex);
+            this._clearFocusOnItem(children[focusedIndex]);
+            this._setFocusOnChild(children, nextIndex);
+            this._scrollIntoView(children[nextIndex]);
+        } else if (event.keyCode === KeyCodes.arrowUp) {
+            const nextIndex = this._findNextVerticleChildUp(children, focusedIndex);
+            this._clearFocusOnItem(children[focusedIndex]);
+            this._setFocusOnChild(children, nextIndex);
+            this._scrollIntoView(children[nextIndex]);
+        } else if (event.keyCode === KeyCodes.arrowLeft) {
+            this._clearFocusOnItem(children[focusedIndex]);
+            focusedIndex = this._setFocusOnChild(children, focusedIndex - 1);
+            this._scrollIntoView(children[focusedIndex]);
+        } else if (event.keyCode === KeyCodes.arrowRight) {
+            this._clearFocusOnItem(children[focusedIndex]);
+            focusedIndex = this._setFocusOnChild(children, focusedIndex + 1);
+            this._scrollIntoView(children[focusedIndex]);
+        }
+
+        event.preventDefault();
+    }
+
+    private _findNextVerticleChildDown(children: HTMLCollection, index: number) {
+        // Flexbox can have various arrangements of children that make for some edge cases in using the down arrow key
+
+        // This difficulty does not exist with less than 7 children because we are gaurenteed that the child to go
+        // down to is within a child's width (curChild.clientWidth) of the current child or that there is only one child below
+
+        //      [1]     |      [1] [2]     |    [1] [2] [3]    |   [1] [2] [3] [4]
+        //      [2]     |      [3] [4]     |      [4] [5]      |         [5]
+        //      [3]     |        [5]       |                   |
+        //      [4]     |                  |                   |
+        //      [5]     |                  |                   |
+
+        // ----------------------------------------------------------------------------------------------
+
+        //     [1] [2]  |    [1] [2] [3] [4] [5]    |  [1] [2] [3] [4]      |   [1] [2] [3] [4] [5] [6]
+        //     [3] [4]  |            [6]            |      [5] [6]          |
+        //     [5] [6]  |                           |                       |
+
+
+        // However with 7 children we reach the 'base case' of difficulty:
+        // We need logic that ensures children map to the closest below them when there are multiple options
+        // on the row below them and none of them are within the the child's width (curChild.clientWidth) of their position
+
+        //     [1] [2] [3] [4] [5]   |   [1] [2] [3] [4] [5] [6]   |   [1] [2] [3] [4] [5]    |   ETC....
+        //           [6] [7]         |           [7] [8]           |       [6] [7] [8]        |
+
+        let nextRowPosition = 0;
+        let foundNextRowPosition = false;
+        let closestchildIndex = index;
+        let closestchildDistance = 0;
+
+        const curChild = <HTMLElement>children[index];
+        const curChildPosition = Dom.getElementCoordinates(curChild);
+
+        for (let i = index + 1; i < children.length; i++) {
+            const nextchildPosition = Dom.getElementCoordinates(<HTMLElement>children[i]);
+            if (!foundNextRowPosition && nextchildPosition.top > curChildPosition.top) {
+                nextRowPosition = nextchildPosition.top;
+                foundNextRowPosition = true;
+                closestchildIndex = i;
+                closestchildDistance = Math.abs(curChildPosition.left - nextchildPosition.left);
+                if (closestchildDistance < curChild.clientWidth) {
+                    return closestchildIndex;
+                }
+                continue;
+            }
+            if (foundNextRowPosition) {
+                if (nextchildPosition.top === nextRowPosition && Math.abs(curChildPosition.left - nextchildPosition.left) < closestchildDistance) {
+                    closestchildDistance = Math.abs(curChildPosition.left - nextchildPosition.left);
+                    closestchildIndex = i;
+                    if (closestchildDistance < curChild.clientWidth) {
+                        return closestchildIndex;
+                    }
+                } else {
+                    return closestchildIndex;
+                }
+            }
+        }
+
+        // If you don't find the position of the next row it means the current child is on the bottom row
+        if (!foundNextRowPosition) {
+            for (let i = 0; i < index; i++) {
+                const nextchildPosition = Dom.getElementCoordinates(<HTMLElement>children[i]);
+                if (nextchildPosition.top <= curChildPosition.top && Math.abs(nextchildPosition.left - curChildPosition.left) < curChild.clientWidth) {
+                    closestchildIndex = i;
+                    return closestchildIndex;
+                }
+            }
+        }
+
+        return closestchildIndex;
+    }
+
+    private _findNextVerticleChildUp(children: HTMLCollection, index: number) {
+        // Up arrow is much easier for Flexbox
+        // The row above always has more than or equal to the number of boxes of the current row
+        // This means there is a child above the current child that will be within its width (curChild.clientWidth)
+
+        // However, since the up arrow should be able to wrap around, the top row will map to the bottom
+        // In this case the logic is the same as arrow down from the n-1th row to the nth row (where n = total # of rows)
+
+        let nextRowPosition = 0;
+        let foundNextRowPosition = false;
+        let closestchildIndex = index;
+        let closestchildDistance = 0;
+
+        const curChild = <HTMLElement>children[index];
+        const currentchildPosition = Dom.getElementCoordinates(curChild);
+
+        for (let i = index - 1; i >= 0; i--) {
+            const nextchildPosition = Dom.getElementCoordinates(<HTMLElement>children[i]);
+            if (nextchildPosition.top <= currentchildPosition.top && Math.abs(nextchildPosition.left - currentchildPosition.left) < curChild.clientWidth) {
+                closestchildIndex = i;
+                return closestchildIndex;
+            }
+        }
+
+        // If you don't find the position of the next row it means the current child is on the top row
+        for (let i = children.length - 1; i > index; i--) {
+            const nextchildPosition = Dom.getElementCoordinates(<HTMLElement>children[i]);
+            if (!foundNextRowPosition && nextchildPosition.top > currentchildPosition.top) {
+                nextRowPosition = nextchildPosition.top;
+                foundNextRowPosition = true;
+                closestchildIndex = i;
+                closestchildDistance = Math.abs(currentchildPosition.left - nextchildPosition.left);
+                if (closestchildDistance < curChild.clientWidth) {
+                    return closestchildIndex;
+                }
+                continue;
+            }
+            if (foundNextRowPosition) {
+                if (nextchildPosition.top === nextRowPosition && Math.abs(currentchildPosition.left - nextchildPosition.left) < closestchildDistance) {
+                    closestchildDistance = Math.abs(currentchildPosition.left - nextchildPosition.left);
+                    closestchildIndex = i;
+                    if (closestchildDistance < curChild.clientWidth) {
+                        return closestchildIndex;
+                    }
+                } else {
+                    return closestchildDistance;
+                }
+            }
+        }
+
+        return closestchildIndex;
+    }
+
+    private _getFocusedChildIndex() {
+        const children = this._nativeElement.children;
+        for (let i = 0; i < children.length; i++) {
+            if ((<HTMLElement>children[i]).tabIndex >= 0) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private _clearFocusOnItem(item: Element) {
+        Dom.clearFocus(<HTMLElement>item);
+    }
+
+    private _setFocusOnChild(children: HTMLCollection, targetIndex: number) {
+
+        if (children.length === 0) {
+            targetIndex = -1;
+        } else if (targetIndex < 0) {
+            targetIndex = children.length - 1;
+        } else if (targetIndex >= children.length) {
+            targetIndex = 0;
+        }
+
+        if (targetIndex > -1) {
+            Dom.setFocus(<HTMLElement>children[targetIndex]);
+        }
+
+        return targetIndex;
+    }
+
+    private _scrollIntoView(elem: Element) {
+        Dom.scrollIntoView(<HTMLElement>elem, window.document.body);
+    }
+}

--- a/client/src/app/controls/right-tabs/right-tabs.component.ts
+++ b/client/src/app/controls/right-tabs/right-tabs.component.ts
@@ -6,8 +6,7 @@ import { Component, OnInit, AfterContentInit, ContentChildren, QueryList } from 
 
 @Component({
   selector: 'right-tabs',
-  templateUrl: './right-tabs.component.html',
-  styleUrls: ['./right-tabs.component.scss']
+  templateUrl: './right-tabs.component.html'
 })
 export class RightTabsComponent implements OnInit, AfterContentInit {
 

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -3,6 +3,7 @@
     public static azureFunctions = 'azureFunctions';
     public static azureFunctionsRuntime = 'azureFunctionsRuntime';
     public static cancel = 'cancel';
+    public static apply = 'apply';
     public static configure = 'configure';
     public static upgrade = 'upgrade';
     public static upgradeToEnable = 'upgradeToEnable';
@@ -976,6 +977,7 @@
     public static pricing_scaleUp = 'pricing_scaleUp';
     public static pricing_pricePerHour = 'pricing_pricePerHour';
     public static pricing_scaleUpDescription = 'pricing_scaleUpDescription';
+    public static pricing_applyButtonLabel = 'pricing_applyButtonLabel';
     public static proxyJsonInvalid = 'proxyJsonInvalid';
     public static schemaJsonInvalid = 'schemaJsonInvalid';
     public static operationId = 'operationId';

--- a/client/src/app/shared/shared.module.ts
+++ b/client/src/app/shared/shared.module.ts
@@ -71,6 +71,7 @@ import { BillingService } from './services/billing.service';
 import { ApplicationInsightsService } from './services/application-insights.service';
 import { InvalidmessageDirective } from './directives/invalid-control-message.directive';
 import { NgUploaderModule } from 'ngx-uploader';
+import { FlexListDirective } from '../controls/flex-list/flex-list.directive';
 
 export function ArmServiceFactory(
     http: Http,
@@ -129,7 +130,8 @@ export function AiServiceFactory() {
         TabComponent,
         ActivateWithKeysDirective,
         CardInfoControlComponent,
-        InvalidmessageDirective
+        InvalidmessageDirective,
+        FlexListDirective
     ],
     exports: [
         CommonModule,
@@ -170,7 +172,8 @@ export function AiServiceFactory() {
         ActivateWithKeysDirective,
         CardInfoControlComponent,
         InvalidmessageDirective,
-        NgUploaderModule
+        NgUploaderModule,
+        FlexListDirective
     ],
     imports: [
         FormsModule,

--- a/client/src/app/site/site-dashboard/site-tab/site-tab.component.ts
+++ b/client/src/app/site/site-dashboard/site-tab/site-tab.component.ts
@@ -9,7 +9,6 @@ import { Component, OnChanges, Input, Type, ViewChild, ComponentFactoryResolver,
         <div [hidden]="!active"
           [id]="'site-tab-content-' + id"
           [attr.aria-label]="title"
-          [attr.aria-label]="title"
           role="tabpanel">
 
           <busy-state [name]="id" cssClass="busy-site-tabs"></busy-state>
@@ -19,7 +18,6 @@ import { Component, OnChanges, Input, Type, ViewChild, ComponentFactoryResolver,
 })
 export class SiteTabComponent implements OnChanges {
     @ViewChild(BusyStateComponent) busyState: BusyStateComponent;
-
 
     // initialized is important because it ensures that we don't load any content or child components until the
     // tab gets inputs for the first time.  Once initialized, it ensures that we also don't reinitialize

--- a/client/src/app/site/spec-picker/price-spec-manager/premiumv2-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premiumv2-plan-price-spec.ts
@@ -2,7 +2,6 @@ import { PortalResources } from 'app/shared/models/portal-resources';
 import { PlanService } from './../../../shared/services/plan.service';
 import { PriceSpec, PriceSpecInput } from './price-spec';
 import { Observable } from 'rxjs/Observable';
-import { Kinds } from '../../../shared/models/constants';
 import { Injector } from '@angular/core';
 import { ResourceId } from '../../../shared/models/arm/arm-obj';
 
@@ -79,9 +78,7 @@ export abstract class PremiumV2PlanPriceSpec extends PriceSpec {
                     });
             }
         } else if (input.plan) {
-            if (input.plan.kind && input.plan.kind.toLowerCase().indexOf(Kinds.linux) > -1) {
-                this.state = 'hidden';
-            } else if (input.plan.properties.hostingEnvironmentProfile) {
+            if (input.plan.properties.hostingEnvironmentProfile) {
                 this.state = 'hidden';
             } else {
 

--- a/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
@@ -14,6 +14,7 @@ export abstract class PriceSpecGroup {
     abstract iconUrl: string;
     abstract specs: PriceSpec[];
     abstract title: string;
+    abstract id: string;            // Unique HTML element id
     abstract description: string;
     abstract emptyMessage: string;
     abstract emptyInfoLink: string;
@@ -44,6 +45,7 @@ export class DevSpecGroup extends PriceSpecGroup {
     selectedSpec = null;
     iconUrl = 'image/tools.svg';
     title = this.ts.instant(PortalResources.pricing_devTestTitle);
+    id = 'devtest';
     description = this.ts.instant(PortalResources.pricing_devTestDesc);
     emptyMessage = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
     emptyInfoLink = 'https://microsoft.com';
@@ -79,6 +81,7 @@ export class ProdSpecGroup extends PriceSpecGroup {
     selectedSpec = null;
     iconUrl = 'image/app-service-plan.svg';
     title = this.ts.instant(PortalResources.pricing_productionTitle);
+    id = 'prod';
     description = this.ts.instant(PortalResources.pricing_productionDesc);
     emptyMessage = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
     emptyInfoLink = 'https://microsoft.com';
@@ -108,8 +111,8 @@ export class IsolatedSpecGroup extends PriceSpecGroup {
     selectedSpec = null;
     iconUrl = 'image/app-service-environment.svg';
     title = this.ts.instant(PortalResources.pricing_isolatedTitle);
+    id = 'isolated';
     description = this.ts.instant(PortalResources.pricing_isolatedDesc);
-
     emptyMessage = this.ts.instant(PortalResources.pricing_emptyIsolatedGroup);
     emptyInfoLink = 'https://microsoft.com';
 

--- a/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
@@ -14,7 +14,7 @@ export abstract class PriceSpecGroup {
     abstract iconUrl: string;
     abstract specs: PriceSpec[];
     abstract title: string;
-    abstract id: string;            // Unique HTML element id
+    abstract id: string;
     abstract description: string;
     abstract emptyMessage: string;
     abstract emptyInfoLink: string;

--- a/client/src/app/site/spec-picker/spec-list/spec-list.component.html
+++ b/client/src/app/site/spec-picker/spec-list/spec-list.component.html
@@ -10,11 +10,10 @@
     [id]="specGroup.id + spec.skuCode">
 
     <h2>{{spec.skuCode}}</h2>
-    <div class="invisible"></div>
     <div class="top-features" [attr.aria-label]="'pricing_availableFeatures' | translate">
       <div *ngIf="spec.state === 'enabled'">
         <div *ngFor="let topFeature of spec.topLevelFeatures">{{topFeature}}</div>
-        <div *ngIf="spec.priceString" >{{spec.priceString}}</div>
+        <div *ngIf="spec.priceString">{{spec.priceString}}</div>
         <div *ngIf="!spec.priceString">{{'loading' | translate}}</div>
       </div>
 

--- a/client/src/app/site/spec-picker/spec-list/spec-list.component.html
+++ b/client/src/app/site/spec-picker/spec-list/spec-list.component.html
@@ -1,15 +1,20 @@
-<article class="spec-container">
+<article class="spec-container"
+  flex-list
+  (onEnterKeyPressed)="selectSpecByEnterKey($event)">
+
   <div *ngFor="let spec of specs"
-  [class]="spec.cssClass"
-  (click)="selectSpec(spec)"
-  [class.selected]="spec === specGroup.selectedSpec"
-  [class.disabled]="spec.state === 'disabled'">
+    [class]="spec.cssClass"
+    (click)="selectSpec(spec)"
+    [class.selected]="spec === specGroup.selectedSpec"
+    [class.disabled]="spec.state === 'disabled'"
+    [id]="specGroup.id + spec.skuCode">
 
     <h2>{{spec.skuCode}}</h2>
-    <div class="top-features">
+    <div class="invisible"></div>
+    <div class="top-features" [attr.aria-label]="'pricing_availableFeatures' | translate">
       <div *ngIf="spec.state === 'enabled'">
         <div *ngFor="let topFeature of spec.topLevelFeatures">{{topFeature}}</div>
-        <div *ngIf="spec.priceString">{{spec.priceString}}</div>
+        <div *ngIf="spec.priceString" >{{spec.priceString}}</div>
         <div *ngIf="!spec.priceString">{{'loading' | translate}}</div>
       </div>
 

--- a/client/src/app/site/spec-picker/spec-list/spec-list.component.ts
+++ b/client/src/app/site/spec-picker/spec-list/spec-list.component.ts
@@ -11,7 +11,7 @@ import { PriceSpec } from '../price-spec-manager/price-spec';
 })
 export class SpecListComponent implements OnChanges {
   @Input() specGroup: PriceSpecGroup;
-  @Input() isExpanded: boolean = false;
+  @Input() isExpanded = false;
   @Output() onSelectedSpec = new Subject<PriceSpec>();
 
   specs: PriceSpec[];
@@ -28,5 +28,12 @@ export class SpecListComponent implements OnChanges {
 
   selectSpec(spec: PriceSpec) {
     this.onSelectedSpec.next(spec);
+  }
+
+  selectSpecByEnterKey(element: HTMLElement) {
+    const spec = this.specs.find(s => element.id.endsWith(s.skuCode));
+    if (spec) {
+      this.selectSpec(spec);
+    }
   }
 }

--- a/client/src/app/site/spec-picker/spec-picker.component.html
+++ b/client/src/app/site/spec-picker/spec-picker.component.html
@@ -1,11 +1,18 @@
 <div id="spec-picker-container" *ngIf="specManager && specManager.selectedSpecGroup">
   <div id="spec-picker-shield" *ngIf="isUpdating || shieldEnabled" [class.spec-picker-shield-menu]="isOpenedFromMenu"></div>
 
-  <nav>
+  <nav id="spec-group-tabs" role="tablist" #specGroupTabs>
     <div *ngFor="let specGroup of specManager.specGroups"
       (click)="selectGroup(specGroup)"
       class="clickable spec-group"
-      [class.selected-spec-group]="specGroup === specManager.selectedSpecGroup">
+      [class.selected-spec-group]="specGroup === specManager.selectedSpecGroup"
+      [tabindex]="specGroup === specManager.selectedSpecGroup ? 0 : -1"
+      (keydown)="onGroupTabKeyPress($event)"
+      role="tab"
+      [id]="'spec-group-tab-' + specGroup.id"
+      [attr.aria-controls]="'spec-group-tab-' + specGroup.id"
+      [attr.aria-selected]="specGroup === specManager.selectedSpecGroup"
+      [attr.aria-label]="specGroup.title">
 
       <div [load-image]="specGroup.iconUrl" class="icon-medium"></div>
       <h3>{{specGroup.title}}</h3>
@@ -13,57 +20,65 @@
     </div>
   </nav>
 
-  <section>
-    <info-box *ngIf="specManager.selectedSpecGroup.bannerMessage" [infoText]="specManager.selectedSpecGroup.bannerMessage" typeClass="info"></info-box>
-  </section>
+  <section role="tabpanel"
+    [id]="'spec-group-tab-' + specManager.selectedSpecGroup.id"
+    [attr.aria-label]="specManager.selectedSpecGroup.title">
 
-  <section *ngIf="specManager.selectedSpecGroup.specs.length === 0" class="empty-group">
-    <div [load-image]="specManager.selectedSpecGroup.iconUrl" class="icon-large"></div>
-    <article>
-      {{specManager.selectedSpecGroup.emptyMessage}}
-      <a [href]="specManager.selectedSpecGroup.emptyInfoLink">{{'clickToLearnMore' | translate}}</a>
-    </article>
-  </section>
+    <section>
+      <info-box *ngIf="specManager.selectedSpecGroup.bannerMessage" [infoText]="specManager.selectedSpecGroup.bannerMessage" typeClass="info"></info-box>
+    </section>
 
-  <section class="centered">
-    <spec-list
-      [specGroup]="specManager.selectedSpecGroup"
-      [isExpanded]="specManager.selectedSpecGroup.isExpanded"
-      (onSelectedSpec)="selectSpec($event)"></spec-list>
+    <section *ngIf="specManager.selectedSpecGroup.specs.length === 0" class="empty-group">
+      <div [load-image]="specManager.selectedSpecGroup.iconUrl" class="icon-large"></div>
+      <article>
+        {{specManager.selectedSpecGroup.emptyMessage}}
+        <a [href]="specManager.selectedSpecGroup.emptyInfoLink">{{'clickToLearnMore' | translate}}</a>
+      </article>
+    </section>
 
-    <div class="spec-expander" *ngIf=" specManager.selectedSpecGroup.specs.length > 4">
-      <span *ngIf="!specManager.selectedSpecGroup.isExpanded" (click)="specManager.selectedSpecGroup.isExpanded = true">
-        <span  load-image="image/caret-down.svg" class="expand-icon"></span>
-        <a tabindex="0">{{'seeMoreOptions' | translate}}</a>
-      </span>
-      <span *ngIf="specManager.selectedSpecGroup.isExpanded" (click)="specManager.selectedSpecGroup.isExpanded = false">
-        <span load-image="image/caret-up.svg" class="expand-icon"></span>
-        <a tabindex="0">{{'seeLessOptions' | translate}}</a>
-      </span>
-    </div>
-  </section>
+    <section class="centered">
+      <spec-list
+        [specGroup]="specManager.selectedSpecGroup"
+        [isExpanded]="specManager.selectedSpecGroup.isExpanded"
+        (onSelectedSpec)="selectSpec($event)"></spec-list>
 
-  <section *ngIf="specManager.selectedSpecGroup.selectedSpec" class="feature-lists-container centered">
-    <article class="feature-list" *ngIf="specManager.selectedSpecGroup.selectedSpec.featureItems">
-        <spec-feature-list
-          [title]="'pricing_includedFeatures' | translate"
-          [description]="'pricing_includedFeaturesDesc' | translate"
-          [featureItems]="specManager.selectedSpecGroup.selectedSpec.featureItems"></spec-feature-list>
-    </article>
+      <div class="spec-expander" *ngIf=" specManager.selectedSpecGroup.specs.length > 4">
+        <span
+          (click)="specManager.selectedSpecGroup.isExpanded = !specManager.selectedSpecGroup.isExpanded"
+          (keydown)="onExpandKeyPress($event)">
 
-    <article class="feature-list" *ngIf="specManager.selectedSpecGroup.selectedSpec.hardwareItems">
-        <spec-feature-list
-          [title]="'pricing_includedHardware' | translate"
-          [description]="'pricing_includedHardwareDesc' | translate"
-          [featureItems]="specManager.selectedSpecGroup.selectedSpec.hardwareItems"></spec-feature-list>
-    </article>
+          <span [load-image]="!specManager.selectedSpecGroup.isExpanded ? 'image/caret-down.svg' : 'image/caret-up.svg'" class="expand-icon"></span>
+          <a tabindex="0">{{ (!specManager.selectedSpecGroup.isExpanded ? 'seeMoreOptions' : 'seeLessOptions') | translate}}</a>
+        </span>
+      </div>
+    </section>
 
-  </section>
+    <section *ngIf="specManager.selectedSpecGroup.selectedSpec" class="feature-lists-container centered">
+      <article class="feature-list" *ngIf="specManager.selectedSpecGroup.selectedSpec.featureItems">
+          <spec-feature-list
+            [title]="'pricing_includedFeatures' | translate"
+            [description]="'pricing_includedFeaturesDesc' | translate"
+            [featureItems]="specManager.selectedSpecGroup.selectedSpec.featureItems"></spec-feature-list>
+      </article>
+
+      <article class="feature-list" *ngIf="specManager.selectedSpecGroup.selectedSpec.hardwareItems">
+          <spec-feature-list
+            [title]="'pricing_includedHardware' | translate"
+            [description]="'pricing_includedHardwareDesc' | translate"
+            [featureItems]="specManager.selectedSpecGroup.selectedSpec.hardwareItems"></spec-feature-list>
+      </article>
+
+    </section>
+  </section>  <!-- End tabpanel -->
 
   <footer>
     <div id="spec-picker-footer">
-      <button class="custom-button" [disabled]="!applyButtonEnabled" (click)="clickApply()">
-        <span *ngIf="!isUpdating">Apply</span>
+      <button class="custom-button"
+        [disabled]="!applyButtonEnabled"
+        (click)="clickApply()"
+        [attr.aria-label]="'pricing_applyButtonLabel' | translate">
+
+        <span *ngIf="!isUpdating">{{'apply' | translate}}</span>
         <span *ngIf="isUpdating" load-image="image/loader.svg" class="icon-medium fa-spin"></span>
       </button>
         <span class="message-icon icon-medium"

--- a/client/src/app/site/spec-picker/spec-picker.component.ts
+++ b/client/src/app/site/spec-picker/spec-picker.component.ts
@@ -201,34 +201,21 @@ export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPicke
 
   onGroupTabKeyPress(event: KeyboardEvent) {
     const groups = this.specManager.specGroups;
-    let curIndex = groups.findIndex(g => g === this.specManager.selectedSpecGroup);
 
-    if (event.keyCode === KeyCodes.arrowRight) {
-      const tabElements = this._getTabElements()
+    if (event.keyCode === KeyCodes.arrowRight || event.keyCode === KeyCodes.arrowLeft) {
+      let curIndex = groups.findIndex(g => g === this.specManager.selectedSpecGroup);
+      const tabElements = this._getTabElements();
       this._updateFocusOnGroupTab(false, tabElements, curIndex);
 
-      if (curIndex === groups.length - 1) {
-        curIndex = 0;
+      if (event.keyCode === KeyCodes.arrowRight) {
+        curIndex = this._getTargetIndex(groups, curIndex + 1);
       } else {
-        curIndex++;
+        curIndex = this._getTargetIndex(groups, curIndex - 1);
       }
 
       this.selectGroup(groups[curIndex]);
       this._updateFocusOnGroupTab(true, tabElements, curIndex);
 
-      event.preventDefault();
-    } else if (event.keyCode === KeyCodes.arrowLeft) {
-      const tabElements = this._getTabElements()
-      this._updateFocusOnGroupTab(false, tabElements, curIndex);
-
-      if (curIndex === 0) {
-        curIndex = groups.length - 1;
-      } else {
-        curIndex--;
-      }
-
-      this.selectGroup(groups[curIndex]);
-      this._updateFocusOnGroupTab(true, tabElements, curIndex);
       event.preventDefault();
     }
   }
@@ -240,11 +227,21 @@ export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPicke
     }
   }
 
-  _getTabElements() {
+  private _getTargetIndex(groups: PriceSpecGroup[], targetIndex: number) {
+    if (targetIndex < 0) {
+      targetIndex = groups.length - 1;
+    } else if (targetIndex >= groups.length) {
+      targetIndex = 0;
+    }
+
+    return targetIndex;
+  }
+
+  private _getTabElements() {
     return this.groupElements.nativeElement.children;
   }
 
-  _updateFocusOnGroupTab(set: boolean, elements: HTMLCollection, index: number) {
+  private _updateFocusOnGroupTab(set: boolean, elements: HTMLCollection, index: number) {
     const tab = Dom.getTabbableControl(<HTMLElement>elements[index]);
 
     if (set) {
@@ -253,6 +250,4 @@ export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPicke
       Dom.clearFocus(tab);
     }
   }
-
-
 }

--- a/client/src/sass/base/_base.scss
+++ b/client/src/sass/base/_base.scss
@@ -62,6 +62,10 @@ pre {
     display: none;
 }
 
+.invisible{
+    visibility: hidden;
+}
+
 #app-root[theme=dark]{
     pre{
         background-color: lighten($body-bg-color-dark, 5%);

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -117,6 +117,9 @@
   <data name="cancel" xml:space="preserve">
     <value>Cancel</value>
   </data>
+  <data name="apply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
   <data name="configure" xml:space="preserve">
     <value>Configure</value>
   </data>
@@ -3054,6 +3057,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
   </data>
   <data name="pricing_scaleUpDescription" xml:space="preserve">
     <value>Choose a different pricing tier to add more resources for your plan</value>
+  </data>
+  <data name="pricing_applyButtonLabel" xml:space="preserve">
+    <value>Update App Service plan</value>
   </data>
   <data name="proxyJsonInvalid" xml:space="preserve">
     <value>The proxies.json is not valid. Error: '{0}'.</value>


### PR DESCRIPTION
1. Added keyboard/screenreader support to spec group tabs
2. Added new flex-list directive to handle keyboard navigation for the items in a flex box.  This is used for navigating the list of specs.

![image](https://user-images.githubusercontent.com/5695405/38902005-5e96f234-4253-11e8-8bf9-9f4c5b85f9d3.png)

