### PR TITLE
Fix issue where UI doesn't handle scaling an isolated SKU.  Plus other bug fixes

### DIFF
--- a/client/src/app/shared/models/constants.ts
+++ b/client/src/app/shared/models/constants.ts
@@ -266,6 +266,7 @@ export class LogCategories {
     public static readonly addSlot = 'AddSlot';
     public static readonly applicationInsightsQuery = 'ApplicationInsightsQuery';
     public static readonly applicationInsightsConfigure = 'ApplicationInsightsConfigure';
+    public static readonly serverFarm = 'ServerFarm';
 }
 
 export class SubscriptionQuotaIds {

--- a/client/src/app/shared/models/constants.ts
+++ b/client/src/app/shared/models/constants.ts
@@ -112,6 +112,7 @@ export class Links {
     public static pythonLearnMore = 'https://go.microsoft.com/fwlink/?linkid=852196';
     public static clientAffinityLearnMore = 'https://go.microsoft.com/fwlink/?linkid=798249';
     public static FTPAccessLearnMore = 'https://go.microsoft.com/fwlink/?linkid=871316';
+    public static vmSizeLearnMore = 'https://docs.microsoft.com/azure/virtual-machines/windows/sizes-general';
 }
 
 export class Kinds {

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -955,6 +955,7 @@
     public static diagnostics_file = 'diagnostics_file';
     public static diagnostics_line = 'diagnostics_line';
     public static pricing_recommendedTiers = 'pricing_recommendedTiers';
+    public static pricing_additionalTiers = 'pricing_additionalTiers';
     public static pricing_subscriptionNotAllowed = 'pricing_subscriptionNotAllowed';
     public static pricing_devTestTitle = 'pricing_devTestTitle';
     public static pricing_devTestDesc = 'pricing_devTestDesc';
@@ -969,6 +970,8 @@
     public static pricing_planUpdateTitle = 'pricing_planUpdateTitle';
     public static pricing_planUpdateDesc = 'pricing_planUpdateDesc';
     public static pricing_planUpdateSuccessFormat = 'pricing_planUpdateSuccessFormat';
+    public static pricing_planUpdateJobSuccessFormat = 'pricing_planUpdateJobSuccessFormat';
+    public static pricing_planScaleInProgress = 'pricing_planScaleInProgress';
     public static pricing_planUpdateFailFormat = 'pricing_planUpdateFailFormat';
     public static pricing_includedFeatures = 'pricing_includedFeatures';
     public static pricing_includedFeaturesDesc = 'pricing_includedFeaturesDesc';

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -990,7 +990,8 @@
     public static pricing_applyButtonLabel = 'pricing_applyButtonLabel';
     public static pricing_sharedInfrastructure = 'pricing_sharedInfrastructure';
     public static pricing_sharedCpu = 'pricing_sharedCpu';
-    public static pricing_dedicatedCpu = 'pricing_dedicatedCpu';
+    public static pricing_aSeriesDedicatedCpu = 'pricing_aSeriesDedicatedCpu';
+    public static pricing_dv2SeriesDedicatedCpu = 'pricing_dv2SeriesDedicatedCpu';
     public static pricing_sharedMemory = 'pricing_sharedMemory';
     public static pricing_dedicatedMemory = 'pricing_dedicatedMemory';
     public static pricing_sharedDisk = 'pricing_sharedDisk';
@@ -1016,6 +1017,8 @@
     public static pricing_memory = 'pricing_memory';
     public static pricing_computeLimit = 'pricing_computeLimit';
     public static pricing_numCores = 'pricing_numCores';
+    public static pricing_aSeriesCompute = 'pricing_aSeriesCompute';
+    public static pricing_dSeriesCompute = 'pricing_dSeriesCompute';
     public static proxyJsonInvalid = 'proxyJsonInvalid';
     public static schemaJsonInvalid = 'schemaJsonInvalid';
     public static operationId = 'operationId';

--- a/client/src/app/shared/models/server-farm.ts
+++ b/client/src/app/shared/models/server-farm.ts
@@ -6,4 +6,5 @@ export interface ServerFarm {
     resoruceGroupName: string;
     geoRegion: string;
     hostingEnvironmentProfile?: HostingEnvironmentProfile;
+    provisioningState: 'InProgress' | 'Succeeded' | 'Failed';
 }

--- a/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
@@ -17,7 +17,8 @@ export abstract class BasicPlanPriceSpec extends PriceSpec {
     hardwareItems = [{
         iconUrl: 'image/app-service-plan.svg',
         title: this._ts.instant(PortalResources.cpu),
-        description: this._ts.instant(PortalResources.pricing_dedicatedCpu)
+        description: this._ts.instant(PortalResources.pricing_dedicatedCpu),
+        learnMoreUrl: 'https://docs.microsoft.com/en-us/azure/virtual-machines/windows/acu'
     },
     {
         iconUrl: 'image/website-power.svg',

--- a/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
@@ -1,3 +1,4 @@
+import { Links } from './../../../shared/models/constants';
 import { PortalResources } from 'app/shared/models/portal-resources';
 import { PriceSpec, PriceSpecInput } from './price-spec';
 
@@ -17,8 +18,8 @@ export abstract class BasicPlanPriceSpec extends PriceSpec {
     hardwareItems = [{
         iconUrl: 'image/app-service-plan.svg',
         title: this._ts.instant(PortalResources.cpu),
-        description: this._ts.instant(PortalResources.pricing_dedicatedCpu),
-        learnMoreUrl: 'https://docs.microsoft.com/en-us/azure/virtual-machines/windows/acu'
+        description: this._ts.instant(PortalResources.pricing_aSeriesDedicatedCpu),
+        learnMoreUrl: Links.vmSizeLearnMore
     },
     {
         iconUrl: 'image/website-power.svg',
@@ -56,7 +57,7 @@ export class BasicSmallPlanPriceSpec extends BasicPlanPriceSpec {
     topLevelFeatures = [
         this._ts.instant(PortalResources.pricing_numCores).format('1x'),
         this._ts.instant(PortalResources.pricing_memory).format('1.75'),
-        '100 ACU'
+        this._ts.instant(PortalResources.pricing_aSeriesCompute)
     ];
 
     meterFriendlyName = 'Basic Small App Service Hours';
@@ -76,7 +77,7 @@ export class BasicMediumPlanPriceSpec extends BasicPlanPriceSpec {
     topLevelFeatures = [
         this._ts.instant(PortalResources.pricing_numCores).format('2x'),
         this._ts.instant(PortalResources.pricing_memory).format('3.5'),
-        '200 ACU'
+        this._ts.instant(PortalResources.pricing_aSeriesCompute)
     ];
 
     meterFriendlyName = 'Basic Medium App Service Hours';
@@ -96,7 +97,7 @@ export class BasicLargePlanPriceSpec extends BasicPlanPriceSpec {
     topLevelFeatures = [
         this._ts.instant(PortalResources.pricing_numCores).format('4x'),
         this._ts.instant(PortalResources.pricing_memory).format('7'),
-        '400 ACU'
+        this._ts.instant(PortalResources.pricing_aSeriesCompute)
     ];
 
     meterFriendlyName = 'Basic Large App Service Hours';

--- a/client/src/app/site/spec-picker/price-spec-manager/isolated-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/isolated-plan-price-spec.ts
@@ -31,7 +31,8 @@ export abstract class IsolatedPlanPriceSpec extends PriceSpec {
     hardwareItems = [{
         iconUrl: 'image/app-service-plan.svg',
         title: this._ts.instant(PortalResources.cpu),
-        description: this._ts.instant(PortalResources.pricing_dedicatedCpu)
+        description: this._ts.instant(PortalResources.pricing_dedicatedCpu),
+        learnMoreUrl: 'https://docs.microsoft.com/en-us/azure/virtual-machines/windows/acu'
     },
     {
         iconUrl: 'image/website-power.svg',
@@ -62,9 +63,7 @@ export abstract class IsolatedPlanPriceSpec extends PriceSpec {
             this.state = 'hidden';
         } else if (input.plan) {
 
-            if (input.plan.kind && input.plan.kind.toLowerCase().indexOf(Kinds.linux) > -1) {
-                this.state = 'hidden';
-            } else if (!input.plan.properties.hostingEnvironmentProfile) {
+            if (!input.plan.properties.hostingEnvironmentProfile) {
                 this.state = 'hidden';
             } else {
                 return this._aseService.getAse(input.plan.properties.hostingEnvironmentProfile.id)

--- a/client/src/app/site/spec-picker/price-spec-manager/isolated-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/isolated-plan-price-spec.ts
@@ -1,3 +1,4 @@
+import { Links } from 'app/shared/models/constants';
 import { Kinds } from './../../../shared/models/constants';
 import { NationalCloudEnvironment } from './../../../shared/services/scenario/national-cloud.environment';
 import { PriceSpec, PriceSpecInput } from './price-spec';
@@ -31,8 +32,8 @@ export abstract class IsolatedPlanPriceSpec extends PriceSpec {
     hardwareItems = [{
         iconUrl: 'image/app-service-plan.svg',
         title: this._ts.instant(PortalResources.cpu),
-        description: this._ts.instant(PortalResources.pricing_dedicatedCpu),
-        learnMoreUrl: 'https://docs.microsoft.com/en-us/azure/virtual-machines/windows/acu'
+        description: this._ts.instant(PortalResources.pricing_dv2SeriesDedicatedCpu),
+        learnMoreUrl: Links.vmSizeLearnMore
     },
     {
         iconUrl: 'image/website-power.svg',

--- a/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
@@ -209,7 +209,7 @@ export class PlanPriceSpecManager {
                     || !p.isSuccessful;
             })
             .do(p => {
-                this._specPicker.disableUpdates = false;
+                this._specPicker.disableUpdates = true;
 
                 this.specGroups.forEach((g, i) => {
                     g.bannerMessage = curBannerMessages[i];

--- a/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
@@ -29,7 +29,8 @@ export abstract class PremiumPlanPriceSpec extends PriceSpec {
     hardwareItems = [{
         iconUrl: 'image/app-service-plan.svg',
         title: this._ts.instant(PortalResources.cpu),
-        description: this._ts.instant(PortalResources.pricing_dedicatedCpu)
+        description: this._ts.instant(PortalResources.pricing_dedicatedCpu),
+        learnMoreUrl: 'https://docs.microsoft.com/en-us/azure/virtual-machines/windows/acu'
     },
     {
         iconUrl: 'image/website-power.svg',
@@ -109,7 +110,7 @@ export class PremiumMediumPlanPriceSpec extends PremiumPlanPriceSpec {
 }
 
 export class PremiumLargePlanPriceSpec extends PremiumPlanPriceSpec {
-    skuCode = 'P2';
+    skuCode = 'P3';
     legacySkuName = 'large_premium';
     topLevelFeatures = [
         this._ts.instant(PortalResources.pricing_numCores).format('4x'),

--- a/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
@@ -1,3 +1,4 @@
+import { Links } from 'app/shared/models/constants';
 import { PriceSpec, PriceSpecInput } from './price-spec';
 import { Kinds } from '../../../shared/models/constants';
 import { Injector } from '@angular/core';
@@ -29,8 +30,8 @@ export abstract class PremiumPlanPriceSpec extends PriceSpec {
     hardwareItems = [{
         iconUrl: 'image/app-service-plan.svg',
         title: this._ts.instant(PortalResources.cpu),
-        description: this._ts.instant(PortalResources.pricing_dedicatedCpu),
-        learnMoreUrl: 'https://docs.microsoft.com/en-us/azure/virtual-machines/windows/acu'
+        description: this._ts.instant(PortalResources.pricing_aSeriesDedicatedCpu),
+        learnMoreUrl: Links.vmSizeLearnMore
     },
     {
         iconUrl: 'image/website-power.svg',
@@ -75,7 +76,7 @@ export class PremiumSmallPlanPriceSpec extends PremiumPlanPriceSpec {
     topLevelFeatures = [
         this._ts.instant(PortalResources.pricing_numCores).format('1x'),
         this._ts.instant(PortalResources.pricing_memory).format('1.75'),
-        '100 ACU'
+        this._ts.instant(PortalResources.pricing_aSeriesCompute)
     ];
 
     meterFriendlyName = 'Premium Small App Service Hours';
@@ -95,7 +96,7 @@ export class PremiumMediumPlanPriceSpec extends PremiumPlanPriceSpec {
     topLevelFeatures = [
         this._ts.instant(PortalResources.pricing_numCores).format('2x'),
         this._ts.instant(PortalResources.pricing_memory).format('3.5'),
-        '200 ACU'
+        this._ts.instant(PortalResources.pricing_aSeriesCompute)
     ];
 
     meterFriendlyName = 'Premium Medium App Service Hours';
@@ -115,7 +116,7 @@ export class PremiumLargePlanPriceSpec extends PremiumPlanPriceSpec {
     topLevelFeatures = [
         this._ts.instant(PortalResources.pricing_numCores).format('4x'),
         this._ts.instant(PortalResources.pricing_memory).format('7'),
-        '400 ACU'
+        this._ts.instant(PortalResources.pricing_aSeriesCompute)
     ];
 
     meterFriendlyName = 'Premium Large App Service Hours';

--- a/client/src/app/site/spec-picker/price-spec-manager/premiumv2-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premiumv2-plan-price-spec.ts
@@ -1,3 +1,4 @@
+import { Links } from './../../../shared/models/constants';
 import { PortalResources } from 'app/shared/models/portal-resources';
 import { PlanService } from './../../../shared/services/plan.service';
 import { PriceSpec, PriceSpecInput } from './price-spec';
@@ -33,8 +34,8 @@ export abstract class PremiumV2PlanPriceSpec extends PriceSpec {
     hardwareItems = [{
         iconUrl: 'image/app-service-plan.svg',
         title: this._ts.instant(PortalResources.cpu),
-        description: this._ts.instant(PortalResources.pricing_dedicatedCpu),
-        learnMoreUrl: 'https://docs.microsoft.com/en-us/azure/virtual-machines/windows/acu'
+        description: this._ts.instant(PortalResources.pricing_dv2SeriesDedicatedCpu),
+        learnMoreUrl: Links.vmSizeLearnMore
     },
     {
         iconUrl: 'image/website-power.svg',
@@ -119,7 +120,7 @@ export class PremiumV2SmallPlanPriceSpec extends PremiumV2PlanPriceSpec {
     topLevelFeatures = [
         this._ts.instant(PortalResources.pricing_numCores).format('1x'),
         this._ts.instant(PortalResources.pricing_memory).format('3.5'),
-        '210 ACU'
+        this._ts.instant(PortalResources.pricing_dSeriesCompute)
     ];
 
     meterFriendlyName = 'Premium V2 Small App Service Hours';
@@ -139,7 +140,7 @@ export class PremiumV2MediumPlanPriceSpec extends PremiumV2PlanPriceSpec {
     topLevelFeatures = [
         this._ts.instant(PortalResources.pricing_numCores).format('2x'),
         this._ts.instant(PortalResources.pricing_memory).format('7'),
-        '420 ACU'
+        this._ts.instant(PortalResources.pricing_dSeriesCompute)
     ];
 
     meterFriendlyName = 'Premium V2 Medium App Service Hours';
@@ -159,7 +160,7 @@ export class PremiumV2LargePlanPriceSpec extends PremiumV2PlanPriceSpec {
     topLevelFeatures = [
         this._ts.instant(PortalResources.pricing_numCores).format('4x'),
         this._ts.instant(PortalResources.pricing_memory).format('14'),
-        '840 ACU'
+        this._ts.instant(PortalResources.pricing_dSeriesCompute)
     ];
 
     meterFriendlyName = 'Premium V2 Large App Service Hours';

--- a/client/src/app/site/spec-picker/price-spec-manager/premiumv2-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premiumv2-plan-price-spec.ts
@@ -33,7 +33,8 @@ export abstract class PremiumV2PlanPriceSpec extends PriceSpec {
     hardwareItems = [{
         iconUrl: 'image/app-service-plan.svg',
         title: this._ts.instant(PortalResources.cpu),
-        description: this._ts.instant(PortalResources.pricing_dedicatedCpu)
+        description: this._ts.instant(PortalResources.pricing_dedicatedCpu),
+        learnMoreUrl: 'https://docs.microsoft.com/en-us/azure/virtual-machines/windows/acu'
     },
     {
         iconUrl: 'image/website-power.svg',
@@ -62,14 +63,22 @@ export abstract class PremiumV2PlanPriceSpec extends PriceSpec {
             if (input.specPickerInput.data.hostingEnvironmentName) {
                 this.state = 'hidden';
             } else {
-                return this._planService.getAvailablePremiumV2GeoRegions(input.specPickerInput.data.subscriptionId)
-                    .do(geoRegions => {
-                        if (!geoRegions.find(g => g.properties.name.toLowerCase() === input.specPickerInput.data.location.toLowerCase())) {
-                            this.state = 'disabled';
-                            this.disabledMessage = this._ts.instant(PortalResources.pricing_pv2NotAvailable);
-                            this.disabledInfoLink = this._disabledLink;
+                return this.checkIfDreamspark(input.subscriptionId)
+                    .switchMap(isDreamspark => {
+                        if (!isDreamspark) {
+                            return this._planService.getAvailablePremiumV2GeoRegions(input.specPickerInput.data.subscriptionId)
+                                .do(geoRegions => {
+                                    if (!geoRegions.find(g => g.properties.name.toLowerCase() === input.specPickerInput.data.location.toLowerCase())) {
+                                        this.state = 'disabled';
+                                        this.disabledMessage = this._ts.instant(PortalResources.pricing_pv2NotAvailable);
+                                        this.disabledInfoLink = this._disabledLink;
+                                    }
+                                });
                         }
+
+                        return Observable.of(null);
                     });
+
             }
         } else if (input.plan) {
             if (input.plan.properties.hostingEnvironmentProfile) {

--- a/client/src/app/site/spec-picker/price-spec-manager/price-spec-detail.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/price-spec-detail.ts
@@ -2,4 +2,5 @@ export interface PriceSpecDetail {
     iconUrl: string;
     title: string;
     description: string;
+    learnMoreUrl?: string;
 }

--- a/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
@@ -1,3 +1,4 @@
+import { StatusMessage } from './../spec-picker.component';
 import { PriceSpec, PriceSpecInput } from './price-spec';
 import { FreePlanPriceSpec } from './free-plan-price-spec';
 import { SharedPlanPriceSpec } from './shared-plan-price-spec';
@@ -20,7 +21,7 @@ export abstract class PriceSpecGroup {
     abstract emptyMessage: string;
     abstract emptyInfoLink: string;
 
-    bannerMessage: string;
+    bannerMessage: StatusMessage;
     selectedSpec: PriceSpec = null;
     isExpanded = false;
 
@@ -60,9 +61,16 @@ export class DevSpecGroup extends PriceSpecGroup {
     initialize(input: PriceSpecInput) {
         if (input.specPickerInput.data) {
             if (input.specPickerInput.data.isLinux) {
-                this.bannerMessage = this.ts.instant(PortalResources.pricing_linuxTrial);
+                this.bannerMessage = {
+                    message: this.ts.instant(PortalResources.pricing_linuxTrial),
+                    level: 'info'
+                };
+
             } else if (input.specPickerInput.data.isXenon) {
-                this.bannerMessage = this.ts.instant(PortalResources.pricing_windowsContainers);
+                this.bannerMessage = {
+                    message: this.ts.instant(PortalResources.pricing_windowsContainers),
+                    level: 'info'
+                };
             }
         }
     }
@@ -99,9 +107,15 @@ export class ProdSpecGroup extends PriceSpecGroup {
     initialize(input: PriceSpecInput) {
         if (input.specPickerInput.data) {
             if (input.specPickerInput.data.isLinux) {
-                this.bannerMessage = this.ts.instant(PortalResources.pricing_linuxTrial);
+                this.bannerMessage = {
+                    message: this.ts.instant(PortalResources.pricing_linuxTrial),
+                    level: 'info'
+                };
             } else if (input.specPickerInput.data.isXenon) {
-                this.bannerMessage = this.ts.instant(PortalResources.pricing_windowsContainers);
+                this.bannerMessage = {
+                    message: this.ts.instant(PortalResources.pricing_windowsContainers),
+                    level: 'info'
+                };
             }
         }
     }
@@ -130,7 +144,10 @@ export class IsolatedSpecGroup extends PriceSpecGroup {
 
     initialize(input: PriceSpecInput) {
         if (input.specPickerInput.data && input.specPickerInput.data.isLinux) {
-            this.bannerMessage = this.ts.instant(PortalResources.pricing_linuxAseDiscount);
+            this.bannerMessage = {
+                message: this.ts.instant(PortalResources.pricing_linuxAseDiscount),
+                level: 'info'
+            };
         }
     }
 }

--- a/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
@@ -13,12 +13,12 @@ export abstract class StandardPlanPriceSpec extends PriceSpec {
     {
         iconUrl: 'image/scale-up.svg',
         title: this._ts.instant(PortalResources.pricing_autoScale),
-        description: this._ts.instant(PortalResources.pricing_scaleDesc).format(10)
+        description: this._ts.instant(PortalResources.pricing_scaleDesc).format(5)
     },
     {
         iconUrl: 'image/slots.svg',
         title: this._ts.instant(PortalResources.pricing_stagingSlots),
-        description: this._ts.instant(PortalResources.pricing_slotsDesc).format(10)
+        description: this._ts.instant(PortalResources.pricing_slotsDesc).format(5)
     },
     {
         iconUrl: 'image/backups.svg',
@@ -29,7 +29,8 @@ export abstract class StandardPlanPriceSpec extends PriceSpec {
     hardwareItems = [{
         iconUrl: 'image/app-service-plan.svg',
         title: this._ts.instant(PortalResources.cpu),
-        description: this._ts.instant(PortalResources.pricing_dedicatedCpu)
+        description: this._ts.instant(PortalResources.pricing_dedicatedCpu),
+        learnMoreUrl: 'https://docs.microsoft.com/en-us/azure/virtual-machines/windows/acu'
     },
     {
         iconUrl: 'image/website-power.svg',

--- a/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
@@ -1,3 +1,4 @@
+import { Links } from './../../../shared/models/constants';
 import { PortalResources } from 'app/shared/models/portal-resources';
 import { Observable } from 'rxjs/Observable';
 import { Injector } from '@angular/core/src/core';
@@ -29,8 +30,8 @@ export abstract class StandardPlanPriceSpec extends PriceSpec {
     hardwareItems = [{
         iconUrl: 'image/app-service-plan.svg',
         title: this._ts.instant(PortalResources.cpu),
-        description: this._ts.instant(PortalResources.pricing_dedicatedCpu),
-        learnMoreUrl: 'https://docs.microsoft.com/en-us/azure/virtual-machines/windows/acu'
+        description: this._ts.instant(PortalResources.pricing_aSeriesDedicatedCpu),
+        learnMoreUrl: Links.vmSizeLearnMore
     },
     {
         iconUrl: 'image/website-power.svg',
@@ -68,7 +69,7 @@ export class StandardSmallPlanPriceSpec extends StandardPlanPriceSpec {
     topLevelFeatures = [
         this._ts.instant(PortalResources.pricing_numCores).format('1x'),
         this._ts.instant(PortalResources.pricing_memory).format('1.75'),
-        '100 ACU'
+        this._ts.instant(PortalResources.pricing_aSeriesCompute)
     ];
 
     meterFriendlyName = 'Standard Small App Service Hours';
@@ -88,7 +89,7 @@ export class StandardMediumPlanPriceSpec extends StandardPlanPriceSpec {
     topLevelFeatures = [
         this._ts.instant(PortalResources.pricing_numCores).format('2x'),
         this._ts.instant(PortalResources.pricing_memory).format('3.5'),
-        '200 ACU'
+        this._ts.instant(PortalResources.pricing_aSeriesCompute)
     ];
 
     meterFriendlyName = 'Standard Medium App Service Hours';
@@ -117,7 +118,7 @@ export class StandardLargePlanPriceSpec extends StandardPlanPriceSpec {
     topLevelFeatures = [
         this._ts.instant(PortalResources.pricing_numCores).format('4x'),
         this._ts.instant(PortalResources.pricing_memory).format('7'),
-        '400 ACU'
+        this._ts.instant(PortalResources.pricing_aSeriesCompute)
     ];
 
     meterFriendlyName = 'Standard Large App Service Hours';

--- a/client/src/app/site/spec-picker/spec-feature-list/spec-feature-list.component.html
+++ b/client/src/app/site/spec-picker/spec-feature-list/spec-feature-list.component.html
@@ -1,10 +1,12 @@
 <h2>{{title}}</h2>
-<div class="feature-description">{{description}}</div>
+<div>{{description}}</div>
 <div *ngFor="let feature of featureItems" class="feature-item">
 
   <div [load-image]="feature.iconUrl" class="icon-medium"></div>
-  <div class="feature-description">
+  <div class="feature-body">
     <h4>{{feature.title}}</h4>
-    <div>{{feature.description}}</div>
+    <div class="feature-description">{{feature.description}}
+    </div>
+    <div><a *ngIf="feature.learnMoreUrl" [href]="feature.learnMoreUrl">{{'topBar_learnMore' | translate}}</a></div>
   </div>
 </div>

--- a/client/src/app/site/spec-picker/spec-feature-list/spec-feature-list.component.html
+++ b/client/src/app/site/spec-picker/spec-feature-list/spec-feature-list.component.html
@@ -7,6 +7,6 @@
     <h4>{{feature.title}}</h4>
     <div class="feature-description">{{feature.description}}
     </div>
-    <div><a *ngIf="feature.learnMoreUrl" [href]="feature.learnMoreUrl">{{'topBar_learnMore' | translate}}</a></div>
+    <div><a *ngIf="feature.learnMoreUrl" [href]="feature.learnMoreUrl" target="_blank">{{'topBar_learnMore' | translate}}</a></div>
   </div>
 </div>

--- a/client/src/app/site/spec-picker/spec-picker.component.html
+++ b/client/src/app/site/spec-picker/spec-picker.component.html
@@ -34,7 +34,7 @@
       <div [load-image]="specManager.selectedSpecGroup.iconUrl" class="icon-large"></div>
       <article>
         {{specManager.selectedSpecGroup.emptyMessage}}
-        <a [href]="specManager.selectedSpecGroup.emptyInfoLink">{{'clickToLearnMore' | translate}}</a>
+        <a [href]="specManager.selectedSpecGroup.emptyInfoLink" target="_blank">{{'clickToLearnMore' | translate}}</a>
       </article>
     </section>
 
@@ -61,8 +61,6 @@
         [isRecommendedList]="false"
         (onSelectedSpec)="selectSpec($event)"></spec-list>
     </section>
-
-
 
     <section *ngIf="specManager.selectedSpecGroup.selectedSpec" class="feature-lists-container centered">
       <article class="feature-list" *ngIf="specManager.selectedSpecGroup.selectedSpec.featureItems">

--- a/client/src/app/site/spec-picker/spec-picker.component.html
+++ b/client/src/app/site/spec-picker/spec-picker.component.html
@@ -25,7 +25,9 @@
     [attr.aria-label]="specManager.selectedSpecGroup.title">
 
     <section>
-      <info-box *ngIf="specManager.selectedSpecGroup.bannerMessage" [infoText]="specManager.selectedSpecGroup.bannerMessage" typeClass="info"></info-box>
+      <info-box *ngIf="specManager.selectedSpecGroup.bannerMessage"
+        [infoText]="specManager.selectedSpecGroup.bannerMessage.message"
+        [typeClass]="specManager.selectedSpecGroup.bannerMessage.level"></info-box>
     </section>
 
     <section *ngIf="isEmpty" class="empty-group">
@@ -37,7 +39,7 @@
     </section>
 
     <section class="centered">
-      <h2 class="recommended-tiers" *ngIf="specManager.selectedSpecGroup.recommendedSpecs.length > 0">{{'pricing_recommendedTiers' | translate}}</h2>
+      <h2 class="tiers-header" *ngIf="specManager.selectedSpecGroup.recommendedSpecs.length > 0">{{'pricing_recommendedTiers' | translate}}</h2>
       <spec-list *ngIf="specManager.selectedSpecGroup.recommendedSpecs.length > 0"
         [specGroup]="specManager.selectedSpecGroup"
         [isRecommendedList]="true"
@@ -53,6 +55,7 @@
           </span>
         </div>
 
+      <h2 class="tiers-header" *ngIf="showAllSpecs">{{'pricing_additionalTiers' | translate}}</h2>
       <spec-list *ngIf="showAllSpecs"
         [specGroup]="specManager.selectedSpecGroup"
         [isRecommendedList]="false"
@@ -93,7 +96,10 @@
           *ngIf="statusMessage?.message"
           [load-image]="statusMessage?.level === 'error' ? 'image/error.svg' : 'image/success.svg'"></span>
 
-        <span class="message-text" [class.message-error]="statusMessage?.level === 'error'" [class.message-success]="statusMessage?.level === 'success'">
+        <span class="message-text"
+          [class.message-error]="statusMessage?.level === 'error'"
+          [class.message-success]="statusMessage?.level === 'success'">
+
           {{statusMessage?.message}}
         </span>  
     </div>

--- a/client/src/app/site/spec-picker/spec-picker.component.scss
+++ b/client/src/app/site/spec-picker/spec-picker.component.scss
@@ -1,4 +1,5 @@
 @import '../../../sass/common/variables';
+@import '../../../sass/common/mixins';
 
 $footer-height: 55px;
 $spec-card-max-width: 350px;
@@ -25,7 +26,7 @@ $center-column-max-width: calc(#{$spec-card-max-width}*4 - 40px);
         display: flex;
     }
 
-    .recommended-tiers{
+    .tiers-header{
         margin: 20px 0px 0px 15px;
     }
 
@@ -178,10 +179,6 @@ $center-column-max-width: calc(#{$spec-card-max-width}*4 - 40px);
         width: calc(100% / 2);
     }
 
-    .feature-description{
-        margin-bottom: 10px;
-    }
-
     .feature-item{
         position: relative;
         height: 70px;
@@ -201,12 +198,29 @@ $center-column-max-width: calc(#{$spec-card-max-width}*4 - 40px);
             transform: translateY(-50%);
         }
 
-        .feature-description{
+        .feature-body{
             position: absolute;
             left: 50px;
             left: 50px;
             top: 50%;
             transform: translateY(-50%);
+        }
+
+        // Multi-line text truncation with ellipsis only really works nicely in Chrome.  For all other browsers,
+        // the text will truncate, but there won't be an ellipsis.  There's a lot of weird hacky ways to get
+        // to work, but so far this is the only one that seemed to truncate properly cross-browser without
+        // messing up something else.
+        // https://www.consolelog.io/multiple-line-ellipsis-css-effect/
+        .feature-description{
+            display: block;
+            display: -webkit-box;
+            max-width: 100%;
+            margin: 0 auto;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-height: 36px;       /* fallback */
         }
     }
 

--- a/client/src/app/site/spec-picker/spec-picker.component.ts
+++ b/client/src/app/site/spec-picker/spec-picker.component.ts
@@ -38,8 +38,9 @@ export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPicke
   specManager: PlanPriceSpecManager;
   statusMessage: StatusMessage = null;
   isInitializing = false;
-  disableUpdates = false;
+  isUpdating = false;
   shieldEnabled = false;
+  disableUpdates = false;
 
   private _planOrSubResourceId: ResourceId;
   private _input: SpecPickerInput<NewPlanSpecPickerData>;
@@ -54,9 +55,7 @@ export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPicke
       && this.specManager.selectedSpecGroup.selectedSpec.skuCode === this.specManager.currentSkuCode) {
 
       return false;
-    } else if (this.disableUpdates) {
-      return false;
-    } else if (this.isInitializing) {
+    } else if (this.isUpdating || this.isInitializing || this.disableUpdates) {
       return false;
     } else {
       return true;
@@ -163,14 +162,14 @@ export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPicke
     // This is an existing plan, so just upgrade in-place
     if (!this._input.data) {
       this._portalService.updateDirtyState(true, this._ts.instant(PortalResources.clearDirtyConfirmation));
+      this.isUpdating = true;
       this.disableUpdates = true;
 
       this.specManager.applySelectedSpec()
         .subscribe(applyButtonState => {
+          this.isUpdating = false;
 
-          if (applyButtonState === 'enabled') {
-            this.disableUpdates = false;
-          }
+          this.disableUpdates = applyButtonState === 'disabled' ? true : false;
           this._portalService.updateDirtyState(false);
         });
     } else {

--- a/client/src/app/site/spec-picker/spec-picker.component.ts
+++ b/client/src/app/site/spec-picker/spec-picker.component.ts
@@ -38,7 +38,7 @@ export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPicke
   specManager: PlanPriceSpecManager;
   statusMessage: StatusMessage = null;
   isInitializing = false;
-  isUpdating = false;
+  disableUpdates = false;
   shieldEnabled = false;
 
   private _planOrSubResourceId: ResourceId;
@@ -54,7 +54,7 @@ export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPicke
       && this.specManager.selectedSpecGroup.selectedSpec.skuCode === this.specManager.currentSkuCode) {
 
       return false;
-    } else if (this.isUpdating) {
+    } else if (this.disableUpdates) {
       return false;
     } else if (this.isInitializing) {
       return false;
@@ -163,11 +163,14 @@ export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPicke
     // This is an existing plan, so just upgrade in-place
     if (!this._input.data) {
       this._portalService.updateDirtyState(true, this._ts.instant(PortalResources.clearDirtyConfirmation));
-      this.isUpdating = true;
+      this.disableUpdates = true;
 
       this.specManager.applySelectedSpec()
-        .subscribe(r => {
-          this.isUpdating = false;
+        .subscribe(applyButtonState => {
+
+          if (applyButtonState === 'enabled') {
+            this.disableUpdates = false;
+          }
           this._portalService.updateDirtyState(false);
         });
     } else {

--- a/client/src/app/site/spec-picker/spec-picker.component.ts
+++ b/client/src/app/site/spec-picker/spec-picker.component.ts
@@ -1,9 +1,10 @@
+import { OnDestroy } from '@angular/core/src/metadata/lifecycle_hooks';
 import { PortalService } from 'app/shared/services/portal.service';
 import { TranslateService } from '@ngx-translate/core';
 import { ArmResourceDescriptor } from './../../shared/resourceDescriptors';
 import { AuthzService } from 'app/shared/services/authz.service';
 import { PlanPriceSpecManager, NewPlanSpecPickerData, SpecPickerInput } from './price-spec-manager/plan-price-spec-manager';
-import { Component, OnInit, Input, Injector, ViewEncapsulation, ViewChild, ElementRef } from '@angular/core';
+import { Component, Input, Injector, ViewEncapsulation, ViewChild, ElementRef } from '@angular/core';
 import { FeatureComponent } from '../../shared/components/feature-component';
 import { TreeViewInfo } from '../../tree-view/models/tree-view-info';
 import { Observable } from 'rxjs/Observable';
@@ -14,9 +15,9 @@ import { PortalResources } from '../../shared/models/portal-resources';
 import { SiteTabIds, KeyCodes } from '../../shared/models/constants';
 import { Dom } from '../../shared/Utilities/dom';
 
-interface StatusMessage {
+export interface StatusMessage {
   message: string;
-  level: 'error' | 'success';
+  level: 'error' | 'success' | 'warning' | 'info';
 }
 
 @Component({
@@ -25,7 +26,7 @@ interface StatusMessage {
   styleUrls: ['./spec-picker.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
-export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPickerInput<NewPlanSpecPickerData>>> implements OnInit {
+export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPickerInput<NewPlanSpecPickerData>>> implements OnDestroy {
 
   @Input() set viewInfoInput(viewInfo: TreeViewInfo<SpecPickerInput<NewPlanSpecPickerData>>) {
     this.setInput(viewInfo);
@@ -73,7 +74,9 @@ export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPicke
     this.featureName = 'SpecPickerComponent';
   }
 
-  ngOnInit() {
+  ngOnDestroy() {
+    super.ngOnDestroy();
+    this.specManager.dispose();
   }
 
   protected setup(inputEvents: Observable<TreeViewInfo<SpecPickerInput<NewPlanSpecPickerData>>>) {
@@ -136,7 +139,6 @@ export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPicke
       });
   }
 
-
   selectGroup(group: PriceSpecGroup) {
     this.specManager.selectedSpecGroup = group;
   }
@@ -163,35 +165,10 @@ export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPicke
       this._portalService.updateDirtyState(true, this._ts.instant(PortalResources.clearDirtyConfirmation));
       this.isUpdating = true;
 
-      let notificationId: string = null;
-      const planDescriptor = new ArmResourceDescriptor(this._planOrSubResourceId);
-      this._portalService.startNotification(
-        this._ts.instant(PortalResources.pricing_planUpdateTitle),
-        this._ts.instant(PortalResources.pricing_planUpdateDesc).format(planDescriptor.resourceName))
-        .first()
-        .switchMap(notification => {
-
-          notificationId = notification.id;
-          return this.specManager.applySelectedSpec();
-
-        })
+      this.specManager.applySelectedSpec()
         .subscribe(r => {
           this.isUpdating = false;
           this._portalService.updateDirtyState(false);
-
-          if (r.isSuccessful) {
-            this._portalService.stopNotification(
-              notificationId,
-              r.isSuccessful,
-              this._ts.instant(PortalResources.pricing_planUpdateSuccessFormat).format(planDescriptor.resourceName)
-            );
-          } else {
-            this._portalService.stopNotification(
-              notificationId,
-              r.isSuccessful,
-              r.error.message ? r.error.message : this._ts.instant(PortalResources.pricing_planUpdateFailFormat).format(planDescriptor.resourceName)
-            );
-          }
         });
     } else {
       // This is a new plan, so return plan information to parent blade

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -3097,8 +3097,11 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
   <data name="pricing_sharedCpu" xml:space="preserve">
     <value>Shared compute resources used to run applications deployed in the App Service Plan.</value>
   </data>
-  <data name="pricing_dedicatedCpu" xml:space="preserve">
-    <value>Dedicated compute resources used to run applications deployed in the App Service Plan.  Relative performance is measured by Azure Compute Units (ACUs) per instance.  </value>
+  <data name="pricing_aSeriesDedicatedCpu" xml:space="preserve">
+    <value>Dedicated A-series compute resources used to run applications deployed in the App Service Plan.</value>
+  </data>
+  <data name="pricing_dv2SeriesDedicatedCpu" xml:space="preserve">
+    <value>Dedicated Dv2-series compute resources used to run applications deployed in the App Service Plan.</value>
   </data>
   <data name="pricing_sharedMemory" xml:space="preserve">
     <value>Memory available to run applications deployed and running in the App Service plan.</value>
@@ -3174,6 +3177,12 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
   </data>
   <data name="pricing_numCores" xml:space="preserve">
     <value>{0} cores</value>
+  </data>
+  <data name="pricing_aSeriesCompute" xml:space="preserve">
+    <value>A-Series compute</value>
+  </data>
+  <data name="pricing_dSeriesCompute" xml:space="preserve">
+    <value>Dv2-Series compute</value>
   </data>
   <data name="proxyJsonInvalid" xml:space="preserve">
     <value>The proxies.json is not valid. Error: '{0}'.</value>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -3041,7 +3041,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <value>Successfully submitted job to scale the plan '{0}'.</value>
   </data>
   <data name="pricing_planScaleInProgress" xml:space="preserve">
-    <value>A scale operation is currently in progress for the plan '{0}'.</value>
+    <value>A scale operation is currently in progress for the plan '{0}'.  Please wait for the operation to complete before scaling again.</value>
   </data>
   <data name="pricing_planUpdateFailFormat" xml:space="preserve">
     <value>Failed to update the plan '{0}'</value>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -863,7 +863,7 @@
     <value>Upload</value>
   </data>
   <data name="seeAllOptions" xml:space="preserve">
-    <value>See all options</value>
+    <value>See additional options</value>
   </data>
   <data name="seeRecommendedOptions" xml:space="preserve">
     <value>See only recommended options</value>
@@ -2990,7 +2990,10 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <value>Line</value>
   </data>
   <data name="pricing_recommendedTiers" xml:space="preserve">
-    <value>Recommended Pricing Tiers</value>
+    <value>Recommended pricing tiers</value>
+  </data>
+  <data name="pricing_additionalTiers" xml:space="preserve">
+    <value>Additional pricing tiers</value>
   </data>
   <data name="pricing_subscriptionNotAllowed" xml:space="preserve">
     <value>Your subscription does not allow this pricing tier</value>
@@ -3033,6 +3036,12 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
   </data>
   <data name="pricing_planUpdateSuccessFormat" xml:space="preserve">
     <value>The plan '{0}' was updated successfully!</value>
+  </data>
+  <data name="pricing_planUpdateJobSuccessFormat" xml:space="preserve">
+    <value>Successfully submitted job to scale the plan '{0}'.</value>
+  </data>
+  <data name="pricing_planScaleInProgress" xml:space="preserve">
+    <value>A scale operation is currently in progress for the plan '{0}'.</value>
   </data>
   <data name="pricing_planUpdateFailFormat" xml:space="preserve">
     <value>Failed to update the plan '{0}'</value>
@@ -3089,7 +3098,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <value>Shared compute resources used to run applications deployed in the App Service Plan.</value>
   </data>
   <data name="pricing_dedicatedCpu" xml:space="preserve">
-    <value>Compute resources in the form of dedicated instances used to run applications deployed in the App Service Plan. The relative performance of a tier is measured by the number of Azure Compute Units (ACUs) per instance.</value>
+    <value>Dedicated compute resources used to run applications deployed in the App Service Plan.  Relative performance is measured by Azure Compute Units (ACUs) per instance.  </value>
   </data>
   <data name="pricing_sharedMemory" xml:space="preserve">
     <value>Memory available to run applications deployed and running in the App Service plan.</value>


### PR DESCRIPTION
Scale operations on an Isolated plan return a different HTTP status code than regular plans.  Isolated scale operations also take way longer than regular plans so we need to handle them in the UI differently.  The approach I decided to take was to submit the scale job like normal, but then show a banner that says "scale operation in progress" while it's being scaled (see below).

Note: The GIF has a bug at the end where the apply button gets enabled when you click on another SKU, but I fixed it so that it stays disabled during a scale operation.

![2018-04-23_09-07-31](https://user-images.githubusercontent.com/5695405/39139909-ff3fb738-46d7-11e8-99ec-4e6e90ddbdee.gif)


