### PR TITLE
Changing auth token to be passed through body of passthrough rather t…

### DIFF
--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-bitbucket/configure-bitbucket.component.spec.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-bitbucket/configure-bitbucket.component.spec.ts
@@ -150,6 +150,10 @@ class MockDeploymentCenterStateManager {
     public get sourceSettings(): FormGroup {
         return (this.wizardForm && (this.wizardForm.controls.sourceSettings as FormGroup)) || null;
     }
+
+    public getToken() {
+        return '';
+    }
 }
 
 

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-bitbucket/configure-bitbucket.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-bitbucket/configure-bitbucket.component.ts
@@ -55,7 +55,8 @@ export class ConfigureBitbucketComponent implements OnDestroy {
         this.reposLoading = true;
         this._cacheService
             .post(Constants.serviceHost + `api/bitbucket/passthrough?repo=`, true, null, {
-                url: `${DeploymentCenterConstants.bitbucketApiUrl}/repositories?role=admin`
+                url: `${DeploymentCenterConstants.bitbucketApiUrl}/repositories?role=admin`,
+                authToken: this.wizard.getToken()
             })
             .subscribe(
                 r => {
@@ -85,7 +86,8 @@ export class ConfigureBitbucketComponent implements OnDestroy {
         this.BranchList = [];
         this._cacheService
             .post(Constants.serviceHost + `api/bitbucket/passthrough?branch=${repo}`, true, null, {
-                url: `${DeploymentCenterConstants.bitbucketApiUrl}/repositories/${repo}/refs/branches`
+                url: `${DeploymentCenterConstants.bitbucketApiUrl}/repositories/${repo}/refs/branches`,
+                authToken: this.wizard.getToken()
             })
             .subscribe(
                 r => {

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-dropbox/configure-dropbox.component.spec.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-dropbox/configure-dropbox.component.spec.ts
@@ -141,6 +141,10 @@ class MockDeploymentCenterStateManager {
     public get sourceSettings(): FormGroup {
         return (this.wizardForm && (this.wizardForm.controls.sourceSettings as FormGroup)) || null;
     }
+    
+    public getToken() {
+        return '';
+    }
 }
 
 

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-dropbox/configure-dropbox.component.spec.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-dropbox/configure-dropbox.component.spec.ts
@@ -77,10 +77,10 @@ describe('ConfigureDropboxComponent', () => {
         it('should be able to select folder', () => {
             wizard.resourceIdStream$.next(siteId);
             testFixture.detectChanges();
-             NgSelectTestHelpers.selectOption(testFixture, 'configure-dropbox-folder-select', KeyCode.ArrowDown, 1);
-             testFixture.detectChanges();
-             const expectedRepoUrl = `${DeploymentCenterConstants.dropboxUri}/testName1`;
-             expect(component.selectedFolder).toBe(expectedRepoUrl);
+            NgSelectTestHelpers.selectOption(testFixture, 'configure-dropbox-folder-select', KeyCode.ArrowDown, 1);
+            testFixture.detectChanges();
+            const expectedRepoUrl = `${DeploymentCenterConstants.dropboxUri}/testName1`;
+            expect(component.selectedFolder).toBe(expectedRepoUrl);
         });
 
     });
@@ -138,10 +138,11 @@ class MockDeploymentCenterStateManager {
     public get wizardValues(): WizardForm {
         return this.wizardForm.value;
     }
+
     public get sourceSettings(): FormGroup {
         return (this.wizardForm && (this.wizardForm.controls.sourceSettings as FormGroup)) || null;
     }
-    
+
     public getToken() {
         return '';
     }

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-dropbox/configure-dropbox.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-dropbox/configure-dropbox.component.ts
@@ -49,6 +49,7 @@ export class ConfigureDropboxComponent implements OnInit {
         return this._cacheService
             .post(Constants.serviceHost + 'api/dropbox/passthrough', true, null, {
                 url: `${DeploymentCenterConstants.dropboxApiUrl}/files/list_folder`,
+                authToken: this.wizard.getToken(),
                 arg: {
                     path: ''
                 },

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-dropbox/configure-dropbox.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-dropbox/configure-dropbox.component.ts
@@ -34,6 +34,7 @@ export class ConfigureDropboxComponent implements OnInit {
     ngOnInit() {
         this.updateFormValidation();
     }
+
     updateFormValidation() {
         const required = new RequiredValidator(this._translateService, false);
         this.wizard.sourceSettings.get('repoUrl').setValidators(required.validate.bind(required));
@@ -43,6 +44,7 @@ export class ConfigureDropboxComponent implements OnInit {
         this.wizard.sourceSettings.get('branch').updateValueAndValidity();
         this.wizard.sourceSettings.get('isMercurial').updateValueAndValidity();
     }
+
     public fillDropboxFolders() {
         this.foldersLoading = true;
         this.folderList = [];

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/configure-github.component.spec.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/configure-github.component.spec.ts
@@ -240,6 +240,10 @@ class MockDeploymentCenterStateManager {
     public get sourceSettings(): FormGroup {
         return (this.wizardForm && (this.wizardForm.controls.sourceSettings as FormGroup)) || null;
     }
+
+    public getToken() {
+        return '';
+    }
 }
 
 

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/configure-github.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/configure-github.component.ts
@@ -64,10 +64,12 @@ export class ConfigureGithubComponent implements OnDestroy {
     fetchOrgs() {
         return Observable.zip(
             this._cacheService.post(Constants.serviceHost + 'api/github/passthrough?orgs=', true, null, {
-                url: `${DeploymentCenterConstants.githubApiUrl}/user/orgs`
+                url: `${DeploymentCenterConstants.githubApiUrl}/user/orgs`,
+                authToken: this.wizard.getToken()
             }),
             this._cacheService.post(Constants.serviceHost + 'api/github/passthrough?user=', true, null, {
-                url: `${DeploymentCenterConstants.githubApiUrl}/user`
+                url: `${DeploymentCenterConstants.githubApiUrl}/user`,
+                authToken: this.wizard.getToken()
             }),
             (orgs, user) => ({
                 orgs: orgs.json(),
@@ -101,7 +103,8 @@ export class ConfigureGithubComponent implements OnDestroy {
             if (org.toLocaleLowerCase().indexOf('github.com/users/') > -1) {
                 fetchListCall = this._cacheService
                     .post(Constants.serviceHost + `api/github/passthrough?repo=${org}`, true, null, {
-                        url: `${DeploymentCenterConstants.githubApiUrl}/user/repos?type=owner`
+                        url: `${DeploymentCenterConstants.githubApiUrl}/user/repos?type=owner`,
+                        authToken: this.wizard.getToken()
                     })
                     .switchMap(r => {
                         const linkHeader = r.headers.toJSON().link;
@@ -122,7 +125,8 @@ export class ConfigureGithubComponent implements OnDestroy {
             } else {
                 fetchListCall = this._cacheService
                     .post(Constants.serviceHost + `api/github/passthrough?repo=${org}`, true, null, {
-                        url: `${org}/repos?per_page=100`
+                        url: `${org}/repos?per_page=100`,
+                        authToken: this.wizard.getToken()
                     })
                     .switchMap(r => {
                         const linkHeader = r.headers.toJSON().link;
@@ -133,7 +137,8 @@ export class ConfigureGithubComponent implements OnDestroy {
                             for (let i = 2; i <= lastPageNumber; i++) {
                                 pageCalls.push(
                                     this._cacheService.post(Constants.serviceHost + `api/github/passthrough?repo=${org}&t=${Guid.newTinyGuid()}`, true, null, {
-                                        url: `${org}/repos?per_page=100&page=${i}`
+                                        url: `${org}/repos?per_page=100&page=${i}`,
+                                        authToken: this.wizard.getToken()
                                     })
                                 );
                             }
@@ -178,7 +183,8 @@ export class ConfigureGithubComponent implements OnDestroy {
             this.BranchList = [];
             this._cacheService
                 .post(Constants.serviceHost + `api/github/passthrough?branch=${repo}`, true, null, {
-                    url: `${DeploymentCenterConstants.githubApiUrl}/repos/${this.repoUrlToNameMap[repo]}/branches?per_page=100`
+                    url: `${DeploymentCenterConstants.githubApiUrl}/repos/${this.repoUrlToNameMap[repo]}/branches?per_page=100`,
+                    authToken: this.wizard.getToken()
                 })
                 .switchMap(r => {
                     const linkHeader = r.headers.toJSON().link;
@@ -189,7 +195,8 @@ export class ConfigureGithubComponent implements OnDestroy {
                         for (let i = 2; i <= lastPageNumber; i++) {
                             pageCalls.push(
                                 this._cacheService.post(Constants.serviceHost + `api/github/passthrough?t=${Guid.newTinyGuid()}`, true, null, {
-                                    url: `${DeploymentCenterConstants.githubApiUrl}/repos/${this.repoUrlToNameMap[repo]}/branches?per_page=100&page=${i}`
+                                    url: `${DeploymentCenterConstants.githubApiUrl}/repos/${this.repoUrlToNameMap[repo]}/branches?per_page=100&page=${i}`,
+                                    authToken: this.wizard.getToken()
                                 })
                             );
                         }

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-onedrive/configure-onedrive.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-onedrive/configure-onedrive.component.ts
@@ -39,7 +39,8 @@ export class ConfigureOnedriveComponent implements OnDestroy {
             .takeUntil(this._ngUnsubscribe$)
             .switchMap(() =>
                 this._cacheService.post(Constants.serviceHost + 'api/onedrive/passthrough', true, null, {
-                    url: `${DeploymentCenterConstants.onedriveApiUri}/children`
+                    url: `${DeploymentCenterConstants.onedriveApiUri}/children`,
+                    authToken: this.wizard.getToken()
                 })
             )
             .subscribe(

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-deployment-slot/step-deployment-slot.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-deployment-slot/step-deployment-slot.component.ts
@@ -7,7 +7,6 @@ import { PortalResources } from '../../../../shared/models/portal-resources';
 import { SlotNameValidator } from '../validators/slot-name-validator';
 import { RequiredValidator } from '../../../../shared/validators/requiredValidator';
 import { SiteService } from '../../../../shared/services/site.service';
-
 @Component({
   selector: 'app-step-deployment-slot',
   templateUrl: './step-deployment-slot.component.html',
@@ -27,7 +26,6 @@ export class StepDeploymentSlotComponent implements OnDestroy {
   selectedDeploymentSlot = '';
   private _resourceId: string;
   private _ngUnsubscribe$ = new Subject();
-
   constructor(
     public wizard: DeploymentCenterStateManager,
     private _translateService: TranslateService,

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-source-control/step-source-control.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-source-control/step-source-control.component.ts
@@ -18,7 +18,7 @@ import { ProviderCard } from '../../Models/provider-card';
 })
 export class StepSourceControlComponent {
 
-   private _authProviderSpots = {
+    private _authProviderSpots = {
         onedrive: 0,
         github: 1,
         bitbucket: 4,
@@ -150,7 +150,8 @@ export class StepSourceControlComponent {
             .delay(3000)
             .switchMap(() =>
                 _cacheService.post(Constants.serviceHost + 'api/github/passthrough', true, null, {
-                    url: 'https://api.github.com/user'
+                    url: 'https://api.github.com/user',
+                    authToken: this._wizardService.getToken()
                 })
             )
             .subscribe(
@@ -173,7 +174,8 @@ export class StepSourceControlComponent {
             .delay(3000)
             .switchMap(() =>
                 _cacheService.post(Constants.serviceHost + 'api/bitbucket/passthrough', true, null, {
-                    url: 'https://api.bitbucket.org/2.0/user'
+                    url: 'https://api.bitbucket.org/2.0/user',
+                    authToken: this._wizardService.getToken()
                 })
             )
             .subscribe(
@@ -196,7 +198,8 @@ export class StepSourceControlComponent {
             .delay(3000)
             .switchMap(() =>
                 _cacheService.post(Constants.serviceHost + 'api/onedrive/passthrough', true, null, {
-                    url: 'https://api.onedrive.com/v1.0/drive'
+                    url: 'https://api.onedrive.com/v1.0/drive',
+                    authToken: this._wizardService.getToken()
                 })
             )
             .subscribe(
@@ -218,7 +221,8 @@ export class StepSourceControlComponent {
             .delay(3000)
             .switchMap(() =>
                 _cacheService.post(Constants.serviceHost + 'api/dropbox/passthrough', true, null, {
-                    url: 'https://api.dropboxapi.com/2/users/get_current_account'
+                    url: 'https://api.dropboxapi.com/2/users/get_current_account',
+                    authToken: this._wizardService.getToken()
                 })
             )
             .subscribe(
@@ -233,7 +237,9 @@ export class StepSourceControlComponent {
 
         this._wizardService.resourceIdStream$
             .takeUntil(this._ngUnsubscribe$)
-            .switchMap(r => this._cacheService.get(Constants.serviceHost + 'api/SourceControlAuthenticationState'))
+            .switchMap(r => this._cacheService.post(Constants.serviceHost + 'api/SourceControlAuthenticationState', true, null, {
+                authToken: this._wizardService.getToken()
+            }))
             .subscribe(
                 dep => {
                     const r = dep.json();
@@ -300,7 +306,8 @@ export class StepSourceControlComponent {
 
                     this._cacheService
                         .post(`${Constants.serviceHost}auth/${provider}/storeToken`, true, null, {
-                            redirUrl: win.document.URL
+                            redirUrl: win.document.URL,
+                            authToken: this._wizardService.getToken()
                         })
                         .subscribe(() => {
                             this.updateProvider(provider);

--- a/client/src/app/site/deployment-center/deployment-center-setup/wizard-logic/deployment-center-state-manager.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/wizard-logic/deployment-center-state-manager.ts
@@ -122,7 +122,7 @@ export class DeploymentCenterStateManager implements OnDestroy {
         };
         const setupvsoCall = this._cacheService.post(`${Constants.serviceHost}api/sepupvso?accountName=${this.wizardValues.buildSettings.vstsAccount}`, true, this.getVstsPassthroughHeaders(), deploymentObject);
         if (this.wizardValues.buildSettings.createNewVsoAccount) {
-            return this._cacheService.post(`https://app.vsaex.visualstudio.com/_apis/HostAcquisition/collections?collectionName=${this.wizardValues.buildSettings.vstsAccount}&preferredRegion=${this.wizardValues.buildSettings.location}&api-version=4.0-preview.1`, true, this.getVstsPassthroughHeaders())
+            return this._cacheService.post(`https://app.vsaex.visualstudio.com/_apis/HostAcquisition/collections?collectionName=${this.wizardValues.buildSettings.vstsAccount}&preferredRegion=${this.wizardValues.buildSettings.location}&api-version=4.0-preview.1`, true, this.getVstsDirectHeaders())
                 .switchMap(r => setupvsoCall)
                 .switchMap(r => Observable.of(r.json().id));
         }
@@ -304,7 +304,7 @@ export class DeploymentCenterStateManager implements OnDestroy {
         const headers = new Headers();
         headers.append('Content-Type', 'application/json');
         headers.append('Accept', 'application/json');
-        headers.append('Authorization', `Bearer ${this._token}`);
+        headers.append('Authorization', this.getToken());
         headers.append('Vstsauthorization', `Bearer ${this._vstsApiToken}`);
         return headers;
     }
@@ -314,11 +314,14 @@ export class DeploymentCenterStateManager implements OnDestroy {
         const headers = new Headers();
         headers.append('Content-Type', 'application/json');
         headers.append('Accept', 'application/json');
-        headers.append('Authorization', `Bearer ${this._token}`);
+        headers.append('Authorization', this.getToken());
         headers.append('X-VSS-ForceMsaPassThrough', 'true');
         return headers;
     }
 
+    public getToken(): string {
+        return `Bearer ${this._token}`;
+    }
 
     ngOnDestroy(): void {
         this._ngUnsubscribe$.next();

--- a/client/src/app/site/deployment-center/deployment-center-setup/wizard-logic/deployment-center-state-manger.service.spec.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/wizard-logic/deployment-center-state-manger.service.spec.ts
@@ -117,6 +117,14 @@ describe('Deployment State Manager', () => {
         it('get tfs token on first load', inject([DeploymentCenterStateManager], (service: DeploymentCenterStateManager) => {
             expect(service['_vstsApiToken']).toBe('vststoken');
         }));
+
+        it('get ad token on first load', inject([DeploymentCenterStateManager], (service: DeploymentCenterStateManager) => {
+            expect(service['_token']).toBe('adtoken');
+        }));
+
+        it('get token should return ad token', inject([DeploymentCenterStateManager], (service: DeploymentCenterStateManager) => {
+            expect(service.getToken()).toBe('Bearer adtoken');
+        }));
     });
 
     describe('wizard form', () => {

--- a/server/src/deployment-center/bitbucket-auth.ts
+++ b/server/src/deployment-center/bitbucket-auth.ts
@@ -7,7 +7,7 @@ import { LogHelper } from '../logHelper';
 import { ApiRequest, PassthroughRequestBody } from '../types/request';
 const oauthHelper: oAuthHelper = new oAuthHelper('bitbucket');
 export async function getBitbucketTokens(req: any): Promise<any> {
-    return await oauthHelper.getToken(req.headers.authorization);
+    return await oauthHelper.getToken(req.body.authToken);
 }
 export function setupBitbucketAuthentication(app: Application) {
     app.post('/api/bitbucket/passthrough', async (req: ApiRequest<PassthroughRequestBody>, res) => {
@@ -79,7 +79,7 @@ export function setupBitbucketAuthentication(app: Application) {
                 }
             );
             const token = { access_token: r.data.access_token, refresh_token: r.data.refresh_token };
-            oauthHelper.saveToken(token.access_token, req.headers.authorization as string, token.refresh_token as string, environment);
+            oauthHelper.saveToken(token.access_token, req.body.authToken as string, token.refresh_token as string, environment);
             res.sendStatus(200);
         } catch (err) {
             LogHelper.error('bitbucket-token-store', err);

--- a/server/src/deployment-center/deployment-center.ts
+++ b/server/src/deployment-center/deployment-center.ts
@@ -10,11 +10,11 @@ import { LogHelper } from '../logHelper';
 import { setupVsoPassthroughAuthentication } from './vso-deployment-passthrough';
 
 export function setupDeploymentCenter(app: Application) {
-    app.get('/api/SourceControlAuthenticationState', async (req, res) => {
+    app.post('/api/SourceControlAuthenticationState', async (req, res) => {
         try {
             const r = await axios.get(`${staticConfig.config.env.azureResourceManagerEndpoint}/providers/Microsoft.Web/sourcecontrols?api-version=${constants.AntaresApiVersion}`, {
                 headers: {
-                    Authorization: req.headers.authorization
+                    Authorization: req.body.authToken
                 }
             });
             if(r.status !== 200){

--- a/server/src/deployment-center/dropbox-auth.ts
+++ b/server/src/deployment-center/dropbox-auth.ts
@@ -8,7 +8,7 @@ import { constants } from '../constants';
 
 const oauthHelper: oAuthHelper = new oAuthHelper('dropbox');
 export async function getDropboxTokens(req: any): Promise<any> {
-    return await oauthHelper.getToken(req.headers.authorization);
+    return await oauthHelper.getToken(req.body.authToken);
 }
 export function setupDropboxAuthentication(app: Application) {
     app.post('/api/dropbox/passthrough', async (req: ApiRequest<PassthroughRequestBody>, res) => {
@@ -73,7 +73,7 @@ export function setupDropboxAuthentication(app: Application) {
                 }
             );
             const token = r.data.access_token as string;
-            oauthHelper.saveToken(token, req.headers.authorization as string);
+            oauthHelper.saveToken(token, req.body.authToken as string);
             res.sendStatus(200);
         } catch (err) {
             LogHelper.error('dropbox-token-store', err);

--- a/server/src/deployment-center/github-auth.ts
+++ b/server/src/deployment-center/github-auth.ts
@@ -7,7 +7,7 @@ import { LogHelper } from '../logHelper';
 import { ApiRequest, PassthroughRequestBody } from '../types/request';
 const oauthHelper: oAuthHelper = new oAuthHelper('github');
 export async function getGithubTokens(req: any): Promise<any> {
-    return await oauthHelper.getToken(req.headers.authorization);
+    return await oauthHelper.getToken(req.body.authToken);
 }
 
 export function setupGithubAuthentication(app: Application) {
@@ -69,7 +69,7 @@ export function setupGithubAuthentication(app: Application) {
                 code: code
             });
             const token = oauthHelper.getParameterByName('access_token', '?' + r.data);
-            oauthHelper.saveToken(token, req.headers.authorization as string);
+            oauthHelper.saveToken(token, req.body.authToken as string);
             res.sendStatus(200);
         } catch (err) {
             LogHelper.error('github-token-store', err);

--- a/server/src/deployment-center/onedrive-auth.ts
+++ b/server/src/deployment-center/onedrive-auth.ts
@@ -8,7 +8,7 @@ import { constants } from '../constants';
 
 const oauthHelper: oAuthHelper = new oAuthHelper('onedrive');
 export async function getOnedriveTokens(req: any): Promise<any> {
-    return await oauthHelper.getToken(req.headers.authorization);
+    return await oauthHelper.getToken(req.body.authToken);
 }
 export function setupOnedriveAuthentication(app: Application) {
     app.post('/api/onedrive/passthrough', async (req: ApiRequest<PassthroughRequestBody>, res) => {
@@ -72,7 +72,7 @@ export function setupOnedriveAuthentication(app: Application) {
             );
             const token = r.data.access_token as string;
             const refreshToken = r.data.refresh_token as string;
-            await oauthHelper.saveToken(token, req.headers.authorization as string, refreshToken);
+            await oauthHelper.saveToken(token, req.body.authToken as string, refreshToken);
             res.sendStatus(200);
         } catch (err) {
             LogHelper.error('onedrive-token-store', err);


### PR DESCRIPTION
…han header

For some reason I don't fully understand the authorization header is getting overwritten in our web apps so I can't rely on it for pass through API calls. This is moving the auth token to the body of the call instead similar to how our /api/proxy call works today.