### PR TITLE
Add busy state when opening create sidebar

### DIFF
--- a/client/src/app/function/extension-checker/extension-checker.component.html
+++ b/client/src/app/function/extension-checker/extension-checker.component.html
@@ -1,3 +1,4 @@
+<busy-state name='sidebar'></busy-state>
 <ng-container *ngIf="showExtensionInstallDetail">
     <div class="headerBox" [style.background-color]="_functionCard.barcolor" >{{_functionCard.name}}
         <img [src]="_functionCard.icon" [style.background-color]="_functionCard.color" />

--- a/client/src/app/function/extension-checker/extension-checker.component.ts
+++ b/client/src/app/function/extension-checker/extension-checker.component.ts
@@ -16,6 +16,7 @@ import { BaseExtensionInstallComponent } from '../../extension-install/base-exte
 import { TranslateService } from '@ngx-translate/core';
 import { AiService } from '../../shared/services/ai.service';
 import { FunctionAppContext } from '../../shared/function-app-context';
+import { GlobalStateService } from '../../shared/services/global-state.service';
 
 @Component({
     selector: 'extension-checker',
@@ -49,9 +50,11 @@ export class ExtensionCheckerComponent extends BaseExtensionInstallComponent {
         private _functionAppService: FunctionAppService,
         broadcastService: BroadcastService,
         translateService: TranslateService,
-        aiService: AiService) {
+        aiService: AiService,
+        private _globalStateService: GlobalStateService) {
 
         super('extension-checker', _functionAppService, broadcastService, aiService, translateService);
+        this._globalStateService.setBusyState();
         this.functionCardStream = new Subject();
         this.functionCardStream
             .takeUntil(this.ngUnsubscribe)
@@ -84,6 +87,7 @@ export class ExtensionCheckerComponent extends BaseExtensionInstallComponent {
                 } else {
                     this.showExtensionInstallDetail = true;
                 }
+                this._globalStateService.clearBusyState();
             });
     }
 

--- a/client/src/app/function/extension-checker/extension-checker.component.ts
+++ b/client/src/app/function/extension-checker/extension-checker.component.ts
@@ -45,7 +45,7 @@ export class ExtensionCheckerComponent extends BaseExtensionInstallComponent  {
     public installJobs: ExtensionInstallStatus[] = [];
 
     private functionCardStream: Subject<CreateCard>;
-    private __busyManager: BusyStateScopeManager;
+    private _busyManager: BusyStateScopeManager;
 
     constructor(private _logService: LogService,
         private _functionAppService: FunctionAppService,
@@ -55,12 +55,12 @@ export class ExtensionCheckerComponent extends BaseExtensionInstallComponent  {
 
         super('extension-checker', _functionAppService, broadcastService, aiService, translateService);
 
-        this.__busyManager = new BusyStateScopeManager(this._broadcastService, 'sidebar');
+        this._busyManager = new BusyStateScopeManager(this._broadcastService, 'sidebar');
         this.functionCardStream = new Subject();
         this.functionCardStream
             .takeUntil(this.ngUnsubscribe)
             .switchMap(card => {
-                this.__busyManager.setBusy();
+                this._busyManager.setBusy();
                 this._functionCard = card;
                 return this._functionAppService.getTemplates(this.passedContext);
             })
@@ -89,7 +89,7 @@ export class ExtensionCheckerComponent extends BaseExtensionInstallComponent  {
                 } else {
                     this.showExtensionInstallDetail = true;
                 }
-                this.__busyManager.clearBusy();
+                this._busyManager.clearBusy();
             });
     }
 


### PR DESCRIPTION
Can sometimes take a few seconds to load sidebar if extensions needed to be fetched. Add busy state so it does not appear empty