### PR TITLE
Reverting changes to allow linux vs windows pricing

### DIFF
--- a/client/src/app/shared/services/plan.service.ts
+++ b/client/src/app/shared/services/plan.service.ts
@@ -102,15 +102,10 @@ export class PlanService {
             });
     }
 
-    getBillingMeters(subscriptionId: string, osType?: 'windows' | 'linux', location?: string): Observable<ArmObj<BillingMeter>[]> {
-
+    getBillingMeters(subscriptionId: string, location?: string): Observable<ArmObj<BillingMeter>[]> {
         let url = `${this._armService.armUrl}/subscriptions/${subscriptionId}/providers/Microsoft.Web/billingMeters?api-version=${this._armService.websiteApiVersion}`;
         if (location) {
             url += `&billingLocation=${location}`;
-        }
-
-        if (osType) {
-            url += `&osType=${osType}`;
         }
 
         const getMeters = this._cacheService.get(url);

--- a/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
@@ -1,4 +1,3 @@
-import { AppKind } from './../../../shared/Utilities/app-kind';
 import { TranslateService } from '@ngx-translate/core';
 import { PortalResources } from 'app/shared/models/portal-resources';
 import { SpecPickerComponent, StatusMessage } from './../spec-picker.component';
@@ -249,14 +248,12 @@ export class PlanPriceSpecManager {
                         return Observable.of(null);
                     }
 
-                    const osType = AppKind.hasKinds(this._plan, ['linux']) ? 'linux' : 'windows';
-                    return this._planService.getBillingMeters(this._subscriptionId, osType, this._plan.location);
+                    return this._planService.getBillingMeters(this._subscriptionId, this._plan.location);
                 });
         }
 
         // We're getting meters for a new plan
-        const osType = inputs.data.isLinux ? 'linux' : 'windows';
-        return this._planService.getBillingMeters(inputs.data.subscriptionId, osType, inputs.data.location);
+        return this._planService.getBillingMeters(inputs.data.subscriptionId, inputs.data.location);
     }
 
     private _updatePriceStrings(result: SpecCostQueryResult, specs: PriceSpec[]) {


### PR DESCRIPTION
Apparently this API isn't ready for BUILD, so we're going back to the Windows billing api for everything.