### PR TITLE
prevent users of V2 app to switch to classic view.

### DIFF
--- a/client/src/app/function-monitor/monitor-configure/monitor-configure.component.ts
+++ b/client/src/app/function-monitor/monitor-configure/monitor-configure.component.ts
@@ -102,9 +102,17 @@ export class MonitorConfigureComponent extends FeatureComponent<MonitorConfigure
   private _setupSwitchToClassicButton() {
     this.allowSwitchToClassic =
       !this.isLinuxApp &&
+      this._isV1App() &&
       (!this._errorEvent ||
       (this._errorEvent.errorId !== errorIds.preconditionsErrors.clientCertEnabled &&
       this._errorEvent.errorId !== errorIds.applicationInsightsInstrumentationKeyMismatch));
+  }
+
+  private _isV1App() {
+      return this._functionMonitorInfo &&
+        this._functionMonitorInfo.functionAppSettings &&
+        this._functionMonitorInfo.functionAppSettings['FUNCTIONS_EXTENSION_VERSION'] &&
+        this._functionMonitorInfo.functionAppSettings['FUNCTIONS_EXTENSION_VERSION'] === '~1';
   }
 
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/493476/39731090-4ac2b71c-521a-11e8-99c4-f0c10fbf9df2.png)

The user will be able to configure the application insights, just not go to the classic view. This change is needed as the logs to web jobs are only written for V1 windows apps.