### PR TITLE
SpecPicker - Ensure current sku is selected by default. Fixes #2667, Fixes #2664

### DIFF
--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -987,6 +987,7 @@
     public static pricing_emptyProdGroup = 'pricing_emptyProdGroup';
     public static pricing_pv2NotAvailable = 'pricing_pv2NotAvailable';
     public static pricing_scaleUp = 'pricing_scaleUp';
+    public static free = 'free';
     public static pricing_pricePerHour = 'pricing_pricePerHour';
     public static pricing_scaleUpDescription = 'pricing_scaleUpDescription';
     public static pricing_applyButtonLabel = 'pricing_applyButtonLabel';

--- a/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
@@ -319,7 +319,7 @@ export class PlanPriceSpecManager {
             if (!costResult) {
                 spec.priceString = ' ';
             } else if (costResult.amount === 0.0) {
-                spec.priceString = 'Free';
+                spec.priceString = this._ts.instant(PortalResources.free);
             } else {
                 const meter = costResult.firstParty[0].meters[0];
                 spec.priceString = this._ts.instant(PortalResources.pricing_pricePerHour).format(meter.perUnitAmount, meter.perUnitCurrencyCode);

--- a/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
@@ -330,6 +330,7 @@ export class PlanPriceSpecManager {
     private _cleanUpGroups() {
         let nonEmptyGroupIndex = 0;
         let foundNonEmptyGroup = false;
+        let foundDefaultGroup = false;
 
         // Remove hidden and forbidden specs and move disabled specs to end of list.
         this.specGroups.forEach((g, i) => {
@@ -343,17 +344,24 @@ export class PlanPriceSpecManager {
             g.recommendedSpecs = recommendedSpecs;
             g.additionalSpecs = specs;
 
-            // Find if there's already a spec that's selected within a group.  Otherwise
-            // just choose the first spec you can find
+            // Find if there's a spec in the current group that matches the plan sku
             g.selectedSpec = this._findSelectedSpec(g.recommendedSpecs);
             if (!g.selectedSpec) {
                 g.selectedSpec = this._findSelectedSpec(g.additionalSpecs);
             }
 
+            // If a plan's sku matches a spec in the current group, then make that group the default group
+            if (g.selectedSpec && !foundDefaultGroup) {
+                foundDefaultGroup = true;
+                this.selectedSpecGroup = this.specGroups[i];
+            }
+
+            // If we still haven't found a default spec in the group, pick the first recommended one
             if (!g.selectedSpec && g.recommendedSpecs.length > 0) {
                 g.selectedSpec = g.recommendedSpecs[0];
             }
 
+            // If we still haven't found a defautl spec in the group, pick the first additional one
             if (!g.selectedSpec && g.additionalSpecs.length > 0) {
                 g.selectedSpec = g.additionalSpecs[0];
             }
@@ -368,11 +376,7 @@ export class PlanPriceSpecManager {
             }
         });
 
-        if (nonEmptyGroupIndex < this.specGroups.length) {
-            // The UI loads the default set of cards immediately, but the specManager filters them out
-            // based on each cards initialization logic.  Angular isn't able to detect the updated filtered
-            // view in the list, so we're forcing an update by creating a new reference
-            this.specGroups[nonEmptyGroupIndex] = Object.assign({}, this.specGroups[nonEmptyGroupIndex]);
+        if (!foundDefaultGroup && nonEmptyGroupIndex < this.specGroups.length) {
             this.selectedSpecGroup = this.specGroups[nonEmptyGroupIndex];
 
             // Find the first group with a selectedSpec and make that group the default

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -3088,6 +3088,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
   <data name="pricing_scaleUp" xml:space="preserve">
     <value>Scale up</value>
   </data>
+  <data name="free" xml:space="preserve">
+    <value>Free</value>
+  </data>
   <data name="pricing_pricePerHour" xml:space="preserve">
     <value>{0} {1}/Hour (Estimated)</value>
   </data>


### PR DESCRIPTION
If you open an existing plan, or if you pass in a default sku for create scenarios, then we need to make sure that we're properly selecting it after initialization.