### PR TITLE
Don't force ignoring cache if there is no need to

### DIFF
--- a/client/src/app/api/api-details/api-details.component.ts
+++ b/client/src/app/api/api-details/api-details.component.ts
@@ -16,6 +16,7 @@ import { AiService } from '../../shared/services/ai.service';
 import { RequestResposeOverrideComponent } from '../request-respose-override/request-respose-override.component';
 import { ArmSiteDescriptor } from '../../shared/resourceDescriptors';
 import { NavigableComponent, ExtendedTreeViewInfo } from '../../shared/components/navigable-component';
+import { SiteService } from '../../shared/services/site.service';
 
 @Component({
     selector: 'api-details',
@@ -42,6 +43,7 @@ export class ApiDetailsComponent extends NavigableComponent implements OnDestroy
         private _translateService: TranslateService,
         private _aiService: AiService,
         private _functionAppService: FunctionAppService,
+        private _siteService: SiteService,
         injector: Injector) {
         super('api-details', injector, DashboardType.ProxyDashboard);
 
@@ -62,7 +64,7 @@ export class ApiDetailsComponent extends NavigableComponent implements OnDestroy
                         this.initEdit();
                         return Observable.zip(
                             this._functionAppService.getApiProxies(context),
-                            this._functionAppService.getFunctionAppAzureAppSettings(context));
+                            this._siteService.getAppSettings(context.site.id));
                     });
             })
             .do(r => {

--- a/client/src/app/api/api-new/api-new.component.ts
+++ b/client/src/app/api/api-new/api-new.component.ts
@@ -15,6 +15,7 @@ import { FunctionInfo } from '../../shared/models/function-info';
 import { errorIds } from '../../shared/models/error-ids';
 import { RequestResposeOverrideComponent } from '../request-respose-override/request-respose-override.component';
 import { NavigableComponent } from '../../shared/components/navigable-component';
+import { SiteService } from '../../shared/services/site.service';
 
 @Component({
     selector: 'api-new',
@@ -55,6 +56,7 @@ export class ApiNewComponent extends NavigableComponent {
         private _translateService: TranslateService,
         private _aiService: AiService,
         private _functionAppService: FunctionAppService,
+        private _siteService: SiteService,
         fb: FormBuilder,
         injector: Injector) {
         super('api-new', injector, DashboardType.CreateProxyDashboard);
@@ -94,7 +96,7 @@ export class ApiNewComponent extends NavigableComponent {
                         return Observable.zip(
                             this._functionAppService.getFunctions(context),
                             this._functionAppService.getApiProxies(context),
-                            this._functionAppService.getFunctionAppAzureAppSettings(context),
+                            this._siteService.getAppSettings(context.site.id),
                             (f, p, a) => ({ fcs: f, proxies: p, appSettings: a, context: context }));
                     });
             })

--- a/client/src/app/binding/binding.component.ts
+++ b/client/src/app/binding/binding.component.ts
@@ -17,6 +17,7 @@ import { FunctionInfo } from '../shared/models/function-info';
 import { FunctionAppService } from 'app/shared/services/function-app.service';
 import { FunctionAppContext } from 'app/shared/function-app-context';
 import { FunctionAppContextComponent } from 'app/shared/components/function-app-context-component';
+import { SiteService } from '../shared/services/site.service';
 
 declare var marked: any;
 
@@ -59,6 +60,7 @@ export class BindingComponent extends FunctionAppContextComponent implements OnD
     constructor(@Inject(ElementRef) elementRef: ElementRef,
         broadcastService: BroadcastService,
         private _functionAppService: FunctionAppService,
+        private _siteService: SiteService,
         private _portalService: PortalService,
         private _cacheService: CacheService,
         private _translateService: TranslateService,
@@ -116,7 +118,7 @@ export class BindingComponent extends FunctionAppContextComponent implements OnD
             .switchMap(viewInfo => {
                 // TODO: [alrod] handle error
                 this._functionInfo = viewInfo.functionInfo.result;
-                return this._functionAppService.getFunctionAppAzureAppSettings(viewInfo.context);
+                return this._siteService.getAppSettings(viewInfo.context.site.id);
             })
             .subscribe(appSettingsResult => {
                 // TODO: [alrod] handle error

--- a/client/src/app/function-monitor/function-monitor.component.ts
+++ b/client/src/app/function-monitor/function-monitor.component.ts
@@ -14,6 +14,7 @@ import { BroadcastEvent } from '../shared/models/broadcast-event';
 import { PortalResources } from '../shared/models/portal-resources';
 import { TranslateService } from '@ngx-translate/core';
 import { ApplicationInsightsService } from '../shared/services/application-insights.service';
+import { SiteService } from '../shared/services/site.service';
 
 @Component({
     selector: ComponentNames.functionMonitor,
@@ -29,6 +30,7 @@ export class FunctionMonitorComponent extends NavigableComponent {
 
     constructor(
         private _functionAppService: FunctionAppService,
+        private _siteService: SiteService,
         private _scenarioService: ScenarioService,
         private _translateService: TranslateService,
         private _applicationInsightsService: ApplicationInsightsService,
@@ -62,7 +64,7 @@ export class FunctionMonitorComponent extends NavigableComponent {
             .switchMap(tuple => Observable.zip(
                 Observable.of(tuple[0]),
                 this._functionAppService.getFunction(tuple[0], tuple[1].functionDescriptor.name),
-                this._functionAppService.getFunctionAppAzureAppSettings(tuple[0]),
+                this._siteService.getAppSettings(tuple[0].site.id),
                 this._scenarioService.checkScenarioAsync(ScenarioIds.appInsightsConfigurable, { site: tuple[0].site })
             ))
             .map((tuple): FunctionMonitorInfo => ({

--- a/client/src/app/function-quickstart/function-quickstart.component.ts
+++ b/client/src/app/function-quickstart/function-quickstart.component.ts
@@ -25,6 +25,7 @@ import { Dom } from '../shared/Utilities/dom';
 import { Observable } from 'rxjs/Observable';
 import { ArmObj } from '../shared/models/arm/arm-obj';
 import { ApplicationSettings } from '../shared/models/arm/application-settings';
+import { SiteService } from '../shared/services/site.service';
 
 
 type TemplateType = 'HttpTrigger' | 'TimerTrigger' | 'QueueTrigger';
@@ -59,7 +60,8 @@ export class FunctionQuickstartComponent extends FunctionAppContextComponent {
         private _globalStateService: GlobalStateService,
         private _translateService: TranslateService,
         private _aiService: AiService,
-        private _functionAppService: FunctionAppService) {
+        private _functionAppService: FunctionAppService,
+        private _siteService: SiteService) {
         super('function-quickstart', _functionAppService, broadcastService, () => _globalStateService.setBusyState());
 
         this.selectedFunction = 'HttpTrigger';
@@ -78,7 +80,7 @@ export class FunctionQuickstartComponent extends FunctionAppContextComponent {
                 return Observable.zip(
                     this._functionAppService.getFunctions(this.context),
                     this._functionAppService.getRuntimeGeneration(this.context),
-                    this._functionAppService.getFunctionAppAzureAppSettings(this.context));
+                    this._siteService.getAppSettings(this.context.site.id));
             })
             .do(null, e => {
                 this._aiService.trackException(e, '/errors/function-quickstart');

--- a/client/src/app/function/binding-v2/binding-v2.component.ts
+++ b/client/src/app/function/binding-v2/binding-v2.component.ts
@@ -21,6 +21,7 @@ import { FunctionAppService } from 'app/shared/services/function-app.service';
 import { FunctionAppContextComponent } from 'app/shared/components/function-app-context-component';
 import { Subscription } from 'rxjs/Subscription';
 import { FunctionAppContext } from 'app/shared/function-app-context';
+import { SiteService } from '../../shared/services/site.service';
 
 declare var marked: any;
 
@@ -76,6 +77,7 @@ export class BindingV2Component extends FunctionAppContextComponent {
         private _translateService: TranslateService,
         private _aiService: AiService,
         private _functionAppService: FunctionAppService,
+        private _siteService: SiteService,
         private _logService: LogService) {
         super('binding-v2', _functionAppService, broadcastService);
 
@@ -124,7 +126,7 @@ export class BindingV2Component extends FunctionAppContextComponent {
             .switchMap(view => {
                 this._functionInfo = view.functionInfo.result;
                 return Observable.zip(
-                    this._functionAppService.getFunctionAppAzureAppSettings(view.context),
+                    this._siteService.getAppSettings(view.context.site.id),
                     this._functionAppService.getAuthSettings(view.context),
                     Observable.of(view)
                 );

--- a/client/src/app/function/function-new/function-new.component.ts
+++ b/client/src/app/function/function-new/function-new.component.ts
@@ -25,6 +25,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { ScenarioService } from '../../shared/services/scenario/scenario.service';
 import { ArmObj } from '../../shared/models/arm/arm-obj';
 import { ApplicationSettings } from '../../shared/models/arm/application-settings';
+import { SiteService } from '../../shared/services/site.service';
 
 interface CategoryOrder {
     name: string;
@@ -132,7 +133,8 @@ export class FunctionNewComponent extends FunctionAppContextComponent implements
         private _globalStateService: GlobalStateService,
         private _translateService: TranslateService,
         private _logService: LogService,
-        private _functionAppService: FunctionAppService) {
+        private _functionAppService: FunctionAppService,
+        private _siteService: SiteService) {
         super('function-new', _functionAppService, _broadcastService, () => _globalStateService.setBusyState());
 
         this.disabled = !!_broadcastService.getDirtyState('function_disabled');
@@ -155,7 +157,7 @@ export class FunctionNewComponent extends FunctionAppContextComponent implements
                 return Observable.zip(
                     this._functionAppService.getFunctions(this.context),
                     this._functionAppService.getRuntimeGeneration(this.context),
-                    this._functionAppService.getFunctionAppAzureAppSettings(this.context),
+                    this._siteService.getAppSettings(this.context.site.id),
                     this._functionAppService.getBindingConfig(this.context),
                     this._functionAppService.getTemplates(this.context));
             })

--- a/client/src/app/shared/services/function-app.service.ts
+++ b/client/src/app/shared/services/function-app.service.ts
@@ -286,12 +286,6 @@ export class FunctionAppService {
                 .map(r => r.json()));
     }
 
-    getFunctionAppAzureAppSettings(context: FunctionAppContext) {
-        return this.azure.executeWithConditions([], { resourceId: context.site.id }, t =>
-            this._cacheService.postArm(`${context.site.id}/config/appsettings/list`, false)
-                .map(r => r.json() as ArmObj<{ [key: string]: string }>));
-    }
-
     createFunctionV2(context: FunctionAppContext, functionName: string, files: any, config: any) {
         const filesCopy = Object.assign({}, files);
         const sampleData = filesCopy['sample.dat'];

--- a/client/src/app/shared/services/function-app.service.ts
+++ b/client/src/app/shared/services/function-app.service.ts
@@ -73,7 +73,7 @@ export class FunctionAppService {
                 } else if (ArmUtil.isLinuxApp(context.site)) {
                     return this._cacheService.get(Constants.serviceHost + `api/runtimetoken${context.site.id}`, false, this.portalHeaders(info.token))
                 } else {
-                    return this._cacheService.get(context.urlTemplates.scmTokenUrl, true, this.headers(info.token));
+                    return this._cacheService.get(context.urlTemplates.scmTokenUrl, false, this.headers(info.token));
                 }
             })
             .map(r => r.json());
@@ -261,7 +261,7 @@ export class FunctionAppService {
 
                     return this._cacheService.get(
                         `${Constants.cdnHost}api/templates?runtime=${(extensionVersion || 'latest')}&cacheBreak=${window.appsvc.cacheBreakQuery}`,
-                        true,
+                        false,
                         headers);
                 })
                 .map(r => {
@@ -288,7 +288,7 @@ export class FunctionAppService {
 
     getFunctionAppAzureAppSettings(context: FunctionAppContext) {
         return this.azure.executeWithConditions([], { resourceId: context.site.id }, t =>
-            this._cacheService.postArm(`${context.site.id}/config/appsettings/list`, true)
+            this._cacheService.postArm(`${context.site.id}/config/appsettings/list`, false)
                 .map(r => r.json() as ArmObj<{ [key: string]: string }>));
     }
 
@@ -780,7 +780,7 @@ export class FunctionAppService {
         return this.azure.executeWithConditions([], { resourceId: context.site.id },
             Observable.zip(
                 this.isSourceControlEnabled(context),
-                this.azure.executeWithConditions([], { resourceId: context.site.id }, this._cacheService.postArm(`${context.site.id}/config/appsettings/list`, true)),
+                this.azure.executeWithConditions([], { resourceId: context.site.id }, this._cacheService.postArm(`${context.site.id}/config/appsettings/list`, false)),
                 this.isSlot(context)
                     ? Observable.of({ isSuccessful: true, result: true, error: null })
                     : this.getSlotsList(context).map(r => r.isSuccessful ? Object.assign(r, { result: r.result.length > 0 }) : r),


### PR DESCRIPTION
We seem to be too aggressive in issuing requests that could be perfectly fine if cached. I'm not sure why some of these were changed to ignore cache to begin with like in https://github.com/Azure/azure-functions-ux/pull/2555 


/cc @davidebbo 