### PR TITLE
Styling changes to make the API Definition page better.

### DIFF
--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1,5 +1,5 @@
 // This file is auto generated
-export class PortalResources {
+    export class PortalResources {
     public static azureFunctions = 'azureFunctions';
     public static azureFunctionsRuntime = 'azureFunctionsRuntime';
     public static cancel = 'cancel';
@@ -1133,5 +1133,4 @@ export class PortalResources {
     public static edit = 'edit';
     public static sync = 'sync';
     public static deploymentCredentials = 'deploymentCredentials';
-    public static featureNotSupportedForXenonApps = 'featureNotSupportedForXenonApps';
 }

--- a/client/src/app/site/swagger-definition/swagger-definition.component.html
+++ b/client/src/app/site/swagger-definition/swagger-definition.component.html
@@ -10,14 +10,14 @@
                 <br>
                 <label class="subtitle">{{'swaggerDefinition_subtitle' | translate}}</label>
             </div>
-            <div *ngIf="exportToPowerAppsEnabled" [class.collapse]="!swaggerEnabled">
+            <div *ngIf="exportToPowerAppsAvailable" [class.collapse]="!swaggerEnabled">
                 <label id="useApiDefinition" class="setting-title">{{'swaggerDefinition_useAPIdefinition' | translate}}</label>
                 <pop-over [position]="'bottom'" [message]="'swaggerDefinition_exporthelp' | translate">
                     <span class="glyphicon glyphicon-info-sign button-title"></span>
                 </pop-over>
                 <div class="setting-wrapper">
                     <!--<button class="custom-button medium">Download Function Keys</button>-->
-                    <button id="powerAppsFlowButton" class="custom-button medium" style="margin-left:0px;" (click)='openBlade("ExportToPowerApps")'
+                    <button [disabled]="exportToPowerAppsDisabled" id="powerAppsFlowButton" class="custom-button medium" style="margin-left:0px;" (click)='openBlade("ExportToPowerApps")'
                         aria-labelledby="useApiDefinition powerAppsFlowButton" tabindex="0">{{'swaggerDefinition_powerAppsFlow' | translate}}</button>
                 </div>
             </div>

--- a/client/src/app/site/swagger-definition/swagger-definition.component.scss
+++ b/client/src/app/site/swagger-definition/swagger-definition.component.scss
@@ -60,7 +60,7 @@ ul {
 }
 .setting-wrapper {
     padding: 0px 20px 15px 20px;
-    display: flex;
+    display: block;
 }
 
 .subtitle {

--- a/client/src/app/site/swagger-definition/swagger-definition.component.ts
+++ b/client/src/app/site/swagger-definition/swagger-definition.component.ts
@@ -40,7 +40,8 @@ export class SwaggerDefinitionComponent extends FunctionAppContextComponent impl
     public keyVisible: boolean;
     public documentationVisible: boolean;
     public swaggerEnabled: boolean;
-    public exportToPowerAppsEnabled = false;
+    public exportToPowerAppsAvailable = false;
+    public exportToPowerAppsDisabled = true;
     public swaggerStatusOptions: SelectOption<boolean>[];
     public valueChange: Subject<boolean>;
     public swaggerKey: string;
@@ -99,10 +100,11 @@ export class SwaggerDefinitionComponent extends FunctionAppContextComponent impl
             .switchMap(result => {
                 this.generation = result.gen;
                 this.swaggerEnabled = false;
-                this.exportToPowerAppsEnabled = this._scenarioService.checkScenario(ScenarioIds.enableExportToPowerApps).status !== 'disabled';
                 if (result.host && result.host.result.swagger && typeof (result.host.result.swagger.enabled) === 'boolean') {
                     this.swaggerEnabled = result.host.result.swagger.enabled;
                 }
+
+                this.exportToPowerAppsAvailable = this._scenarioService.checkScenario(ScenarioIds.enableExportToPowerApps).status !== 'disabled';
 
                 if (this.swaggerEnabled) {
                     return this.restoreSwaggerSecrets();
@@ -308,6 +310,7 @@ export class SwaggerDefinitionComponent extends FunctionAppContextComponent impl
                     .subscribe(updatedDocument => {
                         this.swaggerDocument = updatedDocument.result;
                         this._busyManager.clearBusy();
+                        this.exportToPowerAppsDisabled = false;
                     }, () => {
                         this._busyManager.clearBusy();
                     });
@@ -447,6 +450,8 @@ export class SwaggerDefinitionComponent extends FunctionAppContextComponent impl
                 const document = swaggerDoc.isSuccessful
                     ? swaggerDoc.result
                     : this._translateService.instant(PortalResources.swaggerDefinition_placeHolder);
+
+                this.exportToPowerAppsDisabled = !swaggerDoc.isSuccessful;
 
                 this.swaggerDocument = document;
                 this.assignDocumentToEditor(document);


### PR DESCRIPTION
Word wrap link in pre tag.
Disable 'export to powerapps+flow' button till the Swagger is saved.