### PR TITLE
Bug 12871279:[UR3]General Settings section in settings blade is not showing any option. Some options that are not applicable in seeings blade need to be hidden for xenon app

### DIFF
--- a/client/src/app/shared/models/constants.ts
+++ b/client/src/app/shared/models/constants.ts
@@ -195,9 +195,17 @@ export class ScenarioIds {
     public static readonly enableBackups = 'EnableBackups';
     public static readonly enableTinfoil = 'EnableTinfoil';
     public static readonly dotNetFrameworkSupported = 'DotNetFrameworkSupported';
+    public static readonly platform64BitSupported = 'Platform64BitSupported';
+    public static readonly webSocketsSupported = 'WebSocketsSupported';
+    public static readonly classicPipelineModeSupported = 'ClassicPipelineModeSupported';
+    public static readonly remoteDebuggingSupported = 'RemoteDebuggingSupported';
     public static readonly phpSupported = 'phpSupported';
     public static readonly pythonSupported = 'PythonSupported';
     public static readonly javaSupported = 'JavaSupported';
+    public static readonly defaultDocumentsSupported = 'DefaultDocumentsSupported';
+    public static readonly autoSwapSuuported = 'AutoSwapSuuported';
+    public static readonly handlerMappingsSupported = 'HandlerMappingsSupported';
+    public static readonly virtualDirectoriesSupported = 'VirtualDirectoriesSupported';
     public static readonly enableDiagnoseAndSolve = 'EnableDiagnoseAndSolve';
     public static readonly showSitePin = 'ShowSitePin';
     public static readonly showCreateRefreshSub = 'ShowCreateRefreshSub';
@@ -206,7 +214,6 @@ export class ScenarioIds {
     public static readonly enableAlwaysOn = 'EnableAlwaysOn';
     public static readonly enableRemoteDebugging = 'EnableRemoteDebugging';
     public static readonly deleteAppDirectly = 'deleteAppDirectly';
-    public static readonly autoSwapSuuported = 'AutoSwapSuuported';
     public static readonly enableAutoSwap = 'EnableAutoSwap';
     public static readonly enableSlots = 'EnableSlots';
     public static readonly createApp = 'createApp';

--- a/client/src/app/shared/services/scenario/onprem.environment.ts
+++ b/client/src/app/shared/services/scenario/onprem.environment.ts
@@ -13,11 +13,13 @@ export class OnPremEnvironment extends Environment {
     name = 'OnPrem';
     private _quotaService: QuotaService;
     private _translateService: TranslateService;
+    private _upSellMessage: string;
 
     constructor(injector: Injector) {
         super();
         this._quotaService = injector.get(QuotaService);
         this._translateService = injector.get(TranslateService);
+        this._upSellMessage = this._translateService.instant(PortalResources.upgradeUpsell);
         this.scenarioChecks[ScenarioIds.addSiteFeaturesTab] = {
             id: ScenarioIds.addSiteFeaturesTab,
             runCheck: () => {
@@ -42,8 +44,8 @@ export class OnPremEnvironment extends Environment {
             }
         };
 
-        this.scenarioChecks[ScenarioIds.enableRemoteDebugging] = {
-            id: ScenarioIds.enableRemoteDebugging,
+        this.scenarioChecks[ScenarioIds.remoteDebuggingSupported] = {
+            id: ScenarioIds.remoteDebuggingSupported,
             runCheck: () => {
                 return { status: 'disabled' };
             }
@@ -52,6 +54,12 @@ export class OnPremEnvironment extends Environment {
         this.scenarioChecks[ScenarioIds.enableAlwaysOn] = {
             id: ScenarioIds.enableAlwaysOn,
             runCheckAsync: (input: ScenarioCheckInput) => {
+                if (!input || !input.site || !input.site.id) {
+                    return Observable.of<ScenarioResult> ({
+                        status: 'disabled',
+                        data: this._upSellMessage
+                    });
+                }
                 const armResourceDescriptor = new ArmResourceDescriptor(input.site.id);
                 return this._quotaService.getQuotaLimit(
                     armResourceDescriptor.subscription,
@@ -63,7 +71,7 @@ export class OnPremEnvironment extends Environment {
                     return <ScenarioResult> {
                         // limit is infinity when it is -1
                         status: limit !== 0 ? 'enabled' : 'disabled',
-                        data: this._translateService.instant(PortalResources.upgradeUpsell)
+                        data: this._upSellMessage
                     };
                 });
             }
@@ -72,6 +80,12 @@ export class OnPremEnvironment extends Environment {
         this.scenarioChecks[ScenarioIds.enableAutoSwap] = {
             id: ScenarioIds.enableAutoSwap,
             runCheckAsync: (input: ScenarioCheckInput) => {
+                if (!input || !input.site || !input.site.id) {
+                    return Observable.of<ScenarioResult> ({
+                        status: 'disabled',
+                        data: this._upSellMessage
+                    });
+                }
                 const armResourceDescriptor = new ArmResourceDescriptor(input.site.id);
                 return this._quotaService.getQuotaLimit(
                     armResourceDescriptor.subscription,
@@ -80,8 +94,8 @@ export class OnPremEnvironment extends Environment {
                     input.site.properties.computeMode
                 ).map(limit => {
                     return <ScenarioResult> {
-                        status: limit > 1 ? 'enabled' : 'disabled',
-                        data: this._translateService.instant(PortalResources.upgradeUpsell)
+                        status: limit > 1 || limit === -1 ? 'enabled' : 'disabled',
+                        data: this._upSellMessage
                     };
                 });
             }
@@ -90,6 +104,12 @@ export class OnPremEnvironment extends Environment {
         this.scenarioChecks[ScenarioIds.enablePlatform64] = {
             id: ScenarioIds.enablePlatform64,
             runCheckAsync: (input: ScenarioCheckInput) => {
+                if (!input || !input.site || !input.site.id) {
+                    return Observable.of<ScenarioResult> ({
+                        status: 'disabled',
+                        data: this._upSellMessage
+                    });
+                }
                 const armResourceDescriptor = new ArmResourceDescriptor(input.site.id);
                 return this._quotaService.getQuotaLimit(
                     armResourceDescriptor.subscription,
@@ -99,7 +119,7 @@ export class OnPremEnvironment extends Environment {
                 ).map(limit => {
                     return <ScenarioResult> {
                         status: limit !== 0 ? 'enabled' : 'disabled',
-                        data: this._translateService.instant(PortalResources.upgradeUpsell)
+                        data: this._upSellMessage
                     };
                 });
             }
@@ -108,6 +128,12 @@ export class OnPremEnvironment extends Environment {
         this.scenarioChecks[ScenarioIds.webSocketsEnabled] = {
             id: ScenarioIds.webSocketsEnabled,
             runCheckAsync: (input: ScenarioCheckInput) => {
+                if (!input || !input.site || !input.site.id) {
+                    return Observable.of<ScenarioResult> ({
+                        status: 'disabled',
+                        data: this._upSellMessage
+                    });
+                }
                 const armResourceDescriptor = new ArmResourceDescriptor(input.site.id);
                 return this._quotaService.getQuotaLimit(
                     armResourceDescriptor.subscription,
@@ -117,7 +143,7 @@ export class OnPremEnvironment extends Environment {
                 ).map(limit => {
                     return <ScenarioResult> {
                         status: limit !== 0 ? 'enabled' : 'disabled',
-                        data: this._translateService.instant(PortalResources.upgradeUpsell)
+                        data: this._upSellMessage
                     };
                 });
             }

--- a/client/src/app/shared/services/scenario/xenon-site.environment.ts
+++ b/client/src/app/shared/services/scenario/xenon-site.environment.ts
@@ -28,6 +28,41 @@ export class XenonSiteEnvironment extends Environment {
             runCheck: () => disabledResult
         };
 
+        this.scenarioChecks[ScenarioIds.platform64BitSupported] = {
+            id: ScenarioIds.platform64BitSupported,
+            runCheck: () => disabledResult
+        };
+
+        this.scenarioChecks[ScenarioIds.webSocketsSupported] = {
+            id: ScenarioIds.webSocketsSupported,
+            runCheck: () => disabledResult
+        };
+
+        this.scenarioChecks[ScenarioIds.classicPipelineModeSupported] = {
+            id: ScenarioIds.classicPipelineModeSupported,
+            runCheck: () => disabledResult
+        };
+
+        this.scenarioChecks[ScenarioIds.defaultDocumentsSupported] = {
+            id: ScenarioIds.defaultDocumentsSupported,
+            runCheck: () => disabledResult
+        };
+
+        this.scenarioChecks[ScenarioIds.virtualDirectoriesSupported] = {
+            id: ScenarioIds.virtualDirectoriesSupported,
+            runCheck: () => disabledResult
+        };
+
+        this.scenarioChecks[ScenarioIds.handlerMappingsSupported] = {
+            id: ScenarioIds.handlerMappingsSupported,
+            runCheck: () => disabledResult
+        };
+
+        this.scenarioChecks[ScenarioIds.remoteDebuggingSupported] = {
+            id: ScenarioIds.remoteDebuggingSupported,
+            runCheck: () => disabledResult
+        };
+
         this.scenarioChecks[ScenarioIds.phpSupported] = {
             id: ScenarioIds.phpSupported,
             runCheck: () => disabledResult

--- a/client/src/app/site/site-config/general-settings/general-settings.component.ts
+++ b/client/src/app/site/site-config/general-settings/general-settings.component.ts
@@ -327,15 +327,28 @@ export class GeneralSettingsComponent extends ConfigSaveComponent implements OnC
                 FTPAccessSupported = false;
             }
 
-            if (this._scenarioService.checkScenario(ScenarioIds.enableRemoteDebugging).status === 'disabled') {
-                remoteDebuggingSupported = false;
-            }
             if (this._scenarioService.checkScenario(ScenarioIds.addHTTPSwitch, { site: siteArm }).status === 'disabled') {
                 http20Supported = false;
             }
 
             if (this._scenarioService.checkScenario(ScenarioIds.dotNetFrameworkSupported, { site: siteArm }).status === 'disabled') {
                 netFrameworkSupported = false;
+            }
+
+            if (this._scenarioService.checkScenario(ScenarioIds.platform64BitSupported, { site: siteArm }).status === 'disabled') {
+                platform64BitSupported = false;
+            }
+
+            if (this._scenarioService.checkScenario(ScenarioIds.webSocketsSupported, { site: siteArm }).status === 'disabled') {
+                webSocketsSupported = false;
+            }
+
+            if (this._scenarioService.checkScenario(ScenarioIds.classicPipelineModeSupported, { site: siteArm }).status === 'disabled') {
+                classicPipelineModeSupported = false;
+            }
+
+            if (this._scenarioService.checkScenario(ScenarioIds.remoteDebuggingSupported, { site: siteArm }).status === 'disabled') {
+                remoteDebuggingSupported = false;
             }
 
             if (this._scenarioService.checkScenario(ScenarioIds.phpSupported, { site: siteArm }).status === 'disabled') {

--- a/client/src/app/site/site-config/site-config.component.ts
+++ b/client/src/app/site/site-config/site-config.component.ts
@@ -17,11 +17,12 @@ import { HandlerMappingsComponent } from './handler-mappings/handler-mappings.co
 import { VirtualDirectoriesComponent } from './virtual-directories/virtual-directories.component';
 import { PortalService } from './../../shared/services/portal.service';
 import { AuthzService } from './../../shared/services/authz.service';
-import { LogCategories, SiteTabIds } from './../../shared/models/constants';
+import { LogCategories, SiteTabIds, ScenarioIds } from './../../shared/models/constants';
 import { LogService } from './../../shared/services/log.service';
 import { ArmUtil } from 'app/shared/Utilities/arm-utils';
 import { FeatureComponent } from 'app/shared/components/feature-component';
 import { ArmSaveConfigs, ArmSaveResult, ArmSaveResults } from 'app/shared/components/config-save-component';
+import { ScenarioService } from 'app/shared/services/scenario/scenario.service';
 
 export interface SaveOrValidationResult {
     success: boolean;
@@ -67,6 +68,7 @@ export class SiteConfigComponent extends FeatureComponent<TreeViewInfo<SiteData>
         private _authZService: AuthzService,
         private _cacheService: CacheService,
         private _siteService: SiteService,
+        private _scenarioService: ScenarioService,
         injector: Injector
     ) {
         super('site-config', injector, SiteTabIds.applicationSettings);
@@ -90,6 +92,18 @@ export class SiteConfigComponent extends FeatureComponent<TreeViewInfo<SiteData>
                     this.defaultDocumentsSupported = true;
                     this.handlerMappingsSupported = true;
                     this.virtualDirectoriesSupported = true;
+                }
+
+                if (this._scenarioService.checkScenario(ScenarioIds.defaultDocumentsSupported, { site: this._site }).status === 'disabled') {
+                    this.defaultDocumentsSupported = false;
+                }
+
+                if (this._scenarioService.checkScenario(ScenarioIds.handlerMappingsSupported, { site: this._site }).status === 'disabled') {
+                    this.handlerMappingsSupported = false;
+                }
+
+                if (this._scenarioService.checkScenario(ScenarioIds.virtualDirectoriesSupported, { site: this._site }).status === 'disabled') {
+                    this.virtualDirectoriesSupported = false;
                 }
 
                 this._setupForm();


### PR DESCRIPTION
Bug 12871279:[UR3][AzureStack]General Settings section in settings blade is not showing any option. Some options that are not applicable in seeings blade need to be hidden for xenon app

- It turns out that site object can be null in ScenrioCheks. We are now handling this properly
- Some options not applicable for xenon are now hidden
