### PR TITLE
Updating FunctionDevComponent to collapse log-streaming and function-console controls when viewport becomes too narrow

### DIFF
--- a/client/src/app/function-console/function-console.component.html
+++ b/client/src/app/function-console/function-console.component.html
@@ -1,5 +1,6 @@
 <div class= "console-container">
-    <div class="console-toolbar">
+
+    <div *ngIf="!controlsCollapsed" class="console-toolbar">
         <span class="console-empty-space"></span>
         <span class="link action" (click)="clearConsole()"
             tabindex="0" role="button" attr.aria-label="{{ 'logStreaming_clear' | translate }}">
@@ -26,6 +27,46 @@
             {{ 'logStreaming_compress' | translate }}
         </span>
     </div>
+
+    <div *ngIf="controlsCollapsed"
+        class="menu-container"
+        (focusin)="onMenuFocusIn()"
+        (focusout)="onMenuFocusOut()">
+        <div class="menu-button-container">
+            <span role="button"
+                tabindex="0"
+                [attr.title]="'actions' | translate"
+                class="link action"
+                (click)="toggleMenu()"
+                [activate-with-keys]>
+                <span class="fa fa-ellipsis-v" aria-hidden="true"></span>
+            </span>
+        </div>
+        <ul *ngIf="!menuHidden" role="menu" [attr.aria-label]="'context_menu' | translate" (click)="hideMenu()">
+            <li role="menuitem" tabindex="0" class="link action"
+                (click)="clearConsole()"
+                [activate-with-keys]
+                [attr.aria-label]="'logStreaming_clear' | translate">
+                <span class="fa fa-book"></span>
+                {{ 'logStreaming_clear' | translate }}
+            </li>
+            <li role="menuitem" tabindex="0" class="link action"
+                (click)="copyLogs($event)"
+                [activate-with-keys]
+                [attr.aria-label]="'logStreaming_copyLogs' | translate">
+                <span class="fa fa-clone"></span>
+                {{ 'copypre_copy' | translate }}
+            </li>
+            <li role="menuitem" tabindex="0" class="link action"
+                (click)="isExpanded ? compress() : expand()"
+                [activate-with-keys]
+                [attr.aria-label]="(isExpanded ? 'logStreaming_compress' : 'logStreaming_expand') | translate">
+                <span [ngClass]="isExpanded ? 'fa fa-compress' : 'fa fa-expand'"></span>
+                {{ (isExpanded ? 'logStreaming_compress' : 'logStreaming_expand') | translate }}
+            </li>
+        </ul>
+    </div>
+
     <pre id= "console-body" class="console-body" tabindex="0"
          (keydown)="handleKeyPress($event)"
          (click)="focusConsole()">

--- a/client/src/app/function-console/function-console.component.scss
+++ b/client/src/app/function-console/function-console.component.scss
@@ -86,3 +86,47 @@ span.linux-cursor {
         visibility: hidden;
     }
 }
+
+.menu-container{
+    position: relative;
+    top: -13px;
+
+    .menu-button-container{
+        position: relative;
+        float: right;
+        text-align:
+        right; z-index: 1;
+
+        [role=button]{
+            display: inline-block;
+            padding: 6px 10px 6px 10px;
+            margin: 0;
+            background: white;
+
+            span{
+                padding: 0px;
+            }
+        }
+    }
+
+    [role=menu]{
+        position: relative;
+        float: right;
+        padding: 0px;
+        margin: 0px 5px 0px 0px;
+        box-shadow: 0 4px 8px 0 rgba(0,0,0,.14);
+        z-index: 1;
+
+        [role=menuitem]{
+            display: block;
+            padding:
+            6px 10px 6px 10px;
+            margin: 0;
+            background: white;
+
+            span{
+                padding-right: 5px;
+            }
+        }
+    }
+}

--- a/client/src/app/function-console/function-console.component.scss
+++ b/client/src/app/function-console/function-console.component.scss
@@ -101,7 +101,7 @@ span.linux-cursor {
             display: inline-block;
             padding: 6px 10px 6px 10px;
             margin: 0;
-            background: white;
+            background: $body-bg-color;
 
             span{
                 padding: 0px;
@@ -114,7 +114,8 @@ span.linux-cursor {
         float: right;
         padding: 0px;
         margin: 0px 5px 0px 0px;
-        box-shadow: 0 4px 8px 0 rgba(0,0,0,.14);
+        box-shadow: 0 4px 8px 0 rgba($default-text-color,.14);
+        border: 1px solid rgba(204,204,204,.8);
         z-index: 1;
 
         [role=menuitem]{
@@ -122,10 +123,28 @@ span.linux-cursor {
             padding:
             6px 10px 6px 10px;
             margin: 0;
-            background: white;
+            background: $body-bg-color;
 
             span{
                 padding-right: 5px;
+            }
+        }
+    }
+}
+
+:host-context(#app-root[theme=dark]){
+    .menu-container{
+        .menu-button-container{
+            [role=button]{
+                background: $body-bg-color-dark;
+            }
+        }
+
+        [role=menu]{
+            border: 1px solid #605e5c;
+
+            [role=menuitem]{
+                background: $body-bg-color-dark;
             }
         }
     }

--- a/client/src/app/function-console/function-console.component.ts
+++ b/client/src/app/function-console/function-console.component.ts
@@ -1,4 +1,4 @@
-import { OnDestroy, Component, ViewContainerRef, ViewChild, ComponentRef, ComponentFactory, ComponentFactoryResolver, EventEmitter, Output, Input } from '@angular/core';
+import { OnDestroy, Component, ViewContainerRef, ViewChild, ComponentRef, ComponentFactory, ComponentFactoryResolver, EventEmitter, Output, Input, SimpleChanges, OnChanges } from '@angular/core';
 import { FunctionAppContextComponent } from '../shared/components/function-app-context-component';
 import { FunctionAppService } from '../shared/services/function-app.service';
 import { BroadcastService } from '../shared/services/broadcast.service';
@@ -22,7 +22,7 @@ import { UtilitiesService } from '../shared/services/utilities.service';
     templateUrl: './function-console.component.html',
     styleUrls: ['./function-console.component.scss', '../function-dev/function-dev.component.scss'],
 })
-export class FunctionConsoleComponent extends FunctionAppContextComponent implements OnDestroy {
+export class FunctionConsoleComponent extends FunctionAppContextComponent implements OnChanges, OnDestroy {
 
     public appName: string;
     public isLinux = false;
@@ -91,6 +91,12 @@ export class FunctionConsoleComponent extends FunctionAppContextComponent implem
                     });
             }
             );
+    }
+
+    ngOnChanges(changes: SimpleChanges) {
+        if (changes['controlsCollapsed']) {
+            this.menuHidden = true;
+        }
     }
 
     ngOnDestroy() {

--- a/client/src/app/function-console/function-console.component.ts
+++ b/client/src/app/function-console/function-console.component.ts
@@ -27,7 +27,7 @@ export class FunctionConsoleComponent extends FunctionAppContextComponent implem
     public appName: string;
     public isLinux = false;
     public isExpanded = false;
-    public command = {'left': '', 'mid': ' ', 'right': '', 'complete': ''};
+    public command = { 'left': '', 'mid': ' ', 'right': '', 'complete': '' };
     public dir: string;
     public isFocused: boolean;
     public leftSideText = '';
@@ -49,7 +49,7 @@ export class FunctionConsoleComponent extends FunctionAppContextComponent implem
     private _messageComponent: ComponentFactory<any>;
     private _errorComponent: ComponentFactory<any>;
     private _msgComponents: ComponentRef<any>[] = [];
-    @ViewChild('prompt', {read: ViewContainerRef})
+    @ViewChild('prompt', { read: ViewContainerRef })
     private _prompt: ViewContainerRef;
     @Output() expandClicked = new EventEmitter<boolean>();
 
@@ -84,7 +84,7 @@ export class FunctionConsoleComponent extends FunctionAppContextComponent implem
                         this._updateDirectory();
                     });
             }
-        );
+            );
     }
 
     ngOnDestroy() {
@@ -171,9 +171,11 @@ export class FunctionConsoleComponent extends FunctionAppContextComponent implem
     /**
      * Compress the console interface
      */
-    compress() {
+    compress(preventEvent?: boolean) {
         this.isExpanded = false;
-        this.expandClicked.emit(false);
+        if (!preventEvent) {
+            this.expandClicked.emit(false);
+        }
     }
 
     /**
@@ -624,7 +626,7 @@ export class FunctionConsoleComponent extends FunctionAppContextComponent implem
         if (this.isLinux) {
             const result = cmd.split(ConsoleConstants.linuxNewLine);
             this.dir = result[result.length - 1];
-        }else {
+        } else {
             const result = cmd.split(ConsoleConstants.windowsNewLine);
             this.dir = result[result.length - 1];
         }
@@ -708,7 +710,7 @@ export class FunctionConsoleComponent extends FunctionAppContextComponent implem
             },
         );
         res.subscribe(data => {
-            const {Output} = data.json();
+            const { Output } = data.json();
             this.dir = Output.trim() + ConsoleConstants.singleBackslash + this._functionName;
             this._setLeftSideText();
         });

--- a/client/src/app/function-console/function-console.component.ts
+++ b/client/src/app/function-console/function-console.component.ts
@@ -1,4 +1,4 @@
-import { OnDestroy, Component, ViewContainerRef, ViewChild, ComponentRef, ComponentFactory, ComponentFactoryResolver, EventEmitter, Output } from '@angular/core';
+import { OnDestroy, Component, ViewContainerRef, ViewChild, ComponentRef, ComponentFactory, ComponentFactoryResolver, EventEmitter, Output, Input } from '@angular/core';
 import { FunctionAppContextComponent } from '../shared/components/function-app-context-component';
 import { FunctionAppService } from '../shared/services/function-app.service';
 import { BroadcastService } from '../shared/services/broadcast.service';
@@ -31,6 +31,10 @@ export class FunctionConsoleComponent extends FunctionAppContextComponent implem
     public dir: string;
     public isFocused: boolean;
     public leftSideText = '';
+    public menuHidden = true;
+    @Input() controlsCollapsed: boolean;
+
+    private _menuHasFocus: boolean;
     private _tabKeyPointer: number;
     private _resourceId: string;
     private _functionName: string;
@@ -68,6 +72,8 @@ export class FunctionConsoleComponent extends FunctionAppContextComponent implem
         return this.viewInfoEvents
             .subscribe(view => {
                 this.isFocused = false;
+                this.menuHidden = true;
+                this._menuHasFocus = false;
                 this._resourceId = view.siteDescriptor.resourceId;
                 this._functionName = view.functionDescriptor.name;
                 this.clearConsole();
@@ -714,5 +720,26 @@ export class FunctionConsoleComponent extends FunctionAppContextComponent implem
             this.dir = Output.trim() + ConsoleConstants.singleBackslash + this._functionName;
             this._setLeftSideText();
         });
+    }
+
+    public hideMenu() {
+        this.menuHidden = true;
+    }
+
+    public toggleMenu() {
+        this.menuHidden = !this.menuHidden;
+    }
+
+    public onMenuFocusOut() {
+        this._menuHasFocus = false;
+        setTimeout(_ => {
+            if (!this._menuHasFocus) {
+                this.hideMenu();
+            }
+        });
+    }
+
+    public onMenuFocusIn() {
+        this._menuHasFocus = true;
     }
 }

--- a/client/src/app/function-dev/function-dev.component.html
+++ b/client/src/app/function-dev/function-dev.component.html
@@ -239,18 +239,20 @@
   </aside>
 
   <footer id="bottom-tabs-bar">
+    <div class="tab-heading" (click)="clickBottomTab(bottomBarExpanded ? bottomTab : 'logs')">
+      <h4 tabindex="0"
+        class="tab-label"
+        (keydown)="keyDown($event, 'clickBottomTab', bottomBarExpanded ? bottomTab : 'logs')">
+          <i *ngIf="bottomBarExpanded" class="fa fa-chevron-down"></i>
+          <i *ngIf="!bottomBarExpanded" class="fa fa-chevron-up"></i>
+      </h4>
+    </div>
+
     <div class="tab-heading" (click)="clickBottomTab('logs')">
       <h4 [class.tab-label-disabled]="bottomTab !== 'logs'"
         [class.tab-label-selected]="bottomTab === 'logs'"
         tabindex="0"
         (keydown)="keyDown($event, 'clickBottomTab', 'logs')">{{ 'logStreaming_logs' | translate }}</h4>
-
-      <h4 tabindex="0"
-        class="tab-label"
-        (keydown)="keyDown($event, 'clickBottomTab', 'logs')">
-          <i *ngIf="bottomTab !== 'logs'" class="fa fa-chevron-up"></i>
-          <i *ngIf="bottomTab === 'logs'" class="fa fa-chevron-down"></i>
-      </h4>
     </div>
 
     <div *ngIf="showErrorsAndWarnings | async" class="tab-heading" (click)="clickBottomTab('errors')">
@@ -258,13 +260,6 @@
         [class.tab-label-selected]="bottomTab === 'errors'"
         tabindex="0"
         (keydown)="keyDown($event, 'clickBottomTab', 'errors')">{{ 'diagnostics_errorsAndWarnings' | translate }}</h4>
-
-      <h4 tabindex="0"
-        class="tab-label"
-        (keydown)="keyDown($event, 'clickBottomTab', 'errors')">
-          <i *ngIf="bottomTab !== 'errors'" class="fa fa-chevron-up"></i>
-          <i *ngIf="bottomTab === 'errors'" class="fa fa-chevron-down"></i>
-      </h4>
     </div>
 
     <div *ngIf="showConsole" class="tab-heading" (click)="clickBottomTab('console')">
@@ -272,13 +267,6 @@
         [class.tab-label-selected]="bottomTab === 'console'"
         tabindex="0"
         (keydown)="keyDown($event, 'clickBottomTab', 'console')">{{ 'feature_consoleName' | translate }}</h4>
-
-      <h4 tabindex="0"
-        class="tab-label"
-        (keydown)="keyDown($event, 'clickBottomTab', 'console')">
-          <i *ngIf="bottomTab !== 'console'" class="fa fa-chevron-up"></i>
-          <i *ngIf="bottomTab === 'console'" class="fa fa-chevron-down"></i>
-      </h4>
     </div>
 
     <log-streaming [hidden]="bottomTab !== 'logs'"

--- a/client/src/app/function-dev/function-dev.component.html
+++ b/client/src/app/function-dev/function-dev.component.html
@@ -50,7 +50,7 @@
   [class.bottom-tabs-expanded]="bottomBarExpanded"
   [class.bottom-tabs-maximized]="expandLogs">
 
-  <section id="editor-section">
+  <section #editorSection id="editor-section">
     <div id="command-bar-container">
       <h2
         tabindex="0" class="filename-title">
@@ -270,6 +270,7 @@
     </div>
 
     <log-streaming [hidden]="bottomTab !== 'logs'"
+      [controlsCollapsed]="bottomControlsCollapsed"
       [viewInfo]="viewInfo"
       (expandClicked)="expandLogsClicked($event)"> </log-streaming>
 
@@ -280,6 +281,7 @@
       [monacoEditor]="codeEditor"></errors-warnings>
 
     <console [hidden]="bottomTab !== 'console'"
+      [controlsCollapsed]="bottomControlsCollapsed"
       [viewInfo]="viewInfo"
       (expandClicked)="expandLogsClicked($event)"> </console>
 

--- a/client/src/app/function-dev/function-dev.component.html
+++ b/client/src/app/function-dev/function-dev.component.html
@@ -257,7 +257,7 @@
       <h4 [class.tab-label-disabled]="bottomTab !== 'errors'"
         [class.tab-label-selected]="bottomTab === 'errors'"
         tabindex="0"
-        (keydown)="keyDown($event, 'clickBottomTab', 'logs')">{{ 'diagnostics_errorsAndWarnings' | translate }}</h4>
+        (keydown)="keyDown($event, 'clickBottomTab', 'errors')">{{ 'diagnostics_errorsAndWarnings' | translate }}</h4>
 
       <h4 tabindex="0"
         class="tab-label"
@@ -283,20 +283,16 @@
 
     <log-streaming [hidden]="bottomTab !== 'logs'"
       [viewInfo]="viewInfo"
-      (closeClicked)="clickBottomTab('logs')"
       (expandClicked)="expandLogsClicked($event)"> </log-streaming>
 
     <errors-warnings *ngIf="showErrorsAndWarnings | async"
       [hidden]="bottomTab !== 'errors'"
       (selectFile)="selectedFileStream.next($event)"
       [viewInfo]="viewInfo"
-      [monacoEditor]="codeEditor"
-      (expandClicked)="expandLogsClicked($event)"
-      (diagnosticDblClicked)="clickRightTab('files')"></errors-warnings>
+      [monacoEditor]="codeEditor"></errors-warnings>
 
     <console [hidden]="bottomTab !== 'console'"
       [viewInfo]="viewInfo"
-      (closeClicked)="clickBottomTab('console')"
       (expandClicked)="expandLogsClicked($event)"> </console>
 
   </footer>

--- a/client/src/app/function-dev/function-dev.component.scss
+++ b/client/src/app/function-dev/function-dev.component.scss
@@ -182,9 +182,16 @@
     flex-grow: 1;
 }
 
-
 .tab-heading {
     display: inline-block;
+}
+
+.tab-label {
+    margin-left: 0px;
+}
+
+.tab-label-disabled, .tab-label-selected {
+    margin-left: 5px;
 }
 
 .tab-label-dev {

--- a/client/src/app/function-dev/function-dev.component.scss
+++ b/client/src/app/function-dev/function-dev.component.scss
@@ -241,6 +241,7 @@
   grid-column: 1;
   -ms-grid-row: 1;
   grid-row: 1;
+  min-width: 550px;
   #text-editor-container {
     height: calc(100% - 40px);
     border-bottom: $border;

--- a/client/src/app/function-dev/function-dev.component.ts
+++ b/client/src/app/function-dev/function-dev.component.ts
@@ -15,6 +15,7 @@ import { TranslateService } from '@ngx-translate/core';
 
 import { FunctionInfo } from '../shared/models/function-info';
 import { VfsObject } from '../shared/models/vfs-object';
+import { FunctionConsoleComponent } from '../function-console/function-console.component';
 import { LogStreamingComponent } from '../log-streaming/log-streaming.component';
 import { BroadcastService } from '../shared/services/broadcast.service';
 import { BroadcastEvent } from '../shared/models/broadcast-event';
@@ -51,8 +52,10 @@ export class FunctionDevComponent extends FunctionAppContextComponent implements
     @ViewChildren(BusyStateComponent) BusyStates: QueryList<BusyStateComponent>;
     @ViewChildren(MonacoEditorDirective) monacoEditors: QueryList<MonacoEditorDirective>;
     @ViewChildren(LogStreamingComponent) logStreamings: QueryList<LogStreamingComponent>;
+    @ViewChild(FunctionConsoleComponent) functionConsole: FunctionConsoleComponent;
 
     @ViewChild('functionContainer') functionContainer: ElementRef;
+    @ViewChild('editorSection') editorSection: ElementRef;
     @ViewChild('rightContainer') rightContainer: ElementRef;
     @ViewChild('selectKeys') selectKeys: ElementRef;
 
@@ -92,6 +95,7 @@ export class FunctionDevComponent extends FunctionAppContextComponent implements
     public selectedFileStream: Subject<FileSelectionEvent>;
     public functionKey: string;
 
+    public bottomControlsCollapsed = false;
     public bottomBarExpanded: boolean;
     public rightBarExpanded: boolean;
 
@@ -327,6 +331,8 @@ export class FunctionDevComponent extends FunctionAppContextComponent implements
             this.testDataEditor.resize();
         }
 
+        if (this.editorSection && this.editorSection.nativeElement) {
+            this.bottomControlsCollapsed = this.editorSection.nativeElement.clientWidth < 800;
         }
     }
 

--- a/client/src/app/function-dev/function-dev.component.ts
+++ b/client/src/app/function-dev/function-dev.component.ts
@@ -54,7 +54,6 @@ export class FunctionDevComponent extends FunctionAppContextComponent implements
 
     @ViewChild('functionContainer') functionContainer: ElementRef;
     @ViewChild('rightContainer') rightContainer: ElementRef;
-    @ViewChild('bottomContainer') bottomContainer: ElementRef;
     @ViewChild('selectKeys') selectKeys: ElementRef;
 
     public functionInfo: FunctionInfo;
@@ -207,8 +206,8 @@ export class FunctionDevComponent extends FunctionAppContextComponent implements
                         status.errors = status.errors || [];
                         this.showComponentError({
                             message: this._translateService.instant(PortalResources.error_functionRuntimeIsUnableToStart)
-                                + '\n'
-                                + status.errors.reduce((a, b) => `${a}\n${b}`, '\n'),
+                            + '\n'
+                            + status.errors.reduce((a, b) => `${a}\n${b}`, '\n'),
                             errorId: errorIds.functionRuntimeIsUnableToStart,
                             resourceId: this.context.site.id
                         });
@@ -328,27 +327,27 @@ export class FunctionDevComponent extends FunctionAppContextComponent implements
             this.testDataEditor.resize();
         }
 
-        if (this.bottomContainer) {
-            this.bottomContainer.nativeElement.style.width = this.codeEditor.width + 'px';
         }
     }
 
     clickBottomTab(tab: string) {
+        this.expandLogs = false;
+        if (this.runLogs) {
+            this.runLogs.compress(true);
+        }
+        if (this.functionConsole) {
+            this.functionConsole.compress(true);
+        }
+
         if (this.bottomTab === tab) {
             this.bottomTab = '';
-            this.expandLogs = false;
-            if (this.runLogs) {
-                this.runLogs.compress();
-            }
             this.bottomBarExpanded = false;
         } else {
             this.bottomTab = tab;
             this.bottomBarExpanded = true;
-            this.expandLogs = false;
         }
 
         // double resize to fix pre height
-
         setTimeout(() => {
             this.onResize();
         }, 0);
@@ -540,9 +539,9 @@ export class FunctionDevComponent extends FunctionAppContextComponent implements
                     appResourceId: this.context.site.id
                 });
             },
-                () => {
-                    this._globalStateService.clearBusyState();
-                });
+            () => {
+                this._globalStateService.clearBusyState();
+            });
     }
 
     contentChanged(content: string) {
@@ -708,6 +707,9 @@ export class FunctionDevComponent extends FunctionAppContextComponent implements
             switch (key) {
                 case 'clickRightTab':
                     this.clickRightTab(param);
+                    break;
+                case 'clickBottomTab':
+                    this.clickBottomTab(param);
                     break;
                 case 'setShowFunctionInvokeUrlModal':
                     this.setShowFunctionInvokeUrlModal(param);

--- a/client/src/app/log-streaming/log-streaming.component.html
+++ b/client/src/app/log-streaming/log-streaming.component.html
@@ -1,51 +1,108 @@
 <div class="log-streaming-container">
-    <div *ngIf="!isHttpLogs" class="log-toolbar">
-        <span class="log-empty-space"></span>
-        <span (click)="reconnect()" class="link action"
-             role="button" attr.aria-label="{{ 'logStreaming_reconnect' | translate }}">
-            <pop-over message="{{ getPopoverText() | translate }}" hideAfter="{{popOverTimeout}}">
-                <span class="link">
-                    <i class="fa fa-plug"></i>
-                    {{ 'logStreaming_reconnect' | translate }}
-                </span>
-            </pop-over>
-        </span>
-        <span (click)="copyLogs($event)" class="link action"
-            (keydown)="keyDown($event, 'copyLogs')" role="button" attr.aria-label="{{ 'logStreaming_copyLogs' | translate }}">
-            <pop-over message="{{ 'logStreaming_copied' | translate }}" hideAfter="{{popOverTimeout}}">
-                <span class="link">
-                    <i class="fa fa-clone"></i>
-                    {{ 'logStreaming_copyLogs' | translate }}
-                </span>
-            </pop-over>
-        </span>
-        <span class="link action" *ngIf="stopped" (click)="startLogs()"
-            (keydown)="keyDown($event, 'startLogs')" tabindex="0" role="button" attr.aria-label="{{ 'logStreaming_start' | translate }}">
-            <i class="fa fa-play"></i>
-            {{ 'logStreaming_start' | translate }}
-        </span>
-        <span class="link action" *ngIf="!stopped" (click)="stopLogs()"
-            (keydown)="keyDown($event, 'stopLogs')" tabindex="0" role="button" attr.aria-label="{{ 'logStreaming_pause' | translate }}">
-            <i class="fa fa-pause"></i>
-            {{ 'logStreaming_pause' | translate }}
-        </span>
-        <span class="link action" (click)="clearLogs()"
-            (keydown)="keyDown($event, 'clearLogs')" tabindex="0" role="button" attr.aria-label="{{ 'logStreaming_clear' | translate }}">
-            <i class="fa fa-book"></i>
-            {{ 'logStreaming_clear' | translate }}
-        </span>
-        <span *ngIf="!isExpanded" class="link action" (click)="expand()"
-            (keydown)="keyDown($event, 'expand')" tabindex="0" role="button" attr.aria-label="{{ 'logStreaming_expand' | translate }}">
-            <i class="fa fa-expand"></i>
-            {{ 'logStreaming_expand' | translate }}
-        </span>
+    <ng-container *ngIf="!isHttpLogs">
 
-        <span *ngIf="isExpanded" class="link action" (click)="compress()"
-            (keydown)="keyDown($event, 'compress')" tabindex="0" role="button" attr.aria-label="{{ 'logStreaming_compress' | translate }}">
-            <i class="fa fa-compress"></i>
-            {{ 'logStreaming_compress' | translate }}
-        </span>
-    </div>
+        <div *ngIf="!controlsCollapsed" class="log-toolbar">
+            <span class="log-empty-space"></span>
+            <span (click)="reconnect()" class="link action"
+                role="button" attr.aria-label="{{ 'logStreaming_reconnect' | translate }}">
+                <pop-over message="{{ getPopoverText() | translate }}" hideAfter="{{popOverTimeout}}">
+                    <span class="link">
+                        <i class="fa fa-plug"></i>
+                        {{ 'logStreaming_reconnect' | translate }}
+                    </span>
+                </pop-over>
+            </span>
+            <span (click)="copyLogs($event)" class="link action"
+                (keydown)="keyDown($event, 'copyLogs')" role="button" attr.aria-label="{{ 'logStreaming_copyLogs' | translate }}">
+                <pop-over message="{{ 'logStreaming_copied' | translate }}" hideAfter="{{popOverTimeout}}">
+                    <span class="link">
+                        <i class="fa fa-clone"></i>
+                        {{ 'logStreaming_copyLogs' | translate }}
+                    </span>
+                </pop-over>
+            </span>
+            <span class="link action" *ngIf="stopped" (click)="startLogs()"
+                (keydown)="keyDown($event, 'startLogs')" tabindex="0" role="button" attr.aria-label="{{ 'logStreaming_start' | translate }}">
+                <i class="fa fa-play"></i>
+                {{ 'logStreaming_start' | translate }}
+            </span>
+            <span class="link action" *ngIf="!stopped" (click)="stopLogs()"
+                (keydown)="keyDown($event, 'stopLogs')" tabindex="0" role="button" attr.aria-label="{{ 'logStreaming_pause' | translate }}">
+                <i class="fa fa-pause"></i>
+                {{ 'logStreaming_pause' | translate }}
+            </span>
+            <span class="link action" (click)="clearLogs()"
+                (keydown)="keyDown($event, 'clearLogs')" tabindex="0" role="button" attr.aria-label="{{ 'logStreaming_clear' | translate }}">
+                <i class="fa fa-book"></i>
+                {{ 'logStreaming_clear' | translate }}
+            </span>
+            <span *ngIf="!isExpanded" class="link action" (click)="expand()"
+                (keydown)="keyDown($event, 'expand')" tabindex="0" role="button" attr.aria-label="{{ 'logStreaming_expand' | translate }}">
+                <i class="fa fa-expand"></i>
+                {{ 'logStreaming_expand' | translate }}
+            </span>
+
+            <span *ngIf="isExpanded" class="link action" (click)="compress()"
+                (keydown)="keyDown($event, 'compress')" tabindex="0" role="button" attr.aria-label="{{ 'logStreaming_compress' | translate }}">
+                <i class="fa fa-compress"></i>
+                {{ 'logStreaming_compress' | translate }}
+            </span>
+        </div>
+
+        <div *ngIf="controlsCollapsed"
+            class="menu-container"
+            (focusin)="onMenuFocusIn()"
+            (focusout)="onMenuFocusOut()">
+            <div class="menu-button-container">
+                <span role="button"
+                    tabindex="0"
+                    [attr.title]="'actions' | translate"
+                    class="link action"
+                    (click)="toggleMenu()"
+                    [activate-with-keys]>
+                    <span class="fa fa-ellipsis-v" aria-hidden="true"></span>
+                </span>
+            </div>
+            <ul *ngIf="!menuHidden" role="menu" [attr.aria-label]="'context_menu' | translate" (click)="hideMenu()">
+                <li role="menuitem" tabindex="0" class="link action"
+                    (click)="reconnect()"
+                    [activate-with-keys]
+                    [attr.aria-label]="'logStreaming_reconnect' | translate">
+                    <span class="fa fa-plug"></span>
+                    {{ 'logStreaming_reconnect' | translate }}
+                </li>
+                <li role="menuitem" tabindex="0" class="link action"
+                    (click)="copyLogs($event)"
+                    [activate-with-keys]
+                    [attr.aria-label]="'logStreaming_copyLogs' | translate">
+                    <span class="fa fa-clone"></span>
+                    {{ 'logStreaming_copyLogs' | translate }}
+                </li>
+                <li role="menuitem" tabindex="0" class="link action"
+                    (click)="stopped ? startLogs() : stopLogs()"
+                    [activate-with-keys]
+                    [attr.aria-label]="(stopped ? 'logStreaming_start' : 'logStreaming_pause') | translate">
+                    <span [ngClass]="stopped ? 'fa fa-play' : 'fa fa-pause'"></span>
+                    {{ (stopped ? 'logStreaming_start' : 'logStreaming_pause') | translate }}
+                </li>
+                <li role="menuitem" tabindex="0" class="link action"
+                    (click)="clearLogs()"
+                    [activate-with-keys]
+                    [attr.aria-label]="'logStreaming_clear' | translate">
+                    <span class="fa fa-book"></span>
+                    {{ 'logStreaming_clear' | translate }}
+                </li>
+                <li role="menuitem" tabindex="0" class="link action"
+                    (click)="isExpanded ? compress() : expand()"
+                    [activate-with-keys]
+                    [attr.aria-label]="(isExpanded ? 'logStreaming_compress' : 'logStreaming_expand') | translate">
+                    <span [ngClass]="isExpanded ? 'fa fa-compress' : 'fa fa-expand'"></span>
+                    {{ (isExpanded ? 'logStreaming_compress' : 'logStreaming_expand') | translate }}
+                </li>
+            </ul>
+        </div>
+
+    </ng-container>
     <pre id="log-stream" class="log-stream" tabindex="0"
          (keydown)="handleKeyPress($event)"
          [class.height-fixed]="isHttpLogs"

--- a/client/src/app/log-streaming/log-streaming.component.scss
+++ b/client/src/app/log-streaming/log-streaming.component.scss
@@ -89,7 +89,7 @@ pre {
             display: inline-block;
             padding: 6px 10px 6px 10px;
             margin: 0;
-            background: white;
+            background: $body-bg-color;
 
             span{
                 padding: 0px;
@@ -102,7 +102,8 @@ pre {
         float: right;
         padding: 0px;
         margin: 0px 5px 0px 0px;
-        box-shadow: 0 4px 8px 0 rgba(0,0,0,.14);
+        box-shadow: 0 4px 8px 0 rgba($default-text-color,.14);
+        border: 1px solid rgba(204,204,204,.8);
         z-index: 1;
 
         [role=menuitem]{
@@ -110,10 +111,28 @@ pre {
             padding:
             6px 10px 6px 10px;
             margin: 0;
-            background: white;
+            background: $body-bg-color;
 
             span{
                 padding-right: 5px;
+            }
+        }
+    }
+}
+
+:host-context(#app-root[theme=dark]){
+    .menu-container{
+        .menu-button-container{
+            [role=button]{
+                background: $body-bg-color-dark;
+            }
+        }
+
+        [role=menu]{
+            border: 1px solid #605e5c;
+
+            [role=menuitem]{
+                background: $body-bg-color-dark;
             }
         }
     }

--- a/client/src/app/log-streaming/log-streaming.component.scss
+++ b/client/src/app/log-streaming/log-streaming.component.scss
@@ -74,3 +74,47 @@ pre {
 .warning-content {
     color: $log-warning;
 }
+
+.menu-container{
+    position: relative;
+    top: -13px;
+
+    .menu-button-container{
+        position: relative;
+        float: right;
+        text-align:
+        right; z-index: 1;
+
+        [role=button]{
+            display: inline-block;
+            padding: 6px 10px 6px 10px;
+            margin: 0;
+            background: white;
+
+            span{
+                padding: 0px;
+            }
+        }
+    }
+
+    [role=menu]{
+        position: relative;
+        float: right;
+        padding: 0px;
+        margin: 0px 5px 0px 0px;
+        box-shadow: 0 4px 8px 0 rgba(0,0,0,.14);
+        z-index: 1;
+
+        [role=menuitem]{
+            display: block;
+            padding:
+            6px 10px 6px 10px;
+            margin: 0;
+            background: white;
+
+            span{
+                padding-right: 5px;
+            }
+        }
+    }
+}

--- a/client/src/app/log-streaming/log-streaming.component.ts
+++ b/client/src/app/log-streaming/log-streaming.component.ts
@@ -1,5 +1,5 @@
 import { BroadcastService } from './../shared/services/broadcast.service';
-import { Component, OnDestroy, Input, Inject, ElementRef, Output, EventEmitter, ViewChild, ViewContainerRef, ComponentFactory, ComponentFactoryResolver, ComponentRef } from '@angular/core';
+import { Component, OnDestroy, Input, Inject, ElementRef, Output, EventEmitter, ViewChild, ViewContainerRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, SimpleChanges, OnChanges } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 import { FunctionInfo } from '../shared/models/function-info';
 import { UserService } from '../shared/services/user.service';
@@ -20,7 +20,7 @@ import { PortalResources } from '../shared/models/portal-resources';
     templateUrl: './log-streaming.component.html',
     styleUrls: ['./log-streaming.component.scss', '../function-dev/function-dev.component.scss']
 })
-export class LogStreamingComponent extends FunctionAppContextComponent implements OnDestroy {
+export class LogStreamingComponent extends FunctionAppContextComponent implements OnChanges, OnDestroy {
     public log: string;
     public stopped: boolean;
     public timerInterval = 1000;
@@ -83,6 +83,12 @@ export class LogStreamingComponent extends FunctionAppContextComponent implement
                     // start polling logs
                     .subscribe(() => this._startPollingRequest());
             });
+    }
+
+    ngOnChanges(changes: SimpleChanges) {
+        if (changes['controlsCollapsed']) {
+            this.menuHidden = true;
+        }
     }
 
     ngOnDestroy() {

--- a/client/src/app/log-streaming/log-streaming.component.ts
+++ b/client/src/app/log-streaming/log-streaming.component.ts
@@ -26,6 +26,8 @@ export class LogStreamingComponent extends FunctionAppContextComponent implement
     public timerInterval = 1000;
     public isExpanded = false;
     public popOverTimeout = 500;
+    public menuHidden = true;
+    private _menuHasFocus: boolean;
     private _isConnectionSuccessful = true;
     private _xhReq: XMLHttpRequest;
     private _timeouts: number[];
@@ -38,6 +40,7 @@ export class LogStreamingComponent extends FunctionAppContextComponent implement
     private _logStreamIndex = 0;
     private _logComponents: ComponentRef<any>[] = [];
 
+    @Input() controlsCollapsed: boolean;
     @Input() isHttpLogs: boolean;
     @Output() closeClicked = new EventEmitter<any>();
     @Output() expandClicked = new EventEmitter<boolean>();
@@ -60,6 +63,8 @@ export class LogStreamingComponent extends FunctionAppContextComponent implement
     setup(): Subscription {
         return this.viewInfoEvents
             .subscribe(view => {
+                this.menuHidden = true;
+                this._menuHasFocus = false;
                 this._functionInfo = view.functionInfo.result;
                 // clear logs on navigation to a new viewInfo
                 this.log = '';
@@ -404,5 +409,26 @@ export class LogStreamingComponent extends FunctionAppContextComponent implement
         component.instance.logs = logs;
         component.instance.type = type;
         this._logComponents.push(component);
+    }
+
+    public hideMenu() {
+        this.menuHidden = true;
+    }
+
+    public toggleMenu() {
+        this.menuHidden = !this.menuHidden;
+    }
+
+    public onMenuFocusOut() {
+        this._menuHasFocus = false;
+        setTimeout(_ => {
+            if (!this._menuHasFocus) {
+                this.hideMenu();
+            }
+        });
+    }
+
+    public onMenuFocusIn() {
+        this._menuHasFocus = true;
     }
 }

--- a/client/src/app/log-streaming/log-streaming.component.ts
+++ b/client/src/app/log-streaming/log-streaming.component.ts
@@ -133,9 +133,11 @@ export class LogStreamingComponent extends FunctionAppContextComponent implement
         this.expandClicked.emit(true);
     }
 
-    compress() {
+    compress(preventEvent?: boolean) {
         this.isExpanded = false;
-        this.expandClicked.emit(false);
+        if (!preventEvent) {
+            this.expandClicked.emit(false);
+        }
     }
 
     keyDown(KeyboardEvent: any, command: string) {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5387224/45890027-c8f39f80-bd76-11e8-9644-fbf59fb63d1d.png)

![image](https://user-images.githubusercontent.com/5387224/45890007-bd07dd80-bd76-11e8-8289-225109260457.png)


Now:
![image](https://user-images.githubusercontent.com/5387224/45889740-099ee900-bd76-11e8-95cb-ca3db5e07e32.png)

![image](https://user-images.githubusercontent.com/5387224/45889799-2dfac580-bd76-11e8-8031-b1a3c33fdcd3.png)

![image](https://user-images.githubusercontent.com/5387224/45889893-6d291680-bd76-11e8-8a90-a59505035b4f.png)