### PR TITLE
Remove the authorization header from the pass throught container validation api

### DIFF
--- a/client/src/app/site/container-settings/services/container-validation.service.ts
+++ b/client/src/app/site/container-settings/services/container-validation.service.ts
@@ -4,6 +4,7 @@ import { UserService } from '../../../shared/services/user.service';
 import { ConditionalHttpClient, Result } from '../../../shared/conditional-http-client';
 import { ProxyRequest, GetRepositoryTagRequest } from '../container-settings';
 import { Constants } from '../../../shared/models/constants';
+import { Headers } from '@angular/http';
 
 @Injectable()
 export class ContainerValidationService {
@@ -33,12 +34,16 @@ export class ContainerValidationService {
             headers: {},
         };
 
+        const headers = new Headers();
+        headers.append('Content-Type', 'application/json');
+
         const validateImage = this._userService
             .getStartupInfo()
             .first()
             .switchMap(i => {
+                proxyRequest.headers['Authorization'] = `Bearer ${i.token}`;
                 return this._cacheService
-                    .post('/api/validateContainerImage', true, null, proxyRequest)
+                    .post('/api/validateContainerImage', true, headers, proxyRequest)
                     .map(r => r.json());
             });
 

--- a/client/src/app/site/container-settings/services/container-validation.service.ts
+++ b/client/src/app/site/container-settings/services/container-validation.service.ts
@@ -37,7 +37,6 @@ export class ContainerValidationService {
             .getStartupInfo()
             .first()
             .switchMap(i => {
-                proxyRequest.headers['Authorization'] = `Bearer ${i.token}`;
                 return this._cacheService
                     .post('/api/validateContainerImage', true, null, proxyRequest)
                     .map(r => r.json());


### PR DESCRIPTION
inlcuding the auth header is causing a 403 to be thrown in the antares layer. the token is already being included in the body of the POST, which is how the proxy call is using it.