### PR TITLE
Downgrade to V1 scenario

### DIFF
--- a/client/src/app/function/function-new/function-new.component.ts
+++ b/client/src/app/function/function-new/function-new.component.ts
@@ -204,7 +204,8 @@ export class FunctionNewComponent extends FunctionAppContextComponent implements
                     this.selectedTemplateId = this.action.templateId;
                 }
 
-                if (this.appSettingsArm.properties.hasOwnProperty(Constants.functionsWorkerRuntimeAppSettingsName)) {
+                if (this.appSettingsArm.properties.hasOwnProperty(Constants.functionsWorkerRuntimeAppSettingsName)
+                    && this.runtimeVersion === 'V2') {
                     const workerRuntime = this.appSettingsArm.properties[Constants.functionsWorkerRuntimeAppSettingsName];
                     this.functionAppLanguage = WorkerRuntimeLanguages[workerRuntime];
                     this.needsWorkerRuntime = !this.functionAppLanguage;

--- a/client/src/app/site/function-runtime/function-runtime.component.ts
+++ b/client/src/app/site/function-runtime/function-runtime.component.ts
@@ -416,13 +416,17 @@ export class FunctionRuntimeComponent extends FunctionAppContextComponent {
 
         appSettings.properties[Constants.runtimeVersionAppSettingName] = version;
 
+        if (version === '~1' && appSettings.properties[Constants.functionsWorkerRuntimeAppSettingsName]) {
+            delete appSettings.properties[Constants.functionsWorkerRuntimeAppSettingsName];
+        }
+
         if (version === '~2') {
             appSettings.properties[Constants.nodeVersionAppSettingName] = Constants.nodeVersionV2;
         } else {
             appSettings.properties[Constants.nodeVersionAppSettingName] = Constants.nodeVersion;
         }
 
-        return this._cacheService.putArm(appSettings.id, this._armService.websiteApiVersion, appSettings);
+        return this._siteService.updateAppSettings(this.context.site.id, appSettings);
     }
 
     private _updateProxiesVersion(appSettings: ArmObj<any>) {

--- a/client/src/app/site/function-runtime/function-runtime.component.ts
+++ b/client/src/app/site/function-runtime/function-runtime.component.ts
@@ -345,8 +345,9 @@ export class FunctionRuntimeComponent extends FunctionAppContextComponent {
                             }
                         }, 0).delay(3000);
                     });
+                } else {
+                    throw Observable.throw(r.error);
                 }
-                return Observable.of(null);
             })
             .do(null, e => {
                 this._busyManager.clearBusy();

--- a/client/src/app/site/function-runtime/function-runtime.component.ts
+++ b/client/src/app/site/function-runtime/function-runtime.component.ts
@@ -328,7 +328,8 @@ export class FunctionRuntimeComponent extends FunctionAppContextComponent {
                 return this._updateContainerVersion(r.json(), version);
             })
             .mergeMap(r => {
-                return this._functionAppService.getFunctionHostStatus(this.context)
+                if (r.isSuccessful) {
+                    return this._functionAppService.getFunctionHostStatus(this.context)
                     .map(hostStatus => {
                         if (!hostStatus.isSuccessful || !hostStatus.result.version || (hostStatus.result.version === this.exactExtensionVersion && !updateButtonClicked)) {
                             throw Observable.throw('Host version is not updated yet');
@@ -344,6 +345,8 @@ export class FunctionRuntimeComponent extends FunctionAppContextComponent {
                             }
                         }, 0).delay(3000);
                     });
+                }
+                return Observable.of(null);
             })
             .do(null, e => {
                 this._busyManager.clearBusy();


### PR DESCRIPTION
- In function app settings tab, remove FUNCTIONS_WORKER_RUNTIME when downgrading to V1
- In function creation page, only use FUNCTIONS_WORKER_RUNTIME if runtime is V2

fixes #3231 