### PR TITLE
Accessibility bugs

### DIFF
--- a/client/src/app/site/spec-picker/spec-feature-list/spec-feature-list.component.html
+++ b/client/src/app/site/spec-picker/spec-feature-list/spec-feature-list.component.html
@@ -7,12 +7,13 @@
     <div class="feature-body">
       <h4 [id]="feature.title | removeSpaces">{{feature.title}}</h4>
       <div class="feature-description">{{feature.description}}
-        <a *ngIf="feature.learnMoreUrl"
-          [href]="feature.learnMoreUrl"
-          target="_blank"
+        <div *ngIf="feature.learnMoreUrl"
           [attr.aria-labelledBy]="feature.title | removeSpaces"
-          [attr.aria-label]="'topBar_learnMore' | translate"
-          [attr.aria-describedby]="feature.title | removeSpaces">{{'topBar_learnMore' | translate}}</a>
+          [attr.aria-label]="'topBar_learnMore' | translate">
+          <a [href]="feature.learnMoreUrl"
+            target="_blank"
+            [attr.aria-describedby]="feature.title | removeSpaces">{{'topBar_learnMore' | translate}}</a>
+        </div>
       </div>
     </div>
   </div>

--- a/client/src/app/site/spec-picker/spec-feature-list/spec-feature-list.component.html
+++ b/client/src/app/site/spec-picker/spec-feature-list/spec-feature-list.component.html
@@ -7,7 +7,8 @@
     <div class="feature-body">
       <h4 [id]="feature.title | removeSpaces">{{feature.title}}</h4>
       <div class="feature-description">{{feature.description}}
-        <div *ngIf="feature.learnMoreUrl"
+        <div class="feature-learnMore"
+          *ngIf="feature.learnMoreUrl"
           [attr.aria-labelledBy]="feature.title | removeSpaces"
           [attr.aria-label]="'topBar_learnMore' | translate">
           <a [href]="feature.learnMoreUrl"

--- a/client/src/app/site/spec-picker/spec-feature-list/spec-feature-list.component.html
+++ b/client/src/app/site/spec-picker/spec-feature-list/spec-feature-list.component.html
@@ -5,12 +5,13 @@
 
     <div [load-image]="feature.iconUrl" class="icon-medium"></div>
     <div class="feature-body">
-      <h4>{{feature.title}}</h4>
-      <div class="feature-description" [id]="feature.title | removeSpaces">{{feature.description}}
+      <h4 [id]="feature.title | removeSpaces">{{feature.title}}</h4>
+      <div class="feature-description">{{feature.description}}
         <a *ngIf="feature.learnMoreUrl"
           [href]="feature.learnMoreUrl"
           target="_blank"
-          [attr.aria-label]="feature.title"
+          [attr.aria-labelledBy]="feature.title | removeSpaces"
+          [attr.aria-label]="'topBar_learnMore' | translate"
           [attr.aria-describedby]="feature.title | removeSpaces">{{'topBar_learnMore' | translate}}</a>
       </div>
     </div>

--- a/client/src/app/site/spec-picker/spec-picker.component.html
+++ b/client/src/app/site/spec-picker/spec-picker.component.html
@@ -52,10 +52,10 @@
         <div class="spec-expander" *ngIf="showExpander">
           <span (click)="specManager.selectedSpecGroup.isExpanded = !specManager.selectedSpecGroup.isExpanded"
                 (keydown)="onExpandKeyPress($event)"
-                role="link"
+                role="button"
                 tabindex="0"
                 [attr.aria-expanded]="specManager.selectedSpecGroup.isExpanded"
-                [attr.aria-controls]="specManager.selectedSpecGroup.id + specManager.selectedSpecGroup.selectedSpec">
+                [attr.aria-controls]="specManager.selectedSpecGroup.id + specManager.selectedSpecGroup.selectedSpec.skuCode">
     
             <span [load-image]="!specManager.selectedSpecGroup.isExpanded ? 'image/caret-down.svg' : 'image/caret-up.svg'" class="expand-icon"></span>
             <a>{{ (!specManager.selectedSpecGroup.isExpanded ? 'seeAllOptions' : 'seeRecommendedOptions') | translate}}</a>

--- a/client/src/app/site/spec-picker/spec-picker.component.scss
+++ b/client/src/app/site/spec-picker/spec-picker.component.scss
@@ -221,6 +221,10 @@ $center-column-max-width: calc(#{$spec-card-max-width}*4 - 40px);
             text-overflow: ellipsis;
             max-height: 36px;       /* fallback */
         }
+
+        .feature-learnMore{
+            display: inline-block;
+        }
     }
 
     footer{


### PR DESCRIPTION
[Screen Reader - Azure Web - Pricing tier] Incorrect role is defined for 'See additinal options/See only recommended options' on pricing tier blade.
(https://msazure.visualstudio.com/Antares/_workitems/edit/3118152)

[Screen Reader - App Service Plan][MAS 1.3.1]: ARIA attributes must conform to valid values.
(https://msazure.visualstudio.com/Antares/_workitems/edit/3118181)

[Screen Reader -Isolated -Advanced networking and Scale ] Narrator is not reading the name properly of learn more link correctly under Isolated blade.
(https://msazure.visualstudio.com/Antares/_workitems/edit/3118145)

[Note]: using the labelledBy + aria-label combination -> the way the screen reader reads it is the labelledBy id's text then aria-label text and then says link since its a link