### PR TITLE
Prevent retrieving startup file(app command) information for quickstart.

### DIFF
--- a/client/src/app/site/container-settings/container-settings-manager.ts
+++ b/client/src/app/site/container-settings/container-settings-manager.ts
@@ -861,7 +861,7 @@ export class ContainerSettingsManager {
                 const accessType: DockerHubAccessType = imageSourceForm.controls.accessType.value;
                 const dockerHubForm = this.getDockerHubForm(imageSourceForm, accessType);
                 return dockerHubForm.controls.startupFile.value;
-            } else {
+            } else if (imageSourceType !== 'quickstart') {
                 return imageSourceForm.controls.startupFile.value;
             }
         }


### PR DESCRIPTION
related to:
https://msazure.visualstudio.com/Antares/_workitems/edit/3184992
https://msazure.visualstudio.com/Antares/_workitems/edit/3185001

Basically quick start has no concept of startup file, unlike the rest of the image source types.