### PR TITLE
Removing 'id' attribute from buttom element in PopOverComponent

### DIFF
--- a/client/src/app/pop-over/pop-over.component.html
+++ b/client/src/app/pop-over/pop-over.component.html
@@ -16,7 +16,6 @@
 
     <button
         #button
-        id="buttonInfoButton"
         class="pop-over-button"
         attr.aria-label="{{message}}"
         (keydown)="onKeyPress($event)"


### PR DESCRIPTION
(https://msazure.visualstudio.com/Antares/_workitems/edit/3118264)
Bug 3118264: [Screen Reader -External (Build Provider : App Service Kudu build server)-Configure]: MAS 4.1.1: id attribute value must be unique.

(https://msazure.visualstudio.com/Antares/_workitems/edit/3118277)
Bug 3118277: [Screen Reader - FTP ]:MAS 4.1.1: id attribute value must be unique