### PR TITLE
Instead of sharing, re-render common html elements.

### DIFF
--- a/client/src/app/site/container-settings/container-image-source/container-image-source-dockerhub/container-image-source-dockerhub.component.html
+++ b/client/src/app/site/container-settings/container-image-source/container-image-source-dockerhub/container-image-source-dockerhub.component.html
@@ -1,57 +1,78 @@
-<div *ngIf="imageSourceForm" class="container-setting-property" [formGroup] = "imageSourceForm">
+<div *ngIf="imageSourceForm" class="container-setting-property" [formGroup]="imageSourceForm">
     <label>{{ 'containerRepositoryAccess' | translate }}</label>
     <div>
-        <radio-selector
-            [options] = "containerSettingsManager.dockerHubAccessOptions"
-            (value) = "updateAccessOptions($event)"
-            [control] = "imageSourceForm?.controls?.accessType">
+        <radio-selector [options]="containerSettingsManager.dockerHubAccessOptions" (value)="updateAccessOptions($event)"
+            [control]="imageSourceForm?.controls?.accessType">
         </radio-selector>
     </div>
 </div>
 
-<div *ngIf="dockerHubForm" [formGroup] = "dockerHubForm">
-    <div *ngIf = "selectedAccessType === 'private'" class="container-setting-property">
+<div *ngIf="dockerHubForm && selectedAccessType === 'private'" [formGroup]="dockerHubForm">
+    <div class="container-setting-property">
         <label>{{ 'containerLogin' | translate }}</label>
-        <textbox [control] = "dockerHubForm?.controls?.login" [disablePopOverError] = "true"></textbox>
-        <div invalidmessage="login" id="containersettings-dh-login-error" role="alert"></div>
+        <textbox [control]="dockerHubForm?.controls?.login" [disablePopOverError]="true"></textbox>
+        <div invalidmessage="login" id="containersettings-dh-login-error-private" role="alert"></div>
     </div>
 
-    <div *ngIf = "selectedAccessType === 'private'" class="container-setting-property">
+    <div class="container-setting-property">
         <label>{{ 'containerPassword' | translate }}</label>
-        <textbox type="password" [control] = "dockerHubForm?.controls?.password" [disablePopOverError] = "true"></textbox>
-        <div invalidmessage="password" id="containersettings-dh-password-error" role="alert"></div>
+        <textbox type="password" [control]="dockerHubForm?.controls?.password" [disablePopOverError]="true"></textbox>
+        <div invalidmessage="password" id="containersettings-dh-password-error-private" role="alert"></div>
     </div>
 
-    <div *ngIf = "containerImageSourceInfo.container.id === 'single'" class="container-setting-property">
-        <label>{{ 'containerImageAndTag' | translate }}</label>
-        <textbox [control] = "dockerHubForm?.controls?.image" [disablePopOverError] = "true"></textbox>
-        <div invalidmessage="image" [id]="'containersettings-dh-image-error-' + selectedAccessType" role="alert"></div>
-    </div>
+    <ng-container *ngIf="containerImageSourceInfo.container.id === 'single'">
+        <div class="container-setting-property">
+            <label>{{ 'containerImageAndTag' | translate }}</label>
+            <textbox [control]="dockerHubForm?.controls?.image" [disablePopOverError]="true"></textbox>
+            <div invalidmessage="image" id="containersettings-dh-image-error-private" role="alert"></div>
+        </div>
 
-    <div *ngIf = "containerImageSourceInfo.container.id === 'single'" class="container-setting-property">
-        <label>{{ 'containerStartupFile' | translate }}</label>
-        <textbox [control] = "dockerHubForm?.controls?.startupFile" [disablePopOverError] = "true"></textbox>
-        <div invalidmessage="startupFile" [id]="'containersettings-dh-startupFile-error-' + selectedAccessType" role="alert"></div>
-    </div>
+        <div class="container-setting-property">
+            <label>{{ 'containerStartupFile' | translate }}</label>
+            <textbox [control]="dockerHubForm?.controls?.startupFile" [disablePopOverError]="true"></textbox>
+            <div invalidmessage="startupFile" id="containersettings-dh-startupFile-error-private" role="alert"></div>
+        </div>
+    </ng-container>
 
-    <div *ngIf = "containerImageSourceInfo.container.id !== 'single'">
+    <ng-container *ngIf="containerImageSourceInfo.container.id !== 'single'">
         <div class="container-setting-property">
             <label>{{ 'containerMultiConfigurationFile' | translate }}</label>
             <input type="file" (change)="extractConfig($event)">
         </div>
 
         <div class="container-setting-property">
-            <label>{{ 'containerMultiConfiguration' | translate }}</label><br/>
-
-            <ng-container *ngIf="selectedAccessType === 'public'">
-                <textarea class="config" formControlName="config" readonly></textarea>
-                <div invalidmessage="config" id="containersettings-dh-config-error-public" role="alert"></div>
-            </ng-container>
-            
-            <ng-container *ngIf="selectedAccessType === 'private'">
-                <textarea class="config" formControlName="config" readonly></textarea>
-                <div invalidmessage="config" id="containersettings-dh-config-error-private" role="alert"></div>
-            </ng-container>
+            <label>{{ 'containerMultiConfiguration' | translate }}</label><br />
+            <textarea class="config" formControlName="config" readonly></textarea>
+            <div invalidmessage="config" id="containersettings-dh-config-error-private" role="alert"></div>
         </div>
-    </div>
+    </ng-container>
+</div>
+
+<div *ngIf="dockerHubForm && selectedAccessType === 'public'" [formGroup]="dockerHubForm">
+    <ng-container *ngIf="containerImageSourceInfo.container.id === 'single'">
+        <div class="container-setting-property">
+            <label>{{ 'containerImageAndTag' | translate }}</label>
+            <textbox [control]="dockerHubForm?.controls?.image" [disablePopOverError]="true"></textbox>
+            <div invalidmessage="image" id="containersettings-dh-image-error-public" role="alert"></div>
+        </div>
+
+        <div class="container-setting-property">
+            <label>{{ 'containerStartupFile' | translate }}</label>
+            <textbox [control]="dockerHubForm?.controls?.startupFile" [disablePopOverError]="true"></textbox>
+            <div invalidmessage="startupFile" id="containersettings-dh-startupFile-error-public" role="alert"></div>
+        </div>
+    </ng-container>
+
+    <ng-container *ngIf="containerImageSourceInfo.container.id !== 'single'">
+        <div class="container-setting-property">
+            <label>{{ 'containerMultiConfigurationFile' | translate }}</label>
+            <input type="file" (change)="extractConfig($event)">
+        </div>
+
+        <div class="container-setting-property">
+            <label>{{ 'containerMultiConfiguration' | translate }}</label><br />
+            <textarea class="config" formControlName="config" readonly></textarea>
+            <div invalidmessage="config" id="containersettings-dh-config-error-public" role="alert"></div>
+        </div>
+    </ng-container>
 </div>


### PR DESCRIPTION
The issue we're running in to with the form control integration is when the common controls are not re-rendered we are running in to a timing issue of how validation is applied and the textbox is getting disabled. The two ways to solve this is to add a setTimeout to the form itself OR when switching the radio selectors (going from public to private) re-render the textbox. 

The re-render is already being done when switching the container type or the image source... so this is not a new concept for containers.