### PR TITLE
Show a warning in API Definition for V1 readonly apps

### DIFF
--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1369,4 +1369,5 @@
     public static connectionStringsEncryptedInfoText = 'connectionStringsEncryptedInfoText';
     public static team = 'team';
     public static personal = 'personal';
+    public static swaggerDefinitionReadOnly = 'swaggerDefinitionReadOnly';
 }

--- a/client/src/app/site/swagger-definition/swagger-definition.component.html
+++ b/client/src/app/site/swagger-definition/swagger-definition.component.html
@@ -2,7 +2,11 @@
     {{'swaggerDefinition_notSupportedForV2' | translate}}
 </div>
 
-<div *ngIf="generation === 'V1'" class="wrapper">
+<div *ngIf="generation === 'V1' && showReadonlyMessage" class="alert alert-warning alert-dismissible" role="alert">
+    {{ 'swaggerDefinitionReadOnly' | translate }}
+</div>
+
+<div *ngIf="generation === 'V1' && !showReadonlyMessage" class="wrapper">
     <div>
         <div class="section-left full-height" [class.collapse]="isFullscreen">
             <div>

--- a/client/src/app/site/swagger-definition/swagger-definition.component.ts
+++ b/client/src/app/site/swagger-definition/swagger-definition.component.ts
@@ -60,7 +60,7 @@ export class SwaggerDefinitionComponent extends FunctionAppContextComponent impl
         broadcastService: BroadcastService,
         private _translateService: TranslateService,
         private _functionAppService: FunctionAppService,
-        private _scenarioService: ScenarioService
+        private _scenarioService: ScenarioService,
     ) {
         super('swagger-definition', _functionAppService, broadcastService, () => this._busyManager.setBusy());
 
@@ -68,11 +68,11 @@ export class SwaggerDefinitionComponent extends FunctionAppContextComponent impl
         this.swaggerStatusOptions = [
             {
                 displayLabel: this._translateService.instant(PortalResources.swaggerDefinition_internal),
-                value: true
+                value: true,
             },
             {
                 displayLabel: this._translateService.instant(PortalResources.swaggerDefinition_external),
-                value: false
+                value: false,
             }];
 
         this.valueChange = new Subject<boolean>();
@@ -163,7 +163,7 @@ export class SwaggerDefinitionComponent extends FunctionAppContextComponent impl
     openBlade(name: string) {
         this._portalService.openBladeDeprecated({
             detailBlade: name,
-            detailBladeInputs: { resourceUri: this.context.site.id }
+            detailBladeInputs: { resourceUri: this.context.site.id },
         }, name);
     }
 
@@ -210,9 +210,9 @@ export class SwaggerDefinitionComponent extends FunctionAppContextComponent impl
                     return Observable.of({
                         isSuccessful: false,
                         error: {
-                            errorId: ''
+                            errorId: '',
                         },
-                        result: null
+                        result: null,
                     });
                 }
             })
@@ -297,7 +297,7 @@ export class SwaggerDefinitionComponent extends FunctionAppContextComponent impl
                 this.showComponentError({
                     message: this._translateService.instant(PortalResources.swaggerDefinition_prompt),
                     errorId: errorIds.malformedAPIDefinition,
-                    resourceId: this.context.site.id
+                    resourceId: this.context.site.id,
                 });
 
                 this._busyManager.clearBusy();

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -4248,5 +4248,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
   </data>
   <data name="personal" xml:space="preserve">
     <value>Personal</value>
+  <data name="swaggerDefinitionReadOnly" xml:space="preserve">
+    <value>API definition is not available as the Function App is in readonly mode.</value>
   </data>
 </root>


### PR DESCRIPTION
In the current scenario the API definition page hangs due to a null ref, and even with that fix the UI loaded is unusable. Instead provide the user with a message and hide the UI.

Example of V1 readonly app
![image](https://user-images.githubusercontent.com/493476/47053517-2acedb80-d162-11e8-9054-c0c9813143da.png)

Example of V2 app
![image](https://user-images.githubusercontent.com/493476/47053530-3cb07e80-d162-11e8-920d-7fd8bbf35fe0.png)

Example of V1 normal app
![image](https://user-images.githubusercontent.com/493476/47053485-fb1fd380-d161-11e8-9d04-cb7932eedde6.png)
