### PR TITLE
Updating templates to 2.0.0-10296

### DIFF
--- a/server/gulpfile.js
+++ b/server/gulpfile.js
@@ -381,9 +381,9 @@ gulp.task('build-bindings', function (cb) {
 const templateVersionMap = {
     default: '1.0.3.10182',
     '1': '1.0.3.10182',
-    beta: '2.0.0-10291',
+    beta: '2.0.0-10296',
     '2.0.11961.0': '2.0.0-beta-10224',
-    '2': '2.0.0-10291',
+    '2': '2.0.0-10296',
 };
 /*****
  * Download and unzip nuget packages with templates


### PR DESCRIPTION
This fixes the table and blob binding extension issue