### PR TITLE
Open MSI and CORS settings blade as context pane since leaf blades

### DIFF
--- a/client/src/app/feature-group/feature-item.ts
+++ b/client/src/app/feature-group/feature-item.ts
@@ -97,7 +97,7 @@ export class DisableableBladeFeature extends DisableableFeature {
   }
 
   click() {
-    this._portalService.openBladeDeprecated(this._bladeInfo, 'site-manage');
+    this._portalService.openBlade(this._bladeInfo, 'site-manage');
   }
 }
 
@@ -114,7 +114,7 @@ export class BladeFeature extends FeatureItem {
   }
 
   click() {
-    this._portalService.openBladeDeprecated(this.bladeInfo, 'site-manage');
+    this._portalService.openBlade(this.bladeInfo, 'site-manage');
   }
 }
 

--- a/client/src/app/shared/models/portal.ts
+++ b/client/src/app/shared/models/portal.ts
@@ -120,6 +120,7 @@ export interface OpenBladeInfo {
   detailBlade: string;
   detailBladeInputs: any;
   extension?: string;
+  openAsContextBlade?: boolean;
 }
 
 export interface TimerEvent {

--- a/client/src/app/site/site-manage/site-manage.component.ts
+++ b/client/src/app/site/site-manage/site-manage.component.ts
@@ -414,6 +414,7 @@ export class SiteManageComponent extends FeatureComponent<TreeViewInfo<SiteData>
           {
             detailBlade: 'MSIBlade',
             detailBladeInputs: { resourceUri: site.id },
+            openAsContextBlade: true,
           },
           this._portalService,
           null,
@@ -519,6 +520,7 @@ export class SiteManageComponent extends FeatureComponent<TreeViewInfo<SiteData>
         {
           detailBlade: 'ApiCors',
           detailBladeInputs: { resourceUri: site.id },
+          openAsContextBlade: true,
         },
         this._portalService
       ),


### PR DESCRIPTION
Managed service identity should open as context pane since leaf blade
(https://msazure.visualstudio.com/Antares/_workitems/edit/3122214)

CORS should open as context pane since leaf blade
(https://msazure.visualstudio.com/Antares/_workitems/edit/3122218)


[The openasContextpane option is already there on the Ibiza side]