### PR TITLE
FW: Use old spec picker for azure stack

### DIFF
--- a/client/src/app/shared/models/constants.ts
+++ b/client/src/app/shared/models/constants.ts
@@ -233,6 +233,7 @@ export class ScenarioIds {
   public static readonly webSocketsSupported = 'WebSocketsSupported';
   public static readonly classicPipelineModeSupported = 'ClassicPipelineModeSupported';
   public static readonly remoteDebuggingSupported = 'RemoteDebuggingSupported';
+  public static readonly pcv3Supported = 'Pcv3Supported';
   public static readonly phpSupported = 'phpSupported';
   public static readonly pythonSupported = 'PythonSupported';
   public static readonly javaSupported = 'JavaSupported';

--- a/client/src/app/shared/models/constants.ts
+++ b/client/src/app/shared/models/constants.ts
@@ -233,7 +233,7 @@ export class ScenarioIds {
   public static readonly webSocketsSupported = 'WebSocketsSupported';
   public static readonly classicPipelineModeSupported = 'ClassicPipelineModeSupported';
   public static readonly remoteDebuggingSupported = 'RemoteDebuggingSupported';
-  public static readonly pcv3Supported = 'Pcv3Supported';
+  public static readonly useOldScaleUpBlade = 'UseOldScaleUpBlade';
   public static readonly phpSupported = 'phpSupported';
   public static readonly pythonSupported = 'PythonSupported';
   public static readonly javaSupported = 'JavaSupported';

--- a/client/src/app/shared/services/scenario/onprem.environment.ts
+++ b/client/src/app/shared/services/scenario/onprem.environment.ts
@@ -52,10 +52,10 @@ export class OnPremEnvironment extends Environment {
       },
     };
 
-    this.scenarioChecks[ScenarioIds.pcv3Supported] = {
-      id: ScenarioIds.pcv3Supported,
+    this.scenarioChecks[ScenarioIds.useOldScaleUpBlade] = {
+      id: ScenarioIds.useOldScaleUpBlade,
       runCheck: () => {
-        return { status: 'disabled' };
+        return { status: 'enabled' };
       },
     };
 

--- a/client/src/app/shared/services/scenario/onprem.environment.ts
+++ b/client/src/app/shared/services/scenario/onprem.environment.ts
@@ -52,6 +52,13 @@ export class OnPremEnvironment extends Environment {
       },
     };
 
+    this.scenarioChecks[ScenarioIds.pcv3Supported] = {
+      id: ScenarioIds.pcv3Supported,
+      runCheck: () => {
+        return { status: 'disabled' };
+      },
+    };
+
     this.scenarioChecks[ScenarioIds.functionBeta] = {
       id: ScenarioIds.functionBeta,
       runCheck: () => {

--- a/client/src/app/site/site-config/general-settings/general-settings.component.html
+++ b/client/src/app/site/site-config/general-settings/general-settings.component.html
@@ -1,6 +1,6 @@
 <div class="settings-group-wrapper">
 
-  <h3 class="first-config-heading">{{ 'feature_generalSettingsName' | translate }}</h3>
+  <h3 class="first-config-heading">{{ 'dfsfsddsfdsdd' | translate }}</h3>
   <info-box
     *ngIf="!hasWritePermissions && showPermissionsMessage"
     typeClass="warning"

--- a/client/src/app/site/site-config/general-settings/general-settings.component.html
+++ b/client/src/app/site/site-config/general-settings/general-settings.component.html
@@ -1,6 +1,6 @@
 <div class="settings-group-wrapper">
 
-  <h3 class="first-config-heading">{{ 'dfsfsddsfdsdd' | translate }}</h3>
+  <h3 class="first-config-heading">{{ 'feature_generalSettingsName' | translate }}</h3>
   <info-box
     *ngIf="!hasWritePermissions && showPermissionsMessage"
     typeClass="warning"

--- a/client/src/app/site/site-config/general-settings/general-settings.component.ts
+++ b/client/src/app/site/site-config/general-settings/general-settings.component.ts
@@ -67,7 +67,7 @@ export class GeneralSettingsComponent extends ConfigSaveComponent implements OnC
   public alwaysOnSupported = false;
   public classicPipelineModeSupported = false;
   public remoteDebuggingSupported = false;
-  public pcv3Supported = false;
+  public useOldScaleUpBlade = false;
   public clientAffinitySupported = false;
   public FTPAccessSupported = false;
 
@@ -224,7 +224,7 @@ export class GeneralSettingsComponent extends ConfigSaveComponent implements OnC
 
   scaleUp() {
     this.setBusy();
-    if (this.pcv3Supported) {
+    if (!this.useOldScaleUpBlade) {
       this._portalService
         .openBlade(
           {
@@ -302,7 +302,7 @@ export class GeneralSettingsComponent extends ConfigSaveComponent implements OnC
     this.alwaysOnSupported = false;
     this.classicPipelineModeSupported = false;
     this.remoteDebuggingSupported = false;
-    this.pcv3Supported = false;
+    this.useOldScaleUpBlade = false;
     this.clientAffinitySupported = false;
     this.autoSwapSupported = false;
     this.linuxRuntimeSupported = false;
@@ -321,7 +321,7 @@ export class GeneralSettingsComponent extends ConfigSaveComponent implements OnC
       let alwaysOnSupported = true;
       let classicPipelineModeSupported = true;
       let remoteDebuggingSupported = true;
-      let pcv3Supported = true;
+      let useOldScaleUpBlade = false;
       let clientAffinitySupported = true;
       let autoSwapSupported = true;
       let linuxRuntimeSupported = false;
@@ -394,8 +394,8 @@ export class GeneralSettingsComponent extends ConfigSaveComponent implements OnC
         remoteDebuggingSupported = false;
       }
 
-      if (this._scenarioService.checkScenario(ScenarioIds.pcv3Supported, { site: siteArm }).status === 'disabled') {
-        pcv3Supported = false;
+      if (this._scenarioService.checkScenario(ScenarioIds.useOldScaleUpBlade, { site: siteArm }).status === 'enabled') {
+        useOldScaleUpBlade = true;
       }
 
       if (this._scenarioService.checkScenario(ScenarioIds.phpSupported, { site: siteArm }).status === 'disabled') {
@@ -423,7 +423,7 @@ export class GeneralSettingsComponent extends ConfigSaveComponent implements OnC
       this.alwaysOnSupported = alwaysOnSupported;
       this.classicPipelineModeSupported = classicPipelineModeSupported;
       this.remoteDebuggingSupported = remoteDebuggingSupported;
-      this.pcv3Supported = pcv3Supported;
+      this.useOldScaleUpBlade = useOldScaleUpBlade;
       this.clientAffinitySupported = clientAffinitySupported;
       this.autoSwapSupported = autoSwapSupported;
       this.linuxRuntimeSupported = linuxRuntimeSupported;

--- a/client/src/app/site/site-config/general-settings/general-settings.component.ts
+++ b/client/src/app/site/site-config/general-settings/general-settings.component.ts
@@ -67,6 +67,7 @@ export class GeneralSettingsComponent extends ConfigSaveComponent implements OnC
   public alwaysOnSupported = false;
   public classicPipelineModeSupported = false;
   public remoteDebuggingSupported = false;
+  public pcv3Supported = false;
   public clientAffinitySupported = false;
   public FTPAccessSupported = false;
 
@@ -223,23 +224,42 @@ export class GeneralSettingsComponent extends ConfigSaveComponent implements OnC
 
   scaleUp() {
     this.setBusy();
-
-    this._portalService
-      .openBlade(
-        {
-          detailBlade: 'SpecPickerFrameBlade',
-          detailBladeInputs: {
-            id: this.siteArm.properties.serverFarmId,
-            feature: 'scaleup',
-            data: null,
+    if (this.pcv3Supported) {
+      this._portalService
+        .openBlade(
+          {
+            detailBlade: 'SpecPickerFrameBlade',
+            detailBladeInputs: {
+              id: this.siteArm.properties.serverFarmId,
+              feature: 'scaleup',
+              data: null,
+            },
           },
+          this.componentName
+        )
+        .subscribe(r => {
+          this.clearBusy();
+          this._logService.debug(LogCategories.siteConfig, `Scale up ${r.reason === 'childClosedSelf' ? 'succeeded' : 'cancelled'}`);
+        });
+    } else {
+      const inputs = {
+        aspResourceId: this.siteArm.properties.serverFarmId,
+        aseResourceId: this.siteArm.properties.hostingEnvironmentProfile && this.siteArm.properties.hostingEnvironmentProfile.id,
+      };
+
+      const openScaleUpBlade = this._portalService.openCollectorBladeWithInputs('', inputs, 'site-manage', null, 'WebsiteSpecPickerV3');
+
+      openScaleUpBlade.first().subscribe(
+        r => {
+          this.clearBusy();
+          this._logService.debug(LogCategories.siteConfig, `Scale up ${r ? 'succeeded' : 'cancelled'}`);
         },
-        this.componentName
-      )
-      .subscribe(r => {
-        this.clearBusy();
-        this._logService.debug(LogCategories.siteConfig, `Scale up ${r.reason === 'childClosedSelf' ? 'succeeded' : 'cancelled'}`);
-      });
+        e => {
+          this.clearBusy();
+          this._logService.error(LogCategories.siteConfig, '/scale-up', `Scale up failed: ${e}`);
+        }
+      );
+    }
   }
 
   private _resetSlotsInfo() {
@@ -282,6 +302,7 @@ export class GeneralSettingsComponent extends ConfigSaveComponent implements OnC
     this.alwaysOnSupported = false;
     this.classicPipelineModeSupported = false;
     this.remoteDebuggingSupported = false;
+    this.pcv3Supported = false;
     this.clientAffinitySupported = false;
     this.autoSwapSupported = false;
     this.linuxRuntimeSupported = false;
@@ -300,6 +321,7 @@ export class GeneralSettingsComponent extends ConfigSaveComponent implements OnC
       let alwaysOnSupported = true;
       let classicPipelineModeSupported = true;
       let remoteDebuggingSupported = true;
+      let pcv3Supported = true;
       let clientAffinitySupported = true;
       let autoSwapSupported = true;
       let linuxRuntimeSupported = false;
@@ -372,6 +394,10 @@ export class GeneralSettingsComponent extends ConfigSaveComponent implements OnC
         remoteDebuggingSupported = false;
       }
 
+      if (this._scenarioService.checkScenario(ScenarioIds.pcv3Supported, { site: siteArm }).status === 'disabled') {
+        pcv3Supported = false;
+      }
+
       if (this._scenarioService.checkScenario(ScenarioIds.phpSupported, { site: siteArm }).status === 'disabled') {
         phpSupported = false;
       }
@@ -397,6 +423,7 @@ export class GeneralSettingsComponent extends ConfigSaveComponent implements OnC
       this.alwaysOnSupported = alwaysOnSupported;
       this.classicPipelineModeSupported = classicPipelineModeSupported;
       this.remoteDebuggingSupported = remoteDebuggingSupported;
+      this.pcv3Supported = pcv3Supported;
       this.clientAffinitySupported = clientAffinitySupported;
       this.autoSwapSupported = autoSwapSupported;
       this.linuxRuntimeSupported = linuxRuntimeSupported;


### PR DESCRIPTION
New spec picker is not supported yet for azure stack. Using old spec