### PR TITLE
Add null check for sites in limited state. The Sku value is null.

### DIFF
--- a/client/src/app/shared/services/scenario/dynamic-site.environment.ts
+++ b/client/src/app/shared/services/scenario/dynamic-site.environment.ts
@@ -45,7 +45,7 @@ export class DynamicSiteEnvironment extends Environment {
   }
 
   public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {
-    if (input && input.site) {
+    if (input && input.site && input.site.properties.sku) {
       return input.site.properties.sku.toLowerCase() === 'dynamic';
     }
 


### PR DESCRIPTION
Currently the AppSettings blade will fail to load due to a null ref error for a site in limited state.