### PR TITLE
Hotfix the default selection of ACR repository and tags.

### DIFF
--- a/client/src/app/site/container-settings/container-image-source/container-image-source-acr/container-image-source-acr.component.ts
+++ b/client/src/app/site/container-settings/container-image-source/container-image-source-acr/container-image-source-acr.component.ts
@@ -31,9 +31,9 @@ export class ContainerImageSourceACRComponent extends FeatureComponent<Container
   public registryDropdownItems: DropDownElement<string>[];
   public registryItems: ACRRegistry[];
   public repositoryDropdownItems: DropDownElement<string>[];
-  public repositoryItems: string[];
+  public repositoryItems: string[] = [];
   public tagDropdownItems: DropDownElement<string>[];
-  public tagItems: string[];
+  public tagItems: string[] = [];
   public containerImageSourceInfo: ContainerImageSourceData;
   public selectedRegistry: string;
   public selectedRepository: string;
@@ -173,6 +173,10 @@ export class ContainerImageSourceACRComponent extends FeatureComponent<Container
               value: item,
             }));
             this.loadingRepo = false;
+
+            if (this.selectedRepository) {
+              this._loadTags();
+            }
           }
         } else {
           this.loadingRepo = false;


### PR DESCRIPTION
With the recent changes to paginate the ACR repositories and tags, the concept of appending items to their respective arrays was introduced. This missed the initialization of items array to an empty set. 