### PR TITLE
AB#3988746 Allow users to set routing rules with 0% reroutePercentage

### DIFF
--- a/client/src/app/site/slots/deployment-slots/deployment-slots.component.ts
+++ b/client/src/app/site/slots/deployment-slots/deployment-slots.component.ts
@@ -395,7 +395,7 @@ export class DeploymentSlotsComponent extends FeatureComponent<TreeViewInfo<Site
 
     const decimalRangeValidator = new DecimalRangeValidator(this._translateService);
     return this._fb.control(
-      { value: rule ? rule.reroutePercentage : 0, disabled: false },
+      { value: rule ? rule.reroutePercentage : '', disabled: false },
       decimalRangeValidator.validate.bind(decimalRangeValidator)
     );
   }
@@ -444,9 +444,17 @@ export class DeploymentSlotsComponent extends FeatureComponent<TreeViewInfo<Site
                 const nameParts = name.split('/');
                 const ruleName = nameParts.length === 2 ? nameParts[1] : 'production';
                 const index = rampUpRules.findIndex(r => r.name.toLowerCase() === ruleName.toLowerCase());
-                const value = !ruleControl.value ? 0 : Number(ruleControl.value).valueOf();
 
-                if (value === 0) {
+                // If the user explicitly clears the routing percentage for an exising rule, we will delete the enitre rule from config.
+                // If the user sets the routing percentage for a new/existing rule to a valid value (including 0%), we will update/add
+                // the rule with the routing percentage specified.
+
+                const value =
+                  ruleControl.value === '' || ruleControl.value === null || ruleControl.value === undefined
+                    ? null
+                    : Number(ruleControl.value).valueOf();
+
+                if (value === null) {
                   if (index >= 0) {
                     rampUpRules.splice(index, 1);
                   }


### PR DESCRIPTION
Currently, the Deployment Slots UI will delete an existing routing rule (or fail to add a new routing rule) if the user sets the reroutePercentage for the rule to either 0 or null/undefined.

With these changes, the UI will honor reroutePercentage=0 and will update/create routing rules accordingly.
If a user wants to delete an existing rule, they can still do so by clearing the value in the "TRAFFIC %" textbox (setting it null/undefined) instead of setting it to 0.
