### PR TITLE
[DO NOT MERGE] AB#3962028 Updating DeploymentSlotsComponent to allow viewing/editing routing rules on the production slot only

### DIFF
--- a/client/src/app/site/slots/deployment-slots/deployment-slots.component.html
+++ b/client/src/app/site/slots/deployment-slots/deployment-slots.component.html
@@ -1,6 +1,7 @@
 <div>
     <command-bar>
         <command
+            *ngIf="!isSlot"
             [displayText]="'save' | translate"
             iconUrl="image/save.svg"
             (click)="save()"
@@ -8,6 +9,7 @@
         </command>
 
         <command
+            *ngIf="!isSlot"
             [displayText]="'discard' | translate"
             iconUrl="image/discard.svg"
             (click)="discard()"
@@ -122,23 +124,23 @@
                 [name]="'feature_deploymentSlotsName' | translate">
 
                 <tr class="header-row" table-row>
-                    <th class="one-quarter-col padded-col" table-cell>
+                    <th class="padded-col" table-cell>
                         {{ 'slotsList_nameHeader' | translate }}
                     </th>
-                    <th class="one-quarter-col padded-col" table-cell>
+                    <th class="padded-col" table-cell>
                         {{ 'slotsList_statusHeader' | translate }}
                     </th>
-                    <th class="one-quarter-col padded-col" table-cell>
+                    <th class="padded-col" table-cell>
                         {{ 'slotsList_serverfarmHeader' | translate }}
                     </th>
-                    <th class="one-quarter-col padded-col" table-cell>
+                    <th *ngIf="!isSlot" class="padded-col" table-cell>
                         {{ 'slotsList_trafficPercentHeader' | translate }}
                     </th>
                 </tr>
 
                 <tr *ngIf="siteArm" table-row>
 
-                    <td class="one-quarter-col padded-col" table-cell>
+                    <td class="padded-col" table-cell>
                         {{ (siteArm && siteArm.name) ? siteArm.name.replace('/', '-') : '-' }}
                         <div
                             *ngIf="siteArm?.type === 'Microsoft.Web/sites'"
@@ -147,15 +149,15 @@
                         </div>
                     </td>
 
-                    <td class="one-quarter-col padded-col" table-cell>
+                    <td class="padded-col" table-cell>
                         {{ siteArm ? siteArm.properties.state : '-' }}
                     </td>
 
-                    <td class="one-quarter-col padded-col" table-cell>
+                    <td class="padded-col" table-cell>
                         {{ siteArm ? getSegment(siteArm.properties.serverFarmId, 8) : '-' }}
                     </td>
 
-                    <td class="one-quarter-col padded-col" table-cell>
+                    <td *ngIf="!isSlot" class="padded-col" table-cell>
                         <div class="pct-wrapper">
                             <textbox
                                 disabled="true"
@@ -169,7 +171,7 @@
 
                 <tr *ngFor="let relativeSlotArm of (siteArm ? relativeSlotsArm : [])" table-row>
 
-                    <td class="one-quarter-col padded-col" table-cell>
+                    <td class="padded-col" table-cell>
 
                         <a *ngIf="!navigationDisabled"
                             tabindex="0"
@@ -187,15 +189,15 @@
                         </div>
                     </td>
 
-                    <td class="one-quarter-col padded-col" table-cell>
+                    <td class="padded-col" table-cell>
                         {{ relativeSlotArm.properties.state }}
                     </td>
 
-                    <td class="one-quarter-col padded-col" table-cell>
+                    <td class="padded-col" table-cell>
                         {{ getSegment(relativeSlotArm.properties.serverFarmId, 8) }}
                     </td>
 
-                    <td class="one-quarter-col padded-col" table-cell [editable]="true">
+                    <td *ngIf="!isSlot" class="padded-col" table-cell [editable]="true">
                         <div class="pct-wrapper">
                             <textbox
                                 [control]="(mainForm && mainForm.controls['rulesGroup']) ? mainForm.controls['rulesGroup'].controls[relativeSlotArm.name] : null"
@@ -211,11 +213,11 @@
                 <!-- If ARM call did not return successfully or there are no entries to display, display a placeholder row -->
                 <tr *ngIf="!siteArm || !relativeSlotsArm || relativeSlotsArm.length === 0" table-row>
 
-                    <td *ngIf="fetchingContent" class="message-row" colspan="4" table-cell>
+                    <td *ngIf="fetchingContent" class="message-row" [attr.colspan]="!isSlot ? 4 : 3" table-cell>
                         {{ 'loading' | translate }}
                     </td>
 
-                    <td *ngIf="!fetchingContent && !siteArm" class="message-row" colspan="4" table-cell>
+                    <td *ngIf="!fetchingContent && !siteArm" class="message-row" [attr.colspan]="!isSlot ? 4 : 3" table-cell>
                         {{ 'error_unableToLoadSlotsList' | translate }}
                     </td>
 

--- a/client/src/app/site/slots/deployment-slots/deployment-slots.component.ts
+++ b/client/src/app/site/slots/deployment-slots/deployment-slots.component.ts
@@ -42,6 +42,7 @@ export class DeploymentSlotsComponent extends FeatureComponent<TreeViewInfo<Site
   public SumValidator = RoutingSumValidator;
   public viewInfo: TreeViewInfo<SiteData>;
   public resourceId: ResourceId;
+  public isSlot: boolean;
 
   public addSlotCommandDisabled = true;
   public swapSlotsCommandDisabled = true;
@@ -75,8 +76,6 @@ export class DeploymentSlotsComponent extends FeatureComponent<TreeViewInfo<Site
   public saving: boolean;
 
   private _siteConfigArm: ArmObj<SiteConfig>;
-
-  private _isSlot: boolean;
 
   private _slotName: string;
 
@@ -176,7 +175,7 @@ export class DeploymentSlotsComponent extends FeatureComponent<TreeViewInfo<Site
 
         const siteDescriptor = new ArmSiteDescriptor(this.viewInfo.resourceId);
 
-        this._isSlot = !!siteDescriptor.slot;
+        this.isSlot = !!siteDescriptor.slot;
         this._slotName = siteDescriptor.slot || 'production';
 
         this.resourceId = siteDescriptor.getTrimmedResourceId().toLowerCase();
@@ -211,7 +210,7 @@ export class DeploymentSlotsComponent extends FeatureComponent<TreeViewInfo<Site
         if (success) {
           this._siteConfigArm = siteConfigResult.result;
 
-          if (this._isSlot) {
+          if (this.isSlot) {
             this.siteArm = slotsResult.result.value.filter(s => s.id.toLowerCase() === this.resourceId.toLowerCase())[0];
             this.relativeSlotsArm = slotsResult.result.value.filter(s => s.id.toLowerCase() !== this.resourceId.toLowerCase());
             this.relativeSlotsArm.unshift(siteResult.result);
@@ -385,7 +384,7 @@ export class DeploymentSlotsComponent extends FeatureComponent<TreeViewInfo<Site
     this.swapSlotsCommandDisabled =
       this.saveAndDiscardCommandsDisabled || !this.hasSwapAccess || !this.relativeSlotsArm || !this.relativeSlotsArm.length;
 
-    this.navigationDisabled = this._isSlot || this._addControlsOpen || this._swapControlsOpen;
+    this.navigationDisabled = this.isSlot || this._addControlsOpen || this._swapControlsOpen;
   }
 
   private _generateRuleControl(siteArm: ArmObj<Site>): FormControl {


### PR DESCRIPTION
There is no change when viewing the Deployment Slots blade for the production slot.

When viewing the Deployment Slots blade for a deployment slot, the "Save" and "Discard" buttons are removed from the action bar, and the "TRAFFIC %" column is removed from the slots table.

**Before:**
![image](https://user-images.githubusercontent.com/5387224/53782600-e8b0f700-3ec2-11e9-81be-c6488bce7184.png)

**After:**
![image](https://user-images.githubusercontent.com/5387224/53782591-d59e2700-3ec2-11e9-83b3-387e1c9c1dd4.png)
