### PR TITLE
Fixes AB#4469570 If a save operation fails, we should surface the API…

### DIFF
--- a/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
@@ -140,6 +140,7 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
       : {
           metadata: {
             success: true,
+            error: null,
           },
         };
 
@@ -150,7 +151,11 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
       });
       portalContext.stopNotification(notificationId, true, t('configUpdateSuccess'));
     } else {
-      portalContext.stopNotification(notificationId, false, t('configUpdateFailure'));
+      const siteError = siteResult.metadata.error && siteResult.metadata.error.Message;
+      const configError = configResult.metadata.error && configResult.metadata.error.Message;
+      const slotConfigError = slotConfigResults.metadata.error && slotConfigResults.metadata.error.Message;
+      const errMessage = siteError || configError || slotConfigError || t('configUpdateFailure');
+      portalContext.stopNotification(notificationId, false, errMessage);
     }
   };
   if (!initialLoading || !initialValues) {


### PR DESCRIPTION
… failure message to the user
![image](https://user-images.githubusercontent.com/13208452/57599599-20b06800-750c-11e9-8983-e8c87bbbb7ff.png)
