### PR TITLE
AB #4665153 Fix logService for Angular and React so that data is displayed properly in our telemetry

### DIFF
--- a/client-react/src/utils/LogService.ts
+++ b/client-react/src/utils/LogService.ts
@@ -31,7 +31,8 @@ export default class LogService {
     const errorId = `/errors/${category}/${id}`;
 
     if (AppInsights) {
-      AppInsights.trackEvent(errorId, data);
+      const properties = typeof data === 'object' ? data : { message: data };
+      AppInsights.trackEvent(errorId, properties);
     }
     if (this._logToConsole) {
       console.error(`[${category}] - ${data}`);
@@ -46,7 +47,8 @@ export default class LogService {
     const warningId = `/warnings/${category}/${id}`;
 
     if (AppInsights) {
-      AppInsights.trackEvent(warningId, data);
+      const properties = typeof data === 'object' ? data : { message: data };
+      AppInsights.trackEvent(warningId, properties);
     }
     if (this._logToConsole) {
       console.warn(`[${category}] - ${data}`);
@@ -61,7 +63,8 @@ export default class LogService {
     const warningId = `/event/${category}/${id}`;
 
     if (AppInsights) {
-      AppInsights.trackEvent(warningId, data);
+      const properties = typeof data === 'object' ? data : { message: data };
+      AppInsights.trackEvent(warningId, properties);
     }
     if (this._logToConsole) {
       console.log(`%c[${category}] - ${data}`, 'color: #ff8c00');

--- a/client/src/app/shared/services/log.service.ts
+++ b/client/src/app/shared/services/log.service.ts
@@ -40,7 +40,8 @@ export class LogService {
     const errorId = `/errors/${category}/${id}`;
 
     // Always log errors to App Insights
-    this._aiService.trackEvent(errorId, data);
+    const properties = typeof data === 'object' ? data : { message: data };
+    this._aiService.trackEvent(errorId, properties);
 
     if (this._shouldLog(category, LogLevel.error)) {
       console.error(`[${category}] - ${data}`);
@@ -55,7 +56,8 @@ export class LogService {
     const warningId = `/warnings/${category}/${id}`;
 
     // Always log warnings to App Insights
-    this._aiService.trackEvent(warningId, data);
+    const properties = typeof data === 'object' ? data : { message: data };
+    this._aiService.trackEvent(warningId, properties);
 
     if (this._shouldLog(category, LogLevel.warning)) {
       console.log(`%c[${category}] - ${data}`, 'color: #ff8c00');

--- a/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
@@ -552,7 +552,11 @@ export class PlanPriceSpecManager {
       if (osType === OsType.Linux && spec.skuCode === SkuCode.Free.F1) {
         spec.specResourceSet.firstParty[0].resourceId = 'a90aec9f-eecb-42c7-8421-9b96716996dc';
       } else {
-        this._logService.error(LogCategories.specPicker, '/meter-not-found', `No meter found for ${spec.skuCode}`);
+        this._logService.error(LogCategories.specPicker, '/meter-not-found', {
+          skuCode: spec.skuCode,
+          osType: osType,
+          location: this._isUpdateScenario(this._inputs) ? this._plan.location : this._inputs.data.location,
+        });
       }
       return;
     }


### PR DESCRIPTION
Currently, the data gets converted to json on the aiservice side before it logs it and messes it up since all callers are passing in a string to our logservice.

Eg.: 
If we pass in "Failed to get/set price for specs: ${e}"
Gets logged as:
{
	"0": "F",
	"1": "a",
	"2": "i",
	"3": "l",
	"4": "e",
	"5": "d",
	"6": "",
	"7": "t",
	"8": "o",
	"9": "",
	"10": "g",
	"11": "e",
	"12": "t",
	"13": "/",
	"14": "s",
	"15": "e",
	"16": "t",
	"17": "",
	"18": "p",
	"19": "r",
	"20": "i",
	"21": "c",
	"22": "e",
	"23": "",
	"24": "f",
	"25": "o",
	"26": "r",
	"27": "",
	"28": "s",
	"29": "p",
	"30": "e",
	"31": "c",
	"32": "s",
	"33": ":",
	"34": "",
	"35": "T",
	"36": "y",
	"37": "p",
	"38": "e",
	"39": "E",
	"40": "r",
	"41": "r",
	"42": "o",
	"43": "r",
	"44": ":",
	"45": "",
	"46": "C",
	"47": "a",
	"48": "n",
	"49": "n",
	"50": "o",
	"51": "t",
	"52": "",
	"53": "r",
	"54": "e",
	"55": "a",
	"56": "d",
	"57": "",
	"58": "p",
	"59": "r",
	"60": "o",
	"61": "p",
	"62": "e",
	"63": "r",
	"64": "t",
	"65": "y",
	"66": "",
	"67": "'",
	"68": "j",
	"69": "s",
	"70": "o",
	"71": "n",
	"72": "'",
	"73": "",
	"74": "o",
	"75": "f",
	"76": "",
	"77": "n",
	"78": "u",
	"79": "l",
	"80": "l",
	"format": "function(){var t=arguments;return this.replace(/{(\\d+)}/g,function(n,e){return\"undefined\"!=typeof t[e]?t[e]:n})}"
}