### PR TITLE
AB#4675469 - Added field wrapper component and fixed issue where changing plan doesn't update essentials

### DIFF
--- a/client-react/src/components/FieldWrapper/FieldWrapper.tsx
+++ b/client-react/src/components/FieldWrapper/FieldWrapper.tsx
@@ -1,0 +1,69 @@
+import React, { useContext, CSSProperties } from 'react';
+import { Stack } from 'office-ui-fabric-react';
+import { style as typeStyle, classes } from 'typestyle';
+import { useWindowSize } from 'react-use';
+import { ThemeExtended } from '../../theme/SemanticColorsExtended';
+import { ThemeContext } from '../../ThemeContext';
+import { InfoTooltip, defaultTooltipClass } from '../InfoTooltip/InfoTooltip';
+
+export enum Layout {
+  horizontal = 'horizontal',
+  vertical = 'vertical',
+}
+
+export interface FieldWrapperProps {
+  children: JSX.Element;
+  label: string;
+  tooltip?: string;
+  required?: boolean;
+  layout?: Layout;
+  style?: CSSProperties;
+}
+
+const labelStyle = typeStyle({
+  width: '250px',
+});
+
+const requiredIcon = (theme: ThemeExtended) => {
+  return typeStyle({
+    color: theme.palette.red,
+  });
+};
+
+const tooltipStyle = typeStyle({
+  marginLeft: '5px',
+});
+
+// It may make sense to have different preset sizes for small, medium, large configurations.
+// I don't want to over-optimize for now so we can figure this out as new requirements come in.
+const MaxHorizontalWidthPx = 750;
+
+// We make a best effort to associate the "label" with the child input field by "id", however if the child
+// element is not an "input" element, then the screen reader won't respect it and won't read the label first.
+// In that case, you'll have to manually specify the "ariaLabel" property on the child element yourself
+export const FieldWrapper = (props: FieldWrapperProps) => {
+  const { label, children, layout, required, style, tooltip } = props;
+  const { width } = useWindowSize();
+  const theme = useContext(ThemeContext);
+
+  return (
+    <Stack horizontal={layout !== Layout.vertical && width > MaxHorizontalWidthPx} style={style}>
+      <label className={labelStyle} htmlFor={children.props.id}>
+        {getRequiredIcon(theme, required)} {label} {getToolTip(tooltip)}
+      </label>
+      {children}
+    </Stack>
+  );
+};
+
+const getRequiredIcon = (theme: ThemeExtended, required?: boolean) => {
+  if (required) {
+    return <span className={requiredIcon(theme)}>*</span>;
+  }
+};
+
+const getToolTip = (tooltip?: string) => {
+  if (tooltip) {
+    return <InfoTooltip className={classes(tooltipStyle, defaultTooltipClass)} content={tooltip} />;
+  }
+};

--- a/client-react/src/components/FormControlWrapper/FormControlWrapper.tsx
+++ b/client-react/src/components/FormControlWrapper/FormControlWrapper.tsx
@@ -11,7 +11,7 @@ export enum Layout {
   vertical = 'vertical',
 }
 
-export interface FieldWrapperProps {
+export interface FormControlWrapperProps {
   children: JSX.Element;
   label: string;
   tooltip?: string;
@@ -41,7 +41,7 @@ const MaxHorizontalWidthPx = 750;
 // We make a best effort to associate the "label" with the child input field by "id", however if the child
 // element is not an "input" element, then the screen reader won't respect it and won't read the label first.
 // In that case, you'll have to manually specify the "ariaLabel" property on the child element yourself
-export const FieldWrapper = (props: FieldWrapperProps) => {
+export const FormControlWrapper = (props: FormControlWrapperProps) => {
   const { label, children, layout, required, style, tooltip } = props;
   const { width } = useWindowSize();
   const theme = useContext(ThemeContext);

--- a/client-react/src/pages/app/change-app-plan/ChangeAppPlan.tsx
+++ b/client-react/src/pages/app/change-app-plan/ChangeAppPlan.tsx
@@ -4,7 +4,7 @@ import { PrimaryButton, IDropdownOption, Stack, Link, ILink, MessageBar, Message
 import { Formik, FormikProps } from 'formik';
 import { ResourceGroup } from '../../../models/resource-group';
 import { ArmObj, Site, ServerFarm, ArmSku, HostingEnvironment } from '../../../models/WebAppModels';
-import { style, classes } from 'typestyle';
+import { style } from 'typestyle';
 import { ArmSiteDescriptor, ArmPlanDescriptor } from '../../../utils/resourceDescriptors';
 import { CreateOrSelectPlan, CreateOrSelectPlanFormValues, NEW_PLAN, addNewPlanToOptions } from './CreateOrSelectPlan';
 import SiteService from '../../../ApiHelpers/SiteService';
@@ -19,9 +19,10 @@ import { ReactComponent as AppServicePlanSvg } from '../../../images/AppService/
 import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';
 import { SpecPickerOutput } from '../spec-picker/specs/PriceSpec';
-import { InfoTooltip, defaultTooltipClass } from '../../../components/InfoTooltip/InfoTooltip';
 import { useWindowSize } from 'react-use';
 import RbacHelper from '../../../utils/rbac-helper';
+import { BroadcastMessageId } from '../../../models/portal-models';
+import { FieldWrapper } from '../../../components/FieldWrapper/FieldWrapper';
 
 export const leftCol = style({
   marginRight: '20px',
@@ -51,10 +52,6 @@ const labelSectionStyle = style({
 
 const labelStyle = style({
   width: '250px',
-});
-
-const tooltipStyle = style({
-  marginLeft: '5px',
 });
 
 const footerStyle = style({
@@ -163,19 +160,17 @@ export const ChangeAppPlan: React.SFC<ChangeAppPlanProps> = props => {
                       <h4 className={labelSectionStyle}>{t('changePlanCurrentPlanDetails')}</h4>
                     </Stack>
 
-                    <Stack horizontal={width > MaxHorizontalWidthPx}>
-                      <label className={labelStyle}>{t('appServicePlan')}</label>
+                    <FieldWrapper label={t('appServicePlan')}>
                       <div tabIndex={0} aria-label={t('appServicePlan') + getPlanName(currentServerFarm)}>
                         {getPlanName(currentServerFarm)}
                       </div>
-                    </Stack>
+                    </FieldWrapper>
 
                     <Stack style={{ marginTop: '50px' }}>
                       <h4 className={labelSectionStyle}>{t('changePlanDestPlanDetails')}</h4>
                     </Stack>
 
-                    <Stack horizontal={width > MaxHorizontalWidthPx} disableShrink>
-                      <label className={labelStyle}>{t('appServicePlan')}</label>
+                    <FieldWrapper label={t('appServicePlan')} required={true}>
                       <CreateOrSelectPlan
                         subscriptionId={subscriptionId}
                         isNewPlan={formProps.values.serverFarmInfo.isNewPlan}
@@ -189,26 +184,21 @@ export const ChangeAppPlan: React.SFC<ChangeAppPlanProps> = props => {
                         serverFarmsInWebspace={serverFarms}
                         hostingEnvironment={hostingEnvironment}
                       />
-                    </Stack>
+                    </FieldWrapper>
 
-                    <Stack horizontal={width > MaxHorizontalWidthPx} style={{ marginTop: '25px' }}>
-                      <label className={labelStyle}>{t('resourceGroup')}</label>
+                    <FieldWrapper label={t('resourceGroup')} style={{ marginTop: '25px' }}>
                       <div
                         tabIndex={0}
                         aria-label={t('resourceGroup') + getSelectedResourceGroupString(formProps.values.serverFarmInfo, t)}>
                         {getSelectedResourceGroupString(formProps.values.serverFarmInfo, t)}
                       </div>
-                    </Stack>
+                    </FieldWrapper>
 
-                    <Stack horizontal={width > MaxHorizontalWidthPx} disableShrink style={fieldStyle}>
-                      <label className={labelStyle}>
-                        <span>{t('region')}</span>
-                        <InfoTooltip className={classes(tooltipStyle, defaultTooltipClass)} content={t('changePlanLocationTooltip')} />
-                      </label>
+                    <FieldWrapper label={t('region')} style={fieldStyle} tooltip={t('changePlanLocationTooltip')}>
                       <span tabIndex={0} aria-label={t('region') + site.location}>
                         {site.location}
                       </span>
-                    </Stack>
+                    </FieldWrapper>
 
                     <Stack horizontal={width > MaxHorizontalWidthPx} disableShrink style={fieldStyle}>
                       <label className={labelStyle}>{t('pricingTier')}</label>
@@ -342,6 +332,7 @@ const onSubmit = async (
 
   if (success) {
     changeComplete();
+    portalCommunicator.broadcastMessage(BroadcastMessageId.siteUpdated, values.site.id);
   }
 
   setIsUpdating(false);

--- a/client-react/src/pages/app/change-app-plan/ChangeAppPlan.tsx
+++ b/client-react/src/pages/app/change-app-plan/ChangeAppPlan.tsx
@@ -22,7 +22,7 @@ import { SpecPickerOutput } from '../spec-picker/specs/PriceSpec';
 import { useWindowSize } from 'react-use';
 import RbacHelper from '../../../utils/rbac-helper';
 import { BroadcastMessageId } from '../../../models/portal-models';
-import { FieldWrapper } from '../../../components/FieldWrapper/FieldWrapper';
+import { FormControlWrapper } from '../../../components/FormControlWrapper/FormControlWrapper';
 
 export const leftCol = style({
   marginRight: '20px',
@@ -160,17 +160,17 @@ export const ChangeAppPlan: React.SFC<ChangeAppPlanProps> = props => {
                       <h4 className={labelSectionStyle}>{t('changePlanCurrentPlanDetails')}</h4>
                     </Stack>
 
-                    <FieldWrapper label={t('appServicePlan')}>
+                    <FormControlWrapper label={t('appServicePlan')}>
                       <div tabIndex={0} aria-label={t('appServicePlan') + getPlanName(currentServerFarm)}>
                         {getPlanName(currentServerFarm)}
                       </div>
-                    </FieldWrapper>
+                    </FormControlWrapper>
 
                     <Stack style={{ marginTop: '50px' }}>
                       <h4 className={labelSectionStyle}>{t('changePlanDestPlanDetails')}</h4>
                     </Stack>
 
-                    <FieldWrapper label={t('appServicePlan')} required={true}>
+                    <FormControlWrapper label={t('appServicePlan')} required={true}>
                       <CreateOrSelectPlan
                         subscriptionId={subscriptionId}
                         isNewPlan={formProps.values.serverFarmInfo.isNewPlan}
@@ -184,21 +184,21 @@ export const ChangeAppPlan: React.SFC<ChangeAppPlanProps> = props => {
                         serverFarmsInWebspace={serverFarms}
                         hostingEnvironment={hostingEnvironment}
                       />
-                    </FieldWrapper>
+                    </FormControlWrapper>
 
-                    <FieldWrapper label={t('resourceGroup')} style={{ marginTop: '25px' }}>
+                    <FormControlWrapper label={t('resourceGroup')} style={{ marginTop: '25px' }}>
                       <div
                         tabIndex={0}
                         aria-label={t('resourceGroup') + getSelectedResourceGroupString(formProps.values.serverFarmInfo, t)}>
                         {getSelectedResourceGroupString(formProps.values.serverFarmInfo, t)}
                       </div>
-                    </FieldWrapper>
+                    </FormControlWrapper>
 
-                    <FieldWrapper label={t('region')} style={fieldStyle} tooltip={t('changePlanLocationTooltip')}>
+                    <FormControlWrapper label={t('region')} style={fieldStyle} tooltip={t('changePlanLocationTooltip')}>
                       <span tabIndex={0} aria-label={t('region') + site.location}>
                         {site.location}
                       </span>
-                    </FieldWrapper>
+                    </FormControlWrapper>
 
                     <Stack horizontal={width > MaxHorizontalWidthPx} disableShrink style={fieldStyle}>
                       <label className={labelStyle}>{t('pricingTier')}</label>

--- a/client-react/src/pages/app/change-app-plan/CreateOrSelectResourceGroup.tsx
+++ b/client-react/src/pages/app/change-app-plan/CreateOrSelectResourceGroup.tsx
@@ -21,7 +21,7 @@ import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';
 import { ValidationRegex } from '../../../utils/constants/ValidationRegex';
 import RbacHelper from '../../../utils/rbac-helper';
-import { FieldWrapper, Layout } from '../../../components/FieldWrapper/FieldWrapper';
+import { FormControlWrapper, Layout } from '../../../components/FormControlWrapper/FormControlWrapper';
 
 export interface CreateOrSelectResourceGroupFormProps {
   onRgChange: (rgInfo: ResourceGroupInfo) => void;
@@ -136,7 +136,7 @@ export const CreateOrSelectResourceGroup = (props: CreateOrSelectResourceGroupFo
 
   return (
     <>
-      <FieldWrapper label={t('resourceGroup')} layout={Layout.vertical} required={true}>
+      <FormControlWrapper label={t('resourceGroup')} layout={Layout.vertical} required={true}>
         <OfficeDropdown
           ariaLabel={t('resourceGroup')}
           selectedKey={isNewResourceGroup ? newResourceGroupName : (existingResourceGroup as ArmObj<ResourceGroup>).id.toLowerCase()}
@@ -145,7 +145,7 @@ export const CreateOrSelectResourceGroup = (props: CreateOrSelectResourceGroupFo
           styles={dropdownStyleOverrides(false, theme, false, '260px')}
           errorMessage={existingRgWritePermissionError}
         />
-      </FieldWrapper>
+      </FormControlWrapper>
 
       <div ref={menuButton => (menuButtonElement.current = menuButton)}>
         {getNewLink(hasSubscriptionWritePermission, onShowCallout, createNewLinkElement, t)}
@@ -161,7 +161,7 @@ export const CreateOrSelectResourceGroup = (props: CreateOrSelectResourceGroupFo
         directionalHint={DirectionalHint.rightBottomEdge}>
         <section className={calloutContainerStyle}>
           <div>{t('resourceGroupDescription')}</div>
-          <FieldWrapper label={t('_name')} layout={Layout.vertical} required={true} style={textFieldStyle}>
+          <FormControlWrapper label={t('_name')} layout={Layout.vertical} required={true} style={textFieldStyle}>
             <OfficeTextField
               id={'createorselectrg-rgname'}
               styles={TextFieldStyles}
@@ -170,7 +170,7 @@ export const CreateOrSelectResourceGroup = (props: CreateOrSelectResourceGroupFo
               placeholder={t('createNew')}
               errorMessage={newRgNameValidationError}
             />
-          </FieldWrapper>
+          </FormControlWrapper>
           <div>
             <PrimaryButton
               className={primaryButtonStyle}

--- a/client-react/src/pages/app/change-app-plan/CreateOrSelectResourceGroup.tsx
+++ b/client-react/src/pages/app/change-app-plan/CreateOrSelectResourceGroup.tsx
@@ -20,8 +20,8 @@ import { TextFieldStyles } from '../../../theme/CustomOfficeFabric/AzurePortal/T
 import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';
 import { ValidationRegex } from '../../../utils/constants/ValidationRegex';
-import { ThemeExtended } from '../../../theme/SemanticColorsExtended';
 import RbacHelper from '../../../utils/rbac-helper';
+import { FieldWrapper, Layout } from '../../../components/FieldWrapper/FieldWrapper';
 
 export interface CreateOrSelectResourceGroupFormProps {
   onRgChange: (rgInfo: ResourceGroupInfo) => void;
@@ -43,20 +43,14 @@ const calloutContainerStyle = style({
   padding: '20px',
 });
 
-const textFieldStyle = style({
+const textFieldStyle = {
   marginTop: '20px',
   marginBottom: '20px',
-});
+};
 
 const primaryButtonStyle = style({
   marginRight: '8px',
 });
-
-const requiredIcon = (theme: ThemeExtended) => {
-  return style({
-    color: theme.palette.red,
-  });
-};
 
 const NEW_RG = '__NewRG__';
 
@@ -142,17 +136,16 @@ export const CreateOrSelectResourceGroup = (props: CreateOrSelectResourceGroupFo
 
   return (
     <>
-      <label id="createplan-rgname">
-        <span className={requiredIcon(theme)}>*</span> {t('resourceGroup')}
-      </label>
-      <OfficeDropdown
-        selectedKey={isNewResourceGroup ? newResourceGroupName : (existingResourceGroup as ArmObj<ResourceGroup>).id.toLowerCase()}
-        options={options}
-        onChange={onChangeDropdown}
-        styles={dropdownStyleOverrides(false, theme, false, '260px')}
-        ariaLabelled-by="createplan-rgname"
-        errorMessage={existingRgWritePermissionError}
-      />
+      <FieldWrapper label={t('resourceGroup')} layout={Layout.vertical} required={true}>
+        <OfficeDropdown
+          ariaLabel={t('resourceGroup')}
+          selectedKey={isNewResourceGroup ? newResourceGroupName : (existingResourceGroup as ArmObj<ResourceGroup>).id.toLowerCase()}
+          options={options}
+          onChange={onChangeDropdown}
+          styles={dropdownStyleOverrides(false, theme, false, '260px')}
+          errorMessage={existingRgWritePermissionError}
+        />
+      </FieldWrapper>
 
       <div ref={menuButton => (menuButtonElement.current = menuButton)}>
         {getNewLink(hasSubscriptionWritePermission, onShowCallout, createNewLinkElement, t)}
@@ -168,19 +161,16 @@ export const CreateOrSelectResourceGroup = (props: CreateOrSelectResourceGroupFo
         directionalHint={DirectionalHint.rightBottomEdge}>
         <section className={calloutContainerStyle}>
           <div>{t('resourceGroupDescription')}</div>
-          <div className={textFieldStyle}>
-            <label id="createorselectrg-rgname">
-              <span className={requiredIcon(theme)}>*</span> {t('_name')}
-            </label>
+          <FieldWrapper label={t('_name')} layout={Layout.vertical} required={true} style={textFieldStyle}>
             <OfficeTextField
+              id={'createorselectrg-rgname'}
               styles={TextFieldStyles}
               value={newRgNameFieldValue}
               onChange={onRgNameTextChange}
               placeholder={t('createNew')}
               errorMessage={newRgNameValidationError}
-              ariaLabelled-by="createorselectrg-rgname"
             />
-          </div>
+          </FieldWrapper>
           <div>
             <PrimaryButton
               className={primaryButtonStyle}

--- a/client-react/src/pages/app/change-app-plan/CreatePlan.tsx
+++ b/client-react/src/pages/app/change-app-plan/CreatePlan.tsx
@@ -8,12 +8,12 @@ import { Subject } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { getServerFarmValidator } from '../../../utils/formValidation/serverFarmValidator';
 import { TextFieldStyles } from '../../../theme/CustomOfficeFabric/AzurePortal/TextField.styles';
-import { style } from 'typestyle';
 import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';
 import { AppKind } from '../../../utils/AppKind';
 import { CommonConstants } from '../../../utils/CommonConstants';
 import RbacHelper from '../../../utils/rbac-helper';
+import { FieldWrapper, Layout } from '../../../components/FieldWrapper/FieldWrapper';
 
 export interface CreatePlanProps {
   newPlanInfo: NewPlanInfo;
@@ -23,10 +23,6 @@ export interface CreatePlanProps {
   hostingEnvironment?: ArmObj<HostingEnvironment>;
   onCreatePanelClose: (newPlanInfo: NewPlanInfo) => void;
 }
-
-const fieldStyle = style({
-  marginTop: '20px',
-});
 
 export const CreatePlan = (props: CreatePlanProps) => {
   const { resourceGroupOptions, serverFarmsInWebspace, subscriptionId, onCreatePanelClose, hostingEnvironment } = props;
@@ -101,17 +97,16 @@ export const CreatePlan = (props: CreatePlanProps) => {
           onRgValidationError={e => onRgValidationError(e, setHasResourceGroupWritePermission)}
         />
 
-        <div className={fieldStyle}>
-          <label id="createplan-planname">* {t('_name')}</label>
+        <FieldWrapper label={t('_name')} layout={Layout.vertical} required={true} style={{ marginTop: '20px' }}>
           <OfficeTextField
+            id="createplan-planname"
             styles={TextFieldStyles}
             value={newPlanInfo.name}
             onChange={onChangePlanName}
             errorMessage={newPlanNameValidationError}
             placeholder={t('planName')}
-            ariaLabelled-by="createplan-planname"
           />
-        </div>
+        </FieldWrapper>
       </Panel>
     </>
   );

--- a/client-react/src/pages/app/change-app-plan/CreatePlan.tsx
+++ b/client-react/src/pages/app/change-app-plan/CreatePlan.tsx
@@ -13,7 +13,7 @@ import i18next from 'i18next';
 import { AppKind } from '../../../utils/AppKind';
 import { CommonConstants } from '../../../utils/CommonConstants';
 import RbacHelper from '../../../utils/rbac-helper';
-import { FieldWrapper, Layout } from '../../../components/FieldWrapper/FieldWrapper';
+import { FormControlWrapper, Layout } from '../../../components/FormControlWrapper/FormControlWrapper';
 
 export interface CreatePlanProps {
   newPlanInfo: NewPlanInfo;
@@ -97,7 +97,7 @@ export const CreatePlan = (props: CreatePlanProps) => {
           onRgValidationError={e => onRgValidationError(e, setHasResourceGroupWritePermission)}
         />
 
-        <FieldWrapper label={t('_name')} layout={Layout.vertical} required={true} style={{ marginTop: '20px' }}>
+        <FormControlWrapper label={t('_name')} layout={Layout.vertical} required={true} style={{ marginTop: '20px' }}>
           <OfficeTextField
             id="createplan-planname"
             styles={TextFieldStyles}
@@ -106,7 +106,7 @@ export const CreatePlan = (props: CreatePlanProps) => {
             errorMessage={newPlanNameValidationError}
             placeholder={t('planName')}
           />
-        </FieldWrapper>
+        </FormControlWrapper>
       </Panel>
     </>
   );


### PR DESCRIPTION
Added a broadcast message to update the website cache in Ibiza once an app is changed to a new plan.  Also added a new component called "FieldWrapper" which makes it easier to handle dynamic input field layout with consistent label and tooltip styles.