### PR TITLE
AB#4803601 [Safari] It cannot show the frame correctly when select ASP's pricing tire

### DIFF
--- a/client/src/app/site/spec-picker/spec-picker.component.scss
+++ b/client/src/app/site/spec-picker/spec-picker.component.scss
@@ -103,6 +103,7 @@ $center-column-max-width: calc(#{$spec-card-max-width}* 4 - 40px);
     margin: 10px 5px;
     position: relative;
     cursor: pointer;
+    outline: 0 solid $border-selection-color;
 
     h2 {
       color: $body-bg-color;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/14221995/61499864-935f1900-a97d-11e9-9814-f0286b2f9ae7.png)

After:
![image](https://user-images.githubusercontent.com/14221995/61499903-c1445d80-a97d-11e9-9256-9106257a35da.png)
