### PR TITLE
AB#4941153 Add debounce logic fpr saving deployment config.

### DIFF
--- a/client/src/app/site/deployment-center/deployment-center-setup/step-complete/step-complete.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-complete/step-complete.component.ts
@@ -31,6 +31,7 @@ export class StepCompleteComponent {
   resourceId: string;
   private _busyManager: BusyStateScopeManager;
   private _ngUnsubscribe$ = new Subject();
+  private _saveDeploymentConfig$ = new Subject();
 
   constructor(
     public wizard: DeploymentCenterStateManager,
@@ -44,9 +45,20 @@ export class StepCompleteComponent {
     this.wizard.resourceIdStream$.takeUntil(this._ngUnsubscribe$).subscribe(r => {
       this.resourceId = r;
     });
+
+    this._saveDeploymentConfig$
+      .takeUntil(this._ngUnsubscribe$)
+      .debounceTime(500)
+      .subscribe(_ => {
+        this._saveDeploymentConfig();
+      });
   }
 
   Save() {
+    this._saveDeploymentConfig$.next(true);
+  }
+
+  private _saveDeploymentConfig() {
     const saveGuid = Guid.newGuid();
     this._portalService.logAction('deploymentcenter', 'save', {
       id: saveGuid,

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-external/configure-external.component.html
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-external/configure-external.component.html
@@ -24,27 +24,25 @@
         <radio-selector [ariaLabel]="'repoType' | translate" [defaultValue]="repoMode" aria-labelledby="dc-external-repoType-label" [options]="RepoTypeOptions" (value)="repoTypeChanged($event)"></radio-selector>
       </div>
     </div>
-    <ng-container *ngIf="wizard?.wizardValues?.buildProvider === 'vsts'">
+    <div class="setting-wrapper">
+      <label class="setting-label" id="dc-external-privateRepo-label">{{'privateRepo' | translate}}</label>
+      <div class="setting-control-container">
+        <radio-selector [ariaLabel]="'privateRepo' | translate" [defaultValue]="privateRepo" [options]="AccessTypeOptions" (value)="accessTypeChanged($event)"></radio-selector>
+      </div>
+    </div>
+
+    <ng-container *ngIf="wizard?.wizardValues?.sourceSettings?.privateRepo">
+
       <div class="setting-wrapper">
-        <label class="setting-label" id="dc-external-privateRepo-label">{{'privateRepo' | translate}}</label>
+        <label class="setting-label" id="dc-external-privateRepoUserName-label">{{'username' | translate }}</label>
         <div class="setting-control-container">
-          <radio-selector [ariaLabel]="'privateRepo' | translate" [defaultValue]="privateRepo" [options]="AccessTypeOptions" (value)="accessTypeChanged($event)"></radio-selector>
+          <textbox [ariaLabel]="'username' | translate" [control]="this.wizard?.sourceSettings?.controls?.username" ></textbox>
         </div>
       </div>
-
-      <ng-container *ngIf="wizard?.wizardValues?.sourceSettings?.privateRepo">
-
-        <div class="setting-wrapper">
-          <label class="setting-label" id="dc-external-privateRepoUserName-label">{{'username' | translate }}</label>
-          <div class="setting-control-container">
-            <textbox [ariaLabel]="'username' | translate" [control]="this.wizard?.sourceSettings?.controls?.username" ></textbox>
-          </div>
+      <div class="setting-wrapper">
+        <label class="setting-label" id="dc-external-privateRepoPassword-label">{{'password' | translate }}</label>
+        <div class="setting-control-container">
+          <textbox [ariaLabel]="'password' | translate" [control]="this.wizard?.sourceSettings?.controls?.password" type="password"></textbox>
         </div>
-        <div class="setting-wrapper">
-          <label class="setting-label" id="dc-external-privateRepoPassword-label">{{'password' | translate }}</label>
-          <div class="setting-control-container">
-            <textbox [ariaLabel]="'password' | translate" [control]="this.wizard?.sourceSettings?.controls?.password" type="password"></textbox>
-          </div>
-        </div>
-      </ng-container>
+      </div>
     </ng-container>


### PR DESCRIPTION
There are certain cases reported where the call to save is going through multiple times in a rapid burst. With the logs we have not been able to identify what would cause this. The current theory is that there might be something happening due to the busy state manager.. hopefully this will fix the issue.