### PR TITLE
Fix Deployment center bugs #4040 and #4045

### DIFF
--- a/client/src/app/shared/models/constants.ts
+++ b/client/src/app/shared/models/constants.ts
@@ -500,6 +500,8 @@ export class DeploymentCenterConstants {
   public static readonly permissionsInfoLink = 'https://go.microsoft.com/fwlink/?linkid=2086046';
   public static readonly vstsPermissionApiUri =
     'https://peprodscussu2.portalext.visualstudio.com/_apis/ContinuousDelivery/PermissionsResult?api-version=4.1-preview.1';
+
+  public static readonly vstsPipelineFeatureId = 'ms.vss-build.pipelines';
   // VSTS Validation constants
   // Build definition
   public static readonly buildSecurityNameSpace = '33344D9C-FC72-4d6f-ABA5-FA317101A7E9';

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1148,7 +1148,10 @@ export class PortalResources {
   public static vstsReleaseBuildPermissions = 'vstsReleaseBuildPermissions';
   public static vstsAgentQueuePermissions = 'vstsAgentQueuePermissions';
   public static vstsCreateRepoPermissions = 'vstsCreateRepoPermissions';
+  public static vstsPipelinesNotEnabled = 'vstsPipelinesNotEnabled';
   public static vstsNameUnavailable = 'vstsNameUnavailable';
+  public static vstsTokenIsInvalid = 'vstsTokenIsInvalid';
+  public static vstsTokenFetchFailed = 'vstsTokenFetchFailed';
   public static FTPBoth = 'FTPBoth';
   public static FTPSOnly = 'FTPSOnly';
   public static FTPDisable = 'FTPDisable';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -3577,8 +3577,17 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
   <data name="vstsCreateRepoPermissions" xml:space="preserve">
     <value>You do not have permissions to create repository in this project. Contact your project administrator or choose a different project</value>
   </data>
+  <data name="vstsPipelinesNotEnabled" xml:space="preserve">
+    <value>Azure Pipelines service is not enabled for this project. Contact your project administrator or choose a different project</value>
+  </data>
   <data name="vstsNameUnavailable" xml:space="preserve">
     <value>The organization name supplied is not valid. Please supply another organization name.</value>
+  </data>
+  <data name="vstsTokenIsInvalid" xml:space="preserve">
+    <value>Could not fetch a valid Azure DevOps token</value>
+  </data>
+  <data name="vstsTokenFetchFailed" xml:space="preserve">
+    <value>Could not fetch Azure DevOps token. More details: {0}</value>
   </data>
   <data name="FTPBoth" xml:space="preserve">
     <value>FTP + FTPS</value>


### PR DESCRIPTION
Fixes #4040
Currently VSTS access token is fetched when component is created. But user can choose to click "finish" at a later time. This can result in stale token.
Also, we see some invalid token errors in Azure DevOps service while configuring CD. Hence adding better validation and error logging for token in UX.

Fixes #4045 
Add a validation for checking whether Pipelines service is enabled for user selected Azure DevOps project.