### PR TITLE
[Functions] Fix issue where passthrough API is not getting called if run action in editor fails due to CORS

### DIFF
--- a/client/src/app/shared/services/function-app.service.ts
+++ b/client/src/app/shared/services/function-app.service.ts
@@ -47,7 +47,6 @@ import { ExtensionInfo, ExtensionsJson } from 'app/shared/models/extension-info'
 import { Version } from 'app/shared/Utilities/version';
 import { ApplicationSettings } from 'app/shared/models/arm/application-settings';
 import { ArmSiteDescriptor } from '../resourceDescriptors';
-import { Http } from '@angular/http';
 import { FunctionService } from './function.service';
 
 type Result<T> = Observable<HttpResult<T>>;
@@ -63,7 +62,6 @@ export class FunctionAppService {
     private _injector: Injector,
     private _siteService: SiteService,
     private _logService: LogService,
-    private _httpClient: Http,
     private _functionService: FunctionService,
     injector: Injector
   ) {
@@ -326,7 +324,7 @@ export class FunctionAppService {
         contentType = 'application/json';
       }
 
-      const headers = new Headers();
+      const headers = this.headers(token);
       if (contentType) {
         headers.append('Content-Type', contentType);
       }
@@ -344,25 +342,25 @@ export class FunctionAppService {
         case HttpMethods.GET:
           // make sure to pass 'true' to force make a request.
           // there is no scenario where we want cached data for a function run.
-          response = this._httpClient.get(url, { headers });
+          response = this._cacheService.get(url, true, headers);
           break;
         case HttpMethods.POST:
-          response = this._httpClient.post(url, content, { headers });
+          response = this._cacheService.post(url, true, headers, content);
           break;
         case HttpMethods.DELETE:
-          response = this._httpClient.delete(url, { headers });
+          response = this._cacheService.delete(url, headers);
           break;
         case HttpMethods.HEAD:
-          response = this._httpClient.head(url, { headers });
+          response = this._cacheService.head(url, true, headers);
           break;
         case HttpMethods.PATCH:
-          response = this._httpClient.patch(url, content, { headers });
+          response = this._cacheService.patch(url, headers, content);
           break;
         case HttpMethods.PUT:
-          response = this._httpClient.put(url, content, { headers });
+          response = this._cacheService.put(url, headers, content);
           break;
         default:
-          response = this._httpClient.request(url, { headers, body: content, method: model.method });
+          response = this._cacheService.send(url, model.method, true, headers, content);
           break;
       }
 


### PR DESCRIPTION
This is reverting Travis's fix.  His issue was that we were always sending the ARM token in every request to our FE and our FE was failing to parse that token in some cases.  I tested this and it looks like that header got removed organically somewhere recently so this shouldn't be an issue anymore.