### PR TITLE
AB#5107315 Pass ResourceId parameter to open Metrics blade with the resource preselectedfrom FunctionApp

### DIFF
--- a/client/src/app/site/site-manage/site-manage.component.ts
+++ b/client/src/app/site/site-manage/site-manage.component.ts
@@ -523,7 +523,7 @@ export class SiteManageComponent extends FeatureComponent<TreeViewInfo<SiteData>
         {
           detailBlade: 'MetricsBladeV3',
           detailBladeInputs: {
-            id: site.id,
+            ResourceId: site.id,
           },
           extension: 'Microsoft_Azure_Monitoring',
         },


### PR DESCRIPTION
**Before: No dropdowns have any value**
![image](https://user-images.githubusercontent.com/14221995/62813505-03197d00-bac0-11e9-9eee-ee8ea14f126b.png)

**After: Resource and Metric namespace have preselected values**
![image](https://user-images.githubusercontent.com/14221995/62813558-512e8080-bac0-11e9-9fee-93e43bff3e1b.png)

