### PR TITLE
Key fix for url template files

### DIFF
--- a/client/src/app/shared/services/function-app.service.ts
+++ b/client/src/app/shared/services/function-app.service.ts
@@ -1099,7 +1099,7 @@ export class FunctionAppService {
       .switchMap(tuple => {
         const newContext = tuple[0];
         const version = tuple[1];
-        newContext.runtimeVersion = version;
+        newContext.urlTemplates.runtimeVersion = version;
         return Observable.of(newContext);
       });
   }

--- a/client/src/app/tree-view/function-node.ts
+++ b/client/src/app/tree-view/function-node.ts
@@ -68,7 +68,7 @@ export class FunctionNode extends TreeNode implements CanBlockNavChange, Disposa
       this.showExpandIcon = false;
     }
 
-    if (this.context.runtimeVersion === FunctionAppVersion.v1) {
+    if (this.context.urlTemplates.runtimeVersion === FunctionAppVersion.v1) {
       if (typeof this.functionInfo.config.disabled === 'string') {
         const settingName = this.functionInfo.config.disabled;
         this._siteService.getAppSettings(this.context.site.id).subscribe(r => {


### PR DESCRIPTION
Runtime version needs to be a property of URL templates for access at context and templates level. 