### PR TITLE
Remove Linux app restart on function creation

### DIFF
--- a/client/src/app/function-quickstart/function-quickstart.component.ts
+++ b/client/src/app/function-quickstart/function-quickstart.component.ts
@@ -190,23 +190,25 @@ export class FunctionQuickstartComponent extends FunctionAppContextComponent {
 
             this.bc.setDefaultValues(selectedTemplate.function.bindings, this._globalStateService.DefaultStorageAccount);
 
-            this._functionService.createFunction(this.context, functionName, selectedTemplate.files, selectedTemplate.function).subscribe(
-              res => {
-                if (res.isSuccessful) {
-                  this._portalService.logAction('intro-create-from-template', 'success', {
-                    template: selectedTemplate.id,
-                    name: functionName,
-                    appResourceId: this.context.site.id,
-                  });
+            this._functionService
+              .createFunction(this.context.site.id, functionName, selectedTemplate.files, selectedTemplate.function)
+              .subscribe(
+                res => {
+                  if (res.isSuccessful) {
+                    this._portalService.logAction('intro-create-from-template', 'success', {
+                      template: selectedTemplate.id,
+                      name: functionName,
+                      appResourceId: this.context.site.id,
+                    });
 
-                  this.functionsNode.addChild(res.result.properties);
+                    this.functionsNode.addChild(res.result.properties);
+                  }
+                  this._globalStateService.clearBusyState();
+                },
+                () => {
+                  this._globalStateService.clearBusyState();
                 }
-                this._globalStateService.clearBusyState();
-              },
-              () => {
-                this._globalStateService.clearBusyState();
-              }
-            );
+              );
           } catch (e) {
             this.showComponentError({
               message: this._translateService.instant(PortalResources.functionCreateErrorDetails, { error: JSON.stringify(e) }),

--- a/client/src/app/function/function-new-detail/function-new-detail.component.ts
+++ b/client/src/app/function/function-new-detail/function-new-detail.component.ts
@@ -318,7 +318,7 @@ export class FunctionNewDetailComponent implements OnChanges {
 
     this._globalStateService.setBusyState();
     this._functionService
-      .createFunction(this.context, this.functionName, this.currentTemplate.files, this.bc.UIToFunctionConfig(this.model.config))
+      .createFunction(this.context.site.id, this.functionName, this.currentTemplate.files, this.bc.UIToFunctionConfig(this.model.config))
       .subscribe(
         newFunctionInfo => {
           if (newFunctionInfo.isSuccessful) {

--- a/client/src/app/shared/services/function.service.ts
+++ b/client/src/app/shared/services/function.service.ts
@@ -8,21 +8,15 @@ import { CacheService } from './cache.service';
 import { UserService } from './user.service';
 import { FunctionInfo } from '../models/function-info';
 import { HostKeyTypes } from '../models/constants';
-import { FunctionAppService } from 'app/shared/services/function-app.service';
-import { FunctionAppContext } from '../function-app-context';
-import { ArmUtil } from '../Utilities/arm-utils';
 
 type Result<T> = Observable<HttpResult<T>>;
 
 @Injectable()
 export class FunctionService {
   private readonly _client: ConditionalHttpClient;
-  private _functionAppService: FunctionAppService;
 
   constructor(userService: UserService, injector: Injector, private _cacheService: CacheService) {
     this._client = new ConditionalHttpClient(injector, _ => userService.getStartupInfo().map(i => i.token));
-    // todo allisonm: Remove _functionAppService onceDOTNET_USE_POLLING_FILE_WATCHER=true in applied to containers
-    setTimeout(() => (this._functionAppService = injector.get(FunctionAppService)));
   }
 
   getFunctions(resourceId: string): Result<ArmArrayResult<FunctionInfo>> {
@@ -37,8 +31,7 @@ export class FunctionService {
     return this._client.execute({ resourceId: resourceId }, t => getFunction);
   }
 
-  createFunction(context: FunctionAppContext, functionName: string, files: any, config: any): Result<ArmObj<FunctionInfo>> {
-    const resourceId = context.site.id;
+  createFunction(resourceId: string, functionName: string, files: any, config: any): Result<ArmObj<FunctionInfo>> {
     const filesCopy = Object.assign({}, files);
     const sampleData = filesCopy['sample.dat'];
     delete filesCopy['sample.dat'];
@@ -51,15 +44,7 @@ export class FunctionService {
       },
     });
 
-    const createFunction = this._cacheService
-      .putArm(`${resourceId}/functions/${functionName}`, null, payload)
-      .map(r => r.json())
-      .concatMap(r => {
-        return ArmUtil.isLinuxApp(context.site) ? this._functionAppService.restartFunctionsHost(context).map(() => r) : Observable.of(r);
-      })
-      .do(() => {
-        this._cacheService.clearCachePrefix(context.urlTemplates.scmSiteUrl);
-      });
+    const createFunction = this._cacheService.putArm(`${resourceId}/functions/${functionName}`, null, payload).map(r => r.json());
 
     return this._client.execute({ resourceId: resourceId }, t => createFunction);
   }

--- a/client/src/app/site/quickstart/step-create-portal-function/step-create-portal-function.component.ts
+++ b/client/src/app/site/quickstart/step-create-portal-function/step-create-portal-function.component.ts
@@ -141,7 +141,7 @@ export class StepCreatePortalFunctionComponent implements OnInit, OnDestroy {
             const functionName = BindingManager.getFunctionName(selectedTemplate.metadata.defaultFunctionName, this.functionsInfo);
             this.bindingManager.setDefaultValues(selectedTemplate.function.bindings, this._globalStateService.DefaultStorageAccount);
             this._functionService
-              .createFunction(this.context, functionName, selectedTemplate.files, selectedTemplate.function)
+              .createFunction(this.context.site.id, functionName, selectedTemplate.files, selectedTemplate.function)
               .subscribe(res => {
                 this._globalStateService.clearBusyState();
                 if (res.isSuccessful) {


### PR DESCRIPTION
DOTNET_USE_POLLING_FILE_WATCHER=true has been fully deployed, so this restart is no longer needed!

Fixes AB#5136429