### PR TITLE
AB#5160316 [FunctionAppFullScreenCreate][Fusion] Update spec picker to support showing only Elastic Premium sku's scenario

### DIFF
--- a/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
@@ -51,7 +51,7 @@ export abstract class BasicPlanPriceSpec extends PriceSpec {
         this.state = 'hidden';
       }
     } else if (input.specPickerInput.data) {
-      if (input.specPickerInput.data.hostingEnvironmentName || input.specPickerInput.data.isXenon) {
+      if (input.specPickerInput.data.hostingEnvironmentName || input.specPickerInput.data.isXenon || input.specPickerInput.data.isElastic) {
         this.state = 'hidden';
       }
     }

--- a/client/src/app/site/spec-picker/price-spec-manager/elastic-premium-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/elastic-premium-plan-price-spec.ts
@@ -64,7 +64,7 @@ export abstract class ElasticPremiumPlanPriceSpec extends DV2SeriesPriceSpec {
   }
 
   protected _shouldHideForNewPlan(data: PlanSpecPickerData): boolean {
-    return !!data.hostingEnvironmentName || data.isXenon || !data.isFunctionApp;
+    return !!data.hostingEnvironmentName || data.isXenon || !data.isFunctionApp || !data.isElastic;
   }
 
   protected _shouldHideForExistingPlan(plan: ArmObj<ServerFarm>): boolean {

--- a/client/src/app/site/spec-picker/price-spec-manager/free-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/free-plan-price-spec.ts
@@ -87,7 +87,7 @@ export class FreePlanPriceSpec extends PriceSpec {
         this.topLevelFeatures.shift();
       }
 
-      if (input.specPickerInput.data.hostingEnvironmentName || input.specPickerInput.data.isXenon) {
+      if (input.specPickerInput.data.hostingEnvironmentName || input.specPickerInput.data.isXenon || input.specPickerInput.data.isXenon) {
         this.state = 'hidden';
       }
 

--- a/client/src/app/site/spec-picker/price-spec-manager/isolated-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/isolated-plan-price-spec.ts
@@ -88,7 +88,10 @@ export abstract class IsolatedPlanPriceSpec extends PriceSpec {
           }
         });
       }
-    } else if (input.specPickerInput.data && (!input.specPickerInput.data.allowAseV2Creation || input.specPickerInput.data.isXenon)) {
+    } else if (
+      input.specPickerInput.data &&
+      (!input.specPickerInput.data.allowAseV2Creation || input.specPickerInput.data.isXenon || input.specPickerInput.data.isElastic)
+    ) {
       this.state = 'hidden';
     }
 

--- a/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
@@ -57,6 +57,7 @@ export interface PlanSpecPickerData {
   isXenon: boolean;
   selectedLegacySkuName: string; // Looks like "small_standard"
   selectedSkuCode?: string; // Can be set in update scenario for initial spec selection
+  isElastic?: boolean;
 }
 
 export type ApplyButtonState = 'enabled' | 'disabled';

--- a/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
@@ -72,7 +72,12 @@ export abstract class PremiumPlanPriceSpec extends PriceSpec {
         this.state = 'hidden';
       }
     } else if (input.specPickerInput.data) {
-      if (input.specPickerInput.data.hostingEnvironmentName || input.specPickerInput.data.isLinux || input.specPickerInput.data.isXenon) {
+      if (
+        input.specPickerInput.data.hostingEnvironmentName ||
+        input.specPickerInput.data.isLinux ||
+        input.specPickerInput.data.isXenon ||
+        input.specPickerInput.data.isElastic
+      ) {
         this.state = 'hidden';
       }
     }

--- a/client/src/app/site/spec-picker/price-spec-manager/premiumv2-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premiumv2-plan-price-spec.ts
@@ -69,7 +69,7 @@ export abstract class PremiumV2PlanPriceSpec extends DV2SeriesPriceSpec {
   }
 
   protected _shouldHideForNewPlan(data: PlanSpecPickerData): boolean {
-    return !!data.hostingEnvironmentName || data.isXenon;
+    return !!data.hostingEnvironmentName || data.isXenon || !data.isElastic;
   }
 
   protected _shouldHideForExistingPlan(plan: ArmObj<ServerFarm>): boolean {

--- a/client/src/app/site/spec-picker/price-spec-manager/shared-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/shared-plan-price-spec.ts
@@ -65,7 +65,12 @@ export class SharedPlanPriceSpec extends PriceSpec {
         this.state = 'hidden';
       }
     } else if (input.specPickerInput.data) {
-      if (input.specPickerInput.data.hostingEnvironmentName || input.specPickerInput.data.isLinux || input.specPickerInput.data.isXenon) {
+      if (
+        input.specPickerInput.data.hostingEnvironmentName ||
+        input.specPickerInput.data.isLinux ||
+        input.specPickerInput.data.isXenon ||
+        input.specPickerInput.data.isElastic
+      ) {
         this.state = 'hidden';
       }
     }

--- a/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
@@ -72,7 +72,7 @@ export abstract class StandardPlanPriceSpec extends PriceSpec {
         this.state = 'hidden';
       }
     } else if (input.specPickerInput.data) {
-      if (input.specPickerInput.data.hostingEnvironmentName || input.specPickerInput.data.isXenon) {
+      if (input.specPickerInput.data.hostingEnvironmentName || input.specPickerInput.data.isXenon || input.specPickerInput.data.isElastic) {
         this.state = 'hidden';
       }
     }


### PR DESCRIPTION
I have created a separate WI to update the React side in S125 (will do it along with the other work left for the spec picker move to React)