### PR TITLE
[React] Adding new iframe RPC call for ARM async update requests

### DIFF
--- a/client-react/src/models/batch-models.ts
+++ b/client-react/src/models/batch-models.ts
@@ -1,0 +1,128 @@
+/**
+ * These interfaces are a way of creating a maintainable or string type
+ * in combination with "keyof". This produces intellisense for apis.
+ * e.g. "GET" | "HEAD" | "POST" | "PUT" | "DELETE"
+ */
+interface BatchHttpMethods {
+  GET: void;
+  HEAD: void;
+  POST: void;
+  PUT: void;
+  DELETE: void;
+  PATCH: void;
+}
+
+export type BatchHttpMethod = keyof BatchHttpMethods;
+
+/**
+ * The settings for the batch call.
+ */
+export interface BatchSettings {
+  /**
+   * The request options.
+   */
+  options?: RequestOptions;
+  /**
+   * The telemetry header to set.
+   */
+  setTelemetryHeader?: string;
+  /**
+   * The http method to use. Defaults to GET.
+   */
+  type?: BatchHttpMethod;
+  /**
+   * The URI to call.
+   */
+  uri: string;
+  /**
+   * Optional content to set for the reqeusts.
+   */
+  content?: any;
+}
+
+export interface BatchUpdateSettings extends BatchSettings {
+  notificationTitle: string;
+  notificationDescription: string;
+  notificationSuccessDescription: string;
+  notificationFailureDescription: string;
+}
+
+export const enum RequestOptions {
+  /**
+   * Default behavior.
+   *    - Defaults to foreground request
+   *    - Calls are batched to ARM every 100 ms
+   *    - Any ServerTimeout (503) failures for foreground GET requests
+   *      are automatically retried by calling the API directly wihtout batch
+   *    - Responses are not cached
+   */
+  None = 0,
+  /**
+   * Make the batch call on the next tick.
+   * DebounceNextTick takes precedence over Debounce100Ms.
+   */
+  DebounceNextTick = 1,
+  /**
+   * Include the request in a batch call that is made after a 100ms delay.
+   * Debounce100Ms takes precedence over DebounceOneMinute
+   */
+  Debounce100ms = 2,
+  /**
+   * Sets this request to run in the background.
+   * Background requests are batched every 60 seconds.
+   */
+  DebounceOneMinute = 4,
+  /**
+   * Forces a retry for any failure returned (statusCode >= 400) regardless of the HTTP method.
+   */
+  RetryForce = 8,
+  /**
+   * Skips the default retry.
+   * SkipRetry takes precedence over ForceRetry if both are set.
+   */
+  RetrySkip = 16,
+  /**
+   * Caches the response for GET requests for 10 seconds.
+   */
+  ResponseCacheEnabled = 32,
+  /**
+   * Skips caching the response for GET requests.
+   */
+  ResponseCacheSkip = 64,
+  /**
+   * Skips retry when a forbidden gateway error is received.
+   */
+  RetrySkipOnForbidden = 128,
+}
+
+export interface BatchResponseItemEx<T> extends BatchResponseItem<T> {
+  isSuccessful: boolean;
+  error?: ArmError;
+}
+
+/**
+ * Response for a request within a batch.
+ */
+interface BatchResponseItem<T> {
+  /**
+   * The response content. Can be success or failure.
+   */
+  readonly content: T;
+  /**
+   * The response headers.
+   */
+  readonly headers: ReadonlyStringMap<string>;
+  /**
+   * The response status code.
+   */
+  readonly httpStatusCode: number;
+}
+
+interface ReadonlyStringMap<T> {
+  readonly [key: string]: T;
+}
+
+interface ArmError {
+  code: 'ResourceNotFound' | 'ScopeLocked';
+  message: string;
+}

--- a/client-react/src/models/portal-models.ts
+++ b/client-react/src/models/portal-models.ts
@@ -265,29 +265,3 @@ export interface BroadcastMessage<T> {
   resourceId: string;
   metadata?: T;
 }
-
-export interface ArmUpdateRequest {
-  resourceId: string;
-  httpMethod: 'PUT' | 'PATCH';
-  content: any;
-  apiVersion: string;
-  notificationTitle: string;
-  notificationDescription: string;
-  notificationSuccessDescription: string;
-  notificationFailureDescription: string;
-}
-
-export interface ResponseItem<T = any> {
-  isSuccessful: boolean;
-  error?: any;
-  content: T;
-  jqXHR: JqXHR;
-  textStatus?: string;
-}
-
-export interface JqXHR {
-  status: number;
-  statusText: string;
-  responseJSON: any;
-  responseText: string;
-}

--- a/client-react/src/models/portal-models.ts
+++ b/client-react/src/models/portal-models.ts
@@ -271,10 +271,10 @@ export interface ArmUpdateRequest {
   httpMethod: 'PUT' | 'PATCH';
   content: any;
   apiVersion: string;
-  notificationTitle?: string;
-  notificationDescription?: string;
-  notificationSuccessDescription?: string;
-  notificationFailureDescription?: string;
+  notificationTitle: string;
+  notificationDescription: string;
+  notificationSuccessDescription: string;
+  notificationFailureDescription: string;
 }
 
 export interface ResponseItem<T = any> {

--- a/client-react/src/models/portal-models.ts
+++ b/client-react/src/models/portal-models.ts
@@ -95,6 +95,7 @@ export class Verbs {
   public static openBladeCollectorInputs = 'open-blade-collector-inputs'; // Deprecated
   public static updateBladeInfo = 'update-blade-info';
   public static returnPCV3Results = 'return-pcv3-results';
+  public static executeArmUpdateRequest = 'arm-update-request';
 
   public static closeBlades = 'close-blades';
   public static closeSelf = 'close-self';
@@ -263,4 +264,30 @@ export interface BroadcastMessage<T> {
   id: BroadcastMessageId;
   resourceId: string;
   metadata?: T;
+}
+
+export interface ArmUpdateRequest {
+  resourceId: string;
+  httpMethod: 'PUT' | 'PATCH';
+  content: any;
+  apiVersion: string;
+  notificationTitle?: string;
+  notificationDescription?: string;
+  notificationSuccessDescription?: string;
+  notificationFailureDescription?: string;
+}
+
+export interface ResponseItem<T = any> {
+  isSuccessful: boolean;
+  error?: any;
+  content: T;
+  jqXHR: JqXHR;
+  textStatus?: string;
+}
+
+export interface JqXHR {
+  status: number;
+  statusText: string;
+  responseJSON: any;
+  responseText: string;
 }

--- a/client-react/src/portal-communicator.ts
+++ b/client-react/src/portal-communicator.ts
@@ -1,3 +1,4 @@
+import { BatchUpdateSettings, BatchResponseItemEx } from './models/batch-models';
 import { loadTheme } from 'office-ui-fabric-react/lib/Styling';
 import { Observable, Subject } from 'rxjs';
 import { filter, first, map } from 'rxjs/operators';
@@ -20,8 +21,6 @@ import {
   LogEntryLevel,
   Verbs,
   TokenType,
-  ArmUpdateRequest,
-  ResponseItem,
 } from './models/portal-models';
 import { ISubscription } from './models/subscription';
 import darkModeTheme from './theme/dark';
@@ -262,10 +261,10 @@ export default class PortalCommunicator {
     });
   }
 
-  public executeArmUpdateRequest(request: ArmUpdateRequest): Promise<ResponseItem> {
+  public executeArmUpdateRequest<T>(request: BatchUpdateSettings): Promise<BatchResponseItemEx<T>> {
     const operationId = Guid.newGuid();
 
-    const payload: IDataMessage<ArmUpdateRequest> = {
+    const payload: IDataMessage<BatchUpdateSettings> = {
       operationId,
       data: request,
     };
@@ -277,7 +276,7 @@ export default class PortalCommunicator {
           filter(o => o.operationId === operationId),
           first()
         )
-        .subscribe((o: IDataMessage<IDataMessageResult<ResponseItem>>) => {
+        .subscribe((o: IDataMessage<IDataMessageResult<BatchResponseItemEx<T>>>) => {
           resolve(o.data.result);
         });
     });


### PR DESCRIPTION
Adding new RPC call which will allow you to send long-running ARM requests thru the iframe boundary.  The benefit of this is that the hosting Ibiza extension can complete the long-running job for you.  Since the extension is a long-lived entity, it should be able to complete any long-running job so that if the user closes their iframe blade, it will still complete.