### PR TITLE
Force Screen Reader to read the updated Name field in Application Setting or Connection String

### DIFF
--- a/client-react/src/pages/app/app-settings/ApplicationSettings/ApplicationSettings.tsx
+++ b/client-react/src/pages/app/app-settings/ApplicationSettings/ApplicationSettings.tsx
@@ -323,7 +323,9 @@ export class ApplicationSettings extends React.Component<FormikProps<AppSettings
           className={defaultCellStyle}
           id={`app-settings-application-settings-name-${index}`}
           onClick={() => this._onShowPanel(item)}>
-          {item[column.fieldName!]}
+          <span aria-live="assertive" role="region">
+            {item[column.fieldName!]}
+          </span>
         </ActionButton>
       );
     }

--- a/client-react/src/pages/app/app-settings/ConnectionStrings/ConnectionStrings.tsx
+++ b/client-react/src/pages/app/app-settings/ConnectionStrings/ConnectionStrings.tsx
@@ -319,7 +319,9 @@ export class ConnectionStrings extends React.Component<FormikProps<AppSettingsFo
           id={`app-settings-connection-strings-name-${index}`}
           className={defaultCellStyle}
           onClick={() => this._onShowPanel(item)}>
-          {item[column.fieldName!]}
+          <span aria-live="assertive" role="region">
+            {item[column.fieldName!]}
+          </span>
         </ActionButton>
       );
     }


### PR DESCRIPTION
Fixes AB#4766364

This change makes sure that the screen reader reads the `Name` field  whenever it is updated for Application-Settings or Connection-Strings before reading any other focused element.