### PR TITLE
Show error message if user level /sourcecontrols API fails

### DIFF
--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1682,4 +1682,5 @@ export class PortalResources {
   public static renewKeyValueContent = 'renewKeyValueContent';
   public static apimUpsell = 'apimUpsell';
   public static version3Preview = 'version3Preview';
+  public static sourceControlAuthStateFailure = 'sourceControlAuthStateFailure';
 }

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-source-control/step-source-control.component.html
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-source-control/step-source-control.component.html
@@ -39,12 +39,15 @@
 </div>
 
 <div class="footer">
-    <button type="button" *ngIf="selectedProvider?.authorizedStatus === 'notAuthorized'" class="custom-button form-button"
+    <button type="button" *ngIf="!authStateError && selectedProvider?.authorizedStatus === 'notAuthorized'" class="custom-button form-button"
       (click)="authorize()">{{'authorize' | translate}}</button>
-    <button type="button" *ngIf="selectedProvider?.authorizedStatus === 'authorized'" class="custom-button form-button"
+    <button type="button" *ngIf="!authStateError && selectedProvider?.authorizedStatus === 'authorized'" class="custom-button form-button"
       (click)="authorize()">{{'changeAuthorization' | translate}}</button>
-    <button type="button" *ngIf="(selectedProvider?.authorizedStatus === 'authorized' || selectedProvider?.authorizedStatus === 'none') && !selectedProvider?.manual"
+    <button type="button" *ngIf="!authStateError && (selectedProvider?.authorizedStatus === 'authorized' || selectedProvider?.authorizedStatus === 'none') && !selectedProvider?.manual"
       class="custom-button form-button" nextStep>{{'continue' | translate}}</button>
-  <button id="step-complete-show-dashboard-button" type="button" *ngIf="selectedProvider?.manual" class="custom-button form-button"
-    (click)="renderDashboard()">{{'dashboard' | translate}}</button>
+    <button id="step-complete-show-dashboard-button" type="button" *ngIf="!authStateError && selectedProvider?.manual" class="custom-button form-button"
+      (click)="renderDashboard()">{{'dashboard' | translate}}</button>
+    <span class="message-text" *ngIf='authStateError'>
+        {{ 'sourceControlAuthStateFailure' | translate}}
+    </span>
 </div>

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-source-control/step-source-control.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-source-control/step-source-control.component.ts
@@ -109,6 +109,7 @@ export class StepSourceControlComponent {
     },
   ];
 
+  public authStateError = false;
   private _githubAuthed = false;
   private _onedriveAuthed = false;
   private _dropboxAuthed = false;
@@ -244,6 +245,7 @@ export class StepSourceControlComponent {
           this.refreshAuth();
         },
         err => {
+          this.authStateError = true;
           this._logService.error(LogCategories.cicd, '/fetch-current-auth-state', err);
         }
       );

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -5218,6 +5218,6 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>~3 (Preview)</value>
     </data>
     <data name="sourceControlAuthStateFailure" xml:space="preserve">
-        <value>Unable to retrieve authentication state. Please try again in a few mins.</value>
+        <value>Unable to retrieve authentication state. Please try again in a few minutes.</value>
     </data>
 </root>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -5217,4 +5217,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="version3Preview" xml:space="preserve">
         <value>~3 (Preview)</value>
     </data>
+    <data name="sourceControlAuthStateFailure" xml:space="preserve">
+        <value>Unable to retrieve authentication state. Please try again in a few mins.</value>
+    </data>
 </root>


### PR DESCRIPTION
fixes AB#4955281

This is a super edge case scenario and very rare. But we have had an instance where the /sourcecontrols API was failing and we repeated asked users to re-authenticate. Instead show a message.

There really isn't a better way to put an error message here. Fortunately we are logging the event, so if the users contact us we will be able to identify exactly what failed.

If all works fine, you should see:
![image](https://user-images.githubusercontent.com/493476/65809774-edd2dd80-e155-11e9-81d4-7fcd199830f1.png)

Currently on failure you see (notice github is asking for authorization again):
![image](https://user-images.githubusercontent.com/493476/65809805-3c807780-e156-11e9-8799-5bd7f26557b2.png)


With the fix you will see an error message:
![image](https://user-images.githubusercontent.com/493476/65809758-cb40c480-e155-11e9-9f72-79c3ae42ec13.png)
