### PR TITLE
Adding explicit interface for opening FrameBlades from Fusion

### DIFF
--- a/client-react/src/models/portal-models.ts
+++ b/client-react/src/models/portal-models.ts
@@ -142,12 +142,18 @@ export interface IWebsiteId {
   SubscriptionId: string;
 }
 
-export interface IOpenBladeInfo {
+export interface IOpenBladeInfo<T = any> {
   detailBlade: string;
-  detailBladeInputs: any;
+  detailBladeInputs: T;
   extension?: string;
   openAsContextBlade?: boolean;
   openAsSubJourney?: boolean;
+}
+
+export interface FrameBladeParams<T> {
+  id?: string;
+  feature?: string;
+  data?: T;
 }
 
 export interface ITimerEvent {

--- a/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
@@ -168,7 +168,7 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
   }, []);
 
   const scaleUpPlan = async () => {
-    await portalContext.openBlade(
+    await portalContext.openFrameBlade(
       { detailBlade: 'SpecPickerFrameBlade', detailBladeInputs: { id: currentSiteNonForm.properties.serverFarmId } },
       'appsettings'
     );

--- a/client-react/src/pages/app/change-app-plan/ChangeAppPlan.tsx
+++ b/client-react/src/pages/app/change-app-plan/ChangeAppPlan.tsx
@@ -316,7 +316,7 @@ const openSpecPicker = async (
   linkElement: React.MutableRefObject<ILink | null>,
   portalCommunicator: PortalCommunicator
 ) => {
-  const result = await portalCommunicator.openBlade<SpecPickerOutput>(
+  const result = await portalCommunicator.openFrameBlade<SpecPickerOutput>(
     {
       detailBlade: 'SpecPickerFrameBlade',
       detailBladeInputs: {

--- a/client-react/src/portal-communicator.ts
+++ b/client-react/src/portal-communicator.ts
@@ -27,6 +27,7 @@ import {
   CheckLockResponse,
   LockType,
   PortalDebugInformation,
+  FrameBladeParams,
 } from './models/portal-models';
 import { ISubscription } from './models/subscription';
 import darkModeTheme from './theme/dark';
@@ -132,8 +133,8 @@ export default class PortalCommunicator {
     }
   }
 
-  public openBlade<T>(bladeInfo: IOpenBladeInfo, source: string): Promise<IBladeResult<T>> {
-    const payload: IDataMessage<IOpenBladeInfo> = {
+  public openBlade<T, U = any>(bladeInfo: IOpenBladeInfo<U>, source: string): Promise<IBladeResult<T>> {
+    const payload: IDataMessage<IOpenBladeInfo<U>> = {
       operationId: Guid.newGuid(),
       data: bladeInfo,
     };
@@ -152,6 +153,10 @@ export default class PortalCommunicator {
           resolve(data);
         });
     });
+  }
+
+  public openFrameBlade<T, U = any>(bladeInfo: IOpenBladeInfo<FrameBladeParams<U>>, source: string): Promise<IBladeResult<T>> {
+    return this.openBlade(bladeInfo, source);
   }
 
   public getSpecCosts(query: SpecCostQueryInput): Observable<SpecCostQueryResult> {

--- a/client/src/app/feature-group/feature-item.ts
+++ b/client/src/app/feature-group/feature-item.ts
@@ -5,7 +5,7 @@ import { Subject } from 'rxjs/Subject';
 import { Subscription as RxSubscription } from 'rxjs/Subscription';
 import { DisableInfo } from './feature-item';
 import { PortalService } from '../shared/services/portal.service';
-import { OpenBladeInfo } from '../shared/models/portal';
+import { OpenBladeInfo, FrameBladeParams } from '../shared/models/portal';
 import { SiteTabIds } from 'app/shared/models/constants';
 import { PortalResources } from 'app/shared/models/portal-resources';
 
@@ -99,39 +99,55 @@ export class DisableableFeature extends FeatureItem {
   }
 }
 
-export class DisableableBladeFeature extends DisableableFeature {
+abstract class BaseDisableableBladeFeature<T = any> extends DisableableFeature {
   constructor(
     title: string,
     keywords: string,
     info: string,
     imageUrl: string,
-    protected _bladeInfo: OpenBladeInfo,
+    protected _bladeInfo: OpenBladeInfo<T>,
     protected _portalService: PortalService,
     disableInfoStream?: Subject<DisableInfo>,
     overrideDisableInfo?: ScenarioResult
   ) {
     super(title, keywords, info, imageUrl, null, disableInfoStream, overrideDisableInfo);
   }
+}
 
+export class DisableableBladeFeature extends BaseDisableableBladeFeature<any> {
   click() {
     this._portalService.openBlade(this._bladeInfo, 'site-manage');
   }
 }
 
-export class BladeFeature extends FeatureItem {
+export class DisableableFrameBladeFeature<T = any> extends BaseDisableableBladeFeature<FrameBladeParams<T>> {
+  click() {
+    this._portalService.openFrameBlade(this._bladeInfo, 'site-manage');
+  }
+}
+
+abstract class BaseBladeFeature<T = any> extends FeatureItem {
   constructor(
     title: string,
     keywords: string,
     info: string,
     imageUrl: string,
-    public bladeInfo: OpenBladeInfo,
-    private _portalService: PortalService
+    public bladeInfo: OpenBladeInfo<T>,
+    protected _portalService: PortalService
   ) {
     super(title, keywords, info, imageUrl);
   }
+}
 
+export class BladeFeature extends BaseBladeFeature<any> {
   click() {
     this._portalService.openBlade(this.bladeInfo, 'site-manage');
+  }
+}
+
+export class FrameBladeFeature<T = any> extends BaseBladeFeature<FrameBladeParams<T>> {
+  click() {
+    this._portalService.openFrameBlade(this.bladeInfo, 'site-manage');
   }
 }
 

--- a/client/src/app/function-edit/function-edit.component.ts
+++ b/client/src/app/function-edit/function-edit.component.ts
@@ -192,7 +192,7 @@ export class FunctionEditComponent extends NavigableComponent implements OnDestr
             iconClass: 'fa fa-exclamation-triangle warning',
             learnMoreLink: 'https://go.microsoft.com/fwlink/?linkid=830855',
             clickCallback: () => {
-              this._portalService.openBlade(
+              this._portalService.openFrameBlade(
                 {
                   detailBlade: 'SiteConfigSettingsFrameBladeReact',
                   detailBladeInputs: {

--- a/client/src/app/function-monitor/monitor-applicationinsights/monitor-applicationinsights.component.ts
+++ b/client/src/app/function-monitor/monitor-applicationinsights/monitor-applicationinsights.component.ts
@@ -161,7 +161,7 @@ export class MonitorApplicationInsightsComponent extends FeatureComponent<Functi
   }
 
   public openDiagnoseAndSolveProblemsBlade() {
-    this._portalService.openBlade(
+    this._portalService.openFrameBlade(
       {
         detailBlade: 'SCIFrameBlade',
         detailBladeInputs: {

--- a/client/src/app/shared/models/portal.ts
+++ b/client/src/app/shared/models/portal.ts
@@ -134,12 +134,18 @@ export interface WebsiteId {
   SubscriptionId: string;
 }
 
-export interface OpenBladeInfo {
+export interface OpenBladeInfo<T = any> {
   detailBlade: string;
-  detailBladeInputs: any;
+  detailBladeInputs: T;
   extension?: string;
   openAsContextBlade?: boolean;
   openAsSubJourney?: boolean;
+}
+
+export interface FrameBladeParams<T = any> {
+  id?: string;
+  feature?: string;
+  data?: T;
 }
 
 export interface TimerEvent {

--- a/client/src/app/shared/services/portal.service.ts
+++ b/client/src/app/shared/services/portal.service.ts
@@ -23,6 +23,7 @@ import {
   CheckLockRequest,
   CheckLockResponse,
   LockType,
+  FrameBladeParams,
 } from './../models/portal';
 import {
   Event,
@@ -170,7 +171,7 @@ export class PortalService implements IPortalService {
   }
 
   // Deprecated
-  openBladeDeprecated(bladeInfo: OpenBladeInfo, source: string) {
+  openBladeDeprecated<T = any>(bladeInfo: OpenBladeInfo<T>, source: string) {
     this.logAction(source, 'open-blade ' + bladeInfo.detailBlade);
     this._aiService.trackEvent('/site/open-blade', {
       targetBlade: bladeInfo.detailBlade,
@@ -181,10 +182,15 @@ export class PortalService implements IPortalService {
     this.postMessage(Verbs.openBlade, this._packageData(bladeInfo));
   }
 
+  // Deprecated
+  openFrameBladeDeprecated<T = any>(bladeInfo: OpenBladeInfo<FrameBladeParams<T>>, source: string) {
+    this.openBladeDeprecated(bladeInfo, source);
+  }
+
   // Returns an Observable which resolves when blade is close.
   // Optionally may also return a value
-  openBlade(bladeInfo: OpenBladeInfo, source: string): Observable<BladeResult<any>> {
-    const payload: DataMessage<OpenBladeInfo> = {
+  openBlade<T = any>(bladeInfo: OpenBladeInfo<T>, source: string): Observable<BladeResult<any>> {
+    const payload: DataMessage<OpenBladeInfo<T>> = {
       operationId: Guid.newGuid(),
       data: bladeInfo,
     };
@@ -196,6 +202,10 @@ export class PortalService implements IPortalService {
       .map((r: DataMessage<DataMessageResult<BladeResult<any>>>) => {
         return r.data.result;
       });
+  }
+
+  openFrameBlade<T = any>(bladeInfo: OpenBladeInfo<FrameBladeParams<T>>, source: string): Observable<BladeResult<any>> {
+    return this.openBlade(bladeInfo, source);
   }
 
   openCollectorBlade(resourceId: string, name: string, source: string, getAppSettingCallback: (appSettingName: string) => void): void {

--- a/client/src/app/site/function-runtime/function-runtime.component.ts
+++ b/client/src/app/site/function-runtime/function-runtime.component.ts
@@ -381,7 +381,7 @@ export class FunctionRuntimeComponent extends FunctionAppContextComponent {
   }
 
   openAppSettings() {
-    this._portalService.openBlade(
+    this._portalService.openFrameBlade(
       {
         detailBlade: 'SiteConfigSettingsFrameBladeReact',
         detailBladeInputs: {

--- a/client/src/app/site/site-config/general-settings/general-settings.component.ts
+++ b/client/src/app/site/site-config/general-settings/general-settings.component.ts
@@ -286,7 +286,7 @@ export class GeneralSettingsComponent extends ConfigSaveComponent implements OnC
     this.setBusy();
     if (!this.useOldScaleUpBlade) {
       this._portalService
-        .openBlade(
+        .openFrameBlade(
           {
             detailBlade: 'SpecPickerFrameBlade',
             detailBladeInputs: {

--- a/client/src/app/site/site-config/mount-storage/mount-storage.component.ts
+++ b/client/src/app/site/site-config/mount-storage/mount-storage.component.ts
@@ -185,7 +185,7 @@ export class MountStorageComponent extends ConfigSaveComponent implements OnChan
       });
     }
 
-    this._portalService.openBlade(
+    this._portalService.openFrameBlade(
       {
         detailBlade: 'ByosPickerFrameBlade',
         detailBladeInputs: {

--- a/client/src/app/site/site-dashboard/site-dashboard.component.ts
+++ b/client/src/app/site/site-dashboard/site-dashboard.component.ts
@@ -128,7 +128,7 @@ export class SiteDashboardComponent extends NavigableComponent implements OnDest
         // the blade, then we'll automatically open the troubleshoot blade again for the first app they load.
         this._openTroubleshoot = Url.getParameterByName(null, 'appsvc.troubleshoot') === 'true';
         if (this._openTroubleshoot) {
-          this._portalService.openBlade(
+          this._portalService.openFrameBlade(
             {
               detailBlade: 'SCIFrameBlade',
               detailBladeInputs: {

--- a/client/src/app/site/site-manage/site-manage.component.ts
+++ b/client/src/app/site/site-manage/site-manage.component.ts
@@ -16,6 +16,7 @@ import {
   DisableableBladeFeature,
   DisableableFeature,
   DisableableTabFeature,
+  DisableableFrameBladeFeature,
 } from './../../feature-group/feature-item';
 import { FeatureGroup } from './../../feature-group/feature-group';
 import { AuthzService } from '../../shared/services/authz.service';
@@ -167,7 +168,7 @@ export class SiteManageComponent extends FeatureComponent<TreeViewInfo<SiteData>
       this._translateService.instant(PortalResources.containerSettingsTitle) + ' ' + this._translateService.instant(PortalResources.linux);
 
     if (ArmUtil.isContainerApp(site)) {
-      const containerSettingsFeature = new DisableableBladeFeature(
+      const containerSettingsFeature = new DisableableFrameBladeFeature(
         this._translateService.instant(PortalResources.containerSettingsTitle),
         containerSettingsKeywords,
         this._translateService.instant(PortalResources.feature_containerSettingsInfo),
@@ -704,7 +705,7 @@ export class SiteManageComponent extends FeatureComponent<TreeViewInfo<SiteData>
     const resourceManagementFeatures = [];
     if (this._scenarioService.checkScenario(ScenarioIds.addDiagnoseAndSolve).status !== 'disabled') {
       resourceManagementFeatures.push(
-        new DisableableBladeFeature(
+        new DisableableFrameBladeFeature(
           this._translateService.instant(PortalResources.feature_diagnoseAndSolveName),
           this._translateService.instant(PortalResources.feature_diagnoseAndSolveName),
           this._translateService.instant(PortalResources.feature_diagnoseAndSolveInfo),

--- a/client/src/app/site/site-summary/site-summary.component.ts
+++ b/client/src/app/site/site-summary/site-summary.component.ts
@@ -44,7 +44,7 @@ import { FunctionAppService } from 'app/shared/services/function-app.service';
 import { FeatureComponent } from 'app/shared/components/feature-component';
 import { errorIds } from '../../shared/models/error-ids';
 import { TopBarNotification } from 'app/top-bar/top-bar-models';
-import { OpenBladeInfo, EventVerbs } from '../../shared/models/portal';
+import { OpenBladeInfo, EventVerbs, FrameBladeParams } from '../../shared/models/portal';
 import { SlotSwapInfo } from '../../shared/models/slot-events';
 import { FlightingUtil } from 'app/shared/Utilities/flighting-utility';
 import { FunctionService } from 'app/shared/services/function.service';
@@ -240,7 +240,7 @@ export class SiteSummaryComponent extends FeatureComponent<TreeViewInfo<SiteData
             iconClass: 'fa fa-exclamation-triangle warning',
             learnMoreLink: null,
             clickCallback: () => {
-              const containerSettingsBladeInput = {
+              const containerSettingsBladeInput: OpenBladeInfo<FrameBladeParams> = {
                 detailBlade: 'ContainerSettingsFrameBlade',
                 detailBladeInputs: {
                   id: this.context.site.id,
@@ -567,7 +567,7 @@ export class SiteSummaryComponent extends FeatureComponent<TreeViewInfo<SiteData
       detailBladeInputs: { resourceUri: this.context.site.id },
     };
 
-    const newBladeInfo: OpenBladeInfo = {
+    const newBladeInfo: OpenBladeInfo<FrameBladeParams> = {
       detailBlade: 'SwapSlotsFrameBlade',
       detailBladeInputs: { id: this.context.site.id },
       openAsContextBlade: true,

--- a/client/src/app/slot-new/slot-new.component.ts
+++ b/client/src/app/slot-new/slot-new.component.ts
@@ -190,7 +190,7 @@ export class SlotNewComponent extends NavigableComponent {
     this.setBusy();
 
     this._portalService
-      .openBlade(
+      .openFrameBlade(
         {
           detailBlade: 'SpecPickerFrameBlade',
           detailBladeInputs: {


### PR DESCRIPTION
I noticed that figuring out how to open a FrameBlade from Fusion can be confusing because the required structure of detailBladeInputs property isn't obvious.

The structure needs to look like below, with a required 'id' property and an optional 'data' property containing some object.

```
detailBladeInputs : {
  id: string,
  data?: <some object>,
}
```

However, a common mistake is to just use the data object directly, like below.

```
detailBladeInputs : <some object>
```

I think we can eliminate this confusion by adding explicit interfaces and functions specific to opening a FrameBlade.
