### PR TITLE
Adding arrows to functions integrate

### DIFF
--- a/client-react/src/images/Functions/double-arrow-left-right.svg
+++ b/client-react/src/images/Functions/double-arrow-left-right.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" preserveAspectRatio="none" viewBox="179 214.7823046210672 201.14285714285722 188.21769537893286" width="197.14" height="184.22">
+   <defs>
+      <path d="M375.92 308.21C351.6 308.21 316.3 308.21 301.39 308.21C289.58 308.21 280 317.78 280 329.6C280 343.68 280 361.49 280 374.81C280 388.72 268.72 400 254.81 400C244.83 400 219.9 400 180 400" id="c2DKuMhC3I" />
+      <path d="M371.24 301.17C372.19 302.38 374.07 304.81 376.91 308.46" id="b5ZQugPZ2w" />
+      <path d="M371 315C372.01 313.83 374.04 311.48 377.07 307.96" id="a5vBp6pUmb" />
+      <path d="M377.14 308.3C352.82 308.3 317.65 308.3 302.78 308.3C290.88 308.3 281.22 298.65 281.22 286.74C281.22 272.55 281.22 254.6 281.22 241.17C281.22 227.15 269.86 215.78 255.83 215.78C245.89 215.78 221.02 215.78 181.22 215.78" id="cWVBs1r92" />
+   </defs>
+   <g>
+      <g>
+         <g>
+            <use xlink:href="#c2DKuMhC3I" opacity="1" fill-opacity="0" stroke="#000000" stroke-width="0.5" stroke-opacity="1" />
+         </g>
+      </g>
+      <g>
+         <g>
+            <use xlink:href="#b5ZQugPZ2w" opacity="1" fill-opacity="0" stroke="#000000" stroke-width="0.5" stroke-opacity="1" />
+         </g>
+      </g>
+      <g>
+         <g>
+            <use xlink:href="#a5vBp6pUmb" opacity="1" fill-opacity="0" stroke="#000000" stroke-width="0.5" stroke-opacity="1" />
+         </g>
+      </g>
+      <g>
+         <g>
+            <use xlink:href="#cWVBs1r92" opacity="1" fill-opacity="0" stroke="#000000" stroke-width="0.5" stroke-opacity="1" />
+         </g>
+      </g>
+   </g>
+</svg>

--- a/client-react/src/images/Functions/single-arrow-left-right.svg
+++ b/client-react/src/images/Functions/single-arrow-left-right.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" preserveAspectRatio="none" viewBox="179 461.5 199.96455767110814 19" width="195.96" height="15">
+   <defs>
+      <path d="M369.46 477.5C370.48 476.33 372.5 473.98 375.54 470.46" id="d1fA6jCU0t" />
+      <path d="M370 462.5C370.94 463.72 372.83 466.15 375.67 469.8" id="f25RRODFZt" />
+      <path d="M375.96 470C343.3 470 277.98 470 180 470" id="a1BoAhIniT" />
+   </defs>
+   <g>
+      <g>
+         <g>
+            <use xlink:href="#d1fA6jCU0t" opacity="1" fill-opacity="0" stroke="#000000" stroke-width="0.5" stroke-opacity="1" />
+         </g>
+      </g>
+      <g>
+         <g>
+            <use xlink:href="#f25RRODFZt" opacity="1" fill-opacity="0" stroke="#000000" stroke-width="0.5" stroke-opacity="1" />
+         </g>
+      </g>
+      <g>
+         <g>
+            <use xlink:href="#a1BoAhIniT" opacity="1" fill-opacity="0" stroke="#000000" stroke-width="0.5" stroke-opacity="1" />
+         </g>
+      </g>
+   </g>
+</svg>

--- a/client-react/src/pages/app/functions/integrate/FunctionIntegrate.tsx
+++ b/client-react/src/pages/app/functions/integrate/FunctionIntegrate.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { ArmObj } from '../../../../models/arm-obj';
 import { FunctionInfo } from '../../../../models/functions/function-info';
-import { Stack } from 'office-ui-fabric-react';
+import { Stack, IStackTokens } from 'office-ui-fabric-react';
 import TriggerBindingCard from './BindingsDiagram/TriggerBindingCard';
 import OutputBindingCard from './BindingsDiagram/OutputBindingCard';
 import InputBindingCard from './BindingsDiagram/InputBindingCard';
@@ -9,14 +9,37 @@ import FunctionNameBindingCard from './BindingsDiagram/FunctionNameBindingCard';
 import { BindingInfo } from '../../../../models/functions/function-binding';
 import { Subject, Observable } from 'rxjs';
 import BindingEditorDataLoader from './binding-editor/BindingEditorDataLoader';
+import { ReactComponent as DoubleArrow } from '../../../../images/Functions/double-arrow-left-right.svg';
+import { ReactComponent as SingleArrow } from '../../../../images/Functions/single-arrow-left-right.svg';
+import { style, classes } from 'typestyle';
 
 export interface FunctionIntegrateProps {
   functionInfo: ArmObj<FunctionInfo>;
 }
 
-const paddingStyle = {
+const diagramWrapperStyle = style({
   padding: '20px',
-};
+  maxWidth: '1200px',
+  minWidth: '930px',
+});
+
+const arrowStyle = style({
+  width: '100%',
+});
+
+const doubleArrowStyle = style({
+  height: '115px',
+  marginTop: '37px',
+});
+
+const singleArrowStyle = style({
+  height: '13px',
+  marginTop: '90px',
+});
+
+const singleCardStackStyle = style({
+  marginTop: '58px',
+});
 
 export interface BindingUpdateInfo {
   newBindingInfo?: BindingInfo;
@@ -72,26 +95,40 @@ export const FunctionIntegrate: React.SFC<FunctionIntegrateProps> = props => {
     updateFunctionInfo: setFunctionInfo,
   };
 
+  const tokens: IStackTokens = {
+    childrenGap: 0,
+  };
+
   return (
     <>
       <BindingEditorContext.Provider value={editorContext}>
         <BindingEditorDataLoader functionInfo={functionInfo} bindingInfo={bindingToUpdate} onPanelClose={onCancel} onSubmit={onSubmit} />
 
-        <div style={paddingStyle}>
-          <Stack horizontal gap={50} horizontalAlign={'center'} disableShrink>
+        <div className={diagramWrapperStyle}>
+          <Stack horizontal horizontalAlign={'center'} tokens={tokens}>
             <Stack.Item grow>
-              <Stack gap={100}>
+              <Stack gap={40}>
                 <TriggerBindingCard functionInfo={functionInfo} />
                 <InputBindingCard functionInfo={functionInfo} />
               </Stack>
             </Stack.Item>
+
             <Stack.Item grow>
-              <Stack verticalAlign="center" verticalFill={true}>
+              <DoubleArrow className={classes(arrowStyle, doubleArrowStyle)} />
+            </Stack.Item>
+
+            <Stack.Item grow>
+              <Stack verticalFill={true} className={singleCardStackStyle}>
                 <FunctionNameBindingCard functionInfo={functionInfo} />
               </Stack>
             </Stack.Item>
+
             <Stack.Item grow>
-              <Stack verticalAlign="center" verticalFill={true}>
+              <SingleArrow className={classes(arrowStyle, singleArrowStyle)} />
+            </Stack.Item>
+
+            <Stack.Item grow>
+              <Stack verticalFill={true} className={singleCardStackStyle}>
                 <OutputBindingCard functionInfo={functionInfo} />
               </Stack>
             </Stack.Item>


### PR DESCRIPTION
Here's my first attempt at adding arrows to the functions integrate page.  We can play around with the look of the arrows and figure out proper min and max-widths.  For shrinking, we still need to figure out what it looks like in a responsive design.

@refortie & @agruning - Please take a look.

![image](https://user-images.githubusercontent.com/5695405/66416603-08595200-e9b3-11e9-9a57-041ac55cdf12.png)
