### PR TITLE
Disable creation when there are 5 mounts specified

### DIFF
--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMounts.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMounts.tsx
@@ -77,14 +77,14 @@ export class AzureStorageMounts extends React.Component<CombinedProps, AzureStor
 
   private _getCommandBarItems = (): ICommandBarItemProps[] => {
     const { editable } = this.context;
-    const { t } = this.props;
+    const { t, values } = this.props;
     return [
       {
         key: 'app-settings-new-azure-storage-mount-button',
         onClick: this._createNewItem,
-        disabled: !editable,
+        disabled: !editable || values.azureStorageMounts.length >= 5,
         iconProps: { iconName: 'Add' },
-        name: t('newAzureStorageMount'),
+        text: t('newAzureStorageMount'),
       },
     ];
   };

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -4972,7 +4972,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>Working directory path should be relative to root of the repository, and cannot start with /, \ or drive names(C:/) in case of Windows. If working directory is in src folder of repository, path should be src/</value>
     </data>
     <data name="mountedStorageInfo" xml:space="preserve">
-        <value>Mounted storage lets you map Azure Files or Blob containers for use with your app.</value>
+        <value>Mounted storage lets you map up to 5 Azure Files or Blob containers for use with your app.</value>
     </data>
     <data name="changePlanName" xml:space="preserve">
         <value>Change App Service plan</value>


### PR DESCRIPTION
The backend only supports the creation of 5 mounts at a time. Even though the APIs will return a 200, it will be inaccessible and on reload vanish from our list.