### PR TITLE
Revert "AB#5488629 Remove Poweshell Preview status bar from function app overview (#4200)"

### DIFF
--- a/client/src/app/site/site-summary/site-summary.component.ts
+++ b/client/src/app/site/site-summary/site-summary.component.ts
@@ -1,3 +1,4 @@
+import { WorkerRuntimeLanguages } from 'app/shared/models/constants';
 import { ArmUtil } from 'app/shared/Utilities/arm-utils';
 import { BroadcastEvent, EventMessage } from 'app/shared/models/broadcast-event';
 import { SiteService } from './../../shared/services/site.service';
@@ -203,6 +204,8 @@ export class SiteSummaryComponent extends FeatureComponent<TreeViewInfo<SiteData
           !this.siteAvailabilityStateNormal;
 
         const appSettings = r.appSettings && r.appSettings.result && r.appSettings.result.properties;
+        const workerRuntime = appSettings && appSettings[Constants.functionsWorkerRuntimeAppSettingsName];
+        const isPowershell = workerRuntime && WorkerRuntimeLanguages[workerRuntime] === WorkerRuntimeLanguages.powershell;
 
         if (
           r.functionsInfo.length === 0 &&
@@ -265,6 +268,17 @@ export class SiteSummaryComponent extends FeatureComponent<TreeViewInfo<SiteData
           });
           this._globalStateService.setTopBarNotifications(this.notifications);
         } else {
+          if (isPowershell) {
+            this.notifications.push({
+              id: NotificationIds.powershellPreview,
+              message: this.ts.instant(PortalResources.powershellPreview),
+              iconClass: 'fa fa-exclamation-triangle warning',
+              learnMoreLink: Links.powershellPreviewLearnMore,
+              clickCallback: null,
+            });
+            this._globalStateService.setTopBarNotifications(this.notifications);
+          }
+
           if (
             r.appInsightsEnablement &&
             r.appInsightsEnablement.status === 'enabled' &&


### PR DESCRIPTION
This reverts commit b53c8efe42c077f6eb56d90034f827eaff06db73.

**Will re-add this in S126 since we want it to go just before Ignite - wait till 10/28**