### PR TITLE
Only invoke the sourcecontrols API if at least one token based sourcecontrol source is available.

### DIFF
--- a/client/src/app/shared/services/scenario/national-cloud.environment.ts
+++ b/client/src/app/shared/services/scenario/national-cloud.environment.ts
@@ -138,13 +138,6 @@ export class NationalCloudEnvironment extends AzureEnvironment {
       },
     };
 
-    // this.scenarioChecks[ScenarioIds.configureAADSupported] = {
-    //   id: ScenarioIds.configureAADSupported,
-    //   runCheck: () => {
-    //     return { status: 'disabled' };
-    //   },
-    // };
-
     this.scenarioChecks[ScenarioIds.configureAADSupported] = {
       id: ScenarioIds.configureAADSupported,
       runCheckAsync: (input: ScenarioCheckInput) => {

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-source-control/step-source-control.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-source-control/step-source-control.component.ts
@@ -270,6 +270,8 @@ export class StepSourceControlComponent {
   }
 
   private _shouldFetchSourceControlTokens(): boolean {
+    // NOTE(michinoy): Only attempt to fetch the source control token if at least one source control provider
+    // is supported.
     const oneDriveSourceScenario = this._scenarioService.checkScenario(ScenarioIds.onedriveSource);
     const dropboxSourceScenario = this._scenarioService.checkScenario(ScenarioIds.dropboxSource);
     const gitHubSourceScenario = this._scenarioService.checkScenario(ScenarioIds.githubSource);


### PR DESCRIPTION
fixes AB#5550541 for National Clouds.