### PR TITLE
Integrate page theme first pass

### DIFF
--- a/client-react/src/images/Functions/double-arrow-left-right.svg
+++ b/client-react/src/images/Functions/double-arrow-left-right.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" preserveAspectRatio="none" viewBox="179 214.7823046210672 201.14285714285722 188.21769537893286" width="197.14" height="184.22">
+<svg xmlns="http://www.w3.org/2000/svg" 
+   xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" preserveAspectRatio="none" viewBox="179 214.7823046210672 201.14285714285722 188.21769537893286" width="197.14" height="184.22">
    <defs>
       <path d="M375.92 308.21C351.6 308.21 316.3 308.21 301.39 308.21C289.58 308.21 280 317.78 280 329.6C280 343.68 280 361.49 280 374.81C280 388.72 268.72 400 254.81 400C244.83 400 219.9 400 180 400" id="c2DKuMhC3I" />
       <path d="M371.24 301.17C372.19 302.38 374.07 304.81 376.91 308.46" id="b5ZQugPZ2w" />
@@ -10,22 +11,22 @@
    <g>
       <g>
          <g>
-            <use xlink:href="#c2DKuMhC3I" opacity="1" fill-opacity="0" stroke="#000000" stroke-width="0.5" stroke-opacity="1" />
+            <use xlink:href="#c2DKuMhC3I" />
          </g>
       </g>
       <g>
          <g>
-            <use xlink:href="#b5ZQugPZ2w" opacity="1" fill-opacity="0" stroke="#000000" stroke-width="0.5" stroke-opacity="1" />
+            <use xlink:href="#b5ZQugPZ2w" />
          </g>
       </g>
       <g>
          <g>
-            <use xlink:href="#a5vBp6pUmb" opacity="1" fill-opacity="0" stroke="#000000" stroke-width="0.5" stroke-opacity="1" />
+            <use xlink:href="#a5vBp6pUmb" />
          </g>
       </g>
       <g>
          <g>
-            <use xlink:href="#cWVBs1r92" opacity="1" fill-opacity="0" stroke="#000000" stroke-width="0.5" stroke-opacity="1" />
+            <use xlink:href="#cWVBs1r92" />
          </g>
       </g>
    </g>

--- a/client-react/src/images/Functions/single-arrow-left-right.svg
+++ b/client-react/src/images/Functions/single-arrow-left-right.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" preserveAspectRatio="none" viewBox="179 461.5 199.96455767110814 19" width="195.96" height="15">
+<svg xmlns="http://www.w3.org/2000/svg" 
+   xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" preserveAspectRatio="none" viewBox="179 461.5 199.96455767110814 19" width="195.96" height="15">
    <defs>
       <path d="M369.46 477.5C370.48 476.33 372.5 473.98 375.54 470.46" id="d1fA6jCU0t" />
       <path d="M370 462.5C370.94 463.72 372.83 466.15 375.67 469.8" id="f25RRODFZt" />
@@ -9,17 +10,17 @@
    <g>
       <g>
          <g>
-            <use xlink:href="#d1fA6jCU0t" opacity="1" fill-opacity="0" stroke="#000000" stroke-width="0.5" stroke-opacity="1" />
+            <use xlink:href="#d1fA6jCU0t" />
          </g>
       </g>
       <g>
          <g>
-            <use xlink:href="#f25RRODFZt" opacity="1" fill-opacity="0" stroke="#000000" stroke-width="0.5" stroke-opacity="1" />
+            <use xlink:href="#f25RRODFZt" />
          </g>
       </g>
       <g>
          <g>
-            <use xlink:href="#a1BoAhIniT" opacity="1" fill-opacity="0" stroke="#000000" stroke-width="0.5" stroke-opacity="1" />
+            <use xlink:href="#a1BoAhIniT" />
          </g>
       </g>
    </g>

--- a/client-react/src/pages/app/functions/integrate/BindingsDiagram/BindingCard.tsx
+++ b/client-react/src/pages/app/functions/integrate/BindingsDiagram/BindingCard.tsx
@@ -4,7 +4,7 @@ import { Link } from 'office-ui-fabric-react';
 import { ThemeContext } from '../../../../../ThemeContext';
 import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';
-import { getCardStyle, getHeaderStyle, listStyle } from './BindingDiagram.styles';
+import { cardStyle, headerStyle, listStyle } from './BindingDiagram.styles';
 import { FunctionInfo } from '../../../../../models/functions/function-info';
 import { ArmObj } from '../../../../../models/arm-obj';
 import { getBindingConfigDirection } from '../binding-editor/BindingEditor';
@@ -14,6 +14,7 @@ import PortalCommunicator from '../../../../../portal-communicator';
 import { PortalContext } from '../../../../../PortalContext';
 import { BindingEditorContext, BindingEditorContextInfo } from '../FunctionIntegrate';
 import { first } from 'rxjs/operators';
+import { ThemeExtended } from '../../../../../theme/SemanticColorsExtended';
 
 export interface BindingCardChildProps {
   functionInfo: ArmObj<FunctionInfo>;
@@ -45,12 +46,12 @@ const BindingCard: React.SFC<BindingCardProps> = props => {
 
   return (
     <>
-      <div className={getCardStyle(theme)}>
-        <div className={getHeaderStyle(theme)}>
+      <div className={cardStyle(theme)}>
+        <div className={headerStyle(theme)}>
           <h3>{title}</h3>
           <Svg />
         </div>
-        {getItemsList(portalCommunicator, functionInfo, items, emptyMessage, t, bindingEditor, functionName, supportsMultipleItems)}
+        {getItemsList(portalCommunicator, functionInfo, items, emptyMessage, t, bindingEditor, theme, functionName, supportsMultipleItems)}
       </div>
     </>
   );
@@ -77,6 +78,7 @@ const getItemsList = (
   emptyMessage: string,
   t: i18next.TFunction,
   bindingEditorContext: BindingEditorContextInfo,
+  theme: ThemeExtended,
   functionName?: string,
   supportsMultipleItems?: boolean
 ) => {
@@ -114,7 +116,7 @@ const getItemsList = (
     );
   }
 
-  return <ul className={listStyle}>{list}</ul>;
+  return <ul className={listStyle(theme)}>{list}</ul>;
 };
 
 const onClick = (

--- a/client-react/src/pages/app/functions/integrate/BindingsDiagram/BindingDiagram.styles.ts
+++ b/client-react/src/pages/app/functions/integrate/BindingsDiagram/BindingDiagram.styles.ts
@@ -2,8 +2,9 @@ import { ThemeExtended } from '../../../../../theme/SemanticColorsExtended';
 import { style } from 'typestyle';
 import { color } from 'csx';
 
-export const getCardStyle = (theme: ThemeExtended) => {
+export const cardStyle = (theme: ThemeExtended) => {
   return style({
+    backgroundColor: theme.palette.neutralLighter,
     border: `solid 1px ${theme.semanticColors.cardBorderColor}`,
     borderRadius: '2px',
     minWidth: '250px',
@@ -13,21 +14,18 @@ export const getCardStyle = (theme: ThemeExtended) => {
   });
 };
 
-export const getHeaderStyle = (theme: ThemeExtended) => {
+export const headerStyle = (theme: ThemeExtended): string => {
   return style({
     height: '35px',
-    backgroundColor: '#fafafa',
+    backgroundColor: theme.palette.neutralLighterAlt,
     borderBottom: `solid 1px ${color(theme.semanticColors.cardBorderColor).lighten('20%')}`,
-
-    // Necessary for some reason to prevent overlap with right border on middle card
-    marginRight: '1px',
 
     $nest: {
       h3: {
         marginTop: '0px',
         paddingTop: '5px',
         paddingLeft: '15px',
-        fontWeight: '600',
+        fontWeight: 600,
         display: 'inline-block',
       },
       svg: {
@@ -38,20 +36,22 @@ export const getHeaderStyle = (theme: ThemeExtended) => {
         float: 'right',
       },
     },
-  } as any);
+  });
 };
 
-export const listStyle = style({
-  listStyleType: 'none',
-  padding: '0px',
-  margin: '0px',
+export const listStyle = (theme: ThemeExtended): string => {
+  return style({
+    listStyleType: 'none',
+    padding: '0px',
+    margin: '0px',
 
-  $nest: {
-    li: {
-      padding: '7px 18px',
+    $nest: {
+      li: {
+        padding: '7px 18px',
+      },
+      '.emptyMessage': {
+        color: theme.semanticColors.disabledBodyText,
+      },
     },
-    '.emptyMessage': {
-      color: '#7f7f7f',
-    },
-  },
-});
+  });
+};

--- a/client-react/src/pages/app/functions/integrate/FunctionIntegrate.style.ts
+++ b/client-react/src/pages/app/functions/integrate/FunctionIntegrate.style.ts
@@ -1,0 +1,37 @@
+import { style } from 'typestyle';
+import { ThemeExtended } from '../../../../theme/SemanticColorsExtended';
+import { SVGAttributes } from 'react';
+
+export const defaultArrowStyle = (theme: ThemeExtended) => {
+  return style({
+    stroke: theme.semanticColors.cardBorderColor,
+    width: '100%',
+  });
+};
+
+export const diagramWrapperStyle = style({
+  padding: '20px',
+  maxWidth: '1200px',
+  minWidth: '930px',
+});
+
+export const doubleArrowStyle = style({
+  height: '115px',
+  marginTop: '37px',
+});
+
+export const singleArrowStyle = style({
+  height: '13px',
+  marginTop: '90px',
+});
+
+export const singleCardStackStyle = style({
+  marginTop: '58px',
+});
+
+export const arrowProps: SVGAttributes<SVGSVGElement> = {
+  opacity: '1',
+  fillOpacity: '0',
+  strokeWidth: '1',
+  strokeOpacity: '1',
+};

--- a/client-react/src/pages/app/functions/integrate/FunctionIntegrate.tsx
+++ b/client-react/src/pages/app/functions/integrate/FunctionIntegrate.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useContext } from 'react';
 import { ArmObj } from '../../../../models/arm-obj';
 import { FunctionInfo } from '../../../../models/functions/function-info';
 import { Stack, IStackTokens } from 'office-ui-fabric-react';
@@ -11,35 +11,20 @@ import { Subject, Observable } from 'rxjs';
 import BindingEditorDataLoader from './binding-editor/BindingEditorDataLoader';
 import { ReactComponent as DoubleArrow } from '../../../../images/Functions/double-arrow-left-right.svg';
 import { ReactComponent as SingleArrow } from '../../../../images/Functions/single-arrow-left-right.svg';
-import { style, classes } from 'typestyle';
+import { classes } from 'typestyle';
+import {
+  diagramWrapperStyle,
+  doubleArrowStyle,
+  singleCardStackStyle,
+  singleArrowStyle,
+  defaultArrowStyle,
+  arrowProps,
+} from './FunctionIntegrate.style';
+import { ThemeContext } from '../../../../ThemeContext';
 
 export interface FunctionIntegrateProps {
   functionInfo: ArmObj<FunctionInfo>;
 }
-
-const diagramWrapperStyle = style({
-  padding: '20px',
-  maxWidth: '1200px',
-  minWidth: '930px',
-});
-
-const arrowStyle = style({
-  width: '100%',
-});
-
-const doubleArrowStyle = style({
-  height: '115px',
-  marginTop: '37px',
-});
-
-const singleArrowStyle = style({
-  height: '13px',
-  marginTop: '90px',
-});
-
-const singleCardStackStyle = style({
-  marginTop: '58px',
-});
 
 export interface BindingUpdateInfo {
   newBindingInfo?: BindingInfo;
@@ -57,6 +42,7 @@ export const BindingEditorContext = React.createContext<BindingEditorContextInfo
 
 export const FunctionIntegrate: React.SFC<FunctionIntegrateProps> = props => {
   const { functionInfo: initialFunctionInfo } = props;
+  const theme = useContext(ThemeContext);
 
   const bindingUpdate$ = useRef(new Subject<BindingUpdateInfo>());
   const [bindingToUpdate, setBindingToUpdate] = useState<BindingInfo | undefined>(undefined);
@@ -121,7 +107,7 @@ export const FunctionIntegrate: React.SFC<FunctionIntegrateProps> = props => {
             </Stack.Item>
 
             <Stack.Item grow>
-              <DoubleArrow className={classes(arrowStyle, doubleArrowStyle)} />
+              <DoubleArrow className={classes(defaultArrowStyle(theme), doubleArrowStyle)} {...arrowProps} />
             </Stack.Item>
 
             <Stack.Item grow>
@@ -131,7 +117,7 @@ export const FunctionIntegrate: React.SFC<FunctionIntegrateProps> = props => {
             </Stack.Item>
 
             <Stack.Item grow>
-              <SingleArrow className={classes(arrowStyle, singleArrowStyle)} />
+              <SingleArrow className={classes(defaultArrowStyle(theme), singleArrowStyle)} {...arrowProps} />
             </Stack.Item>
 
             <Stack.Item grow>

--- a/client-react/src/theme/SemanticColorsExtended.ts
+++ b/client-react/src/theme/SemanticColorsExtended.ts
@@ -1,7 +1,7 @@
 import { ISemanticColors, ITheme } from '@uifabric/styling';
 
 export interface AzurePortalColors {
-  lineSeperator: string;
+  lineSeparator: string;
   sectionDividerScrollbar: string;
   background: string;
   sectionBackground: string;

--- a/client-react/src/theme/dark.ts
+++ b/client-react/src/theme/dark.ts
@@ -2,7 +2,7 @@ import { IPalette } from 'office-ui-fabric-react/lib/Styling';
 import { ThemeExtended } from './SemanticColorsExtended';
 
 const AzurePortalColors = {
-  lineSeperator: 'rgba(107, 132, 156, 0.25)',
+  lineSeparator: 'rgba(107, 132, 156, 0.25)',
   sectionDividerScrollbar: 'rgba(107, 132, 156, 0.35)',
   background: '#111111',
   sectionBackground: 'rgba(107, 132, 156, 0.06)',

--- a/client-react/src/theme/light.ts
+++ b/client-react/src/theme/light.ts
@@ -2,7 +2,7 @@ import { IPalette } from 'office-ui-fabric-react/lib/Styling';
 import { ThemeExtended } from './SemanticColorsExtended';
 
 const AzurePortalColors = {
-  lineSeperator: 'rgba(107, 132, 156, 0.25)',
+  lineSeparator: 'rgba(107, 132, 156, 0.25)',
   sectionDividerScrollbar: 'rgba(107, 132, 156, 0.35)',
   background: '#ffffff',
   sectionBackground: 'rgba(107, 132, 156, 0.06)',


### PR DESCRIPTION
Implements AB#5543870

Add some basic theme-based styling to the page to make it visible in all modes. We don't have final styling from the designers, but this should be enough to continue development in the area

Before dark theme:
![image](https://user-images.githubusercontent.com/37600290/66856465-1d495e80-ef3a-11e9-9a4a-547005c2bd48.png)

Light theme:
![image](https://user-images.githubusercontent.com/37600290/66855397-ff7afa00-ef37-11e9-9d75-2ac0e53f75db.png)

Dark theme:
![image](https://user-images.githubusercontent.com/37600290/66855415-073a9e80-ef38-11e9-9139-4d053070a0d0.png)
