### PR TITLE
AB#5584673 Updating AppSettingsDataLoader to not block on fetchAzureStorageAccounts() call

### DIFF
--- a/client-react/src/pages/app/app-settings/AppSettings.service.ts
+++ b/client-react/src/pages/app/app-settings/AppSettings.service.ts
@@ -17,7 +17,6 @@ export const fetchApplicationSettingValues = async (resourceId: string) => {
     slotConfigNames,
     connectionStrings,
     applicationSettings,
-    storageAccounts,
     azureStorageMounts,
     windowsStacks,
     linuxStacks,
@@ -27,7 +26,6 @@ export const fetchApplicationSettingValues = async (resourceId: string) => {
     SiteService.fetchSlotConfigNames(resourceId),
     SiteService.fetchConnectionStrings(resourceId),
     SiteService.fetchApplicationSettings(resourceId),
-    StorageService.fetchAzureStorageAccounts(resourceId),
     SiteService.fetchAzureStorageMounts(resourceId),
     SiteService.fetchStacks('Windows'),
     SiteService.fetchStacks('Linux'),
@@ -38,11 +36,14 @@ export const fetchApplicationSettingValues = async (resourceId: string) => {
     slotConfigNames,
     connectionStrings,
     applicationSettings,
-    storageAccounts,
     azureStorageMounts,
     windowsStacks,
     linuxStacks,
   };
+};
+
+export const fetchAzureStorageAccounts = (resourceId: string) => {
+  return StorageService.fetchAzureStorageAccounts(resourceId);
 };
 
 export const fetchSlots = (resourceId: string) => {

--- a/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
@@ -83,17 +83,10 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
   };
 
   const fetchData = async () => {
-    const site = await siteContext.fetchSite(resourceId);
-    const {
-      webConfig,
-      metadata,
-      connectionStrings,
-      applicationSettings,
-      slotConfigNames,
-      azureStorageMounts,
-      windowsStacks,
-      linuxStacks,
-    } = await fetchApplicationSettingValues(resourceId);
+    const [
+      site,
+      { webConfig, metadata, connectionStrings, applicationSettings, slotConfigNames, azureStorageMounts, windowsStacks, linuxStacks },
+    ] = await Promise.all([siteContext.fetchSite(resourceId), fetchApplicationSettingValues(resourceId)]);
 
     const loadingFailed =
       armCallFailed(site) ||


### PR DESCRIPTION
Fixes: https://msazure.visualstudio.com/Antares/_workitems/edit/5584673