### PR TITLE
Fixed the AI splash screen and upsell from the classic view

### DIFF
--- a/client/src/app/function-monitor/function-monitor.component.ts
+++ b/client/src/app/function-monitor/function-monitor.component.ts
@@ -88,6 +88,7 @@ export class FunctionMonitorComponent extends NavigableComponent {
           functionAppContext: tuple[0],
           functionAppSettings: tuple[2].result.properties,
           functionName: tuple[1],
+          appInsightResourceEnabled: tuple[3].status === 'enabled',
           appInsightResource: tuple[3].status === 'enabled' ? <ArmObj<ApplicationInsight>>tuple[3].data : null,
           appInsightToken: tuple[3].status === 'enabled' && tuple[4].result ? tuple[4].result.token : null,
         })
@@ -132,7 +133,7 @@ export class FunctionMonitorComponent extends NavigableComponent {
 
     // NOTE(michinoy): Load the classic view if the app insights feature is not enabled on the environment OR
     // the user has selected to switch to classic view and has not setup an instrumentation key.
-    return !this.functionMonitorInfo.appInsightResource || loadClassicView;
+    return !this.functionMonitorInfo.appInsightResourceEnabled || loadClassicView;
   }
 
   private _shouldLoadApplicationInsightsView(): boolean {

--- a/client/src/app/function-monitor/monitor-classic/monitor-classic.component.ts
+++ b/client/src/app/function-monitor/monitor-classic/monitor-classic.component.ts
@@ -91,7 +91,7 @@ export class MonitorClassicComponent extends FeatureComponent<FunctionMonitorInf
   }
 
   get shouldRenderAppInsightsUpsell() {
-    return this.functionMonitorInfo !== null && this.functionMonitorInfo !== null && this.functionMonitorInfo.appInsightResource !== null;
+    return this.functionMonitorInfo !== null && this.functionMonitorInfo !== null && this.functionMonitorInfo.appInsightResourceEnabled;
   }
 
   public refreshMonitorClassicData() {

--- a/client/src/app/shared/models/function-monitor.ts
+++ b/client/src/app/shared/models/function-monitor.ts
@@ -48,6 +48,7 @@ export interface FunctionMonitorInfo {
   functionAppContext: FunctionAppContext;
   functionAppSettings: { [key: string]: string };
   functionName: string;
+  appInsightResourceEnabled: boolean;
   appInsightResource?: ArmObj<ApplicationInsight>;
   appInsightToken?: string;
 }


### PR DESCRIPTION
During one of my recent changes, the check to identify if AI is allowed in an environment got merged with with whether or not the AI resource exists. This caused a bug where users who had opted not to setup AI during creates were left in a state where they could not provision an AI instance. 

**BEFORE (V1 or V2 app without AI during create)**
![image](https://user-images.githubusercontent.com/493476/67341381-65d9bc80-f4e4-11e9-840e-ad560d5d5713.png)

**AFTER (v1 app)**
![image](https://user-images.githubusercontent.com/493476/67341520-bf41eb80-f4e4-11e9-83bc-e7c984d21bb5.png)

If you decide to swith to classic view:
![image](https://user-images.githubusercontent.com/493476/67341428-7db14080-f4e4-11e9-9ea4-ab6b88208eb4.png)

**AFTER (v2 app)**
![image](https://user-images.githubusercontent.com/493476/67341653-121ba300-f4e5-11e9-83f0-5eeb6038d88f.png)
Note: not able to switch to classic view.

**Once AI is configured**
![image](https://user-images.githubusercontent.com/493476/67341781-560ea800-f4e5-11e9-85cc-c8065869d0dd.png)
