### PR TITLE
AB#5785169 Fixing ReactiveFormControl to fill width of parent

### DIFF
--- a/client-react/src/components/form-controls/TextFieldNoFormik.tsx
+++ b/client-react/src/components/form-controls/TextFieldNoFormik.tsx
@@ -58,7 +58,7 @@ const TextFieldNoFormik: FC<ITextFieldProps & CustomTextFieldProps> = props => {
       {copyButton && (
         <TooltipHost content={getCopiedLabel()} calloutProps={{ gapSpace: 0 }} onTooltipToggle={isVisible => changeCopiedLabel(isVisible)}>
           <IconButton
-            className={copyButtonStyle(theme)}
+            className={copyButtonStyle(theme, fullpage)}
             id={`${id}-copy-button`}
             iconProps={{ iconName: 'Copy' }}
             onClick={copyToClipboard}

--- a/client-react/src/components/form-controls/formControl.override.styles.tsx
+++ b/client-react/src/components/form-controls/formControl.override.styles.tsx
@@ -52,6 +52,7 @@ export const textFieldStyleOverrides = (theme: ThemeExtended, fullpage: boolean,
     ...baseStyle,
     root: {
       width: widthOverride || formDefaultWidth,
+      paddingLeft: '5px',
     },
   } as ITextFieldStyles;
 };
@@ -60,7 +61,7 @@ export const controlContainerStyle = (upsellIcon: boolean, fullpage: boolean) =>
 
 export const controlChildrenContainerStyle = (fullpage: boolean) =>
   style({
-    paddingLeft: fullpage ? 0 : '5px',
+    display: 'contents',
   });
 
 export const upsellIconStyle = style({ marginRight: '6px' });

--- a/client-react/src/components/form-controls/formControl.override.styles.tsx
+++ b/client-react/src/components/form-controls/formControl.override.styles.tsx
@@ -52,16 +52,17 @@ export const textFieldStyleOverrides = (theme: ThemeExtended, fullpage: boolean,
     ...baseStyle,
     root: {
       width: widthOverride || formDefaultWidth,
-      paddingLeft: '5px',
     },
   } as ITextFieldStyles;
 };
+
 export const controlContainerStyle = (upsellIcon: boolean, fullpage: boolean) =>
   style({ marginBottom: '15px', marginLeft: upsellIcon && fullpage ? '-20px' : undefined });
 
 export const controlChildrenContainerStyle = (fullpage: boolean) =>
   style({
-    display: 'contents',
+    paddingLeft: fullpage ? 0 : '5px',
+    display: fullpage ? 'contents' : undefined,
   });
 
 export const upsellIconStyle = style({ marginRight: '6px' });
@@ -78,9 +79,9 @@ export const infoIconStyle = (theme: ThemeExtended) =>
     paddingRight: '5px',
   });
 
-export const copyButtonStyle = (theme: ThemeExtended) =>
+export const copyButtonStyle = (theme: ThemeExtended, fullpage: boolean = true) =>
   style({
-    marginLeft: '5px',
+    marginLeft: fullpage ? '5px' : 0,
     width: '25px',
     height: '25px',
     backgroundColor: theme.semanticColors.accentButtonBackground,


### PR DESCRIPTION
### Add/Edit App Setting

**width > 1000px**
Before
![image](https://user-images.githubusercontent.com/5387224/69720667-0153e380-10c8-11ea-95f9-8c42c87ef073.png)

After
![image](https://user-images.githubusercontent.com/5387224/69720681-0a44b500-10c8-11ea-971a-f93c0374e099.png)


**width <= 1000px**
Before
![image](https://user-images.githubusercontent.com/5387224/69720613-e41f1500-10c7-11ea-8d0a-c23b820a5677.png)

After
![image](https://user-images.githubusercontent.com/5387224/69720626-ebdeb980-10c7-11ea-9b48-8e8272c09df0.png)



### Add/Edit App Setting

**width > 1000px**
Before
![image](https://user-images.githubusercontent.com/5387224/69720726-1fb9df00-10c8-11ea-9d99-645dde6307d1.png)

After
![image](https://user-images.githubusercontent.com/5387224/69720741-29dbdd80-10c8-11ea-8712-70537a98dc51.png)


**width <= 1000px**
Before
![image](https://user-images.githubusercontent.com/5387224/69720783-3e1fda80-10c8-11ea-9ea6-2dadb0a99d3b.png)

After
![image](https://user-images.githubusercontent.com/5387224/69720772-35c79f80-10c8-11ea-878d-81773ca3dfbb.png)
