### PR TITLE
Gracefully deprecate K8 from container settings

### DIFF
--- a/client/src/app/controls/group-tabs/group-tabs.component.html
+++ b/client/src/app/controls/group-tabs/group-tabs.component.html
@@ -4,7 +4,7 @@
     #groupTabs>
     <div *ngFor="let tabItem of tabs"
         (click)="select(tabItem.id)"
-        class="clickable group-tab"
+        [class]="groupTabClasses"
         [class.selected-container]="tabItem.id === currentTabId"
         [tabindex]="tabItem.id === currentTabId ? 0 : -1"
         (keydown)="onKeyDown($event)"

--- a/client/src/app/controls/group-tabs/group-tabs.component.scss
+++ b/client/src/app/controls/group-tabs/group-tabs.component.scss
@@ -3,9 +3,16 @@ nav {
   display: flex;
 }
 
+.group-tab-width-2-tabs {
+  width: calc(100% / 2);
+}
+
+.group-tab-width-3-tabs {
+  width: calc(100% / 3);
+}
+
 .group-tab {
   background-color: $border-color;
-  width: calc(100% / 3);
   text-align: center;
   height: 83px;
   padding-top: 7px;

--- a/client/src/app/controls/group-tabs/group-tabs.component.ts
+++ b/client/src/app/controls/group-tabs/group-tabs.component.ts
@@ -31,6 +31,7 @@ export class GroupTabsComponent implements AfterViewInit, OnChanges {
   valueChanged: Subject<string>;
 
   public currentTabId: string;
+  public groupTabClasses = 'clickable group-tab group-tab-width-3-tabs';
   private _originalTabId: string;
 
   constructor() {
@@ -50,6 +51,14 @@ export class GroupTabsComponent implements AfterViewInit, OnChanges {
 
     if (changes['control']) {
       selectedTabId = this.control.value;
+    }
+
+    // NOTE(michinoy): As of right now the only two places using group tab is spec picker
+    // and container configuration. Turns container configuration could have either 2
+    // or 3 tabs. Thus drawing the UX as needed.
+    if (changes['tabs']) {
+      this.groupTabClasses =
+        this.tabs.length == 2 ? 'clickable group-tab group-tab-width-2-tabs' : 'clickable group-tab group-tab-width-3-tabs';
     }
 
     if (selectedTabId) {

--- a/client/src/app/site/container-settings/container-settings-manager.ts
+++ b/client/src/app/site/container-settings/container-settings-manager.ts
@@ -52,6 +52,9 @@ export class ContainerSettingsManager {
   urlValidator: URLValidator;
   yamlValidator: YAMLValidator;
 
+  // NOTE(michinoy): This is temporarily added while we gracefully deprecate kubernetes.
+  private _containerSettingsData: ContainerSettingsData;
+
   constructor(
     private _injector: Injector,
     private _ts: TranslateService,
@@ -420,10 +423,10 @@ export class ContainerSettingsManager {
   }
 
   private _resetContainers(containerSettingInfo: ContainerSettingsData) {
+    this._containerSettingsData = containerSettingInfo;
     this.containers = [
       new SingleContainer(this._injector, containerSettingInfo),
       new DockerComposeContainer(this._injector, containerSettingInfo),
-      new KubernetesContainer(this._injector, containerSettingInfo),
     ];
   }
 
@@ -487,6 +490,12 @@ export class ContainerSettingsManager {
     siteConfig: ContainerSiteConfig,
     publishingCredentials: PublishingCredentials
   ) {
+    // NOTE(michinoy): Only add the Kubernetes tab for container configuration if it is already set
+    // else do not show. This is a graceful way of deprecating the kubernetes support.
+    if (siteConfig && siteConfig.linuxFxVersion && this._getFormContainerType(siteConfig.linuxFxVersion) === 'kubernetes') {
+      this.containers.push(new KubernetesContainer(this._injector, this._containerSettingsData));
+    }
+
     this.webhookUrl = this._getFormWebhookUrl(publishingCredentials);
 
     let fxVersion;


### PR DESCRIPTION
fixes AB#5603287

@btardif let me know if this works.

Basically only show K8 tab IFF the user has it already configured, otherwise hide it from the settings. We've already removed it from creates. 

Spec picker tabs are unaffected
![image](https://user-images.githubusercontent.com/493476/69343290-31ac0580-0c22-11ea-9656-cfedade1d60c.png)

Container settings with K8
![image](https://user-images.githubusercontent.com/493476/69343317-45f00280-0c22-11ea-893c-e6b7edaa73e0.png)

Container setting without K8
![image](https://user-images.githubusercontent.com/493476/69343304-3b356d80-0c22-11ea-88d7-2b3af9c31f32.png)

