### PR TITLE
[HOTFIX] Revert AB#5627799 Updating config blade to combine updateSite and updateWebCofig into a single PUT call and to only call updateSlotConfigNames and updateAzureStorageMount when necessary

### DIFF
--- a/client-react/src/ApiHelpers/SiteService.ts
+++ b/client-react/src/ApiHelpers/SiteService.ts
@@ -106,12 +106,7 @@ export default class SiteService {
 
   public static updateSlotConfigNames = (resourceId: string, slotConfigNames: ArmObj<SlotConfigNames>) => {
     const id = `${SiteService.getProductionId(resourceId)}/config/slotconfignames`;
-    return MakeArmCall<ArmObj<SlotConfigNames>>({
-      resourceId: id,
-      commandName: 'updateSlotConfigNames',
-      method: 'PUT',
-      body: slotConfigNames,
-    });
+    return MakeArmCall<ArmObj<SlotConfigNames>>({ resourceId: id, commandName: 'updateWebConfig', method: 'PUT', body: slotConfigNames });
   };
 
   public static fetchAzureStorageMounts = (resourceId: string) => {

--- a/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
@@ -1,15 +1,22 @@
 import { FormikActions } from 'formik';
 import React, { useState, useEffect, useContext } from 'react';
 import { AppSettingsFormValues, AppSettingsReferences, AppSettingsAsyncData, LoadingStates } from './AppSettings.types';
-import { convertStateToForm, convertFormToState, getCleanedReferences, getFormAzureStorageMount } from './AppSettingsFormData';
+import {
+  convertStateToForm,
+  convertFormToState,
+  flattenVirtualApplicationsList,
+  getCleanedConfigForSave,
+  getCleanedReferences,
+} from './AppSettingsFormData';
 import LoadingComponent from '../../../components/loading/loading-component';
 import {
   fetchApplicationSettingValues,
   fetchSlots,
   updateSite,
+  updateWebConfig,
   updateSlotConfigNames,
-  updateStorageMounts,
   getProductionAppWritePermissions,
+  updateStorageMounts,
   getAllAppSettingReferences,
   fetchAzureStorageAccounts,
   getFunctions,
@@ -268,55 +275,34 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
 
   const onSubmit = async (values: AppSettingsFormValues, actions: FormikActions<AppSettingsFormValues>) => {
     setSaving(true);
+    const { site, config, slotConfigNames, storageMounts } = convertFormToState(values, metadataFromApi, slotConfigNamesFromApi);
     const notificationId = portalContext.startNotification(t('configUpdating'), t('configUpdating'));
-
-    const { site, slotConfigNames, storageMounts, slotConfigNamesModified, storageMountsModified } = convertFormToState(
-      values,
-      metadataFromApi,
-      initialValues!,
-      slotConfigNamesFromApi
-    );
-
-    // TODO (andimarc): Once the API is updated, include azureStorageAccounts on the site config object instead of making a separate call
-    // TASK 5843044 - Combine updateSite and updateAzureStorageMount calls into a single PUT call when saving config
-    const [siteUpdate, slotConfigNamesUpdate, storageMountsUpdate] = [
-      updateSite(resourceId, site),
-      productionPermissions && slotConfigNamesModified ? updateSlotConfigNames(resourceId, slotConfigNames) : Promise.resolve(null),
-      storageMountsModified ? updateStorageMounts(resourceId, storageMounts) : Promise.resolve(null),
-    ];
-
-    const [siteResult, slotConfigNamesResult, storageMountsResult] = await Promise.all([
+    const siteUpdate = updateSite(resourceId, site);
+    const configUpdate = updateWebConfig(resourceId, getCleanedConfigForSave(config));
+    const slotConfigUpdates = productionPermissions ? updateSlotConfigNames(resourceId, slotConfigNames) : Promise.resolve(null);
+    const storageUpdateCall = updateStorageMounts(resourceId, storageMounts);
+    const [siteResult, configResult, slotConfigResults] = await Promise.all([
       siteUpdate,
-      slotConfigNamesUpdate,
-      storageMountsUpdate,
+      configUpdate,
+      slotConfigUpdates,
+      storageUpdateCall,
     ]);
 
-    const success =
-      siteResult.metadata.success &&
-      (!slotConfigNamesResult || slotConfigNamesResult.metadata.success) &&
-      (!storageMountsResult || storageMountsResult.metadata.success);
-
-    if (success) {
-      const azureStorageMounts = storageMountsResult ? getFormAzureStorageMount(storageMountsResult.data) : values.azureStorageMounts;
+    if (siteResult.metadata.success && configResult.metadata.success && (!slotConfigResults || slotConfigResults.metadata.success)) {
       setInitialValues({
         ...values,
-        azureStorageMounts,
+        virtualApplications: flattenVirtualApplicationsList(configResult.data.properties.virtualApplications),
       });
-      if (slotConfigNamesResult) {
-        setSlotConfigNamesFromApi(slotConfigNamesResult.data);
-      }
       fetchReferences();
       if (isFunctionApp(site)) {
         fetchAsyncData();
       }
       portalContext.stopNotification(notificationId, true, t('configUpdateSuccess'));
     } else {
-      const [siteError, slotConfigNamesError, storageMountsError] = [
-        siteResult.metadata.error && siteResult.metadata.error.Message,
-        slotConfigNamesResult && slotConfigNamesResult.metadata.error && slotConfigNamesResult.metadata.error.Message,
-        storageMountsResult && storageMountsResult.metadata.error && storageMountsResult.metadata.error.Message,
-      ];
-      const errMessage = siteError || slotConfigNamesError || storageMountsError || t('configUpdateFailure');
+      const siteError = siteResult.metadata.error && siteResult.metadata.error.Message;
+      const configError = configResult.metadata.error && configResult.metadata.error.Message;
+      const slotConfigError = slotConfigResults && slotConfigResults.metadata.error && slotConfigResults.metadata.error.Message;
+      const errMessage = siteError || configError || slotConfigError || t('configUpdateFailure');
       portalContext.stopNotification(notificationId, false, errMessage);
     }
     setSaving(false);

--- a/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
+++ b/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
@@ -1,12 +1,11 @@
 import SiteService from '../../../ApiHelpers/SiteService';
 import { AppSettingsFormValues, FormAppSetting, FormConnectionString, FormAzureStorageMounts } from './AppSettings.types';
-import { sortBy, isEqual } from 'lodash-es';
+import { sortBy } from 'lodash-es';
 import { ArmObj } from '../../../models/arm-obj';
 import { Site } from '../../../models/site/site';
 import { SiteConfig, ArmAzureStorageMount, ConnStringInfo, VirtualApplication, KeyVaultReference } from '../../../models/site/config';
 import { SlotConfigNames } from '../../../models/site/slot-config-names';
 import { NameValuePair } from '../../../models/name-value-pair';
-import StringUtils from '../../../utils/string';
 
 export const findFormAppSettingIndex = (appSettings: FormAppSetting[], settingName: string) => {
   return !!settingName ? appSettings.findIndex(x => x.name.toLowerCase() === settingName.toLowerCase()) : -1;
@@ -65,53 +64,55 @@ export const getCleanedConfig = (config: ArmObj<SiteConfig>) => {
   return newConfig;
 };
 
-export const getCleanedConfigForSave = (config: SiteConfig) => {
-  // If Remote Debugging Version is set to VS2015, but Remote Debugging is disabled, just change it to VS2017 to prevent the PUT from failing
-  const hasRemoteDebuggingDisabledWithVS2015 = !config.remoteDebuggingEnabled && config.remoteDebuggingVersion === 'VS2015';
-  const remoteDebuggingVersion = hasRemoteDebuggingDisabledWithVS2015 ? 'VS2017' : config.remoteDebuggingVersion;
-
-  let linuxFxVersion = config.linuxFxVersion || '';
+export const getCleanedConfigForSave = (config: ArmObj<SiteConfig>) => {
+  let linuxFxVersion = config.properties.linuxFxVersion ? config.properties.linuxFxVersion : '';
   if (linuxFxVersion) {
     const linuxFxVersionParts = linuxFxVersion.split('|');
     linuxFxVersionParts[0] = linuxFxVersionParts[0].toUpperCase();
     linuxFxVersion = linuxFxVersionParts.join('|');
   }
-  const newConfig: SiteConfig = {
+
+  // If Remote Debugging Version is set to VS2015, but Remote Debugging is disabled, just change it to VS2017 to prevent the PUT from failing
+  const hasRemoteDebuggingDisabledWithVS2015 =
+    !config.properties.remoteDebuggingEnabled && config.properties.remoteDebuggingVersion === 'VS2015';
+  const remoteDebuggingVersion = hasRemoteDebuggingDisabledWithVS2015 ? 'VS2017' : config.properties.remoteDebuggingVersion;
+
+  const newConfig: ArmObj<SiteConfig> = {
     ...config,
-    linuxFxVersion,
-    remoteDebuggingVersion,
+    properties: {
+      ...config.properties,
+      linuxFxVersion,
+      remoteDebuggingVersion,
+    },
   };
   return newConfig;
 };
 
 export interface ApiSetupReturn {
   site: ArmObj<Site>;
+  config: ArmObj<SiteConfig>;
   slotConfigNames: ArmObj<SlotConfigNames>;
   storageMounts: ArmObj<ArmAzureStorageMount>;
-  slotConfigNamesModified: boolean;
-  storageMountsModified: boolean;
 }
 export const convertFormToState = (
   values: AppSettingsFormValues,
   currentMetadata: ArmObj<{ [key: string]: string }>,
-  initialValues: AppSettingsFormValues,
-  oldSlotConfigNames: ArmObj<SlotConfigNames>
+  oldSlotNameSettings: ArmObj<SlotConfigNames>
 ): ApiSetupReturn => {
-  const site = { ...values.site };
-  const slotConfigNames = getStickySettings(values.appSettings, values.connectionStrings, oldSlotConfigNames);
+  const config = values.config;
+  config.properties.virtualApplications = unFlattenVirtualApplicationsList(values.virtualApplications);
+  config.properties.azureStorageAccounts = undefined;
+  const site = values.site;
+
+  site.properties.siteConfig = {
+    appSettings: getAppSettingsFromForm(values.appSettings),
+    connectionStrings: getConnectionStringsFromForm(values.connectionStrings),
+    metadata: getMetadataToSet(currentMetadata, values.currentlySelectedStack),
+  };
+
+  const slotConfigNames = getStickySettings(values.appSettings, values.connectionStrings, oldSlotNameSettings);
+  const configWithStack = getConfigWithStackSettings(config, values);
   const storageMounts = getAzureStorageMountFromForm(values.azureStorageMounts);
-  const slotConfigNamesModified = isSlotConfigNamesModified(oldSlotConfigNames, slotConfigNames);
-  const storageMountsModified = isStorageMountsModified(initialValues, values);
-
-  let config = { ...values.config.properties };
-  config.virtualApplications = unFlattenVirtualApplicationsList(values.virtualApplications);
-  config.appSettings = getAppSettingsFromForm(values.appSettings);
-  config.connectionStrings = getConnectionStringsFromForm(values.connectionStrings);
-  config.metadata = getMetadataToSet(currentMetadata, values.currentlySelectedStack);
-  config = getConfigWithStackSettings(config, values);
-  config = getCleanedConfigForSave(config);
-
-  site.properties.siteConfig = config;
 
   if (site) {
     const [id, location] = [site.id, site.location];
@@ -129,42 +130,24 @@ export const convertFormToState = (
     site,
     slotConfigNames,
     storageMounts,
-    slotConfigNamesModified,
-    storageMountsModified,
+    config: configWithStack,
   };
-};
-
-export const isSlotConfigNamesModified = (oldSlotConfigNames: ArmObj<SlotConfigNames>, slotConfigNames: ArmObj<SlotConfigNames>) => {
-  const [oldProperties, properties] = [oldSlotConfigNames.properties, slotConfigNames.properties];
-  return (
-    !StringUtils.isEqualStringArray(oldProperties.appSettingNames, properties.appSettingNames) ||
-    !StringUtils.isEqualStringArray(oldProperties.connectionStringNames, properties.connectionStringNames) ||
-    !StringUtils.isEqualStringArray(oldProperties.azureStorageConfigNames, properties.azureStorageConfigNames)
-  );
-};
-
-export const isStorageMountsModified = (initialValues: AppSettingsFormValues | null, values: AppSettingsFormValues | null) => {
-  const [azureStorageMountsInitial, azureStorageMounts] = [
-    initialValues && initialValues.azureStorageMounts,
-    values && values.azureStorageMounts,
-  ];
-  return !isEqual(azureStorageMountsInitial, azureStorageMounts);
 };
 
 export function getStickySettings(
   appSettings: FormAppSetting[],
   connectionStrings: FormConnectionString[],
-  oldSlotConfigNames: ArmObj<SlotConfigNames>
+  oldSlotNameSettings: ArmObj<SlotConfigNames>
 ): ArmObj<SlotConfigNames> {
   let appSettingNames = appSettings.filter(x => x.sticky).map(x => x.name);
-  const oldAppSettingNamesToKeep = oldSlotConfigNames.properties.appSettingNames
-    ? oldSlotConfigNames.properties.appSettingNames.filter(x => appSettings.filter(y => y.name === x).length === 0)
+  const oldAppSettingNamesToKeep = oldSlotNameSettings.properties.appSettingNames
+    ? oldSlotNameSettings.properties.appSettingNames.filter(x => appSettings.filter(y => y.name === x).length === 0)
     : [];
   appSettingNames = appSettingNames.concat(oldAppSettingNamesToKeep);
 
   let connectionStringNames = connectionStrings.filter(x => x.sticky).map(x => x.name);
-  const oldConnectionStringNamesToKeep = oldSlotConfigNames.properties.connectionStringNames
-    ? oldSlotConfigNames.properties.connectionStringNames.filter(x => connectionStrings.filter(y => y.name === x).length === 0)
+  const oldConnectionStringNamesToKeep = oldSlotNameSettings.properties.connectionStringNames
+    ? oldSlotNameSettings.properties.connectionStringNames.filter(x => connectionStrings.filter(y => y.name === x).length === 0)
     : [];
   connectionStringNames = connectionStringNames.concat(oldConnectionStringNamesToKeep);
 
@@ -175,7 +158,7 @@ export function getStickySettings(
     properties: {
       appSettingNames,
       connectionStringNames,
-      azureStorageConfigNames: oldSlotConfigNames.properties.azureStorageConfigNames,
+      azureStorageConfigNames: oldSlotNameSettings.properties.azureStorageConfigNames,
     },
   };
 }
@@ -335,12 +318,12 @@ export function getCurrentStackString(config: ArmObj<SiteConfig>, metadata?: Arm
   return 'dotnet';
 }
 
-export function getConfigWithStackSettings(config: SiteConfig, values: AppSettingsFormValues): SiteConfig {
+export function getConfigWithStackSettings(config: ArmObj<SiteConfig>, values: AppSettingsFormValues): ArmObj<SiteConfig> {
   const configCopy = { ...config };
   if (values.currentlySelectedStack !== 'java') {
-    configCopy.javaContainer = '';
-    configCopy.javaContainerVersion = '';
-    configCopy.javaVersion = '';
+    configCopy.properties.javaContainer = '';
+    configCopy.properties.javaContainerVersion = '';
+    configCopy.properties.javaVersion = '';
   }
   return configCopy;
 }

--- a/client-react/src/utils/string.ts
+++ b/client-react/src/utils/string.ts
@@ -1,5 +1,3 @@
-import { isEqual } from 'lodash-es';
-
 export default class StringUtils {
   public static removeSpaces(value: string): string {
     return value.replace(/\s/g, '');
@@ -9,12 +7,5 @@ export default class StringUtils {
     const first = [...str].findIndex(char => char !== character);
     const last = [...str].reverse().findIndex(char => char !== character);
     return str.substring(first, str.length - last);
-  };
-
-  public static isEqualStringArray = (items: string[] | null, otherItems: string[] | null) => {
-    const itmesSorted = items && items.sort();
-    const otherItemsSorted = otherItems && otherItems.sort();
-
-    return isEqual(itmesSorted, otherItemsSorted);
   };
 }


### PR DESCRIPTION
There's an issue with the combine site update API which fails if a user has any routing rules configured.  It'll take a while before the back-end can fix this, so in the meantime we're going to revert @andimarc change and make them multiple PUT calls again.