### PR TITLE
AB#6169538 [WCAG Forever!] scale up (spec picker) -> all cards should wrap and be one below the other for included features and included hardware lists and titles in the tab

### DIFF
--- a/client/src/app/controls/group-tabs/group-tabs.component.scss
+++ b/client/src/app/controls/group-tabs/group-tabs.component.scss
@@ -27,6 +27,7 @@ nav {
   h2 {
     font-size: 12px;
     line-height: 0px;
+    white-space: nowrap;
   }
 
   &.selected-container {

--- a/client/src/app/site/spec-picker/spec-picker.component.scss
+++ b/client/src/app/site/spec-picker/spec-picker.component.scss
@@ -177,6 +177,7 @@ $center-column-max-width: calc(#{$spec-card-max-width}* 4 - 40px);
     margin: 0;
     display: flex;
     justify-content: flex-start;
+    flex-wrap: wrap;
   }
 
   .feature-list {
@@ -184,6 +185,8 @@ $center-column-max-width: calc(#{$spec-card-max-width}* 4 - 40px);
     max-width: 700px;
     margin-top: 10px;
     width: calc(100% / 2);
+    position: relative;
+    min-width: 250px;
   }
 
   .feature-item {


### PR DESCRIPTION
Fixes AB#6169538

**Before:**
![image](https://user-images.githubusercontent.com/14221995/74266464-33351900-4cb9-11ea-9e01-51468f876601.png)

![image](https://user-images.githubusercontent.com/14221995/74266495-3defae00-4cb9-11ea-8b6c-8c9b5e2a22b9.png)


**After:**
![image](https://user-images.githubusercontent.com/14221995/74266605-68da0200-4cb9-11ea-86d7-154b704d3277.png)


![image](https://user-images.githubusercontent.com/14221995/74266641-7a230e80-4cb9-11ea-8928-77756037fc90.png)

