### PR TITLE
Add null check while rendering the dashboard.

### DIFF
--- a/client/src/app/site/deployment-center/provider-dashboards/github-action-dashboard/github-action-dashboard.component.ts
+++ b/client/src/app/site/deployment-center/provider-dashboards/github-action-dashboard/github-action-dashboard.component.ts
@@ -204,9 +204,12 @@ export class GithubActionDashboardComponent extends DeploymentDashboard implemen
             publishingUser: r.publishingUser,
           };
 
-          this.repositoryText = this.deploymentObject.sourceControls.properties.repoUrl;
-          this.githubActionLink = `${this.deploymentObject.sourceControls.properties.repoUrl}/actions`;
-          this.branchText = this.deploymentObject.sourceControls.properties.branch;
+          if (this.deploymentObject.sourceControls && this.deploymentObject.sourceControls.properties) {
+            this.repositoryText = this.deploymentObject.sourceControls.properties.repoUrl;
+            this.githubActionLink = `${this.deploymentObject.sourceControls.properties.repoUrl}/actions`;
+            this.branchText = this.deploymentObject.sourceControls.properties.branch;
+          }
+
           this._populateTable();
         },
         err => {


### PR DESCRIPTION
During the disconnect scenario there is a race condition where the disconnect call has gone through and the dashboard also has just begun a refresh and the call returns null sourcecontrols information due to the disconnect. This check will help prevent an error showing up on the console due to this. 