### PR TITLE
Clean up the CSS and add check for ANY workflow configuration

### DIFF
--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1856,4 +1856,6 @@ export class PortalResources {
   public static functionIntegrateRefreshAriaLabel = 'functionIntegrateRefreshAriaLabel';
   public static gitHubProtectedBranchSelected = 'gitHubProtectedBranchSelected';
   public static noRuntimeVersionWhileFunctionAppStopped = 'noRuntimeVersionWhileFunctionAppStopped';
+  public static githubActionWorkflowsExist = 'githubActionWorkflowsExist';
+  public static githubActionWorkflowOptionUseExistingMessageWithoutPreview = 'githubActionWorkflowOptionUseExistingMessageWithoutPreview';
 }

--- a/client/src/app/site/deployment-center/deployment-center-setup/deployment-center-setup.component.scss
+++ b/client/src/app/site/deployment-center/deployment-center-setup/deployment-center-setup.component.scss
@@ -1,60 +1,63 @@
 @import '../../../../sass/main';
 @import '../../site-config/site-config.component.scss';
 .centered-content {
-    margin: auto;
-    text-align: center;
+  margin: auto;
+  text-align: center;
 }
 
 .form-button {
-    min-width: 114px;
-    height: 25px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  min-width: 114px;
+  height: 25px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-
 .footer {
-    position: fixed;
-    background-color: $body-bg-color;
-    height: 50px;
-    margin-bottom: 0px;
-    bottom: 0px;
-    left: 0px;
-    width: 100vw;
-    box-shadow: 0px -5px 13px -1px rgba(0, 0, 0, 0.38);
-    justify-content: center;
-    display: flex;
-    align-items: center;
-    z-index: 2;
+  position: fixed;
+  background-color: $body-bg-color;
+  height: 50px;
+  margin-bottom: 0px;
+  bottom: 0px;
+  left: 0px;
+  width: 100vw;
+  box-shadow: 0px -5px 13px -1px rgba(0, 0, 0, 0.38);
+  justify-content: center;
+  display: flex;
+  align-items: center;
+  z-index: 2;
+}
+
+.settings-group-wrapper {
+  position: relative;
 }
 
 .settings-wrapper {
-    margin-top: 10px;
-    margin-bottom: 10px;
-    padding-left: 10px;
-    .setting-wrapper {
-        width: 600px;
-    }
+  margin-top: 10px;
+  margin-bottom: 10px;
+  padding-left: 10px;
+  .setting-wrapper {
+    width: 600px;
+  }
 }
 
 .newOrExistingSelection {
-    margin-bottom: 5px;
-    font-size: 12px;
-    color: $value-text-color;
-    input {
-        margin: 0px 10px;
-    }
+  margin-bottom: 5px;
+  font-size: 12px;
+  color: $value-text-color;
+  input {
+    margin: 0px 10px;
+  }
 }
 
 .wizard-container {
-    height: 100vh;
-    padding-left: 25px;
-    padding-right: 25px;
+  height: 100vh;
+  padding-left: 25px;
+  padding-right: 25px;
 }
 
-:host-context(#app-root[theme=dark]) {
-    .footer {
-        background-color: $body-bg-color-dark;
-    }
+:host-context(#app-root[theme='dark']) {
+  .footer {
+    background-color: $body-bg-color-dark;
+  }
 }

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-complete/step-complete.component.html
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-complete/step-complete.component.html
@@ -11,7 +11,7 @@
   <div class="summary-group">
     <h3 class="heading">{{ 'githubActionWorkflowConfiguration' | translate }}</h3>
     <info-box *ngIf="ExistingGitHubActionConfigurationMessage" typeClass="info" [infoText]="ExistingGitHubActionConfigurationMessage"></info-box>
-    <pre>{{GithubActionsWorkflowConfig}}</pre>
+    <pre *ngIf="GithubActionsWorkflowConfig">{{GithubActionsWorkflowConfig}}</pre>
     <br/><br/>
   </div>
 </div>

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-complete/step-complete.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-complete/step-complete.component.ts
@@ -293,8 +293,7 @@ export class StepCompleteComponent {
     const includeFileName =
       !this.wizard.wizardValues.sourceSettings.githubActionWorkflowOption ||
       this.wizard.wizardValues.sourceSettings.githubActionWorkflowOption === WorkflowOptions.Overwrite ||
-      (this.wizard.wizardValues.sourceSettings.githubActionWorkflowOption === WorkflowOptions.UseExisting &&
-        this.wizard.wizardValues.sourceSettings.githubActionExistingWorkflowContents);
+      this.wizard.wizardValues.sourceSettings.githubActionExistingWorkflowContents;
 
     const items = [
       {

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-complete/step-complete.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-complete/step-complete.component.ts
@@ -215,7 +215,9 @@ export class StepCompleteComponent {
     if (this.wizard.wizardValues.sourceSettings.githubActionWorkflowOption === WorkflowOptions.Overwrite) {
       return this._translateService.instant(PortalResources.githubActionWorkflowOptionOverwriteMessage);
     } else if (this.wizard.wizardValues.sourceSettings.githubActionWorkflowOption === WorkflowOptions.UseExisting) {
-      return this._translateService.instant(PortalResources.githubActionWorkflowOptionUseExistingMessage);
+      return this.wizard.wizardValues.sourceSettings.githubActionExistingWorkflowContents
+        ? this._translateService.instant(PortalResources.githubActionWorkflowOptionUseExistingMessage)
+        : this._translateService.instant(PortalResources.githubActionWorkflowOptionUseExistingMessageWithoutPreview);
     } else {
       return '';
     }
@@ -288,20 +290,31 @@ export class StepCompleteComponent {
   }
 
   private _getGitHubActionBuildSummary() {
-    return [
+    const includeFileName =
+      !this.wizard.wizardValues.sourceSettings.githubActionWorkflowOption ||
+      this.wizard.wizardValues.sourceSettings.githubActionWorkflowOption === WorkflowOptions.Overwrite ||
+      (this.wizard.wizardValues.sourceSettings.githubActionWorkflowOption === WorkflowOptions.UseExisting &&
+        this.wizard.wizardValues.sourceSettings.githubActionExistingWorkflowContents);
+
+    const items = [
       {
         label: this._translateService.instant(PortalResources.provider),
         value: this._translateService.instant(PortalResources.gitHubActionBuildServerTitle),
       },
-      {
+    ];
+
+    if (includeFileName) {
+      items.push({
         label: this._translateService.instant(PortalResources.gitHubActionWorkflowFileNameTitle),
         value: this._githubService.getWorkflowFileName(
           this.wizard.wizardValues.sourceSettings.branch,
           this.wizard.siteName,
           this.wizard.slotName
         ),
-      },
-    ];
+      });
+    }
+
+    return items;
   }
 
   private _getDevOpsBuildSummary() {

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/configure-github.component.html
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/configure-github.component.html
@@ -101,10 +101,10 @@
         <div invalidmessage="branch" id="dc-github-branch-error" role="alert"></div>
       </div>
   </div>
-
-  <ng-container *ngIf="!wizard.isFunctionApp && buildProvider === 'github' && showStackSelector">
-    <h3 class="first-config-heading">{{ 'build' | translate }}</h3>
-    <app-stack-selector></app-stack-selector>
-  </ng-container>
-
 </div>
+
+<ng-container *ngIf="!wizard.isFunctionApp && buildProvider === 'github' && showStackSelector">
+  <app-stack-selector></app-stack-selector>
+</ng-container>
+
+

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/configure-github.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/configure-github.component.ts
@@ -207,17 +207,15 @@ export class ConfigureGithubComponent implements OnDestroy {
           });
 
           this.wizard.sourceSettings.get('githubActionExistingWorkflowContents').setValue(atob(appWorkflowConfiguration.content));
-
-          const required = new RequiredValidator(this._translateService, false);
-          this.wizard.sourceSettings.get('githubActionWorkflowOption').setValidators(required.validate.bind(required));
-          this.wizard.sourceSettings.get('githubActionWorkflowOption').updateValueAndValidity();
         } else if (allWorkflowConfigurations && allWorkflowConfigurations.length > 0) {
           this.workflowFileExistsWarningMessage = this._translateService.instant(PortalResources.githubActionWorkflowsExist, {
             branchName: this.selectedBranch,
           });
 
           this.wizard.sourceSettings.get('githubActionExistingWorkflowContents').setValue('');
+        }
 
+        if (appWorkflowConfiguration || (allWorkflowConfigurations && allWorkflowConfigurations.length > 0)) {
           const required = new RequiredValidator(this._translateService, false);
           this.wizard.sourceSettings.get('githubActionWorkflowOption').setValidators(required.validate.bind(required));
           this.wizard.sourceSettings.get('githubActionWorkflowOption').updateValueAndValidity();

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/stack-selector/stack-selector.component.html
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/stack-selector/stack-selector.component.html
@@ -1,4 +1,6 @@
 <div class="settings-group-wrapper" [formGroup]="wizard?.buildSettings" novalidate>
+    <h3 class="first-config-heading">{{ 'build' | translate }}</h3>
+
     <div class="settings-wrapper">
         <div class="setting-wrapper">
             <label id="github-action-configure-stack-label" class="setting-label">{{ 'runtimeStack' | translate }} </label>
@@ -42,8 +44,6 @@
             </div>
         </div>
     </div>
-
-    
 
     <div class="settings-wrapper">
         <div class="setting-wrapper">

--- a/client/src/app/site/deployment-center/deployment-center-setup/wizard-logic/github.service.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/wizard-logic/github.service.ts
@@ -71,6 +71,23 @@ export class GithubService implements OnDestroy {
     });
   }
 
+  fetchAllWorkflowConfigurations(authToken: string, repoUrl: string, repoName: string, branchName: string): Observable<FileContent[]> {
+    const url = `${DeploymentCenterConstants.githubApiUrl}/repos/${repoName}/contents/.github/workflows?ref=${branchName}`;
+
+    return this._cacheService
+      .post(
+        Constants.serviceHost + `api/github/passthrough?branch=${repoUrl}/contents/.github/workflows&t=${Guid.newTinyGuid()}`,
+        true,
+        null,
+        {
+          url,
+          authToken,
+        }
+      )
+      .map(r => r.json())
+      .catch(e => Observable.of(null));
+  }
+
   fetchWorkflowConfiguration(
     authToken: string,
     repoUrl: string,

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -5686,7 +5686,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>Workflow Option</value>
     </data>
     <data name="githubActionWorkflowOptionOverwrite" xml:space="preserve">
-        <value>Add or Overwrite workflow definition</value>
+        <value>Add or overwrite workflow definition</value>
     </data>
     <data name="githubActionWorkflowOptionUseExisting" xml:space="preserve">
         <value>Configure using existing workflow definition</value>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -5686,7 +5686,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>Workflow Option</value>
     </data>
     <data name="githubActionWorkflowOptionOverwrite" xml:space="preserve">
-        <value>Overwrite workflow definition</value>
+        <value>Add or Overwrite workflow definition</value>
     </data>
     <data name="githubActionWorkflowOptionUseExisting" xml:space="preserve">
         <value>Configure using existing workflow definition</value>
@@ -5741,5 +5741,11 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     </data>
     <data name="noRuntimeVersionWhileFunctionAppStopped" xml:space="preserve">
         <value>You are not able to view or modify the runtime version while your Function App is stopped.</value>
+    </data>
+    <data name="githubActionWorkflowsExist" xml:space="preserve">
+        <value>GitHub Action workflow configurations already exists in the '{{branchName}}' branch. Choose an option below to either add a new workflow configuration or continue using the existing workflow configurations.</value>
+    </data>
+    <data name="githubActionWorkflowOptionUseExistingMessageWithoutPreview" xml:space="preserve">
+        <value>Existing workflow configuration in GitHub will be used for build and deployment.</value>
     </data>
 </root>


### PR DESCRIPTION
Fixes AB#6287684
Fixes AB#6287563
Fixes AB#6223484

If the user has a .github/workflows folder than the assumption is that they have some kind of a workflow configuration setup.

So now, if the user has the exact app workflow configuration file (could be due to disconnect and reconnect scenario), we prompt the user to see if we should overwrite that exact file and/or use that exact configuration.

If not the above case, than check if the user has a .github/workflows folder. If so, than they have some configuration in place. We should let the user know that is the case and give them an option to either continue by adding our configuration or using their existing one.

![image](https://user-images.githubusercontent.com/493476/75832543-493f7200-5d6b-11ea-96ac-16876b7dfc53.png)

![image](https://user-images.githubusercontent.com/493476/75832551-4e042600-5d6b-11ea-9071-f981fff40e7c.png)

![image](https://user-images.githubusercontent.com/493476/75832559-52304380-5d6b-11ea-82ac-b008522239c4.png)

![image](https://user-images.githubusercontent.com/493476/75832564-56f4f780-5d6b-11ea-9933-edf0dfa5c85e.png)

If there is an exact file name match
![image](https://user-images.githubusercontent.com/493476/75832573-5b211500-5d6b-11ea-96aa-8798c7b41f53.png)

If there are no configurations
![image](https://user-images.githubusercontent.com/493476/75832580-5fe5c900-5d6b-11ea-8b12-236258793bbe.png)

