### PR TITLE
[Ibizafication][Integrate] Show an error message when the expected app setting is missing

### DIFF
--- a/client-react/src/pages/app/functions/common/ResourceDropdown.tsx
+++ b/client-react/src/pages/app/functions/common/ResourceDropdown.tsx
@@ -15,6 +15,7 @@ import NewDocumentDBConnectionCallout from './callout/NewDocumentDBConnectionCal
 import NewEventHubConnectionCallout from './callout/NewEventHubConnectionCallout';
 import NewServiceBusConnectionCallout from './callout/NewServiceBusConnectionCallout';
 import NewStorageAccountConnectionCallout from './callout/NewStorageAccountConnectionCallout';
+import { useTranslation } from 'react-i18next';
 
 export interface ResourceDropdownProps {
   setting: BindingSetting;
@@ -27,6 +28,9 @@ const ResourceDropdown: React.SFC<ResourceDropdownProps & CustomDropdownProps & 
   const [selectedItem, setSelectedItem] = useState<IDropdownOption | undefined>(undefined);
   const [newAppSetting, setNewAppSetting] = useState<{ key: string; value: string } | undefined>(undefined);
   const [isDialogVisible, setIsDialogVisible] = useState<boolean>(false);
+  const [shownMissingOptionError, setShownMissingOptionError] = useState<boolean>(false);
+
+  const { t } = useTranslation();
 
   useEffect(() => {
     SiteService.fetchApplicationSettings(resourceId).then(r => {
@@ -53,6 +57,11 @@ const ResourceDropdown: React.SFC<ResourceDropdownProps & CustomDropdownProps & 
   if (selectedItem) {
     onChange(selectedItem, formProps, field, appSettings);
     setSelectedItem(undefined);
+  }
+
+  if (field.value && !options.some(option => option.key === field.value) && !shownMissingOptionError) {
+    formProps.setFieldError(field.name, t('resourceDropdown_missingAppSetting'));
+    setShownMissingOptionError(true);
   }
 
   return (

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1869,4 +1869,5 @@ export class PortalResources {
   public static deleteFunctionKeyHeader = 'deleteFunctionKeyHeader';
   public static deleteFunctionKeyMessage = 'deleteFunctionKeyMessage';
   public static fetchFileContentFailureMessage = 'fetchFileContentFailureMessage';
+  public static resourceDropdown_missingAppSetting = 'resourceDropdown_missingAppSetting';
 }

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -47,9 +47,9 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-    <xsd:schema id="root"
-        xmlns=""
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    <xsd:schema id="root" 
+        xmlns="" 
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
         xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
         <xsd:element name="root" msdata:IsDataSet="true">
@@ -5780,5 +5780,8 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     </data>
     <data name="fetchFileContentFailureMessage" xml:space="preserve">
         <value>Failed to fetch the file content</value>
+    </data>
+    <data name="resourceDropdown_missingAppSetting" xml:space="preserve">
+        <value>Selected connection is missing from app settings</value>
     </data>
 </root>


### PR DESCRIPTION
Ignore the juttering cursor, recording didn't link my remote desktop
![missingAppSetting](https://user-images.githubusercontent.com/37600290/76123606-de31ad80-5fad-11ea-9b0b-5adf2acc1c63.gif)
