### PR TITLE
[Ibizafication][Integrate] Closing editor shouldn't show Create binding title

### DIFF
--- a/client-react/src/pages/app/functions/integrate/FunctionIntegrate.tsx
+++ b/client-react/src/pages/app/functions/integrate/FunctionIntegrate.tsx
@@ -83,7 +83,6 @@ export const FunctionIntegrate: React.FunctionComponent<FunctionIntegrateProps> 
 
   const closeEditor = () => {
     setIsOpen(false);
-    setBindingToUpdate(undefined);
   };
 
   const onSubmit = (newBindingInfo: BindingInfo, currentBindingInfo?: BindingInfo) => {
@@ -101,7 +100,6 @@ export const FunctionIntegrate: React.FunctionComponent<FunctionIntegrateProps> 
     });
 
     setIsOpen(false);
-    setBindingToUpdate(undefined);
   };
 
   const onDelete = (currentBindingInfo: BindingInfo) => {
@@ -110,7 +108,6 @@ export const FunctionIntegrate: React.FunctionComponent<FunctionIntegrateProps> 
       closedReason: ClosedReason.Delete,
     });
 
-    setBindingToUpdate(undefined);
     setIsOpen(false);
   };
 


### PR DESCRIPTION
Fixes AB#6216688

Although we set the editor to close before we cleared the old binding, the animation on closing meant that the user would see the Create Binding title flash. Removed unnecessary calls to remove binding to update, we set the binding properly every time we open the panel, so we shouldn't need to clear out the old one