### PR TITLE
[Ibizafication] Labels should overflow

### DIFF
--- a/client-react/src/components/FormControlWrapper/FormControlWrapper.tsx
+++ b/client-react/src/components/FormControlWrapper/FormControlWrapper.tsx
@@ -22,14 +22,15 @@ export interface FormControlWrapperProps {
   multiline?: boolean;
 }
 
-const hostStyle = style({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-  maxWidth: 250,
-});
+const hostStyle = (multiline?: boolean) =>
+  style({
+    overflow: !multiline ? 'hidden' : 'visible',
+    textOverflow: 'ellipsis',
+    whiteSpace: !multiline ? 'nowrap' : 'normal',
+    maxWidth: 250,
+  });
 
-const tooltipStyle: Partial<ITooltipHostStyles> = { root: { display: 'inline-block', float: 'left' } };
+const tooltipStyle: Partial<ITooltipHostStyles> = { root: { display: 'inline', float: 'left' } };
 
 const labelStyle = style({ marginBottom: '5px' });
 
@@ -55,11 +56,7 @@ export const FormControlWrapper = (props: FormControlWrapperProps) => {
   return (
     <Stack horizontal={layout !== Layout.vertical && width > MaxHorizontalWidthPx} style={style}>
       <label className={`${labelStyle} ${defaultLabelClassName || ''}`} htmlFor={children.props.id}>
-        <TooltipHost
-          overflowMode={TooltipOverflowMode.Self}
-          content={label}
-          hostClassName={!multiline ? hostStyle : ''}
-          styles={tooltipStyle}>
+        <TooltipHost overflowMode={TooltipOverflowMode.Self} content={label} hostClassName={hostStyle(multiline)} styles={tooltipStyle}>
           {label}
         </TooltipHost>
         {getRequiredIcon(theme, required)} {getToolTip(`${children.props.id}-tooltip`, toolTipContent)}

--- a/client-react/src/components/FormControlWrapper/FormControlWrapper.tsx
+++ b/client-react/src/components/FormControlWrapper/FormControlWrapper.tsx
@@ -26,7 +26,7 @@ const hostStyle = style({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
-  maxWidth: 100,
+  maxWidth: 250,
 });
 
 const tooltipStyle: Partial<ITooltipHostStyles> = { root: { display: 'inline-block', float: 'left' } };

--- a/client-react/src/components/FormControlWrapper/FormControlWrapper.tsx
+++ b/client-react/src/components/FormControlWrapper/FormControlWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, CSSProperties } from 'react';
-import { Stack } from 'office-ui-fabric-react';
+import { Stack, TooltipHost, TooltipOverflowMode, ITooltipHostStyles } from 'office-ui-fabric-react';
 import { style } from 'typestyle';
 import { useWindowSize } from 'react-use';
 import { ThemeExtended } from '../../theme/SemanticColorsExtended';
@@ -19,12 +19,19 @@ export interface FormControlWrapperProps {
   layout?: Layout;
   style?: CSSProperties;
   defaultLabelClassName?: string;
+  multiline?: boolean;
 }
 
-const labelStyle = style({
-  width: '250px',
-  marginBottom: '5px',
+const hostStyle = style({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  maxWidth: 100,
 });
+
+const tooltipStyle: Partial<ITooltipHostStyles> = { root: { display: 'inline-block', float: 'left' } };
+
+const labelStyle = style({ marginBottom: '5px' });
 
 const requiredIcon = (theme: ThemeExtended) => {
   return style({
@@ -41,14 +48,21 @@ const MaxHorizontalWidthPx = 750;
 // element is not an "input" element, then the screen reader won't respect it and won't read the label first.
 // In that case, you'll have to manually specify the "ariaLabel" property on the child element yourself
 export const FormControlWrapper = (props: FormControlWrapperProps) => {
-  const { label, children, layout, required, style, tooltip: toolTipContent, defaultLabelClassName } = props;
+  const { label, children, layout, required, style, tooltip: toolTipContent, defaultLabelClassName, multiline } = props;
   const { width } = useWindowSize();
   const theme = useContext(ThemeContext);
 
   return (
     <Stack horizontal={layout !== Layout.vertical && width > MaxHorizontalWidthPx} style={style}>
       <label className={`${labelStyle} ${defaultLabelClassName || ''}`} htmlFor={children.props.id}>
-        {label} {getRequiredIcon(theme, required)} {getToolTip(`${children.props.id}-tooltip`, toolTipContent)}
+        <TooltipHost
+          overflowMode={TooltipOverflowMode.Self}
+          content={label}
+          hostClassName={!multiline ? hostStyle : ''}
+          styles={tooltipStyle}>
+          {label}
+        </TooltipHost>
+        {getRequiredIcon(theme, required)} {getToolTip(`${children.props.id}-tooltip`, toolTipContent)}
       </label>
       {children}
     </Stack>


### PR DESCRIPTION
Fixes AB#6217147

Images have width set extra short to show off functionality

Create:
![image](https://user-images.githubusercontent.com/37600290/77109934-0542a300-69e2-11ea-9f1f-1dc7293ff8be.png)

Integrate:
![image](https://user-images.githubusercontent.com/37600290/77112792-de3aa000-69e6-11ea-8ac7-2b8ef7ce6df1.png)

Pivot:
![image](https://user-images.githubusercontent.com/37600290/77110034-2c00d980-69e2-11ea-910f-e32341c1819c.png)

Multiline true for text boxes, false for dropdowns
![image](https://user-images.githubusercontent.com/37600290/77112602-83a14400-69e6-11ea-9604-75c980a7dd70.png)


