### PR TITLE
[Ibizafication][Integrate][WCAG] Increase contrast in card body color

### DIFF
--- a/client-react/src/pages/app/functions/function/integrate/binding-card/BindingCard.styles.ts
+++ b/client-react/src/pages/app/functions/function/integrate/binding-card/BindingCard.styles.ts
@@ -17,7 +17,9 @@ export const cardStyle = (theme: ThemeExtended) => {
 export const headerStyle = (theme: ThemeExtended): string => {
   return style({
     height: '35px',
-    backgroundColor: theme.palette.neutralLighterAlt,
+    backgroundColor: color(theme.semanticColors.cardBackgroundColor)
+      .darken('2%')
+      .toString(),
     borderBottom: `solid 1px ${color(theme.semanticColors.cardBorderColor).lighten('20%')}`,
 
     $nest: {

--- a/client-react/src/theme/dark.ts
+++ b/client-react/src/theme/dark.ts
@@ -43,7 +43,7 @@ const AzurePortalColors = {
   controlErrorStateOutline: '#f63747',
   controlDirtyOutline: '#c87fdc',
   cardBorderColor: '#b2b2b2',
-  cardBackgroundColor: '#363636',
+  cardBackgroundColor: '#2b2b2b',
 };
 
 const themePalette: IPalette = {


### PR DESCRIPTION
Fixes AB#6559512

Need to increase the contrast between the link color and the card body background

Before:
![image](https://user-images.githubusercontent.com/37600290/77584610-58b06780-6ea0-11ea-9a5b-3800d98b65d3.png)

![image](https://user-images.githubusercontent.com/37600290/77584588-4cc4a580-6ea0-11ea-9560-dc5e3cff9542.png)

After:
![image](https://user-images.githubusercontent.com/37600290/77584299-cd36d680-6e9f-11ea-9bb1-b4fbd6132866.png)

![image](https://user-images.githubusercontent.com/37600290/77584547-3d455c80-6ea0-11ea-9f3e-45cd2c4b3209.png)
