### PR TITLE
Fixing info bubble alignment for horizontal layout of FormControlWrapper

### DIFF
--- a/client-react/src/components/FormControlWrapper/FormControlWrapper.tsx
+++ b/client-react/src/components/FormControlWrapper/FormControlWrapper.tsx
@@ -32,7 +32,7 @@ const hostStyle = (multiline?: boolean) =>
 
 const tooltipStyle: Partial<ITooltipHostStyles> = { root: { display: 'inline', float: 'left' } };
 
-const labelStyle = (layout: Layout | undefined) => {
+const labelStyle = (layout?: Layout) => {
   const s = {
     marginBottom: '5px',
   };

--- a/client-react/src/components/FormControlWrapper/FormControlWrapper.tsx
+++ b/client-react/src/components/FormControlWrapper/FormControlWrapper.tsx
@@ -32,7 +32,17 @@ const hostStyle = (multiline?: boolean) =>
 
 const tooltipStyle: Partial<ITooltipHostStyles> = { root: { display: 'inline', float: 'left' } };
 
-const labelStyle = style({ marginBottom: '5px' });
+const labelStyle = (layout: Layout | undefined) => {
+  const s = {
+    marginBottom: '5px',
+  };
+
+  if (layout !== Layout.vertical) {
+    s['width'] = '250px';
+  }
+
+  return style(s);
+};
 
 const requiredIcon = (theme: ThemeExtended) => {
   return style({
@@ -55,7 +65,7 @@ export const FormControlWrapper = (props: FormControlWrapperProps) => {
 
   return (
     <Stack horizontal={layout !== Layout.vertical && width > MaxHorizontalWidthPx} style={style}>
-      <label className={`${labelStyle} ${defaultLabelClassName || ''}`} htmlFor={children.props.id}>
+      <label className={`${labelStyle(layout)} ${defaultLabelClassName || ''}`} htmlFor={children.props.id}>
         <TooltipHost overflowMode={TooltipOverflowMode.Self} content={label} hostClassName={hostStyle(multiline)} styles={tooltipStyle}>
           {label}
         </TooltipHost>


### PR DESCRIPTION
It looks like a recent change to the FormControlWrapper class broke the alignment for horizontal wrappers.  The fix I've made makes it slightly better, though I think to really fix the vertical alignment of the info bubble, should probably redo some of the changes that regressed this.

This is what's in canary today:
![image](https://user-images.githubusercontent.com/5695405/78072596-3ca33f00-7354-11ea-8726-fb3e3f159e29.png)

Here's what it looks like after my fix:
![image](https://user-images.githubusercontent.com/5695405/78077510-585f1300-735d-11ea-9d85-a3a87f9fd6de.png)

I also verified that this doesn't break the integrate blade:
![image](https://user-images.githubusercontent.com/5695405/78077593-7af12c00-735d-11ea-9d18-5701e462aa50.png)

