### PR TITLE
AB#6447323 Hiding Java versions in config

### DIFF
--- a/client-react/src/models/available-stacks.ts
+++ b/client-react/src/models/available-stacks.ts
@@ -4,6 +4,7 @@ export interface MinorVersion {
   isDefault: boolean;
   isRemoteDebuggingEnabled: boolean;
   isEndOfLife?: boolean;
+  isAutoUpdate?: boolean;
 }
 
 export interface MajorVersion {
@@ -20,6 +21,7 @@ export interface MinorVersion2 {
   displayVersion: string;
   runtimeVersion: string;
   isDefault: boolean;
+  isAutoUpdate?: boolean;
 }
 
 export interface MajorVersion2 {

--- a/client-react/src/pages/app/app-settings/GeneralSettings/LinuxStacks/LinuxStacks.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/LinuxStacks/LinuxStacks.tsx
@@ -87,16 +87,6 @@ const getMinorVersions = (builtInStacks: ArmObj<AvailableStack>[], stack: string
     }
   });
 
-  const currentRuntime = currentVersion.runtimeVersion || '';
-  const currentRuntimeToLower = currentRuntime.toLowerCase();
-  if (!includedAlready.has(currentRuntimeToLower)) {
-    linuxFxVersionOptions.unshift({
-      text: currentVersion.isEndOfLife ? t('endOfLifeTagTemplate').format(currentVersion.displayVersion) : currentVersion.displayVersion,
-      key: currentRuntime,
-    });
-    includedAlready.add(currentRuntimeToLower);
-  }
-
   return linuxFxVersionOptions;
 };
 

--- a/client-react/src/pages/app/app-settings/GeneralSettings/WindowsStacks/JavaData.ts
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/WindowsStacks/JavaData.ts
@@ -37,26 +37,25 @@ export const getJavaMinorVersionOptions = (
   newestLabel: string,
   autoUpdateLabel: string
 ) => {
-  const currentJavaMajorVersionOnject = getJavaMajorVersionObject(javaStack, currentJavaMajorVersion);
-  let javaMinorVersionOptions: IDropdownOption[] = [];
-  if (currentJavaMajorVersionOnject) {
-    const version = [
-      {
-        key: currentJavaMajorVersionOnject.runtimeVersion,
-        text: `${currentJavaMajorVersionOnject.displayVersion} (${autoUpdateLabel})`,
-      },
-    ];
-    javaMinorVersionOptions = version.concat(
-      currentJavaMajorVersionOnject.minorVersions.map(val => {
-        const newest = val.isDefault ? ` (${newestLabel})` : '';
-        return {
-          key: val.runtimeVersion,
-          text: `${val.displayVersion}${newest}`,
-        };
-      })
-    );
-  }
-  return javaMinorVersionOptions;
+  const options: IDropdownOption[] = [];
+  const currentJavaMajorVersionObject = getJavaMajorVersionObject(javaStack, currentJavaMajorVersion);
+
+  const minorVersions = (currentJavaMajorVersionObject && currentJavaMajorVersionObject.minorVersions) || [];
+  minorVersions.forEach(minorVersion => {
+    let text = minorVersion.displayVersion;
+    if (minorVersion.isDefault) {
+      text = `${minorVersion.displayVersion} (${newestLabel})`;
+    } else if (minorVersion.isAutoUpdate) {
+      text = `${minorVersion.displayVersion} (${autoUpdateLabel})`;
+    }
+
+    options.push({
+      text,
+      key: minorVersion.runtimeVersion,
+    });
+  });
+
+  return options;
 };
 
 export const getJavaContainersOptions = (javaContainers: ArmObj<AvailableStack>) =>
@@ -68,30 +67,22 @@ export const getJavaContainersOptions = (javaContainers: ArmObj<AvailableStack>)
   });
 
 export const getFrameworkVersionOptions = (javaContainers: ArmObj<AvailableStack>, config: ArmObj<SiteConfig>, autoUpdateLabel: string) => {
+  const options: IDropdownOption[] = [];
   const currentFramework =
     config.properties.javaContainer &&
     javaContainers.properties.frameworks.find(x => x.name.toLowerCase() === config.properties.javaContainer.toLowerCase());
-  let javaFrameworkVersionOptions: IDropdownOption[] = [];
-  if (currentFramework) {
-    const majorVersions = currentFramework.majorVersions.map(val => {
-      const version = [
-        {
-          key: val.runtimeVersion,
-          text: `${val.displayVersion} (${autoUpdateLabel})`,
-        },
-      ];
-      return version.concat(
-        val.minorVersions.map(inner => {
-          return {
-            key: inner.runtimeVersion,
-            text: inner.displayVersion,
-          };
-        })
-      );
+
+  const majorVersions = (currentFramework && currentFramework.majorVersions) || [];
+  majorVersions.forEach(majorVersion => {
+    const minorVersions = majorVersion.minorVersions || [];
+    minorVersions.forEach(minorVersion => {
+      const text = minorVersion.isAutoUpdate ? `${minorVersion.displayVersion} (${autoUpdateLabel})` : minorVersion.displayVersion;
+      options.push({
+        text,
+        key: minorVersion.runtimeVersion,
+      });
     });
-    majorVersions.forEach(x => {
-      javaFrameworkVersionOptions = javaFrameworkVersionOptions.concat(x);
-    });
-  }
-  return javaFrameworkVersionOptions;
+  });
+
+  return options;
 };

--- a/client-react/src/pages/app/app-settings/GeneralSettings/WindowsStacks/JavaStack.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/WindowsStacks/JavaStack.tsx
@@ -122,7 +122,7 @@ const JavaStack: React.SFC<Props> = props => {
         component={Dropdown}
         fullpage
         required
-        label={t('javaContainer')}
+        label={t('javaWebServer')}
         disabled={disableAllControls}
         id="app-settings-java-container-runtime"
         options={frameworks}
@@ -135,7 +135,7 @@ const JavaStack: React.SFC<Props> = props => {
           fullpage
           required
           disabled={disableAllControls}
-          label={t('javaContainerVersion')}
+          label={t('javaWebServerVersion')}
           id="app-settings-java-container-version"
           options={javaFrameworkVersionOptions}
         />

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1459,6 +1459,8 @@ export class PortalResources {
   public static javaMinorVersion = 'javaMinorVersion';
   public static javaContainer = 'javaContainer';
   public static javaContainerVersion = 'javaContainerVersion';
+  public static javaWebServer = 'javaWebServer';
+  public static javaWebServerVersion = 'javaWebServerVersion';
   public static newDocument = 'newDocument';
   public static nameRes = 'nameRes';
   public static value = 'value';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -4523,6 +4523,12 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="javaContainerVersion" xml:space="preserve">
         <value>Java container version</value>
     </data>
+    <data name="javaWebServer" xml:space="preserve">
+        <value>Java web server</value>
+    </data>
+    <data name="javaWebServerVersion" xml:space="preserve">
+        <value>Java web server version</value>
+    </data>
     <data name="newDocument" xml:space="preserve">
         <value>New document</value>
     </data>


### PR DESCRIPTION
Fixes [AB#6447323](https://msazure.visualstudio.com/Antares/_workitems/edit/6447323)

This contains three changes:
1. Change labels 'Java container' and 'Java container version' labels to 'Java web server' and 'Java web server version'.

2. For Linux stacks and Windows Java stacks, we need to insert each major version as a child of itself (to serve as the auto-update version). We currently do this when we're generating the minor version stack options. This change moves up the logic so we apply the change in-place on the availableStacks object we get from the API. This isn't a functional change, but it is necessary because we need to insert these versions before we do additional processing of the availableStacks object.

3. Prune the Windows Java stacks from the availableStacks response based on the logic below.
   * Java Version
     * Java 7
       * Hide all
     * Java 8
       * Hide all Oracle versions.
       * Just display the Zulu versions with JFR support (1.8.0_202 and newer).
       * Remove “(Newest)” tag.
     * Java 11
       * Remove “(Newest)” tag.

   * Java Container Version
     * Jetty
       * Hide all
     * Tomcat
       * Hide all Tomcat 7.x
       * Tomcat 8.x – Just show the last 3 versions.
       * Tomcat 9.x – just show the last 3 versions.
