### PR TITLE
AB#6455986 Adding confirmation dialogue when switching runtime versions

### DIFF
--- a/client-react/src/components/ConfirmDialog/ConfirmDialog.styles.ts
+++ b/client-react/src/components/ConfirmDialog/ConfirmDialog.styles.ts
@@ -21,6 +21,7 @@ export const modalContentStyles = {
     padding: '0px',
   },
   innerContent: {
+    width: 'calc(100vw - 64px)',
     paddingLeft: '28px',
     paddingRight: '36px',
     paddingBottom: '5px',
@@ -29,6 +30,7 @@ export const modalContentStyles = {
 
 export const modalFooterStyles = {
   actionsRight: {
+    width: 'calc(100vw - 25px)',
     borderTop: '1px solid rgba(204,204,204,.8)',
     paddingTop: '10px',
     paddingLeft: '28px',

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1808,6 +1808,8 @@ export class PortalResources {
   public static functionsRuntimeVersionInvalidWarning = 'functionsRuntimeVersionInvalidWarning';
   public static functionsRuntimeVersionCustomInfo = 'functionsRuntimeVersionCustomInfo';
   public static functionsRuntimeVersionExistingFunctionsWarning = 'functionsRuntimeVersionExistingFunctionsWarning';
+  public static functionsRuntimeVersionExistingFunctionsConfirmationTitle = 'functionsRuntimeVersionExistingFunctionsConfirmationTitle';
+  public static functionsRuntimeVersionExistingFunctionsConfirmationMessage = 'functionsRuntimeVersionExistingFunctionsConfirmationMessage';
   public static githubActionWorkflowScopeMissing = 'githubActionWorkflowScopeMissing';
   public static githubActionWorkflowFileExists = 'githubActionWorkflowFileExists';
   public static remoteDebuggingVS2015NotSupported = 'remoteDebuggingVS2015NotSupported';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -5596,7 +5596,13 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>By configuring the value of FUNCTIONS_EXTENSION_VERSION in Application setting, you have opted to use a custom runtime version.</value>
     </data>
     <data name="functionsRuntimeVersionExistingFunctionsWarning" xml:space="preserve">
-        <value>Cannot upgrade with existing functions: Major version upgrades can introduce breaking changes to languages and bindings. When upgrading major versions of the runtime, consider creating a new function app and migrate your functions to this new app.</value>
+        <value>You are updating your runtime version from {0} to {1}. This may introduce breaking changes to the language and bindings for your existing functions. Consider creating a new function app and migrating your functions to it when upgrading major versions of the runtime.</value>
+    </data>
+    <data name="functionsRuntimeVersionExistingFunctionsConfirmationTitle" xml:space="preserve">
+        <value>Update Runtime Version</value>
+    </data>
+    <data name="functionsRuntimeVersionExistingFunctionsConfirmationMessage" xml:space="preserve">
+        <value>Your app is currently running version {0} and has existing functions. Switching to version {1} is not recommended since it can introduce breaking changes to languages and bindings. Are you sure you want to continue?</value>
     </data>
     <data name="githubActionWorkflowScopeMissing" xml:space="preserve">
         <value>Missing 'workflow' scope in GitHub token. Please return to 'source control' step to re-authorize GitHub.</value>


### PR DESCRIPTION
Fixes [AB#6455986](https://msazure.visualstudio.com/Antares/_workitems/edit/6455986)

**BEFORE:**
- If app has functions, the warning is always shown, even if the user isn't trying to switch to a runtime version with breaking changes.
- The breaking versions are disabled in the dropdown with no explanation. 

![image](https://user-images.githubusercontent.com/5387224/80437598-d4923b00-88b6-11ea-801e-6f4f03a40bc9.png)

**AFTER:**
- The breaking versions are not disabled in the dropdown.
- If a breaking version is selected from the dropdown, a confirmation dialogue is shown.
- The warning message (with updated text) is shown only if the breaking version dialog is confirmed.

![image](https://user-images.githubusercontent.com/5387224/80437755-58e4be00-88b7-11ea-9a8f-48935599198a.png)

![image](https://user-images.githubusercontent.com/5387224/80437782-6dc15180-88b7-11ea-92a8-5f8c9971ad8e.png)

![image](https://user-images.githubusercontent.com/5387224/80437806-803b8b00-88b7-11ea-9e01-addde9c58e59.png)

