### PR TITLE
Fixing text overflow and text wrapping in CustomBanner

### DIFF
--- a/client-react/src/components/CustomBanner/CustomBanner.styles.ts
+++ b/client-react/src/components/CustomBanner/CustomBanner.styles.ts
@@ -4,15 +4,15 @@ import { MessageBarType } from 'office-ui-fabric-react';
 
 export const messageBannerStyles = (isCustomIcon: boolean) => {
   const styles = {
-    root: {
-      height: '33px',
-    },
     content: {
-      height: '33px',
       paddingLeft: '15px',
     },
     text: {
       marginTop: '9px',
+      marginBottom: '8px',
+    },
+    innerText: {
+      marginLeft: isCustomIcon ? '24px' : undefined,
     },
     iconContainer: {
       display: isCustomIcon ? ('none' as 'none') : ('contents' as 'contents'),
@@ -28,19 +28,17 @@ export const messageBannerStyles = (isCustomIcon: boolean) => {
   if (!isCustomIcon) {
     styles.icon = {
       marginTop: '9px',
+      marginBottom: '8px',
     };
   }
   return styles;
 };
 
-export const messageBannerTextStyle = style({
-  marginLeft: '24px',
-});
-
 export const messageBannerIconStyle = style({
   position: 'absolute',
   height: '16px',
   width: '16px',
+  marginLeft: '-24px',
 });
 
 export const messageBannerClass = (theme: ThemeExtended, type: MessageBarType) => {

--- a/client-react/src/components/CustomBanner/CustomBanner.tsx
+++ b/client-react/src/components/CustomBanner/CustomBanner.tsx
@@ -5,7 +5,7 @@ import { ReactComponent as ErrorSvg } from '../../images/Common/Error.svg';
 import { ReactComponent as InfoSvg } from '../../images/Common/Info.svg';
 import { ReactComponent as WarningSvg } from '../../images/Common/Warning.svg';
 import { ThemeContext } from '../../ThemeContext';
-import { messageBannerClass, messageBannerIconStyle, messageBannerStyles, messageBannerTextStyle } from './CustomBanner.styles';
+import { messageBannerClass, messageBannerIconStyle, messageBannerStyles } from './CustomBanner.styles';
 
 interface CustomBannerProps {
   message: string;
@@ -35,13 +35,13 @@ const CustomBanner: React.FC<CustomBannerProps> = props => {
     <div>
       <MessageBar
         id={`${id}-custom-banner`}
-        isMultiline={true}
+        isMultiline={false}
         messageBarType={type}
         styles={messageBannerStyles(!!icon)}
         className={className}
         onDismiss={onDismiss}>
         {!!icon ? <span className={messageBannerIconStyle}>{icon}</span> : undefined}
-        <span className={messageBannerTextStyle}>
+        <span>
           {message}
           {learnMoreLink ? (
             <Link href={learnMoreLink} target="_blank">


### PR DESCRIPTION
- Updates
  - Let banner height grow if text overflows, instead of letting text wrap beyond the bottom of the banner.
  - Don't wrap text around icon



- **Screenshots**

  - **Long string + Reflow Min + Fabric UI Icon**
	- Text wraps beyond the height of the banner
	- Large gap between icon and text
	- First line of text is indented


    **BEFORE**
    ![BEFORE_Long_Narrow_FabricIcon](https://user-images.githubusercontent.com/5387224/80657876-a6893400-8a39-11ea-960b-517f1a5819cb.PNG)
  
    **AFTER**
    ![AFTER_Long_Narrow_FabricIcon](https://user-images.githubusercontent.com/5387224/80657863-a2f5ad00-8a39-11ea-96dc-4cb42aea099c.PNG)




  - **Long string + Reflow Min + Custom Icon**
    - Text wraps beyond the height of the banner
    - Text wraps around icon


    **BEFORE**
    ![BEFORE_Long_Narrow_CustomIcon](https://user-images.githubusercontent.com/5387224/80657875-a5f09d80-8a39-11ea-9bf6-3f5a92f5358f.PNG)
    
    **AFTER**
    ![AFTER_Long_Narrow_CustomIcon](https://user-images.githubusercontent.com/5387224/80657862-a25d1680-8a39-11ea-9524-83e3f4959ce8.PNG)




  - **Long string + Reflow Off + Fabric UI Icon**
	- Large gap between icon and text


    **BEFORE**
    ![BEFORE_Long_Wide_FabricIcon](https://user-images.githubusercontent.com/5387224/80657880-a721ca80-8a39-11ea-89f9-df5339c944d9.PNG)
  
    **AFTER**
    ![AFTER_Long_Wide_FabricIcon](https://user-images.githubusercontent.com/5387224/80657868-a426da00-8a39-11ea-8586-f0a3d52d77bf.PNG)




  - **Long string + Reflow Off + Custom Icon**
    - No issues


    **BEFORE**
    ![BEFORE_Long_Wide_CustomIcon](https://user-images.githubusercontent.com/5387224/80657879-a6893400-8a39-11ea-8f6b-7e3b6e0a008b.PNG)
  
    **AFTER**
    ![AFTER_Long_Wide_CustomIcon](https://user-images.githubusercontent.com/5387224/80657867-a426da00-8a39-11ea-9cf8-64b69898a937.PNG)




  - **Short string + Reflow Min + Fabric UI Icon**
	- Large gap between icon and text


    **BEFORE**
    ![BEFORE_Short_Narrow_FabricIcon](https://user-images.githubusercontent.com/5387224/80657883-a7ba6100-8a39-11ea-92fd-2045509cfa8d.PNG)
  
    **AFTER**
    ![AFTER_Short_Narrow_FabricIcon](https://user-images.githubusercontent.com/5387224/80657870-a4bf7080-8a39-11ea-9ee8-c174fa23da6a.PNG)




  - **Short string + Reflow Min + Custom Icon**
    - No issues


    **BEFORE**
    ![BEFORE_Short_Narrow_CustomIcon](https://user-images.githubusercontent.com/5387224/80657881-a7ba6100-8a39-11ea-9581-e8b6c47b000a.PNG)
  
    **AFTER**
    ![AFTER_Short_Narrow_CustomIcon](https://user-images.githubusercontent.com/5387224/80657869-a4bf7080-8a39-11ea-8444-3f115707adb1.PNG)




  - **Short string + Reflow Off + Fabric UI Icon**
	- Large gap between icon and text


    **BEFORE**
    ![BEFORE_Short_Wide_FabricIcon](https://user-images.githubusercontent.com/5387224/80657887-a8eb8e00-8a39-11ea-9361-db8094583f85.PNG)
  
    **AFTER**
    ![AFTER_Short_Wide_FabricIcon](https://user-images.githubusercontent.com/5387224/80657873-a5580700-8a39-11ea-99a6-374987dac3c6.PNG)




  - **Short string + Reflow Off + Custom Icon**
    - No issues


    **BEFORE**
    ![BEFORE_Short_Wide_CustomIcon](https://user-images.githubusercontent.com/5387224/80657885-a852f780-8a39-11ea-8336-a6d5c1553081.PNG)
  
    **AFTER**
    ![AFTER_Short_Wide_CustomIcon](https://user-images.githubusercontent.com/5387224/80657872-a5580700-8a39-11ea-96a4-6de74b2b1912.PNG)
  