### PR TITLE
Deployment Center - Update the condition to be more accurate or Java on Linux

### DIFF
--- a/client/src/app/site/deployment-center/deployment-center-setup/wizard-logic/github.service.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/wizard-logic/github.service.ts
@@ -202,7 +202,7 @@ export class GithubService implements OnDestroy {
   }
 
   private _isJavaWarBuild(buildSettings: BuildSettings) {
-    return buildSettings.runtimeStackVersion.toLocaleLowerCase().indexOf(JavaContainers.Tomcat) > 0;
+    return buildSettings.runtimeStackVersion.toLocaleLowerCase().indexOf(JavaContainers.Tomcat) > -1;
   }
 
   // TODO(michinoy): Need to implement templated github action workflow generation.


### PR DESCRIPTION
This was only tested for Java on Windows where the indexOf is always greater than 0 as TOMCAT is the middle element... but since we enabled this for linux, TOMCAT is the prefix causing the index to be 0.

Also no need to hotfix as it is already like this in prod.