### PR TITLE
[HOTFIX] Switch AddSlotComponent and SwapSlotsComponent back to using <ng-select/>

### DIFF
--- a/client/src/app/site/slots/add-slot/add-slot.component.html
+++ b/client/src/app/site/slots/add-slot/add-slot.component.html
@@ -75,14 +75,13 @@
                     <div>
                         <textbox
                             [ariaLabel]="'slotNew_nameLabel' | translate"
-                            ariaErrorId="name-validation"
                             class="name-textbox"
                             [placeholder]="'enterName' | translate"
                             [disablePopOverError]="true"
                             [control]="addForm ? addForm.controls['name'] : null">
                         </textbox>
                     </div>
-                    <div invalidmessage="name" id="name-validation"></div>
+                    <div invalidmessage="name"></div>
                 </div>
             </div>
 
@@ -92,14 +91,16 @@
                         {{ 'slotNew_cloneConfigLabel' | translate }}
                     </div>
                     <div>
-                        <drop-down
-                            [ariaLabel]="'slotNew_cloneConfigLabel' | translate"
-                            ariaErrorId="clone-src-validation"
-                            [control]="addForm ? addForm.controls['cloneSrcId'] : null"
-                            [options]="cloneSrcIdDropDownOptions"
-                            [highlightDirty]="false">
-                        </drop-down>
-                        <div invalidmessage="cloneSrcId" id="clone-src-validation"></div>
+                        <ng-select
+                            [loading]="false"
+                            [clearable]="false"
+                            [items]="cloneSrcIdDropDownOptions"
+                            bindLabel="displayLabel"
+                            bindValue="value"
+                            class="custom-select"
+                            formControlName="cloneSrcId">
+                        </ng-select>
+                        <div invalidmessage="cloneSrcId"></div>
                     </div>
                 </div>
             </div>

--- a/client/src/app/site/slots/swap-slots/swap-slots.component.html
+++ b/client/src/app/site/slots/swap-slots/swap-slots.component.html
@@ -51,15 +51,17 @@
                         <div *ngIf="swapForm?.controls['srcId']?.value === siteResourceId" class="pill">{{ 'production' | translate }}</div>
                     </div>
                     <div>
-                        <drop-down
-                          [ariaLabel]="'source' | translate"
-                          ariaErrorId="src-validation"
-                          [control]="!!swapForm ? swapForm.controls['srcId'] : null"
-                          [options]="srcDropDownOptions"
-                          [highlightDirty]="false"
-                          (value)="onSlotIdChange()">
-                        </drop-down>
-                        <div *ngIf="swapForm?.controls['srcId']" id="src-validation" class="validation-container">
+                        <ng-select
+                            [loading]="false"
+                            [clearable]="false"
+                            [items]="srcDropDownOptions"
+                            bindLabel="displayLabel"
+                            bindValue="value"
+                            class="custom-select"
+                            formControlName="srcId"
+                            (change)="onSlotIdChange()">
+                        </ng-select>
+                        <div *ngIf="swapForm?.controls['srcId']" class="validation-container">
                             <div *ngIf="!swapForm.pending && swapForm.invalid && swapForm.errors && swapForm.errors['slotsNotUnique']"
                                 class="error-message">
                                     {{ swapForm.errors['slotsNotUnique'] }}
@@ -91,15 +93,17 @@
                         <div *ngIf="swapForm?.controls['destId']?.value === siteResourceId" class="pill">{{ 'production' | translate }}</div>
                     </div>
                     <div>
-                        <drop-down
-                          [ariaLabel]="'target' | translate"
-                          ariaErrorId="dest-validation"
-                          [control]="!!swapForm ? swapForm.controls['destId'] : null"
-                          [options]="destDropDownOptions"
-                          [highlightDirty]="false"
-                          (value)="onSlotIdChange()">
-                        </drop-down>
-                        <div *ngIf="swapForm?.controls['destId']" id="dest-validation" class="validation-container">
+                        <ng-select
+                            [loading]="false"
+                            [clearable]="false"
+                            [items]="destDropDownOptions"
+                            bindLabel="displayLabel"
+                            bindValue="value"
+                            class="custom-select"
+                            formControlName="destId"
+                            (change)="onSlotIdChange()">
+                        </ng-select>
+                        <div *ngIf="swapForm?.controls['destId']" class="validation-container">
                             <div *ngIf="!swapForm.pending && swapForm.invalid && swapForm.errors && swapForm.errors['slotsNotUnique']"
                                 class="error-message">
                                     {{ swapForm.errors['slotsNotUnique'] }}
@@ -205,12 +209,15 @@
                         {{ 'swapActionLabel' | translate }}
                     </div>
                     <div>
-                        <drop-down
-                          [ariaLabel]="'swapActionLabel' | translate"
-                          [control]="!!swapForm ? swapForm.controls['revertSwap'] : null"
-                          [options]="phase2DropDownOptions"
-                          [highlightDirty]="false">
-                        </drop-down>
+                        <ng-select
+                            [loading]="false"
+                            [clearable]="false"
+                            [items]="phase2DropDownOptions"
+                            bindLabel="displayLabel"
+                            bindValue="value"
+                            class="custom-select"
+                            formControlName="revertSwap">
+                        </ng-select>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Revert "Updating AddSlotComponent and SwapSlotsComponent to use <drop-down/> instead of <ng-select/> and setting aria-label attributes"

This reverts commit c0d43c5e48054b50fdf05e44fd5cb6ae49a536cc.