### PR TITLE
Upate password validation condition to only trigger once the password is being typed.

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -68,7 +68,7 @@ export class DeploymentCenterContainerFormBuilder {
         }
       ),
       publishingPassword: Yup.string().test('validateIfNeeded', this._t('userCredsError'), value => {
-        return value && passwordMinimumRequirementsRegex.test(value);
+        return !value || passwordMinimumRequirementsRegex.test(value);
       }),
       // NOTE(michinoy): Cannot use the arrow operator for the test function as 'this' context is required.
       publishingConfirmPassword: Yup.string().test('validateIfNeeded', this._t('nomatchpassword'), function(value) {


### PR DESCRIPTION
Just noticed that the current condition shows and error message on load of the textbox. this update only triggers the error message IF password is being typed and it does not meet the regex standards.