### PR TITLE
[Ibizafication][Integrate] Show message for compiled functions and missing bindings

### DIFF
--- a/client-react/src/models/functions/function-binding.ts
+++ b/client-react/src/models/functions/function-binding.ts
@@ -2,9 +2,14 @@
 // For some reason binding direction is only in/out when
 // stored in Function config.  Binding direction downloaded from templates
 // also have Trigger as a possible direction.
+// Should only be used for FunctionInfo binding direction.
+// For some reason binding direction is only in/out when
+// stored in Function config.  Binding direction downloaded from templates
+// also have Trigger as a possible direction.
 export enum BindingDirection {
   in = 'in',
   out = 'out',
+  trigger = 'trigger',
 }
 
 export enum BindingType {

--- a/client-react/src/models/functions/function-binding.ts
+++ b/client-react/src/models/functions/function-binding.ts
@@ -2,10 +2,6 @@
 // For some reason binding direction is only in/out when
 // stored in Function config.  Binding direction downloaded from templates
 // also have Trigger as a possible direction.
-// Should only be used for FunctionInfo binding direction.
-// For some reason binding direction is only in/out when
-// stored in Function config.  Binding direction downloaded from templates
-// also have Trigger as a possible direction.
 export enum BindingDirection {
   in = 'in',
   out = 'out',

--- a/client-react/src/pages/app/functions/common/BindingFormBuilder.tsx
+++ b/client-react/src/pages/app/functions/common/BindingFormBuilder.tsx
@@ -8,7 +8,7 @@ import Toggle from '../../../../components/form-controls/Toggle';
 import { FormControlWrapper, Layout } from '../../../../components/FormControlWrapper/FormControlWrapper';
 import { Binding, BindingSetting, BindingSettingValue, BindingValidator } from '../../../../models/functions/binding';
 import { BindingInfo, BindingType } from '../../../../models/functions/function-binding';
-import { getFunctionBindingDirection } from '../function/integrate/BindingPanel/BindingEditor';
+import { getFunctionBindingDirection } from '../function/integrate/FunctionIntegrate.utils';
 import { FunctionIntegrateConstants } from '../function/integrate/FunctionIntegrateConstants';
 import HttpMethodMultiDropdown from './HttpMethodMultiDropdown';
 import ResourceDropdown from './ResourceDropdown';

--- a/client-react/src/pages/app/functions/create/CreateCard.tsx
+++ b/client-react/src/pages/app/functions/create/CreateCard.tsx
@@ -1,11 +1,11 @@
-import React, { useContext } from 'react';
-import { ThemeContext } from '../../../../ThemeContext';
-import { getCardStyle, getHeaderStyle, getDescriptionStyle, getTitleStyle, getInfoStyle, getSvg } from './FunctionCreate.styles';
-import { FunctionTemplate } from '../../../../models/functions/function-template';
-import { PivotState } from './FunctionCreate';
 import { KeyCodes } from 'office-ui-fabric-react';
-import { getBindingDirection } from '../function/integrate/BindingPanel/BindingEditor';
+import React, { useContext } from 'react';
+import { FunctionTemplate } from '../../../../models/functions/function-template';
 import { HostStatus } from '../../../../models/functions/host-status';
+import { ThemeContext } from '../../../../ThemeContext';
+import { getBindingDirection } from '../function/integrate/FunctionIntegrate.utils';
+import { PivotState } from './FunctionCreate';
+import { getCardStyle, getDescriptionStyle, getHeaderStyle, getInfoStyle, getSvg, getTitleStyle } from './FunctionCreate.styles';
 
 export interface CreateCardProps {
   functionTemplate: FunctionTemplate;

--- a/client-react/src/pages/app/functions/function/integrate/BindingPanel/BindingCreator.tsx
+++ b/client-react/src/pages/app/functions/function/integrate/BindingPanel/BindingCreator.tsx
@@ -4,17 +4,17 @@ import { IDropdownOption, Link, MessageBar, MessageBarType } from 'office-ui-fab
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ActionBar from '../../../../../../components/ActionBar';
+import Dropdown from '../../../../../../components/form-controls/DropDown';
 import { learnMoreLinkStyle } from '../../../../../../components/form-controls/formControl.override.styles';
 import { FormControlWrapper, Layout } from '../../../../../../components/FormControlWrapper/FormControlWrapper';
 import LoadingComponent from '../../../../../../components/Loading/LoadingComponent';
 import { Binding, BindingDirection } from '../../../../../../models/functions/binding';
 import { BindingInfo, BindingType } from '../../../../../../models/functions/function-binding';
+import { KeyValue } from '../../../../../../models/portal-models';
 import { CommonConstants } from '../../../../../../utils/CommonConstants';
 import { BindingFormBuilder } from '../../../common/BindingFormBuilder';
+import { getFunctionBindingDirection } from '../FunctionIntegrate.utils';
 import { FunctionIntegrateConstants } from '../FunctionIntegrateConstants';
-import { getFunctionBindingDirection } from './BindingEditor';
-import Dropdown from '../../../../../../components/form-controls/DropDown';
-import { KeyValue } from '../../../../../../models/portal-models';
 
 export interface BindingCreatorProps {
   bindingDirection: BindingDirection;

--- a/client-react/src/pages/app/functions/function/integrate/BindingPanel/BindingEditor.tsx
+++ b/client-react/src/pages/app/functions/function/integrate/BindingPanel/BindingEditor.tsx
@@ -3,23 +3,24 @@ import { Link } from 'office-ui-fabric-react';
 import React, { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { style } from 'typestyle';
+import ConfirmDialog from '../../../../../../components/ConfirmDialog/ConfirmDialog';
 import Dropdown from '../../../../../../components/form-controls/DropDown';
 import { FormControlWrapper, Layout } from '../../../../../../components/FormControlWrapper/FormControlWrapper';
 import { ArmObj } from '../../../../../../models/arm-obj';
-import { Binding, BindingDirection } from '../../../../../../models/functions/binding';
-import { BindingDirection as FunctionBindingDirection, BindingInfo } from '../../../../../../models/functions/function-binding';
+import { Binding } from '../../../../../../models/functions/binding';
+import { BindingInfo } from '../../../../../../models/functions/function-binding';
 import { FunctionInfo } from '../../../../../../models/functions/function-info';
 import PortalCommunicator from '../../../../../../portal-communicator';
 import { PortalContext } from '../../../../../../PortalContext';
 import { LogCategories } from '../../../../../../utils/LogCategories';
 import LogService from '../../../../../../utils/LogService';
-import { BindingFormBuilder } from '../../../common/BindingFormBuilder';
-import { FunctionIntegrateConstants } from '../FunctionIntegrateConstants';
-import EditBindingCommandBar from './EditBindingCommandBar';
-import ConfirmDialog from '../../../../../../components/ConfirmDialog/ConfirmDialog';
-import { dialogModelStyle } from '../FunctionIntegrate.style';
-import { DeleteDialog } from './BindingPanel';
 import { ArmFunctionDescriptor } from '../../../../../../utils/resourceDescriptors';
+import { BindingFormBuilder } from '../../../common/BindingFormBuilder';
+import { dialogModelStyle } from '../FunctionIntegrate.style';
+import { getBindingDirection } from '../FunctionIntegrate.utils';
+import { FunctionIntegrateConstants } from '../FunctionIntegrateConstants';
+import { DeleteDialog } from './BindingPanel';
+import EditBindingCommandBar from './EditBindingCommandBar';
 
 export interface BindingEditorProps {
   allBindings: Binding[];
@@ -146,20 +147,6 @@ const BindingEditor: React.SFC<BindingEditorProps> = props => {
       }}
     </Formik>
   );
-};
-
-// Bindings uses 'trigger' as a direction, but functions.json does not
-// These two functions convert between the two kinds
-export const getBindingDirection = (bindingInfo: BindingInfo): BindingDirection => {
-  if (bindingInfo.direction === BindingDirection.in) {
-    return bindingInfo.type.toLowerCase().indexOf('trigger') > -1 ? BindingDirection.trigger : BindingDirection.in;
-  }
-
-  return BindingDirection.out;
-};
-
-export const getFunctionBindingDirection = (bindingDirection: BindingDirection): FunctionBindingDirection => {
-  return bindingDirection === BindingDirection.out ? FunctionBindingDirection.out : FunctionBindingDirection.in;
 };
 
 const onEventGridCreateClick = (functionResourceId: string, portalContext: PortalCommunicator) => {

--- a/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.tsx
+++ b/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.tsx
@@ -204,7 +204,7 @@ export const FunctionIntegrate: React.FunctionComponent<FunctionIntegrateProps> 
   if (bindingsError) {
     // Issue loading bindings or binding settings
     banner = <CustomBanner message={t('integrate_bindingsFailedLoading')} type={MessageBarType.error} />;
-  } else if (isCompiledFunction && functionConfig.bindings.length < 2) {
+  } else if (isCompiledFunction && bindingsMissingDirection.length === 0) {
     // It's a C# compiled function, and older versions of the SDK don't show input/out bindings.
     banner = <CustomBanner message={t('integrate_compiledDoNotShowInputOutput')} type={MessageBarType.info} />;
   } else if (bindingsMissingDirection.length > 0) {

--- a/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.tsx
+++ b/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.tsx
@@ -18,6 +18,7 @@ import { SiteStateContext } from '../../../../../SiteState';
 import { ThemeContext } from '../../../../../ThemeContext';
 import { CommonConstants } from '../../../../../utils/CommonConstants';
 import SiteHelper from '../../../../../utils/SiteHelper';
+import StringUtils from '../../../../../utils/string';
 import FunctionNameBindingCard from './binding-card/FunctionNameBindingCard';
 import InputBindingCard from './binding-card/InputBindingCard';
 import OutputBindingCard from './binding-card/OutputBindingCard';
@@ -34,6 +35,7 @@ import {
   smallPageStyle,
 } from './FunctionIntegrate.style';
 import FunctionIntegrateCommandBar from './FunctionIntegrateCommandBar';
+import { FunctionIntegrateConstants } from './FunctionIntegrateConstants';
 
 export interface FunctionIntegrateProps {
   functionAppId: string;
@@ -188,25 +190,34 @@ export const FunctionIntegrate: React.FunctionComponent<FunctionIntegrateProps> 
     </Stack>
   );
 
-  const isCompiledFunction = functionInfo.properties.config.configurationSource === 'attributes';
-  const bindingsMissingDirection = functionInfo.properties.config.bindings.filter(binding => !binding.direction);
+  const functionConfig = functionInfo.properties.config;
+  const isCompiledFunction = StringUtils.equalsIgnoreCase(
+    functionConfig.configurationSource,
+    FunctionIntegrateConstants.compiledFunctionConfigurationSource
+  );
+
+  const bindingsMissingDirection = functionConfig.bindings.filter(
+    binding => !binding.direction && !StringUtils.endsWithIgnoreCase(binding.type.toString(), 'Trigger')
+  );
 
   let banner: JSX.Element | undefined;
   if (bindingsError) {
+    // Issue loading bindings or binding settings
     banner = <CustomBanner message={t('integrate_bindingsFailedLoading')} type={MessageBarType.error} />;
+  } else if (isCompiledFunction && functionConfig.bindings.length < 2) {
+    // It's a C# compiled function, but we don't older versions of the SDK don't show input/out bindings
+    banner = <CustomBanner message={t('integrate_compiledDoNotShowInputOutput')} type={MessageBarType.info} />;
   } else if (bindingsMissingDirection.length > 0) {
-    if (isCompiledFunction) {
-      banner = <CustomBanner message="Is Compiled functions" type={MessageBarType.warning} />;
-    } else {
-      banner = (
-        <CustomBanner
-          message={t('integrate_bindingsMissingDirection').format(bindingsMissingDirection.map(binding => binding.name).join(', '))}
-          type={MessageBarType.warning}
-          learnMoreLink={CommonConstants.Links.bindingDirectionLearnMore}
-        />
-      );
-    }
+    // Bindings are missing the direction property, we'll likely put them in the wrong spot
+    banner = (
+      <CustomBanner
+        message={t('integrate_bindingsMissingDirection').format(bindingsMissingDirection.map(binding => binding.name).join(', '))}
+        type={MessageBarType.warning}
+        learnMoreLink={CommonConstants.Links.bindingDirectionLearnMore}
+      />
+    );
   } else if (readOnly) {
+    // All readonly situations
     banner = <EditModeBanner />;
   }
 

--- a/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.tsx
+++ b/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.tsx
@@ -188,20 +188,27 @@ export const FunctionIntegrate: React.FunctionComponent<FunctionIntegrateProps> 
     </Stack>
   );
 
+  const isCompiledFunction = functionInfo.properties.config.configurationSource === 'attributes';
   const bindingsMissingDirection = functionInfo.properties.config.bindings.filter(binding => !binding.direction);
-  const banner = bindingsError ? (
-    <CustomBanner message={t('integrate_bindingsFailedLoading')} type={MessageBarType.error} />
-  ) : bindingsMissingDirection.length > 0 ? (
-    <CustomBanner
-      message={t('integrate_bindingsMissingDirection').format(bindingsMissingDirection.map(binding => binding.name).join(', '))}
-      type={MessageBarType.warning}
-      learnMoreLink={CommonConstants.Links.bindingDirectionLearnMore}
-    />
-  ) : readOnly ? (
-    <EditModeBanner />
-  ) : (
-    undefined
-  );
+
+  let banner: JSX.Element | undefined;
+  if (bindingsError) {
+    banner = <CustomBanner message={t('integrate_bindingsFailedLoading')} type={MessageBarType.error} />;
+  } else if (bindingsMissingDirection.length > 0) {
+    if (isCompiledFunction) {
+      banner = <CustomBanner message="Is Compiled functions" type={MessageBarType.warning} />;
+    } else {
+      banner = (
+        <CustomBanner
+          message={t('integrate_bindingsMissingDirection').format(bindingsMissingDirection.map(binding => binding.name).join(', '))}
+          type={MessageBarType.warning}
+          learnMoreLink={CommonConstants.Links.bindingDirectionLearnMore}
+        />
+      );
+    }
+  } else if (readOnly) {
+    banner = <EditModeBanner />;
+  }
 
   return (
     <>

--- a/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.tsx
+++ b/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.tsx
@@ -205,7 +205,7 @@ export const FunctionIntegrate: React.FunctionComponent<FunctionIntegrateProps> 
     // Issue loading bindings or binding settings
     banner = <CustomBanner message={t('integrate_bindingsFailedLoading')} type={MessageBarType.error} />;
   } else if (isCompiledFunction && functionConfig.bindings.length < 2) {
-    // It's a C# compiled function, but we don't older versions of the SDK don't show input/out bindings
+    // It's a C# compiled function, and older versions of the SDK don't show input/out bindings.
     banner = <CustomBanner message={t('integrate_compiledDoNotShowInputOutput')} type={MessageBarType.info} />;
   } else if (bindingsMissingDirection.length > 0) {
     // Bindings are missing the direction property, we'll likely put them in the wrong spot

--- a/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.utils.ts
+++ b/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.utils.ts
@@ -1,0 +1,16 @@
+import { BindingDirection } from '../../../../../models/functions/binding';
+import { BindingDirection as FunctionBindingDirection, BindingInfo } from '../../../../../models/functions/function-binding';
+
+// Bindings uses 'trigger' as a direction, but functions.json does not
+// These two functions convert between the two kinds
+export const getBindingDirection = (bindingInfo: BindingInfo): BindingDirection => {
+  if (bindingInfo.type.toLowerCase().indexOf('trigger') > -1) {
+    return BindingDirection.trigger;
+  }
+
+  return bindingInfo.direction === BindingDirection.in ? BindingDirection.in : BindingDirection.out;
+};
+
+export const getFunctionBindingDirection = (bindingDirection: BindingDirection): FunctionBindingDirection => {
+  return bindingDirection === BindingDirection.out ? FunctionBindingDirection.out : FunctionBindingDirection.in;
+};

--- a/client-react/src/pages/app/functions/function/integrate/FunctionIntegrateConstants.ts
+++ b/client-react/src/pages/app/functions/function/integrate/FunctionIntegrateConstants.ts
@@ -5,4 +5,6 @@ export class FunctionIntegrateConstants {
   public static readonly builtInBindingTypes: string[] = ['httpTrigger', 'timerTrigger', 'http'];
 
   public static readonly rulePrefix: string = 'rule-';
+
+  public static readonly compiledFunctionConfigurationSource: string = 'attributes';
 }

--- a/client-react/src/pages/app/functions/function/integrate/binding-card/InputBindingCard.tsx
+++ b/client-react/src/pages/app/functions/function/integrate/binding-card/InputBindingCard.tsx
@@ -12,8 +12,8 @@ import { PortalContext } from '../../../../../../PortalContext';
 import { ThemeExtended } from '../../../../../../theme/SemanticColorsExtended';
 import { ThemeContext } from '../../../../../../ThemeContext';
 import { BindingFormBuilder } from '../../../common/BindingFormBuilder';
-import { getBindingDirection } from '../BindingPanel/BindingEditor';
 import { BindingEditorContext, BindingEditorContextInfo } from '../FunctionIntegrate';
+import { getBindingDirection } from '../FunctionIntegrate.utils';
 import BindingCard, { createNew, EditableBindingCardProps, editExisting, emptyList } from './BindingCard';
 import { listStyle } from './BindingCard.styles';
 

--- a/client-react/src/pages/app/functions/function/integrate/binding-card/OutputBindingCard.tsx
+++ b/client-react/src/pages/app/functions/function/integrate/binding-card/OutputBindingCard.tsx
@@ -12,8 +12,8 @@ import { PortalContext } from '../../../../../../PortalContext';
 import { ThemeExtended } from '../../../../../../theme/SemanticColorsExtended';
 import { ThemeContext } from '../../../../../../ThemeContext';
 import { BindingFormBuilder } from '../../../common/BindingFormBuilder';
-import { getBindingDirection } from '../BindingPanel/BindingEditor';
 import { BindingEditorContext, BindingEditorContextInfo } from '../FunctionIntegrate';
+import { getBindingDirection } from '../FunctionIntegrate.utils';
 import BindingCard, { createNew, EditableBindingCardProps, editExisting, emptyList } from './BindingCard';
 import { listStyle } from './BindingCard.styles';
 

--- a/client-react/src/pages/app/functions/function/integrate/binding-card/TriggerBindingCard.tsx
+++ b/client-react/src/pages/app/functions/function/integrate/binding-card/TriggerBindingCard.tsx
@@ -12,8 +12,8 @@ import { PortalContext } from '../../../../../../PortalContext';
 import { ThemeExtended } from '../../../../../../theme/SemanticColorsExtended';
 import { ThemeContext } from '../../../../../../ThemeContext';
 import { BindingFormBuilder } from '../../../common/BindingFormBuilder';
-import { getBindingDirection } from '../BindingPanel/BindingEditor';
 import { BindingEditorContext, BindingEditorContextInfo } from '../FunctionIntegrate';
+import { getBindingDirection } from '../FunctionIntegrate.utils';
 import BindingCard, { createNew, EditableBindingCardProps, editExisting, emptyList } from './BindingCard';
 import { listStyle } from './BindingCard.styles';
 

--- a/client-react/src/utils/string.ts
+++ b/client-react/src/utils/string.ts
@@ -27,9 +27,17 @@ export default class StringUtils {
   }
 
   public static isEqualStringArray(items: string[] | null, otherItems: string[] | null): boolean {
-    const itmesSorted = items && items.sort();
+    const itemsSorted = items && items.sort();
     const otherItemsSorted = otherItems && otherItems.sort();
 
-    return isEqual(itmesSorted, otherItemsSorted);
+    return isEqual(itemsSorted, otherItemsSorted);
+  }
+
+  public static equalsIgnoreCase(stringA?: string, stringB?: string): boolean {
+    return !!stringA && !!stringB && stringA.toUpperCase() === stringB.toUpperCase();
+  }
+
+  public static endsWithIgnoreCase(source?: string, substring?: string): boolean {
+    return !!source && !!substring && source.toUpperCase().endsWith(substring.toUpperCase());
   }
 }

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1881,6 +1881,7 @@ export class PortalResources {
   public static integrateDeleteInputConfirmHeader = 'integrateDeleteInputConfirmHeader';
   public static integrateDeleteInputConfirmMessage = 'integrateDeleteInputConfirmMessage';
   public static integrate_bindingsFailedLoading = 'integrate_bindingsFailedLoading';
+  public static integrate_compiledDoNotShowInputOutput = 'integrate_compiledDoNotShowInputOutput';
   public static deleteFunctionKeyHeader = 'deleteFunctionKeyHeader';
   public static deleteFunctionKeyMessage = 'deleteFunctionKeyMessage';
   public static fetchFileContentFailureMessage = 'fetchFileContentFailureMessage';
@@ -2012,8 +2013,8 @@ export class PortalResources {
   public static staticSite_configUpdating = 'staticSite_configUpdating';
   public static staticSite_configUpdateSuccess = 'staticSite_configUpdateSuccess';
   public static staticSite_configUpdateFailure = 'staticSite_configUpdateFailure';
-  public static clickToHideValue = 'clickToHideValue';
   public static clickToShowValue = 'clickToShowValue';
+  public static clickToHideValue = 'clickToHideValue';
   public static testAndRun = 'testAndRun';
   public static appInsightsKeyVaultWarningMessage = 'appInsightsKeyVaultWarningMessage';
   public static clickToUpdateSettings = 'clickToUpdateSettings';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -5817,6 +5817,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="integrate_bindingsFailedLoading" xml:space="preserve">
         <value>One or more bindings failed to load, please refresh the page.</value>
     </data>
+    <data name="integrate_compiledDoNotShowInputOutput" xml:space="preserve">
+        <value>When using compiled functions, bindings defined as attributes may not be shown.</value>
+    </data>
     <data name="deleteFunctionKeyHeader" xml:space="preserve">
         <value>Delete Function Key</value>
     </data>


### PR DESCRIPTION
We will now place the trigger based on the type, not just the direction and also show a banner when we run into a situation with a compiled function and no input/output bindings

![image](https://user-images.githubusercontent.com/37600290/82498095-415ab880-9aa4-11ea-9098-cf8d0db08adc.png)
