### PR TITLE
[Ibizafication] Turn on multiline for all banners

### DIFF
--- a/client-react/src/components/CustomBanner/CustomBanner.tsx
+++ b/client-react/src/components/CustomBanner/CustomBanner.tsx
@@ -36,7 +36,7 @@ const CustomBanner: React.FC<CustomBannerProps> = props => {
     <div>
       <MessageBar
         id={`${id}-custom-banner`}
-        isMultiline={!!undocked}
+        isMultiline={true}
         messageBarType={type}
         styles={messageBannerStyles(!!icon, !!undocked)}
         className={className}


### PR DESCRIPTION
Fixes AB#7024510

Original issue was fixed in the past, but we need to turn on multiline so that we don't ellipses in small, but not quite small enough for reflow.

Before:
![image](https://user-images.githubusercontent.com/37600290/82605366-a842a500-9b6a-11ea-92b9-18ae788537f3.png)

After:
![image](https://user-images.githubusercontent.com/37600290/82605349-a11b9700-9b6a-11ea-8eff-ea3c673af561.png)
