### PR TITLE
AB#7126417 [Visual Requirements - App Service web - App Service Plan - Production] Focus indicator is not visible on the pricing tier buttons.

### DIFF
--- a/client/src/app/site/spec-picker/spec-picker.component.scss
+++ b/client/src/app/site/spec-picker/spec-picker.component.scss
@@ -110,7 +110,6 @@ $center-column-max-width: calc(#{$spec-card-max-width}* 4 - 40px);
     margin: 10px 5px;
     position: relative;
     cursor: pointer;
-    outline: 0 solid $border-selection-color;
 
     h2 {
       color: $body-bg-color;

--- a/client/src/sass/common/_variables.scss
+++ b/client/src/sass/common/_variables.scss
@@ -26,7 +26,7 @@ $back-bar-color: #e8ebed;
 
 $border-selection-color: #0078d4;
 $border-focus-color: #00bcf2;
-$border-focus: $border-focus-color dashed 1px;
+$border-focus: $border-focus-color dashed 2px;
 
 $usermenu-text-color: $heading-text-color;
 $usermenu-border-color: #b3b3b3;


### PR DESCRIPTION
Fixes #7126417

**Before**:
![image](https://user-images.githubusercontent.com/14221995/82608897-56048280-9b70-11ea-980a-cc80583af74b.png)

No focus indicator on the sku's
![image](https://user-images.githubusercontent.com/14221995/82608948-6ae11600-9b70-11ea-9cd3-33d30538d970.png)


**After**:
![image](https://user-images.githubusercontent.com/14221995/82609024-92d07980-9b70-11ea-9042-c07344529d2a.png)

Focus indicator is shown as you move around using arrow keys
![image](https://user-images.githubusercontent.com/14221995/82609097-babfdd00-9b70-11ea-93f2-39a0c6e11f16.png)

![image](https://user-images.githubusercontent.com/14221995/82609255-04a8c300-9b71-11ea-8053-f49a5f240c44.png)

