### PR TITLE
Changed Visual Studio 2017 into Visual Studio 2019.

### DIFF
--- a/server/src/quickstart/cs-CZ/vsDeploymentCenter_cs.md
+++ b/server/src/quickstart/cs-CZ/vsDeploymentCenter_cs.md
@@ -1,6 +1,6 @@
 # Instalace závislostí
 
-Než začnete, měli byste [nainstalovat Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) a ujistit se, že je nainstalovaná i úloha vývoje v Azure.
+Než začnete, měli byste [nainstalovat Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) a ujistit se, že je nainstalovaná i úloha vývoje v Azure.
 
 Až se sada Visual Studio nainstaluje, ujistěte se, že máte [nejnovější nástroje Azure Functions](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/cs-CZ/vsDirectPublish-v2_cs.md
+++ b/server/src/quickstart/cs-CZ/vsDirectPublish-v2_cs.md
@@ -1,6 +1,6 @@
 ### Instalace závislostí
 
-Než začnete, měli byste <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">nainstalovat Visual Studio 2017</a> a ujistit se, že je nainstalovaná i úloha vývoje v Azure.
+Než začnete, měli byste <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">nainstalovat Visual Studio 2019</a> a ujistit se, že je nainstalovaná i úloha vývoje v Azure.
 
 Až se sada Visual Studio nainstaluje, ujistěte se, že máte <a href="https://go.microsoft.com/fwlink/?linkid=2016394" target="_blank">nejnovější nástroje Azure Functions</a>.
 

--- a/server/src/quickstart/cs-CZ/vsDirectPublish_cs.md
+++ b/server/src/quickstart/cs-CZ/vsDirectPublish_cs.md
@@ -1,6 +1,6 @@
 # Instalace závislostí
 
-Než začnete, měli byste [nainstalovat Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) a ujistit se, že je nainstalovaná i úloha vývoje v Azure.
+Než začnete, měli byste [nainstalovat Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) a ujistit se, že je nainstalovaná i úloha vývoje v Azure.
 
 Až se sada Visual Studio nainstaluje, ujistěte se, že máte [nejnovější nástroje Azure Functions](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/fr-FR/vsDeploymentCenter_fr.md
+++ b/server/src/quickstart/fr-FR/vsDeploymentCenter_fr.md
@@ -1,6 +1,6 @@
 # Installer des dépendances
 
-Avant de commencer, vous devez [installer Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) et vous assurer que la charge de travail de développement Azure est également installée.
+Avant de commencer, vous devez [installer Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) et vous assurer que la charge de travail de développement Azure est également installée.
 
 Une fois Visual Studio installé, assurez-vous que vous disposez des [outils Azure Functions les plus récents](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/fr-FR/vsDirectPublish-v2_fr.md
+++ b/server/src/quickstart/fr-FR/vsDirectPublish-v2_fr.md
@@ -1,6 +1,6 @@
 ### Installer des dépendances
 
-Avant de commencer, vous devez <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">installer Visual Studio 2017</a> et vous assurer que la charge de travail de développement Azure est également installée.
+Avant de commencer, vous devez <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">installer Visual Studio 2019</a> et vous assurer que la charge de travail de développement Azure est également installée.
 
 Une fois Visual Studio installé, assurez-vous que vous disposez des <a href="https://go.microsoft.com/fwlink/?linkid=2016394" target="_blank">outils Azure Functions les plus récents</a>.
 

--- a/server/src/quickstart/fr-FR/vsDirectPublish_fr.md
+++ b/server/src/quickstart/fr-FR/vsDirectPublish_fr.md
@@ -1,6 +1,6 @@
 # Installer des dépendances
 
-Avant de commencer, vous devez [installer Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) et vous assurer que la charge de travail de développement Azure est également installée.
+Avant de commencer, vous devez [installer Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) et vous assurer que la charge de travail de développement Azure est également installée.
 
 Une fois Visual Studio installé, assurez-vous que vous disposez des [outils Azure Functions les plus récents](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/hu-HU/vsDeploymentCenter_hu.md
+++ b/server/src/quickstart/hu-HU/vsDeploymentCenter_hu.md
@@ -1,6 +1,6 @@
 # Függőségek telepítése
 
-Kezdés előtt [telepítse a Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389)-et, és győződjön meg arról, hogy az Azure-fejlesztési számítási feladatok is telepítve vannak.
+Kezdés előtt [telepítse a Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389)-et, és győződjön meg arról, hogy az Azure-fejlesztési számítási feladatok is telepítve vannak.
 
 A Visual Studio telepítése után ellenőrizze, hogy rendelkezik-e a [legújabb Azure Functions-eszközökkel](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/hu-HU/vsDirectPublish-v2_hu.md
+++ b/server/src/quickstart/hu-HU/vsDirectPublish-v2_hu.md
@@ -1,6 +1,6 @@
 ### Függőségek telepítése
 
-Kezdés előtt <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">telepítse a Visual Studio 2017</a>-et, és győződjön meg arról, hogy az Azure-fejlesztési számítási feladatok is telepítve vannak.
+Kezdés előtt <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">telepítse a Visual Studio 2019</a>-et, és győződjön meg arról, hogy az Azure-fejlesztési számítási feladatok is telepítve vannak.
 
 A Visual Studio telepítése után ellenőrizze, hogy rendelkezik-e a <a href="https://go.microsoft.com/fwlink/?linkid=2016394" target="_blank">legújabb Azure Functions-eszközökkel</a>.
 

--- a/server/src/quickstart/hu-HU/vsDirectPublish_hu.md
+++ b/server/src/quickstart/hu-HU/vsDirectPublish_hu.md
@@ -1,6 +1,6 @@
 # Függőségek telepítése
 
-Kezdés előtt [telepítse a Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389)-et, és győződjön meg arról, hogy az Azure-fejlesztési számítási feladatok is telepítve vannak.
+Kezdés előtt [telepítse a Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389)-et, és győződjön meg arról, hogy az Azure-fejlesztési számítási feladatok is telepítve vannak.
 
 A Visual Studio telepítése után ellenőrizze, hogy rendelkezik-e a [legújabb Azure Functions-eszközökkel](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/it-IT/vsDeploymentCenter_it.md
+++ b/server/src/quickstart/it-IT/vsDeploymentCenter_it.md
@@ -1,6 +1,6 @@
 # Installare le dipendenze
 
-Prima di iniziare, è necessario [installare Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) e assicurarsi che sia installato anche il carico di lavoro di sviluppo di Azure.
+Prima di iniziare, è necessario [installare Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) e assicurarsi che sia installato anche il carico di lavoro di sviluppo di Azure.
 
 Dopo aver installato Visual Studio, assicurarsi che siano presenti gli [strumenti di Funzioni di Azure più recenti](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/it-IT/vsDirectPublish-v2_it.md
+++ b/server/src/quickstart/it-IT/vsDirectPublish-v2_it.md
@@ -1,6 +1,6 @@
 ### Installare le dipendenze
 
-Prima di iniziare, è necessario <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">installare Visual Studio 2017</a> e assicurarsi che sia installato anche il carico di lavoro di sviluppo di Azure.
+Prima di iniziare, è necessario <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">installare Visual Studio 2019</a> e assicurarsi che sia installato anche il carico di lavoro di sviluppo di Azure.
 
 Dopo aver installato Visual Studio, assicurarsi che siano presenti gli <a href="https://go.microsoft.com/fwlink/?linkid=2016394" target="_blank">strumenti di Funzioni di Azure più recenti</a>.
 

--- a/server/src/quickstart/it-IT/vsDirectPublish_it.md
+++ b/server/src/quickstart/it-IT/vsDirectPublish_it.md
@@ -1,6 +1,6 @@
 # Installare le dipendenze
 
-Prima di iniziare, è necessario [installare Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) e assicurarsi che sia installato anche il carico di lavoro di sviluppo di Azure.
+Prima di iniziare, è necessario [installare Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) e assicurarsi che sia installato anche il carico di lavoro di sviluppo di Azure.
 
 Dopo aver installato Visual Studio, assicurarsi che siano presenti gli [strumenti di Funzioni di Azure più recenti](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/ja-JP/vsDeploymentCenter_ja.md
+++ b/server/src/quickstart/ja-JP/vsDeploymentCenter_ja.md
@@ -1,6 +1,6 @@
 # 依存関係のインストール
 
-作業を開始する前に、[Visual Studio 2017 をインストール](https://go.microsoft.com/fwlink/?linkid=2016389)する必要があります。また、Azure 開発ワークロードもインストールされていることを確認する必要があります。
+作業を開始する前に、[Visual Studio 2019 をインストール](https://go.microsoft.com/fwlink/?linkid=2016389)する必要があります。また、Azure 開発ワークロードもインストールされていることを確認する必要があります。
 
 Visual Studio がインストールされたら、[最新の Azure Functions ツール](https://go.microsoft.com/fwlink/?linkid=2016394)があることを確認します。
 

--- a/server/src/quickstart/ja-JP/vsDirectPublish-v2_ja.md
+++ b/server/src/quickstart/ja-JP/vsDirectPublish-v2_ja.md
@@ -1,6 +1,6 @@
 ### 依存関係のインストール
 
-作業を開始する前に、<a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">Visual Studio 2017 をインストール</a>する必要があります。また、Azure 開発ワークロードもインストールされていることを確認する必要があります。
+作業を開始する前に、<a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">Visual Studio 2019 をインストール</a>する必要があります。また、Azure 開発ワークロードもインストールされていることを確認する必要があります。
 
 Visual Studio がインストールされたら、<a href="https://go.microsoft.com/fwlink/?linkid=2016394" target="_blank">最新の Azure Functions ツール</a>があることを確認します。
 

--- a/server/src/quickstart/ja-JP/vsDirectPublish_ja.md
+++ b/server/src/quickstart/ja-JP/vsDirectPublish_ja.md
@@ -1,6 +1,6 @@
 # 依存関係のインストール
 
-作業を開始する前に、[Visual Studio 2017 をインストール](https://go.microsoft.com/fwlink/?linkid=2016389)する必要があります。また、Azure 開発ワークロードもインストールされていることを確認する必要があります。
+作業を開始する前に、[Visual Studio 2019 をインストール](https://go.microsoft.com/fwlink/?linkid=2016389)する必要があります。また、Azure 開発ワークロードもインストールされていることを確認する必要があります。
 
 Visual Studio がインストールされたら、[最新の Azure Functions ツール](https://go.microsoft.com/fwlink/?linkid=2016394)があることを確認します。
 

--- a/server/src/quickstart/ko-KR/vsDeploymentCenter_ko.md
+++ b/server/src/quickstart/ko-KR/vsDeploymentCenter_ko.md
@@ -1,6 +1,6 @@
 # 종속성 설치
 
-시작하기 전에 [Visual Studio 2017을 설치](https://go.microsoft.com/fwlink/?linkid=2016389)하고 Azure 개발 워크로드 또한 설치되어 있는지 확인해야 합니다.
+시작하기 전에 [Visual Studio 2019을 설치](https://go.microsoft.com/fwlink/?linkid=2016389)하고 Azure 개발 워크로드 또한 설치되어 있는지 확인해야 합니다.
 
 Visual Studio가 설치되면 최신 [Azure Functions 도구](https://go.microsoft.com/fwlink/?linkid=2016394)가 있는지 확인합니다.
 

--- a/server/src/quickstart/ko-KR/vsDirectPublish-v2_ko.md
+++ b/server/src/quickstart/ko-KR/vsDirectPublish-v2_ko.md
@@ -1,6 +1,6 @@
 ### 종속성 설치
 
-시작하기 전에 <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">Visual Studio 2017을 설치</a>하고 Azure 개발 워크로드 또한 설치되어 있는지 확인해야 합니다.
+시작하기 전에 <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">Visual Studio 2019을 설치</a>하고 Azure 개발 워크로드 또한 설치되어 있는지 확인해야 합니다.
 
 Visual Studio가 설치되면 최신 <a href="https://go.microsoft.com/fwlink/?linkid=2016394" target="_blank">Azure Functions 도구</a>가 있는지 확인합니다.
 

--- a/server/src/quickstart/ko-KR/vsDirectPublish_ko.md
+++ b/server/src/quickstart/ko-KR/vsDirectPublish_ko.md
@@ -1,6 +1,6 @@
 # 종속성 설치
 
-시작하기 전에 [Visual Studio 2017을 설치](https://go.microsoft.com/fwlink/?linkid=2016389)하고 Azure 개발 워크로드 또한 설치되어 있는지 확인해야 합니다.
+시작하기 전에 [Visual Studio 2019을 설치](https://go.microsoft.com/fwlink/?linkid=2016389)하고 Azure 개발 워크로드 또한 설치되어 있는지 확인해야 합니다.
 
 Visual Studio가 설치되면 최신 [Azure Functions 도구](https://go.microsoft.com/fwlink/?linkid=2016394)가 있는지 확인합니다.
 

--- a/server/src/quickstart/nl-NL/vsDeploymentCenter_nl.md
+++ b/server/src/quickstart/nl-NL/vsDeploymentCenter_nl.md
@@ -1,6 +1,6 @@
 # Afhankelijkheden installeren
 
-Voordat u aan de slag kunt, moet u [Visual Studio 2017 installeren](https://go.microsoft.com/fwlink/?linkid=2016389) en controleren of de ontwikkelworkload van Azure ook is geïnstalleerd.
+Voordat u aan de slag kunt, moet u [Visual Studio 2019 installeren](https://go.microsoft.com/fwlink/?linkid=2016389) en controleren of de ontwikkelworkload van Azure ook is geïnstalleerd.
 
 Nadat Visual Studio is geïnstalleerd, controleert u of u over de [meest recente Azure Functions-hulpprogramma's beschikt](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/nl-NL/vsDirectPublish-v2_nl.md
+++ b/server/src/quickstart/nl-NL/vsDirectPublish-v2_nl.md
@@ -1,6 +1,6 @@
 ### Afhankelijkheden installeren
 
-Voordat u aan de slag kunt, moet u <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">Visual Studio 2017 installeren</a> en controleren of de ontwikkelworkload van Azure ook is geïnstalleerd.
+Voordat u aan de slag kunt, moet u <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">Visual Studio 2019 installeren</a> en controleren of de ontwikkelworkload van Azure ook is geïnstalleerd.
 
 Nadat Visual Studio is geïnstalleerd, controleert u of u over de <a href="https://go.microsoft.com/fwlink/?linkid=2016394" target="_blank">meest recente Azure Functions-hulpprogramma's beschikt</a>.
 

--- a/server/src/quickstart/nl-NL/vsDirectPublish_nl.md
+++ b/server/src/quickstart/nl-NL/vsDirectPublish_nl.md
@@ -1,6 +1,6 @@
 # Afhankelijkheden installeren
 
-Voordat u aan de slag kunt, moet u [Visual Studio 2017 installeren](https://go.microsoft.com/fwlink/?linkid=2016389) en controleren of de ontwikkelworkload van Azure ook is geïnstalleerd.
+Voordat u aan de slag kunt, moet u [Visual Studio 2019 installeren](https://go.microsoft.com/fwlink/?linkid=2016389) en controleren of de ontwikkelworkload van Azure ook is geïnstalleerd.
 
 Nadat Visual Studio is geïnstalleerd, controleert u of u over de [meest recente Azure Functions-hulpprogramma's beschikt](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/pl-PL/vsDeploymentCenter_pl.md
+++ b/server/src/quickstart/pl-PL/vsDeploymentCenter_pl.md
@@ -1,6 +1,6 @@
 # Instalowanie zależności
 
-Przed rozpoczęciem należy [zainstalować program Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) i upewnić się, że zainstalowany jest także pakiet roboczy projektowania platformy Azure.
+Przed rozpoczęciem należy [zainstalować program Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) i upewnić się, że zainstalowany jest także pakiet roboczy projektowania platformy Azure.
 
 Po zainstalowaniu programu Visual Studio upewnij się, że masz [najnowsze narzędzia usługi Azure Functions](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/pl-PL/vsDirectPublish-v2_pl.md
+++ b/server/src/quickstart/pl-PL/vsDirectPublish-v2_pl.md
@@ -1,6 +1,6 @@
 ### Instalowanie zależności
 
-Przed rozpoczęciem należy <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">zainstalować program Visual Studio 2017</a> i upewnić się, że zainstalowany jest także pakiet roboczy projektowania platformy Azure.
+Przed rozpoczęciem należy <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">zainstalować program Visual Studio 2019</a> i upewnić się, że zainstalowany jest także pakiet roboczy projektowania platformy Azure.
 
 Po zainstalowaniu programu Visual Studio upewnij się, że masz <a href="https://go.microsoft.com/fwlink/?linkid=2016394" target="_blank">najnowsze narzędzia usługi Azure Functions</a>.
 

--- a/server/src/quickstart/pl-PL/vsDirectPublish_pl.md
+++ b/server/src/quickstart/pl-PL/vsDirectPublish_pl.md
@@ -1,6 +1,6 @@
 # Instalowanie zależności
 
-Przed rozpoczęciem należy [zainstalować program Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) i upewnić się, że zainstalowany jest także pakiet roboczy projektowania platformy Azure.
+Przed rozpoczęciem należy [zainstalować program Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) i upewnić się, że zainstalowany jest także pakiet roboczy projektowania platformy Azure.
 
 Po zainstalowaniu programu Visual Studio upewnij się, że masz [najnowsze narzędzia usługi Azure Functions](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/pt-BR/vsDeploymentCenter_pt-BR.md
+++ b/server/src/quickstart/pt-BR/vsDeploymentCenter_pt-BR.md
@@ -1,6 +1,6 @@
 # Instalar dependências
 
-Antes de começar, você deve [instalar o Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) e verificar se a carga de trabalho de desenvolvimento do Azure também está instalada.
+Antes de começar, você deve [instalar o Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) e verificar se a carga de trabalho de desenvolvimento do Azure também está instalada.
 
 Após instalar o Visual Studio, verifique se você tem as [ferramentas do Azure Functions mais recentes](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/pt-BR/vsDirectPublish-v2_pt-BR.md
+++ b/server/src/quickstart/pt-BR/vsDirectPublish-v2_pt-BR.md
@@ -1,6 +1,6 @@
 ### Instalar dependências
 
-Antes de começar, você deve <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">instalar o Visual Studio 2017</a> e verificar se a carga de trabalho de desenvolvimento do Azure também está instalada.
+Antes de começar, você deve <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">instalar o Visual Studio 2019</a> e verificar se a carga de trabalho de desenvolvimento do Azure também está instalada.
 
 Após instalar o Visual Studio, verifique se você tem as <a href="https://go.microsoft.com/fwlink/?linkid=2016394" target="_blank">ferramentas do Azure Functions mais recentes</a>.
 

--- a/server/src/quickstart/pt-BR/vsDirectPublish_pt-BR.md
+++ b/server/src/quickstart/pt-BR/vsDirectPublish_pt-BR.md
@@ -1,6 +1,6 @@
 # Instalar dependências
 
-Antes de começar, você deve [instalar o Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) e verificar se a carga de trabalho de desenvolvimento do Azure também está instalada.
+Antes de começar, você deve [instalar o Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) e verificar se a carga de trabalho de desenvolvimento do Azure também está instalada.
 
 Após instalar o Visual Studio, verifique se você tem as [ferramentas do Azure Functions mais recentes](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/pt-PT/vsDeploymentCenter_pt-PT.md
+++ b/server/src/quickstart/pt-PT/vsDeploymentCenter_pt-PT.md
@@ -1,6 +1,6 @@
 # Instalar dependências
 
-Antes de começar, deve [instalar o Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) e garantir que a carga de trabalho de desenvolvimento do Azure também está instalada.
+Antes de começar, deve [instalar o Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) e garantir que a carga de trabalho de desenvolvimento do Azure também está instalada.
 
 Depois de instalar o Visual Studio, certifique-se de que tem as [ferramentas das Funções do Azure mais recentes](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/pt-PT/vsDirectPublish-v2_pt-PT.md
+++ b/server/src/quickstart/pt-PT/vsDirectPublish-v2_pt-PT.md
@@ -1,6 +1,6 @@
 ### Instalar dependências
 
-Antes de começar, deve <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">instalar o Visual Studio 2017</a> e garantir que a carga de trabalho de desenvolvimento do Azure também está instalada.
+Antes de começar, deve <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">instalar o Visual Studio 2019</a> e garantir que a carga de trabalho de desenvolvimento do Azure também está instalada.
 
 Depois de instalar o Visual Studio, certifique-se de que tem as <a href="https://go.microsoft.com/fwlink/?linkid=2016394" target="_blank">ferramentas das Funções do Azure mais recentes</a>.
 

--- a/server/src/quickstart/pt-PT/vsDirectPublish_pt-PT.md
+++ b/server/src/quickstart/pt-PT/vsDirectPublish_pt-PT.md
@@ -1,6 +1,6 @@
 # Instalar dependências
 
-Antes de começar, deve [instalar o Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) e garantir que a carga de trabalho de desenvolvimento do Azure também está instalada.
+Antes de começar, deve [instalar o Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) e garantir que a carga de trabalho de desenvolvimento do Azure também está instalada.
 
 Depois de instalar o Visual Studio, certifique-se de que tem as [ferramentas das Funções do Azure mais recentes](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/sv-SE/vsDeploymentCenter_sv.md
+++ b/server/src/quickstart/sv-SE/vsDeploymentCenter_sv.md
@@ -1,6 +1,6 @@
 # Installera beroenden
 
-Innan du kan komma igång bör du [installera Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) och se till att arbetsbelastningen Azure Development också är installerad.
+Innan du kan komma igång bör du [installera Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) och se till att arbetsbelastningen Azure Development också är installerad.
 
 När Visual Studio har installerats kontrollerar du att du har [de senaste Azure Functions-verktygen](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/sv-SE/vsDirectPublish-v2_sv.md
+++ b/server/src/quickstart/sv-SE/vsDirectPublish-v2_sv.md
@@ -1,6 +1,6 @@
 ### Installera beroenden
 
-Innan du kan komma igång bör du <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">installera Visual Studio 2017</a> och se till att arbetsbelastningen Azure Development också är installerad.
+Innan du kan komma igång bör du <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">installera Visual Studio 2019</a> och se till att arbetsbelastningen Azure Development också är installerad.
 
 När Visual Studio har installerats kontrollerar du att du har <a href="https://go.microsoft.com/fwlink/?linkid=2016394" target="_blank">de senaste Azure Functions-verktygen</a>.
 

--- a/server/src/quickstart/sv-SE/vsDirectPublish_sv.md
+++ b/server/src/quickstart/sv-SE/vsDirectPublish_sv.md
@@ -1,6 +1,6 @@
 # Installera beroenden
 
-Innan du kan komma igång bör du [installera Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) och se till att arbetsbelastningen Azure Development också är installerad.
+Innan du kan komma igång bör du [installera Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) och se till att arbetsbelastningen Azure Development också är installerad.
 
 När Visual Studio har installerats kontrollerar du att du har [de senaste Azure Functions-verktygen](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/tr-TR/vsDeploymentCenter_tr.md
+++ b/server/src/quickstart/tr-TR/vsDeploymentCenter_tr.md
@@ -1,6 +1,6 @@
 # Bağımlılıkları yükleme
 
-Başlamadan önce, [Visual Studio 2017’yi yüklemeniz](https://go.microsoft.com/fwlink/?linkid=2016389) ve Azure geliştirme iş yükünün de yüklenmiş olduğundan emin olmanız gerekir.
+Başlamadan önce, [Visual Studio 2019’yi yüklemeniz](https://go.microsoft.com/fwlink/?linkid=2016389) ve Azure geliştirme iş yükünün de yüklenmiş olduğundan emin olmanız gerekir.
 
 Visual Studio yüklendiğinde, [en yeni Azure İşlevleri araçlarına](https://go.microsoft.com/fwlink/?linkid=2016394) sahip olduğunuzdan emin olun.
 

--- a/server/src/quickstart/tr-TR/vsDirectPublish-v2_tr.md
+++ b/server/src/quickstart/tr-TR/vsDirectPublish-v2_tr.md
@@ -1,6 +1,6 @@
 ### Bağımlılıkları yükleme
 
-Başlamadan önce, <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">Visual Studio 2017’yi yüklemeniz</a> ve Azure geliştirme iş yükünün de yüklenmiş olduğundan emin olmanız gerekir.
+Başlamadan önce, <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">Visual Studio 2019’yi yüklemeniz</a> ve Azure geliştirme iş yükünün de yüklenmiş olduğundan emin olmanız gerekir.
 
 Visual Studio yüklendiğinde, <a href="https://go.microsoft.com/fwlink/?linkid=2016394" target="_blank">en yeni Azure İşlevleri araçlarına</a> sahip olduğunuzdan emin olun.
 

--- a/server/src/quickstart/tr-TR/vsDirectPublish_tr.md
+++ b/server/src/quickstart/tr-TR/vsDirectPublish_tr.md
@@ -1,6 +1,6 @@
 # Bağımlılıkları yükleme
 
-Başlamadan önce, [Visual Studio 2017’yi yüklemeniz](https://go.microsoft.com/fwlink/?linkid=2016389) ve Azure geliştirme iş yükünün de yüklenmiş olduğundan emin olmanız gerekir.
+Başlamadan önce, [Visual Studio 2019’yi yüklemeniz](https://go.microsoft.com/fwlink/?linkid=2016389) ve Azure geliştirme iş yükünün de yüklenmiş olduğundan emin olmanız gerekir.
 
 Visual Studio yüklendiğinde, [en yeni Azure İşlevleri araçlarına](https://go.microsoft.com/fwlink/?linkid=2016394) sahip olduğunuzdan emin olun.
 

--- a/server/src/quickstart/vsDeploymentCenter.md
+++ b/server/src/quickstart/vsDeploymentCenter.md
@@ -1,6 +1,6 @@
 # Install dependencies
 
-Before you can get started, you should [install Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) and ensure that the Azure development workload is also installed.
+Before you can get started, you should [install Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) and ensure that the Azure development workload is also installed.
 
 Once Visual Studio is installed, make sure you have the [latest Azure Functions tools](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/vsDirectPublish-v2.md
+++ b/server/src/quickstart/vsDirectPublish-v2.md
@@ -1,6 +1,6 @@
 ### Install dependencies
 
-Before you can get started, you should <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">install Visual Studio 2017</a> and ensure that the Azure development workload is also installed.
+Before you can get started, you should <a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">install Visual Studio 2019</a> and ensure that the Azure development workload is also installed.
 
 Once Visual Studio is installed, make sure you have the <a href="https://go.microsoft.com/fwlink/?linkid=2016394" target="_blank">latest Azure Functions tools</a>.
 

--- a/server/src/quickstart/vsDirectPublish.md
+++ b/server/src/quickstart/vsDirectPublish.md
@@ -1,6 +1,6 @@
 # Install dependencies
 
-Before you can get started, you should [install Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) and ensure that the Azure development workload is also installed.
+Before you can get started, you should [install Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) and ensure that the Azure development workload is also installed.
 
 Once Visual Studio is installed, make sure you have the [latest Azure Functions tools](https://go.microsoft.com/fwlink/?linkid=2016394).
 

--- a/server/src/quickstart/zh-CN/vsDeploymentCenter_zh-CN.md
+++ b/server/src/quickstart/zh-CN/vsDeploymentCenter_zh-CN.md
@@ -1,6 +1,6 @@
 # 安装依赖项
 
-开始之前，应[安装 Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) 并确保还安装了 Azure 开发工作负荷。
+开始之前，应[安装 Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) 并确保还安装了 Azure 开发工作负荷。
 
 安装 Visual Studio 后，请确保具有[最新的 Azure Functions 工具](https://go.microsoft.com/fwlink/?linkid=2016394)。
 

--- a/server/src/quickstart/zh-CN/vsDirectPublish-v2_zh-CN.md
+++ b/server/src/quickstart/zh-CN/vsDirectPublish-v2_zh-CN.md
@@ -1,6 +1,6 @@
 ### 安装依赖项
 
-开始之前，应<a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">安装 Visual Studio 2017</a> 并确保还安装了 Azure 开发工作负荷。
+开始之前，应<a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">安装 Visual Studio 2019</a> 并确保还安装了 Azure 开发工作负荷。
 
 安装 Visual Studio 后，请确保具有<a href="https://go.microsoft.com/fwlink/?linkid=2016394" target="_blank">最新的 Azure Functions 工具</a>。
 

--- a/server/src/quickstart/zh-CN/vsDirectPublish_zh-CN.md
+++ b/server/src/quickstart/zh-CN/vsDirectPublish_zh-CN.md
@@ -1,6 +1,6 @@
 # 安装依赖项
 
-开始之前，应[安装 Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389) 并确保还安装了 Azure 开发工作负荷。
+开始之前，应[安装 Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389) 并确保还安装了 Azure 开发工作负荷。
 
 安装 Visual Studio 后，请确保具有[最新的 Azure Functions 工具](https://go.microsoft.com/fwlink/?linkid=2016394)。
 

--- a/server/src/quickstart/zh-TW/vsDeploymentCenter_zh-TW.md
+++ b/server/src/quickstart/zh-TW/vsDeploymentCenter_zh-TW.md
@@ -1,6 +1,6 @@
 # 安裝相依性
 
-開始之前，應[安裝 Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389)，並確定也已安裝 Azure 開發工作負載。
+開始之前，應[安裝 Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389)，並確定也已安裝 Azure 開發工作負載。
 
 安裝 Visual Studio 之後，請確定您擁有[最新版本的 Azure Functions Tools](https://go.microsoft.com/fwlink/?linkid=2016394)。
 

--- a/server/src/quickstart/zh-TW/vsDirectPublish-v2_zh-TW.md
+++ b/server/src/quickstart/zh-TW/vsDirectPublish-v2_zh-TW.md
@@ -1,6 +1,6 @@
 # 安裝相依性
 
-開始之前，應<a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">安裝 Visual Studio 2017</a>，並確定也已安裝 Azure 開發工作負載。
+開始之前，應<a href="https://go.microsoft.com/fwlink/?linkid=2016389" target="_blank">安裝 Visual Studio 2019</a>，並確定也已安裝 Azure 開發工作負載。
 
 安裝 Visual Studio 之後，請確定您擁有<a href="https://go.microsoft.com/fwlink/?linkid=2016394" target="_blank">最新版本的 Azure Functions Tools</a>。
 

--- a/server/src/quickstart/zh-TW/vsDirectPublish_zh-TW.md
+++ b/server/src/quickstart/zh-TW/vsDirectPublish_zh-TW.md
@@ -1,6 +1,6 @@
 # 安裝相依性
 
-開始之前，應[安裝 Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=2016389)，並確定也已安裝 Azure 開發工作負載。
+開始之前，應[安裝 Visual Studio 2019](https://go.microsoft.com/fwlink/?linkid=2016389)，並確定也已安裝 Azure 開發工作負載。
 
 安裝 Visual Studio 之後，請確定您擁有[最新版本的 Azure Functions Tools](https://go.microsoft.com/fwlink/?linkid=2016394)。
 


### PR DESCRIPTION
Hi!

This morning I was looking in the Azure Portal Function's new interface, it is nice, I like it!
There is a button "Develop Locally", when you click on it you can select on the right side of the screen your development environment. If you select "Visual Studio" the text will describe that you have to install Visual Studio 2017:
![image](https://user-images.githubusercontent.com/1397401/82667355-01c4d580-9c38-11ea-81f7-67d178d70dd4.png)

This made me a bit sad, we are already in 2020 and have Visual Studio 2019 :confused:.
After a bit of searching I found this repository and it contains the code for the react panel and the text for the panel, so I hope that by changing the *.md files with "Visual Studio 2017" to "Visual Studio 2019" I can update the text (after you deployed it off course) :grin:.

Thank you in advance!