### PR TITLE
Implemented Deployment Center refresh for client-react

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -85,12 +85,14 @@ export interface DeploymentCenterFtpsProps extends DeploymentCenterFieldProps {
 }
 
 export interface DeploymentCenterContainerFormProps extends DeploymentCenterContainerProps {
+  refresh: () => void;
   showPublishProfilePanel: () => void;
   formData?: DeploymentCenterFormData;
   formValidationSchema?: DeploymentCenterYupValidationSchemaType;
 }
 
 export interface DeploymentCenterCodeFormProps extends DeploymentCenterCodeProps {
+  refresh: () => void;
   showPublishProfilePanel: () => void;
   formData?: DeploymentCenterFormData;
   formValidationSchema?: DeploymentCenterYupValidationSchemaType;
@@ -100,7 +102,7 @@ export interface DeploymentCenterCommandBarProps {
   saveFunction: () => void;
   discardFunction: () => void;
   showPublishProfilePanel: () => void;
-  refreshFunction: () => void;
+  refresh: () => void;
 }
 
 export interface DeploymentCenterPublishProfilePanelProps {

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
@@ -7,7 +7,7 @@ import { SiteStateContext } from '../../../SiteState';
 import { DeploymentCenterCommandBarProps } from './DeploymentCenter.types';
 
 const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = props => {
-  const { saveFunction, discardFunction, showPublishProfilePanel, refreshFunction } = props;
+  const { saveFunction, discardFunction, showPublishProfilePanel, refresh } = props;
   const { t } = useTranslation();
   const siteStateContext = useContext(SiteStateContext);
 
@@ -73,7 +73,7 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
       },
       ariaLabel: t('deploymentCenterRefreshCommandAriaLabel'),
       disabled: !isSiteLoaded(),
-      onClick: refreshFunction,
+      onClick: refresh,
     },
   ];
 

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterDataLoader.tsx
@@ -47,6 +47,7 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
   const [isPublishProfilePanelOpen, setIsPublishProfilePanelOpen] = useState<boolean>(false);
   const [deployments, setDeployments] = useState<ArmArray<DeploymentProperties> | undefined>(undefined);
   const [deploymentsError, setDeploymentsError] = useState<string | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(false);
 
   const deploymentCenterContainerFormBuilder = new DeploymentCenterContainerFormBuilder(t);
 
@@ -81,6 +82,7 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
   };
 
   const fetchData = async () => {
+    setIsLoading(true);
     const writePermissionRequest = portalContext.hasPermission(resourceId, [RbacConstants.writeScope]);
     const getPublishingUserRequest = deploymentCenterData.getPublishingUser();
     const getContainerLogsRequest = deploymentCenterData.fetchContainerLogs(resourceId);
@@ -174,6 +176,9 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
       }
 
       processPublishProfileResponse(publishProfileResponse);
+      setIsLoading(false);
+    } else {
+      setIsLoading(false);
     }
 
     setFormData(deploymentCenterContainerFormBuilder.generateFormData());
@@ -188,6 +193,10 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
     setIsPublishProfilePanelOpen(false);
   };
 
+  const refresh = () => {
+    fetchData();
+  };
+
   useEffect(() => {
     fetchData();
 
@@ -198,7 +207,7 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
     return <LoadingComponent />;
   }
 
-  return (
+  return siteStateContext.site && !isLoading ? (
     <DeploymentCenterContext.Provider value={{ resourceId, hasWritePermission, siteDescriptor }}>
       {isContainerApp(siteStateContext.site) ? (
         <DeploymentCenterContainerForm
@@ -210,6 +219,7 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
           formValidationSchema={formValidationSchema}
           resetApplicationPassword={resetApplicationPassword}
           showPublishProfilePanel={showPublishProfilePanel}
+          refresh={refresh}
         />
       ) : (
         <DeploymentCenterCodeForm
@@ -222,6 +232,7 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
           formValidationSchema={formValidationSchema}
           resetApplicationPassword={resetApplicationPassword}
           showPublishProfilePanel={showPublishProfilePanel}
+          refresh={refresh}
         />
       )}
       <DeploymentCenterPublishProfilePanel
@@ -230,6 +241,8 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
         resetApplicationPassword={resetApplicationPassword}
       />
     </DeploymentCenterContext.Provider>
+  ) : (
+    <LoadingComponent />
   );
 };
 

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterDataLoader.tsx
@@ -203,10 +203,6 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  if (!siteStateContext.site) {
-    return <LoadingComponent />;
-  }
-
   return siteStateContext.site && !isLoading ? (
     <DeploymentCenterContext.Provider value={{ resourceId, hasWritePermission, siteDescriptor }}>
       {isContainerApp(siteStateContext.site) ? (

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
@@ -1,12 +1,17 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Formik, FormikProps } from 'formik';
 import { DeploymentCenterFormData, DeploymentCenterCodeFormProps } from '../DeploymentCenter.types';
 import { KeyCodes } from 'office-ui-fabric-react';
 import DeploymentCenterCommandBar from '../DeploymentCenterCommandBar';
 import { commandBarSticky, pivotContent } from '../DeploymentCenter.styles';
 import DeploymentCenterCodePivot from './DeploymentCenterCodePivot';
+import { useTranslation } from 'react-i18next';
+import ConfirmDialog from '../../../../components/ConfirmDialog/ConfirmDialog';
 
 const DeploymentCenterCodeForm: React.FC<DeploymentCenterCodeFormProps> = props => {
+  const { t } = useTranslation();
+  const [isRefreshConfirmDialogVisible, setIsRefreshConfirmDialogVisible] = useState(false);
+
   const onKeyDown = keyEvent => {
     if ((keyEvent.charCode || keyEvent.keyCode) === KeyCodes.enter) {
       keyEvent.preventDefault();
@@ -22,11 +27,16 @@ const DeploymentCenterCodeForm: React.FC<DeploymentCenterCodeFormProps> = props 
   };
 
   const refreshFunction = () => {
-    throw Error('not implemented');
+    setIsRefreshConfirmDialogVisible(false);
+    props.refresh();
   };
 
   const onSubmit = () => {
     throw Error('not implemented');
+  };
+
+  const hideRefreshConfirmDialog = () => {
+    setIsRefreshConfirmDialogVisible(false);
   };
 
   return (
@@ -44,10 +54,25 @@ const DeploymentCenterCodeForm: React.FC<DeploymentCenterCodeFormProps> = props 
               saveFunction={saveFunction}
               discardFunction={discardFunction}
               showPublishProfilePanel={props.showPublishProfilePanel}
-              refreshFunction={refreshFunction}
+              refresh={() => setIsRefreshConfirmDialogVisible(true)}
             />
           </div>
-
+          <>
+            <ConfirmDialog
+              primaryActionButton={{
+                title: t('ok'),
+                onClick: refreshFunction,
+              }}
+              defaultActionButton={{
+                title: t('cancel'),
+                onClick: hideRefreshConfirmDialog,
+              }}
+              title={t('staticSite_refreshConfirmTitle')}
+              content={t('staticSite_refreshConfirmMessage')}
+              hidden={!isRefreshConfirmDialogVisible}
+              onDismiss={hideRefreshConfirmDialog}
+            />
+          </>
           <div className={pivotContent}>
             <DeploymentCenterCodePivot {...props} formProps={formProps} />
           </div>

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -12,6 +12,7 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
       keyEvent.preventDefault();
     }
   };
+  // change
 
   const saveFunction = () => {
     throw Error('not implemented');

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -1,18 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Formik, FormikProps } from 'formik';
 import { DeploymentCenterFormData, DeploymentCenterContainerFormProps } from '../DeploymentCenter.types';
 import { KeyCodes } from 'office-ui-fabric-react';
 import DeploymentCenterCommandBar from '../DeploymentCenterCommandBar';
 import { commandBarSticky, pivotContent } from '../DeploymentCenter.styles';
 import DeploymentCenterContainerPivot from './DeploymentCenterContainerPivot';
+import ConfirmDialog from '../../../../components/ConfirmDialog/ConfirmDialog';
+import { useTranslation } from 'react-i18next';
 
 const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps> = props => {
+  const { t } = useTranslation();
+  const [isRefreshConfirmDialogVisible, setIsRefreshConfirmDialogVisible] = useState(false);
+
   const onKeyDown = keyEvent => {
     if ((keyEvent.charCode || keyEvent.keyCode) === KeyCodes.enter) {
       keyEvent.preventDefault();
     }
   };
-  // change
 
   const saveFunction = () => {
     throw Error('not implemented');
@@ -23,11 +27,16 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
   };
 
   const refreshFunction = () => {
-    throw Error('not implemented');
+    props.refresh();
   };
 
   const onSubmit = () => {
+    setIsRefreshConfirmDialogVisible(false);
     throw Error('not implemented');
+  };
+
+  const hideRefreshConfirmDialog = () => {
+    setIsRefreshConfirmDialogVisible(false);
   };
 
   return (
@@ -45,10 +54,25 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
               saveFunction={saveFunction}
               discardFunction={discardFunction}
               showPublishProfilePanel={props.showPublishProfilePanel}
-              refreshFunction={refreshFunction}
+              refresh={() => setIsRefreshConfirmDialogVisible(true)}
             />
           </div>
-
+          <>
+            <ConfirmDialog
+              primaryActionButton={{
+                title: t('ok'),
+                onClick: refreshFunction,
+              }}
+              defaultActionButton={{
+                title: t('cancel'),
+                onClick: hideRefreshConfirmDialog,
+              }}
+              title={t('staticSite_refreshConfirmTitle')}
+              content={t('staticSite_refreshConfirmMessage')}
+              hidden={!isRefreshConfirmDialogVisible}
+              onDismiss={hideRefreshConfirmDialog}
+            />
+          </>
           <div className={pivotContent}>
             <DeploymentCenterContainerPivot {...props} formProps={formProps} />
           </div>

--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubDataLoader.tsx
@@ -16,7 +16,7 @@ const DeploymentCenterGitHubDataLoader: React.FC<DeploymentCenterFieldProps> = p
   );
 
   const authorizeGitHubAccount = () => {
-    throw 'Not implemented';
+    throw Error('not implemented');
   };
 
   // TODO(michinoy): We will need to add methods here to manage github specific network calls such as:


### PR DESCRIPTION
Fixes ab#7308736
Note: will do separate PR for making sure Command Bar remains upon refresh but in an inactive state
<img width="1280" alt="dialog" src="https://user-images.githubusercontent.com/25372358/83050983-593db980-a01b-11ea-9cda-e5a5635aa949.PNG">
<img width="1282" alt="reloading" src="https://user-images.githubusercontent.com/25372358/83050986-59d65000-a01b-11ea-8180-87067aff1779.PNG">
