### PR TITLE
Fix width properties for Deployment Center code logs for display on larger screens

### DIFF
--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeLogs.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeLogs.tsx
@@ -98,9 +98,9 @@ const DeploymentCenterCodeLogs: React.FC<DeploymentCenterCodeLogsProps> = props 
   const items: CodeDeploymentsRow[] = rows.sort(dateTimeComparatorReverse);
 
   const columns: IColumn[] = [
-    { key: 'displayTime', name: t('time'), fieldName: 'displayTime', minWidth: 150 },
-    { key: 'commit', name: t('commitId'), fieldName: 'commit', minWidth: 150 },
-    { key: 'status', name: t('status'), fieldName: 'status', minWidth: 210 },
+    { key: 'displayTime', name: t('time'), fieldName: 'displayTime', minWidth: 150, maxWidth: 250 },
+    { key: 'commit', name: t('commitId'), fieldName: 'commit', minWidth: 100, maxWidth: 150 },
+    { key: 'status', name: t('status'), fieldName: 'status', minWidth: 150, maxWidth: 200 },
     { key: 'checkinMessage', name: t('checkinMessage'), fieldName: 'checkinMessage', minWidth: 210 },
   ];
 


### PR DESCRIPTION
Fixes ab#7321067

Sets max-width properties for all columns except checkin message to allow for this property to grow

<img width="1279" alt="width" src="https://user-images.githubusercontent.com/25372358/83190548-96c84280-a100-11ea-91ff-92e57e52fc49.PNG">
