### PR TITLE
[Ibizafication] Remove FormControlWrapper pt1 - Update ReactiveFormControl

### DIFF
--- a/client-react/src/components/form-controls/DropDownnoFormik.tsx
+++ b/client-react/src/components/form-controls/DropDownnoFormik.tsx
@@ -35,6 +35,7 @@ const DropdownNoFormik = (props: IDropdownProps & CustomDropdownProps) => {
         errorMessage={errorMessage}
         {...rest}
         styles={dropdownStyleOverrides(theme, fullpage, widthOverride)}
+        required={false} // ReactiveFormControl will handle displaying required
       />
     </ReactiveFormControl>
   );

--- a/client-react/src/components/form-controls/ReactiveFormControl.tsx
+++ b/client-react/src/components/form-controls/ReactiveFormControl.tsx
@@ -1,22 +1,27 @@
-import React, { ReactNode, useContext } from 'react';
-import { Stack, Label, Link, Icon } from 'office-ui-fabric-react';
+import { Icon, Label, Link, Stack, TooltipHost, TooltipOverflowMode } from 'office-ui-fabric-react';
+import React, { useContext } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useWindowSize } from 'react-use';
+import { style } from 'typestyle';
+import { dirtyElementStyle } from '../../pages/app/app-settings/AppSettings.styles';
+import { ThemeExtended } from '../../theme/SemanticColorsExtended';
+import { ThemeContext } from '../../ThemeContext';
+import { InfoTooltip } from '../InfoTooltip/InfoTooltip';
+import UpsellIcon from '../TooltipIcons/UpsellIcon';
 import {
   controlContainerStyle,
-  upsellIconStyle,
-  infoMessageStyle,
-  infoIconStyle,
-  learnMoreLinkStyle,
-  formStackStyle,
   formLabelStyle,
+  formStackStyle,
+  hostStyle,
+  infoIconStyle,
+  infoMessageStyle,
+  learnMoreLinkStyle,
+  tooltipStyle,
+  upsellIconStyle,
 } from './formControl.override.styles';
-import UpsellIcon from '../TooltipIcons/UpsellIcon';
-import { useWindowSize } from 'react-use';
-import { useTranslation } from 'react-i18next';
-import { ThemeContext } from '../../ThemeContext';
-import { dirtyElementStyle } from '../../pages/app/app-settings/AppSettings.styles';
 
 interface ReactiveFormControlProps {
-  children: ReactNode;
+  children: JSX.Element;
   id: string;
   upsellMessage?: string;
   infoBubbleMessage?: string;
@@ -24,47 +29,67 @@ interface ReactiveFormControlProps {
   learnMoreLink?: string;
   dirty?: boolean;
   formControlClassName?: string;
+  horizontal?: boolean;
+  mouseOverToolTip?: string;
+  required?: boolean;
+  multiline?: boolean;
 }
 
 const ReactiveFormControl = (props: ReactiveFormControlProps) => {
-  const { upsellMessage, label, infoBubbleMessage, learnMoreLink, dirty, formControlClassName } = props;
+  const {
+    upsellMessage,
+    label,
+    infoBubbleMessage,
+    learnMoreLink,
+    dirty,
+    formControlClassName,
+    horizontal,
+    children,
+    id,
+    mouseOverToolTip,
+    required,
+    multiline,
+  } = props;
   const { width } = useWindowSize();
   const { t } = useTranslation();
   const theme = useContext(ThemeContext);
-  const fullpage = width > 1000;
+  const fullPage = width > 1000;
   return (
     <Stack
-      horizontal={fullpage}
+      horizontal={horizontal !== undefined ? horizontal : fullPage}
       verticalAlign="center"
-      className={`${!!formControlClassName ? formControlClassName : ''} ${controlContainerStyle(!!upsellMessage, fullpage)}`}>
+      className={`${!!formControlClassName ? formControlClassName : ''} ${controlContainerStyle(!!upsellMessage, fullPage)}`}>
       {label && (
-        <Stack horizontal verticalAlign="center" className={formStackStyle(!!upsellMessage, fullpage)}>
+        <Stack horizontal verticalAlign="center" className={formStackStyle(!!upsellMessage, fullPage)}>
           {upsellMessage && (
             <div className={upsellIconStyle}>
               <UpsellIcon upsellMessage={upsellMessage} />
             </div>
           )}
           <Label
-            className={`${formLabelStyle(!!upsellMessage, fullpage)} ${dirty ? dirtyElementStyle(theme, true) : ''}`}
-            id={`${props.id}-label`}>
-            {label}
+            className={`${formLabelStyle(!!upsellMessage, fullPage)} ${dirty ? dirtyElementStyle(theme, true) : ''}`}
+            id={`${id}-label`}>
+            <TooltipHost overflowMode={TooltipOverflowMode.Self} content={label} hostClassName={hostStyle(multiline)} styles={tooltipStyle}>
+              {label}
+            </TooltipHost>
+            {getRequiredIcon(theme, required)} {getMouseOverToolTip(`${children.props.id}-tooltip`, mouseOverToolTip)}
           </Label>
         </Stack>
       )}
-      {props.children}
+      {children}
       {infoBubbleMessage && (
-        <div className={infoMessageStyle(fullpage)}>
+        <div className={infoMessageStyle(fullPage)}>
           <Stack horizontal verticalAlign="center">
             <Icon iconName="Info" className={infoIconStyle(theme)} />
             <div>
-              <span id={`${props.id}-infobubble`}>{`${infoBubbleMessage} `}</span>
+              <span id={`${id}-infobubble`}>{`${infoBubbleMessage} `}</span>
               {learnMoreLink && (
                 <Link
-                  id={`${props.id}-learnmore`}
+                  id={`${id}-learnmore`}
                   href={learnMoreLink}
                   target="_blank"
                   className={learnMoreLinkStyle}
-                  aria-labelledby={`${props.id}-infobubble ${props.id}-learnmore`}>
+                  aria-labelledby={`${id}-infobubble ${id}-learnmore`}>
                   {t('learnMore')}
                 </Link>
               )}
@@ -74,6 +99,26 @@ const ReactiveFormControl = (props: ReactiveFormControlProps) => {
       )}
     </Stack>
   );
+};
+
+const getRequiredIcon = (theme: ThemeExtended, required?: boolean) => {
+  if (required) {
+    return (
+      <span
+        className={style({
+          fontWeight: 'bold',
+          color: theme.palette.red,
+        })}>
+        *
+      </span>
+    );
+  }
+};
+
+const getMouseOverToolTip = (id: string, content?: string) => {
+  if (content) {
+    return <InfoTooltip id={id} content={content} />;
+  }
 };
 
 export default ReactiveFormControl;

--- a/client-react/src/components/form-controls/TextFieldNoFormik.tsx
+++ b/client-react/src/components/form-controls/TextFieldNoFormik.tsx
@@ -124,7 +124,7 @@ const TextFieldNoFormik: FC<ITextFieldProps & CustomTextFieldProps> = props => {
           styles={textFieldStyleOverrides(theme, fullpage, widthOverride)}
           onRenderSuffix={onRenderSuffix}
           {...rest}
-          required={false}
+          required={false} // ReactiveFormControl will handle displaying required
         />
         {additionalControls}
       </>

--- a/client-react/src/components/form-controls/TextFieldNoFormik.tsx
+++ b/client-react/src/components/form-controls/TextFieldNoFormik.tsx
@@ -112,19 +112,22 @@ const TextFieldNoFormik: FC<ITextFieldProps & CustomTextFieldProps> = props => {
 
   return (
     <ReactiveFormControl {...props}>
-      <OfficeTextField
-        id={id}
-        aria-labelledby={`${id}-label`}
-        value={hideShowButton && hidden ? CommonConstants.DefaultHiddenValue : value || ''}
-        tabIndex={0}
-        onChange={onChange}
-        onBlur={onBlur}
-        errorMessage={errorMessage}
-        styles={textFieldStyleOverrides(theme, fullpage, widthOverride)}
-        onRenderSuffix={onRenderSuffix}
-        {...rest}
-      />
-      {additionalControls}
+      <>
+        <OfficeTextField
+          id={id}
+          aria-labelledby={`${id}-label`}
+          value={hideShowButton && hidden ? CommonConstants.DefaultHiddenValue : value || ''}
+          tabIndex={0}
+          onChange={onChange}
+          onBlur={onBlur}
+          errorMessage={errorMessage}
+          styles={textFieldStyleOverrides(theme, fullpage, widthOverride)}
+          onRenderSuffix={onRenderSuffix}
+          {...rest}
+          required={false}
+        />
+        {additionalControls}
+      </>
     </ReactiveFormControl>
   );
 };

--- a/client-react/src/components/form-controls/formControl.override.styles.tsx
+++ b/client-react/src/components/form-controls/formControl.override.styles.tsx
@@ -1,5 +1,5 @@
 import { DropDownStyles } from '../../theme/CustomOfficeFabric/AzurePortal/Dropdown.styles';
-import { IDropdownStyles, ITextFieldStyles } from 'office-ui-fabric-react';
+import { IDropdownStyles, ITextFieldStyles, ITooltipHostStyles } from 'office-ui-fabric-react';
 import { style } from 'typestyle';
 import { ThemeExtended } from '../../theme/SemanticColorsExtended';
 import { TextFieldStyles } from '../../theme/CustomOfficeFabric/AzurePortal/TextField.styles';
@@ -91,12 +91,12 @@ export const addEditFormStyle = style({ paddingBottom: '60px' });
 
 export const formStackStyle = (upsellIcon: boolean, fullpage: boolean) =>
   style({
-    width: upsellIcon && fullpage ? '220px' : '200px',
+    minWidth: upsellIcon && fullpage ? '220px' : '200px',
   });
 
 export const formLabelStyle = (upsellIcon: boolean, fullpage: boolean) =>
   style({
-    width: upsellIcon && fullpage ? '220px' : '200px',
+    minWidth: upsellIcon && fullpage ? '220px' : '200px',
     paddingRight: '5px',
   });
 
@@ -106,3 +106,13 @@ export const detailListHeaderStyle = style({
 });
 
 export const filterTextFieldStyle = { root: { marginTop: '5px', height: '25px', width: '300px' } };
+
+export const tooltipStyle: Partial<ITooltipHostStyles> = { root: { display: 'inline', float: 'left' } };
+
+export const hostStyle = (multiline?: boolean) =>
+  style({
+    overflow: !multiline ? 'hidden' : 'visible',
+    textOverflow: 'ellipsis',
+    whiteSpace: !multiline ? 'nowrap' : 'normal',
+    maxWidth: 250,
+  });

--- a/client-react/src/pages/app/functions/common/BindingFormBuilder.tsx
+++ b/client-react/src/pages/app/functions/common/BindingFormBuilder.tsx
@@ -186,45 +186,43 @@ export class BindingFormBuilder {
     }
 
     return (
-      <FormControlWrapper
+      <Field
         label={setting.label}
-        layout={Layout.vertical}
-        tooltip={setting.help}
+        name={setting.name}
+        id={setting.name}
+        component={Dropdown}
+        options={options}
+        disabled={isDisabled}
+        validate={value => this._validateText(value, setting.required, setting.validators)}
+        onPanel={true}
+        horizontal={false}
+        mouseOverToolTip={setting.help}
         required={setting.required}
-        key={setting.name}>
-        <Field
-          name={setting.name}
-          id={setting.name}
-          component={Dropdown}
-          options={options}
-          disabled={isDisabled}
-          validate={value => this._validateText(value, setting.required, setting.validators)}
-          onPanel={true}
-          {...formProps}
-        />
-      </FormControlWrapper>
+        key={setting.name}
+        {...formProps}
+        dirty={false}
+      />
     );
   }
 
   private _getBooleanToggle(setting: BindingSetting, formProps: FormikProps<BindingEditorFormValues>, isDisabled: boolean) {
     return (
-      <FormControlWrapper
+      <Field
         label={setting.label}
-        layout={Layout.vertical}
-        tooltip={setting.help}
+        name={setting.name}
+        id={setting.name}
+        component={Toggle}
+        disabled={isDisabled}
+        onText={this._t('yes')}
+        offText={this._t('no')}
+        validate={(value: boolean) => this._validateBoolean(value, setting.required)}
+        horizontal={false}
+        mouseOverToolTip={setting.help}
         required={setting.required}
-        key={setting.name}>
-        <Field
-          name={setting.name}
-          id={setting.name}
-          component={Toggle}
-          disabled={isDisabled}
-          onText={this._t('yes')}
-          offText={this._t('no')}
-          validate={(value: boolean) => this._validateBoolean(value, setting.required)}
-          {...formProps}
-        />
-      </FormControlWrapper>
+        key={setting.name}
+        {...formProps}
+        dirty={false}
+      />
     );
   }
 
@@ -235,24 +233,23 @@ export class BindingFormBuilder {
     resourceId: string
   ) {
     return (
-      <FormControlWrapper
+      <Field
         label={setting.label}
-        layout={Layout.vertical}
-        tooltip={setting.help}
+        name={setting.name}
+        id={setting.name}
+        component={ResourceDropdown}
+        setting={setting}
+        resourceId={resourceId}
+        disabled={isDisabled}
+        validate={value => this._validateText(value, setting.required, setting.validators)}
+        onPanel={true}
+        horizontal={false}
+        mouseOverToolTip={setting.help}
         required={setting.required}
-        key={setting.name}>
-        <Field
-          name={setting.name}
-          id={setting.name}
-          component={ResourceDropdown}
-          setting={setting}
-          resourceId={resourceId}
-          disabled={isDisabled}
-          validate={value => this._validateText(value, setting.required, setting.validators)}
-          onPanel={true}
-          {...formProps}
-        />
-      </FormControlWrapper>
+        key={setting.name}
+        {...formProps}
+        dirty={false}
+      />
     );
   }
 
@@ -264,23 +261,22 @@ export class BindingFormBuilder {
   ) {
     if (this._bindingInfoList[i].type === BindingType.httpTrigger) {
       return (
-        <FormControlWrapper
+        <Field
           label={setting.label}
-          layout={Layout.vertical}
-          tooltip={setting.help}
+          name={setting.name}
+          id={setting.name}
+          component={HttpMethodMultiDropdown}
+          setting={setting}
+          disabled={isDisabled}
+          validate={value => this._validateText(value, setting.required, setting.validators)}
+          onPanel={true}
+          horizontal={false}
+          mouseOverToolTip={setting.help}
           required={setting.required}
-          key={setting.name}>
-          <Field
-            name={setting.name}
-            id={setting.name}
-            component={HttpMethodMultiDropdown}
-            setting={setting}
-            disabled={isDisabled}
-            validate={value => this._validateText(value, setting.required, setting.validators)}
-            onPanel={true}
-            {...formProps}
-          />
-        </FormControlWrapper>
+          key={setting.name}
+          {...formProps}
+          dirty={false}
+        />
       );
     }
 
@@ -291,24 +287,23 @@ export class BindingFormBuilder {
     }
 
     return (
-      <FormControlWrapper
+      <Field
         label={setting.label}
-        layout={Layout.vertical}
-        tooltip={setting.help}
+        name={setting.name}
+        id={setting.name}
+        component={Dropdown}
+        options={options}
+        multiSelect
+        disabled={isDisabled}
+        validate={value => this._validateText(value, setting.required, setting.validators)}
+        onPanel={true}
+        horizontal={false}
+        mouseOverToolTip={setting.help}
         required={setting.required}
-        key={setting.name}>
-        <Field
-          name={setting.name}
-          id={setting.name}
-          component={Dropdown}
-          options={options}
-          multiSelect
-          disabled={isDisabled}
-          validate={value => this._validateText(value, setting.required, setting.validators)}
-          onPanel={true}
-          {...formProps}
-        />
-      </FormControlWrapper>
+        key={setting.name}
+        {...formProps}
+        dirty={false}
+      />
     );
   }
 

--- a/client-react/src/pages/app/functions/common/BindingFormBuilder.tsx
+++ b/client-react/src/pages/app/functions/common/BindingFormBuilder.tsx
@@ -161,21 +161,20 @@ export class BindingFormBuilder {
 
   private _getTextField(setting: BindingSetting, formProps: FormikProps<BindingEditorFormValues>, isDisabled: boolean) {
     return (
-      <FormControlWrapper
+      <Field
         label={setting.label}
-        layout={Layout.vertical}
-        tooltip={setting.help}
+        name={setting.name}
+        id={setting.name}
+        component={TextField}
+        disabled={isDisabled}
+        validate={value => this._validateText(value, setting.required, setting.validators)}
+        horizontal={false}
+        mouseOverToolTip={setting.help}
         required={setting.required}
-        key={setting.name}>
-        <Field
-          name={setting.name}
-          id={setting.name}
-          component={TextField}
-          disabled={isDisabled}
-          validate={value => this._validateText(value, setting.required, setting.validators)}
-          {...formProps}
-        />
-      </FormControlWrapper>
+        key={setting.name}
+        {...formProps}
+        dirty={false}
+      />
     );
   }
 

--- a/client-react/src/pages/app/functions/common/CreateFunctionFormBuilder.tsx
+++ b/client-react/src/pages/app/functions/common/CreateFunctionFormBuilder.tsx
@@ -7,7 +7,6 @@ import { FunctionInfo } from '../../../../models/functions/function-info';
 import { ArmObj } from '../../../../models/arm-obj';
 import { FormikProps, Field } from 'formik';
 import TextField from '../../../../components/form-controls/TextField';
-import { Layout, FormControlWrapper } from '../../../../components/FormControlWrapper/FormControlWrapper';
 
 export interface CreateFunctionFormValues extends BindingEditorFormValues {
   functionName: string;

--- a/client-react/src/pages/app/functions/common/CreateFunctionFormBuilder.tsx
+++ b/client-react/src/pages/app/functions/common/CreateFunctionFormBuilder.tsx
@@ -57,16 +57,19 @@ export class CreateFunctionFormBuilder extends BindingFormBuilder {
 
   private _getFunctionNameTextField(formProps: FormikProps<CreateFunctionFormValues>, isDisabled: boolean) {
     return (
-      <FormControlWrapper label={this.t('functionCreate_newFunction')} layout={Layout.vertical} key={0} required={true}>
-        <Field
-          name={'functionName'}
-          id={'functionName'}
-          component={TextField}
-          disabled={isDisabled}
-          validate={(value: string) => this._validateFunctionName(value)}
-          {...formProps}
-        />
-      </FormControlWrapper>
+      <Field
+        label={this.t('functionCreate_newFunction')}
+        name={'functionName'}
+        id={'functionName'}
+        component={TextField}
+        disabled={isDisabled}
+        validate={(value: string) => this._validateFunctionName(value)}
+        horizontal={false}
+        required={true}
+        key={0}
+        {...formProps}
+        dirty={false}
+      />
     );
   }
 


### PR DESCRIPTION
Part of AB#6559426

Updating the ReactiveFormControl to have all the functionality of FormControlWrapper. Also setting BindingFormBuilder to use it exclusively.

Followup PRs will change the rest of the uses of FormControlWrapper to start using ReactiveFormControl instead.

Function Create
Before
![image](https://user-images.githubusercontent.com/37600290/83549065-8fff4e00-a4b9-11ea-9326-8920224b793a.png)

After
![image](https://user-images.githubusercontent.com/37600290/83549053-8970d680-a4b9-11ea-9bde-a434888429ef.png)

Function Integrate
Before
![image](https://user-images.githubusercontent.com/37600290/83549150-af967680-a4b9-11ea-93a9-755ec3392837.png)

After
![image](https://user-images.githubusercontent.com/37600290/83549133-aad1c280-a4b9-11ea-8d7c-4df8430f3f2c.png)


Change App Service Plan (Should be no change)
Before
![image](https://user-images.githubusercontent.com/37600290/83547980-e10e4280-a4b7-11ea-8a1d-8695ebd0c74e.png)

After
![image](https://user-images.githubusercontent.com/37600290/83547968-db186180-a4b7-11ea-83aa-e4145ccc6db7.png)

Function Keys (Should be no change)
![image](https://user-images.githubusercontent.com/37600290/83548283-6134a800-a4b8-11ea-9ed2-0e455ad8f8ea.png)

After
![image](https://user-images.githubusercontent.com/37600290/83548265-5843d680-a4b8-11ea-9488-42415945c50f.png)
