### PR TITLE
[Ibizafication][WCAG][Integrate] Convert binding type to use ReactiveFormControl

### DIFF
--- a/client-react/src/pages/app/functions/function/integrate/BindingPanel/BindingCreator.tsx
+++ b/client-react/src/pages/app/functions/function/integrate/BindingPanel/BindingCreator.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import ActionBar from '../../../../../../components/ActionBar';
 import Dropdown from '../../../../../../components/form-controls/DropDown';
 import { learnMoreLinkStyle } from '../../../../../../components/form-controls/formControl.override.styles';
-import { FormControlWrapper, Layout } from '../../../../../../components/FormControlWrapper/FormControlWrapper';
 import LoadingComponent from '../../../../../../components/Loading/LoadingComponent';
 import { Binding, BindingDirection } from '../../../../../../models/functions/binding';
 import { BindingInfo, BindingType } from '../../../../../../models/functions/function-binding';
@@ -73,15 +72,19 @@ const BindingCreator: React.SFC<BindingCreatorProps> = props => {
         return (
           <form>
             <p>{getInstructions(formProps.values.direction, t)}</p>
-            <FormControlWrapper label={t('integrateBindingType')} layout={Layout.vertical}>
-              <Field
-                component={Dropdown}
-                name="type"
-                disabled={onlyBuiltInBindings && dropdownOptions.length === 0}
-                options={dropdownOptions}
-                {...formProps}
-              />
-            </FormControlWrapper>
+            <Field
+              label={t('integrateBindingType')}
+              name="type"
+              id="type"
+              component={Dropdown}
+              options={dropdownOptions}
+              disabled={onlyBuiltInBindings && dropdownOptions.length === 0}
+              onPanel={true}
+              horizontal={false}
+              key="type"
+              {...formProps}
+              dirty={false}
+            />
 
             {/* Extension bundles warning */}
             {onlyBuiltInBindings ? (

--- a/client-react/src/pages/app/functions/function/integrate/BindingPanel/BindingEditor.tsx
+++ b/client-react/src/pages/app/functions/function/integrate/BindingPanel/BindingEditor.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import { style } from 'typestyle';
 import ConfirmDialog from '../../../../../../components/ConfirmDialog/ConfirmDialog';
 import Dropdown from '../../../../../../components/form-controls/DropDown';
-import { FormControlWrapper, Layout } from '../../../../../../components/FormControlWrapper/FormControlWrapper';
 import { ArmObj } from '../../../../../../models/arm-obj';
 import { Binding } from '../../../../../../models/functions/binding';
 import { BindingInfo } from '../../../../../../models/functions/function-binding';
@@ -123,16 +122,20 @@ const BindingEditor: React.SFC<BindingEditorProps> = props => {
                 disabled={readOnly}
               />
               <div className={fieldWrapperStyle}>
-                <FormControlWrapper label={t('integrateBindingType')} layout={Layout.vertical}>
-                  <Field
-                    name="type"
-                    component={Dropdown}
-                    options={[{ key: currentBinding.type, text: currentBinding.displayName }]}
-                    disabled={true}
-                    selectedKey={currentBinding.type}
-                    {...formProps}
-                  />
-                </FormControlWrapper>
+                <Field
+                  label={t('integrateBindingType')}
+                  name="type"
+                  id="type"
+                  component={Dropdown}
+                  options={[{ key: currentBinding.type, text: currentBinding.displayName }]}
+                  disabled={true}
+                  selectedKey={currentBinding.type}
+                  onPanel={true}
+                  horizontal={false}
+                  key="type"
+                  {...formProps}
+                  dirty={false}
+                />
 
                 {builder.getFields(formProps, readOnly || isDisabled, true)}
               </div>


### PR DESCRIPTION
* Fixes missing aria label on drop down

Fixes AB#6559428
Fixes AB#6559479

Before
![image](https://user-images.githubusercontent.com/37600290/83556132-39e3d800-a4c4-11ea-8436-02c82d8a0129.png)

After
![image](https://user-images.githubusercontent.com/37600290/83556116-32243380-a4c4-11ea-9a81-ec7c50d4f453.png)
