### PR TITLE
AB#7121504 [Visual Requirements - App Service web - App Service Plan - Production] Luminosity ratio of the symbol inside the info icon with respect to the icon background color is less than 3:1.

### DIFF
--- a/client/src/app/site/spec-picker/spec-picker.component.scss
+++ b/client/src/app/site/spec-picker/spec-picker.component.scss
@@ -284,7 +284,7 @@ $center-column-max-width: calc(#{$spec-card-max-width}* 4 - 40px);
     }
 
     .message-icon {
-      margin: 0 0 5px 15px;
+      margin: 3px 0 5px 15px;
       height: 24px;
       left: 20px;
     }

--- a/client/src/image/info.svg
+++ b/client/src/image/info.svg
@@ -1,1 +1,8 @@
-<svg viewBox="0 0 50 50" class="fxs-portal-svg" role="presentation" focusable="false" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="FxSymbol0-0ca" width="100%" height="100%"><g><title></title><path d="M47.247 25c0 12.287-9.96 22.246-22.247 22.246S2.753 37.287 2.753 25 12.713 2.753 25 2.753c12.286 0 22.247 9.961 22.247 22.247" class="msportalfx-svg-c16"></path><path d="M25 2.753C12.713 2.753 2.753 12.714 2.753 25c0 5.266 1.84 10.096 4.897 13.906l32.77-29.92c-4-3.851-9.428-6.233-15.42-6.233" class="msportalfx-svg-c15"></path><path d="M28.867 19.518v16.098c0 1.434.166 2.35.499 2.749.333.398.985.626 1.956.684v.782H20.35v-.782c.898-.029 1.564-.29 1.999-.782.289-.333.434-1.217.434-2.651V23.754c0-1.433-.166-2.349-.498-2.748-.334-.398-.979-.627-1.935-.684v-.804h8.517zm-3.041-9.841c.94 0 1.737.33 2.39.989.651.659.976 1.451.976 2.378s-.329 1.717-.987 2.369a3.265 3.265 0 0 1-2.379.977 3.228 3.228 0 0 1-2.369-.977c-.652-.652-.978-1.442-.978-2.369s.326-1.719.978-2.378 1.441-.989 2.369-.989" class="msportalfx-svg-c01"></path></g></svg>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="16px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+<circle fill="#015CDA" cx="8" cy="8" r="8"/>
+<circle fill="#FFFFFF" cx="8" cy="4.116" r="1.449"/>
+<path fill="#FFFFFF" d="M9.1,13.987v-7H6.911l-0.011,7H9.1z"/>
+</svg>


### PR DESCRIPTION
Fixes AB#7121504

Before:
![image](https://user-images.githubusercontent.com/14221995/83577854-2ba8b280-a4ea-11ea-8a47-fcb0601a6694.png)



After:
![image](https://user-images.githubusercontent.com/14221995/83577794-f8feba00-a4e9-11ea-9861-98ca721723a7.png)
