### PR TITLE
[Integrate] Delete fields with empty values

### DIFF
--- a/client-react/src/pages/app/functions/function/integrate/binding-card/BindingCard.tsx
+++ b/client-react/src/pages/app/functions/function/integrate/binding-card/BindingCard.tsx
@@ -135,7 +135,8 @@ const createOrUpdateBinding = (
   // Delete data that isn't needed in function.json
   delete newBindingInfo['newAppSettings'];
   for (const field in newBindingInfo) {
-    if (field.startsWith(FunctionIntegrateConstants.rulePrefix)) {
+    // Delete rules and empty data
+    if (field.startsWith(FunctionIntegrateConstants.rulePrefix) || !newBindingInfo[field]) {
       delete newBindingInfo[field];
     }
   }


### PR DESCRIPTION
Fixes AB#7363182

Instead of empty fields we want to remove them entirely from the object we save. Some optional fields can't handle having empty strings

Also this will be necessary for when we add in optional drop down options, we will want to remove the blank entries from the model then as well See AB#7429210 for that