### PR TITLE
Moved build provider dropdown to build component

### DIFF
--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { DeploymentCenterFieldProps, DeploymentCenterCodeFormData, WorkflowOption } from '../DeploymentCenter.types';
+import { DeploymentCenterFieldProps, DeploymentCenterCodeFormData } from '../DeploymentCenter.types';
 import DeploymentCenterGitHubDataLoader from '../github-provider/DeploymentCenterGitHubDataLoader';
 import { ScmType, BuildProvider } from '../../../../models/site/config';
 import DeploymentCenterCodeBuild from './DeploymentCenterCodeBuild';
@@ -7,20 +7,17 @@ import { DeploymentCenterContext } from '../DeploymentCenterContext';
 import DeploymentCenterGitHubReadOnly from '../github-provider/DeploymentCenterGitHubReadOnly';
 import DeploymentCenterCodeBuildReadOnly from './DeploymentCenterCodeBuildReadOnly';
 import DeploymentCenterGitHubWorkflowConfig from '../github-provider/DeploymentCenterGitHubWorkflowConfig';
-import DeploymentCenterCodeSourceAndBuild from './DeploymentCenterCodeSourceAndBuild';
 import DeploymentCenterGitHubWorkflowConfigSelector from '../github-provider/DeploymentCenterGitHubWorkflowConfigSelector';
+import DeploymentCenterCodeSource from './DeploymentCenterCodeSource';
 
 const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<DeploymentCenterCodeFormData>> = props => {
   const { formProps } = props;
   const deploymentCenterContext = useContext(DeploymentCenterContext);
 
+  const isSourceSelected = formProps && formProps.values.sourceProvider !== ScmType.None;
   const isGitHubSource = formProps && formProps.values.sourceProvider === ScmType.GitHub;
   const isGitHubActionsBuild = formProps && formProps.values.buildProvider === BuildProvider.GitHubAction;
   const isDeploymentSetup = deploymentCenterContext.siteConfig && deploymentCenterContext.siteConfig.properties.scmType !== ScmType.None;
-  const isUsingExistingOrAvailableWorkflowConfig =
-    formProps &&
-    (formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig ||
-      formProps.values.workflowOption === WorkflowOption.UseAvailableWorkflowConfigs);
 
   const disconnectCallback = () => {
     throw Error('not implemented');
@@ -35,14 +32,14 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
         </>
       ) : (
         <>
-          <DeploymentCenterCodeSourceAndBuild formProps={formProps} />
+          <DeploymentCenterCodeSource />
           {isGitHubSource && (
             <>
               <DeploymentCenterGitHubDataLoader formProps={formProps} />
               {isGitHubActionsBuild && <DeploymentCenterGitHubWorkflowConfigSelector formProps={formProps} />}
             </>
           )}
-          {isGitHubActionsBuild && !isUsingExistingOrAvailableWorkflowConfig && <DeploymentCenterCodeBuild formProps={formProps} />}
+          {isSourceSelected && <DeploymentCenterCodeBuild formProps={formProps} />}
           <DeploymentCenterGitHubWorkflowConfig formProps={formProps} />
         </>
       )}

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSource.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSource.tsx
@@ -1,7 +1,7 @@
-import React, { useContext, useState, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IDropdownOption, DropdownMenuItemType, Link, MessageBarType } from 'office-ui-fabric-react';
-import { BuildProvider, ScmType } from '../../../../models/site/config';
+import { ScmType } from '../../../../models/site/config';
 import { Field } from 'formik';
 import Dropdown from '../../../../components/form-controls/DropDown';
 import { learnMoreLinkStyle } from '../../../../components/form-controls/formControl.override.styles';
@@ -9,13 +9,10 @@ import { DeploymentCenterLinks } from '../../../../utils/FwLinks';
 import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
 import { DeploymentCenterContext } from '../DeploymentCenterContext';
 import { deploymentCenterInfoBannerDiv } from '../DeploymentCenter.styles';
-import { BuildDropdownOption, DeploymentCenterFieldProps, DeploymentCenterCodeFormData } from '../DeploymentCenter.types';
 
-const DeploymentCenterCodeSourceAndBuild: React.FC<DeploymentCenterFieldProps<DeploymentCenterCodeFormData>> = props => {
-  const { formProps } = props;
+const DeploymentCenterCodeSource: React.FC<{}> = props => {
+  // const { formProps } = props;
   const { t } = useTranslation();
-
-  const [selectedBuild, setSelectedBuild] = useState<BuildProvider>(BuildProvider.None);
 
   const deploymentCenterContext = useContext(DeploymentCenterContext);
 
@@ -43,40 +40,6 @@ const DeploymentCenterCodeSourceAndBuild: React.FC<DeploymentCenterFieldProps<De
     { key: ScmType.Dropbox, text: t('deploymentCenterCodeSettingsSourceDropbox') },
     { key: ScmType.ExternalGit, text: t('deploymentCenterCodeSettingsSourceExternal') },
   ];
-
-  const buildOptions: BuildDropdownOption[] = [
-    { key: BuildProvider.GitHubAction, text: t('deploymentCenterCodeSettingsBuildGitHubAction'), buildType: BuildProvider.GitHubAction },
-    {
-      key: BuildProvider.AppServiceBuildService,
-      text: t('deploymentCenterCodeSettingsBuildKudu'),
-      buildType: BuildProvider.AppServiceBuildService,
-    },
-  ];
-
-  const updateSelectedBuild = (e: any, option: BuildDropdownOption) => {
-    setSelectedBuild(option.buildType);
-    if (formProps) {
-      formProps.setFieldValue('buildProvider', option.buildType);
-    }
-  };
-
-  const isSourceSelected = formProps && formProps.values.sourceProvider !== ScmType.None;
-  const isGitHubSource = formProps && formProps.values.sourceProvider === ScmType.GitHub;
-
-  useEffect(
-    () => {
-      if (formProps && formProps.values.sourceProvider !== ScmType.GitHub) {
-        setSelectedBuild(BuildProvider.AppServiceBuildService);
-        formProps.setFieldValue('buildProvider', BuildProvider.AppServiceBuildService);
-      }
-
-      if (formProps && formProps.values.sourceProvider === ScmType.GitHub) {
-        setSelectedBuild(BuildProvider.GitHubAction);
-        formProps.setFieldValue('buildProvider', BuildProvider.GitHubAction);
-      }
-    }, // eslint-disable-next-line react-hooks/exhaustive-deps
-    formProps ? [formProps.values.sourceProvider] : []
-  );
 
   return (
     <>
@@ -108,23 +71,8 @@ const DeploymentCenterCodeSourceAndBuild: React.FC<DeploymentCenterFieldProps<De
         options={sourceOptions}
         required={true}
       />
-
-      {isSourceSelected && (
-        <Field
-          id="deployment-center-code-settings-build-option"
-          label={t('deploymentCenterSettingsBuildLabel')}
-          name="buildProvider"
-          component={Dropdown}
-          displayInVerticalLayout={true}
-          options={buildOptions}
-          selectedKey={selectedBuild}
-          onChange={updateSelectedBuild}
-          required={true}
-          disabled={!isGitHubSource}
-        />
-      )}
     </>
   );
 };
 
-export default DeploymentCenterCodeSourceAndBuild;
+export default DeploymentCenterCodeSource;


### PR DESCRIPTION
Moved build provider dropdown to under the build label. It was previously directly under the source dropdown.
<img width="1235" alt="github" src="https://user-images.githubusercontent.com/25372358/85415914-de918c80-b53b-11ea-9602-508da5d298b7.PNG">
<img width="1192" alt="other" src="https://user-images.githubusercontent.com/25372358/85415878-d20d3400-b53b-11ea-8043-d9062b4b9e24.PNG">

