### PR TITLE
ComputeMode, SpecGroup, SpecSection are now strings passed from backend

### DIFF
--- a/client-react/src/models/pricingtier.ts
+++ b/client-react/src/models/pricingtier.ts
@@ -8,9 +8,9 @@ export interface PricingTier {
   currencyCode: string;
   isLinux: boolean;
   isXenon: boolean;
-  specGroup: number;
-  specSection: number;
-  computeMode: number;
+  specGroup: string;
+  specSection: string;
+  computeMode: string;
   numberOfCores: number;
   memorySize: number;
   osVersion: string;

--- a/client-react/src/models/site/compute-mode.ts
+++ b/client-react/src/models/site/compute-mode.ts
@@ -1,5 +1,5 @@
 export enum ComputeMode {
-  Shared = 0,
-  Dedicated,
-  Dynamic,
+  Shared = 'Shared',
+  Dedicated = 'Dedicated',
+  Dynamic = 'Dynamic',
 }

--- a/client/src/app/shared/models/arm/pricingtier.ts
+++ b/client/src/app/shared/models/arm/pricingtier.ts
@@ -8,9 +8,9 @@ export interface PricingTier {
   currencyCode: string;
   isLinux: boolean;
   isXenon: boolean;
-  specGroup: number;
-  specSection: number;
-  computeMode: number;
+  specGroup: string;
+  specSection: string;
+  computeMode: string;
   numberOfCores: number;
   memorySize: number;
   osVersion: string;

--- a/client/src/app/shared/models/arm/site.ts
+++ b/client/src/app/shared/models/arm/site.ts
@@ -1,9 +1,9 @@
 import { HostingEnvironmentProfile } from './hosting-environment';
 
 export enum ComputeMode {
-  Shared,
-  Dedicated,
-  Dynamic,
+  Shared = 'Shared',
+  Dedicated = 'Dedicated',
+  Dynamic = 'Dynamic',
 }
 
 export enum SiteAvailabilityState {

--- a/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
@@ -35,14 +35,14 @@ export enum BannerMessageLevel {
 }
 
 export enum SpecGroup {
-  Development = 0,
-  Production,
-  Isolated,
+  Development = 'Development',
+  Production = 'Production',
+  Isolated = 'Isolated',
 }
 
 export enum SpecSection {
-  Recommended = 0,
-  Additional,
+  Recommended = 'Recommended',
+  Additional = 'Additional',
 }
 
 export interface BannerMessage {
@@ -109,7 +109,7 @@ export class GenericSpecGroup extends PriceSpecGroup {
   }
 
   initialize(input: PriceSpecInput) {
-    this.pricingTiers.value.forEach(pricingTier => {
+    this.pricingTiers.value.forEach((pricingTier) => {
       if (input.plan) {
         if (input.plan.properties.hyperV !== pricingTier.properties.isXenon) {
           return;


### PR DESCRIPTION
It was a bug that the backend returned integer for enum values on api version 2018-11-01. It should return string. With that fixed. The entity receiving the data need to be changed too