### PR TITLE
[Functions][Logs] Add more event tracking for logs in editor

### DIFF
--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
@@ -43,6 +43,7 @@ import { ScenarioIds } from '../../../../../utils/scenario-checker/scenario-ids'
 import { getErrorMessageOrStringify } from '../../../../../ApiHelpers/ArmHelper';
 import { FunctionEditorContext } from './FunctionEditorDataLoader';
 import { isLinuxDynamic } from '../../../../../utils/arm-utils';
+import Url from '../../../../../utils/url';
 
 export interface FunctionEditorProps {
   functionInfo: ArmObj<FunctionInfo>;
@@ -132,7 +133,7 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
     );
     if (fileResponse.metadata.success) {
       setFileContent({ ...fileContent, default: fileContent.latest });
-      setLogPanelExpanded(true);
+      expandLogPanelAndTrackEvent();
       setFileSavedCount(fileSavedCount + 1);
     }
     setSavingFile(false);
@@ -180,7 +181,7 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
     }
     const tempFunctionInfo = functionInfo;
     tempFunctionInfo.properties.test_data = data;
-    setLogPanelExpanded(true);
+    expandLogPanelAndTrackEvent();
     props.run(tempFunctionInfo, values.xFunctionKey);
   };
 
@@ -309,7 +310,11 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
   };
 
   const toggleLogPanelExpansion = () => {
-    setLogPanelExpanded(!logPanelExpanded);
+    if (!logPanelExpanded) {
+      expandLogPanelAndTrackEvent();
+    } else {
+      closeLogPanelAndTrackEvent();
+    }
   };
 
   const getReadOnlyBannerHeight = () => {
@@ -342,6 +347,22 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
 
   const isSelectedFileBlacklisted = () => {
     return functionEditorContext.isBlacklistedFile(!!selectedFile ? (selectedFile.key as string) : '');
+  };
+
+  const expandLogPanelAndTrackEvent = () => {
+    setLogPanelExpanded(true);
+    LogService.trackEvent(LogCategories.functionLog, 'functionEditor-logPanelExpanded', {
+      resourceId: siteStateContext.resourceId,
+      sessionId: Url.getParameterByName(null, 'sessionId'),
+    });
+  };
+
+  const closeLogPanelAndTrackEvent = () => {
+    setLogPanelExpanded(false);
+    LogService.trackEvent(LogCategories.functionLog, 'functionEditor-logPanelClosed', {
+      resourceId: siteStateContext.resourceId,
+      sessionId: Url.getParameterByName(null, 'sessionId'),
+    });
   };
 
   useEffect(() => {

--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
@@ -133,7 +133,7 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
     );
     if (fileResponse.metadata.success) {
       setFileContent({ ...fileContent, default: fileContent.latest });
-      expandLogPanelAndTrackEvent();
+      expandLogPanel();
       setFileSavedCount(fileSavedCount + 1);
     }
     setSavingFile(false);
@@ -181,7 +181,7 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
     }
     const tempFunctionInfo = functionInfo;
     tempFunctionInfo.properties.test_data = data;
-    expandLogPanelAndTrackEvent();
+    expandLogPanel();
     props.run(tempFunctionInfo, values.xFunctionKey);
   };
 
@@ -311,9 +311,9 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
 
   const toggleLogPanelExpansion = () => {
     if (!logPanelExpanded) {
-      expandLogPanelAndTrackEvent();
+      expandLogPanel();
     } else {
-      closeLogPanelAndTrackEvent();
+      closeLogPanel();
     }
   };
 
@@ -349,7 +349,7 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
     return functionEditorContext.isBlacklistedFile(!!selectedFile ? (selectedFile.key as string) : '');
   };
 
-  const expandLogPanelAndTrackEvent = () => {
+  const expandLogPanel = () => {
     setLogPanelExpanded(true);
     LogService.trackEvent(LogCategories.functionLog, 'functionEditor-logPanelExpanded', {
       resourceId: siteStateContext.resourceId,
@@ -357,7 +357,7 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
     });
   };
 
-  const closeLogPanelAndTrackEvent = () => {
+  const closeLogPanel = () => {
     setLogPanelExpanded(false);
     LogService.trackEvent(LogCategories.functionLog, 'functionEditor-logPanelClosed', {
       resourceId: siteStateContext.resourceId,

--- a/client-react/src/pages/app/functions/function/function-log/FunctionLogCommandBar.tsx
+++ b/client-react/src/pages/app/functions/function/function-log/FunctionLogCommandBar.tsx
@@ -8,6 +8,10 @@ import { ArmResourceDescriptor } from '../../../../../utils/resourceDescriptors'
 import { LogLevel } from './FunctionLog.types';
 import { LoggingOptions } from '../function-editor/FunctionEditor.types';
 import FunctionLogOptionsCallout from './FunctionLogOptionsCallout';
+import LogService from '../../../../../utils/LogService';
+import { LogCategories } from '../../../../../utils/LogCategories';
+import Url from '../../../../../utils/url';
+import { SiteStateContext } from '../../../../../SiteState';
 
 interface FunctionLogCommandBarProps {
   isPanelVisible: boolean;
@@ -49,6 +53,7 @@ const FunctionLogCommandBar: React.FC<FunctionLogCommandBarProps> = props => {
     selectedLoggingOption,
   } = props;
   const portalContext = useContext(PortalContext);
+  const siteStateContext = useContext(SiteStateContext);
   const { t } = useTranslation();
 
   const [isLoggingOptionConfirmCallOutVisible, setIsLoggingOptionConfirmCallOutVisible] = useState(false);
@@ -111,6 +116,10 @@ const FunctionLogCommandBar: React.FC<FunctionLogCommandBarProps> = props => {
         setIsLoggingOptionConfirmCallOutVisible(true);
       } else {
         props.setSelectedLoggingOption(LoggingOptions.appInsights);
+        LogService.trackEvent(LogCategories.functionLog, 'appInsights-logging-selected', {
+          resourceId: siteStateContext.resourceId,
+          sessionId: Url.getParameterByName(null, 'sessionId'),
+        });
       }
     }
   };


### PR DESCRIPTION
More work for AB#7613298

1) Track when customer expands log panel so we can see what percentage of users who open logs are switching to Filed-Based
2) Track if customer switches back to App Insights Logs from File-Based