### PR TITLE
[Slots] Fixed issues relating to using boolean values

### DIFF
--- a/client/src/app/site/slots/swap-slots/swap-slots.component.html
+++ b/client/src/app/site/slots/swap-slots/swap-slots.component.html
@@ -240,7 +240,7 @@
                 class="custom-button"
                 [disabled]="executeButtonDisabled || !swapForm || swapForm.pending || !swapForm.valid"
                 (click)="executePhase2()">
-                {{ (swapForm && swapForm.controls['revertSwap'].value === 'cancel' ? 'cancelSwap' : 'completeSwap') | translate }}
+                {{ (swapForm && swapForm.controls['revertSwap'].value === stage2OptionData.CancelSwap ? 'cancelSwap' : 'completeSwap') | translate }}
             </button>
 
             <button

--- a/client/src/app/site/slots/swap-slots/swap-slots.component.html
+++ b/client/src/app/site/slots/swap-slots/swap-slots.component.html
@@ -240,7 +240,7 @@
                 class="custom-button"
                 [disabled]="executeButtonDisabled || !swapForm || swapForm.pending || !swapForm.valid"
                 (click)="executePhase2()">
-                {{ (swapForm && swapForm.controls['revertSwap'].value ? 'cancelSwap' : 'completeSwap') | translate }}
+                {{ (swapForm && swapForm.controls['revertSwap'].value === 'cancel' ? 'cancelSwap' : 'completeSwap') | translate }}
             </button>
 
             <button

--- a/client/src/app/site/slots/swap-slots/swap-slots.component.ts
+++ b/client/src/app/site/slots/swap-slots/swap-slots.component.ts
@@ -38,6 +38,11 @@ export type SwapStep =
   | 'phase2-complete'
   | 'complete';
 
+export enum Stage2OptionData {
+  CompleteSwap = 'complete',
+  CancelSwap = 'cancel',
+}
+
 export interface SwapSlotParameters extends SlotSwapInfo {
   uri: string;
   content?: any;
@@ -52,6 +57,10 @@ export type StickySettingValue = null | string | ConnectionString;
   styleUrls: ['./../common.scss', './swap-slots.component.scss'],
 })
 export class SwapSlotsComponent extends FeatureComponent<ResourceId> implements OnDestroy {
+  get stage2OptionData() {
+    return Stage2OptionData;
+  }
+
   @Input()
   set resourceIdInput(resourceId: ResourceId) {
     this._resourceId = resourceId;
@@ -86,7 +95,7 @@ export class SwapSlotsComponent extends FeatureComponent<ResourceId> implements 
   public showPreviewChanges = true;
 
   public showPhase2Controls = false;
-  public phase2DropDownOptions: DropDownElement<string>[];
+  public phase2DropDownOptions: DropDownElement<Stage2OptionData>[];
   public previewLink: string;
   public showPreviewLink = false;
 
@@ -146,12 +155,12 @@ export class SwapSlotsComponent extends FeatureComponent<ResourceId> implements 
     this.phase2DropDownOptions = [
       {
         displayLabel: this._translateService.instant(PortalResources.completeSwap),
-        value: 'complete',
+        value: Stage2OptionData.CompleteSwap,
         default: true,
       },
       {
         displayLabel: this._translateService.instant(PortalResources.cancelSwap),
-        value: 'cancel',
+        value: Stage2OptionData.CancelSwap,
         default: false,
       },
     ];
@@ -329,7 +338,7 @@ export class SwapSlotsComponent extends FeatureComponent<ResourceId> implements 
 
     const multiPhaseCtrl = this._fb.control({ value: false, disabled: true });
 
-    const revertSwapCtrl = this._fb.control({ value: 'complete', disabled: true });
+    const revertSwapCtrl = this._fb.control({ value: Stage2OptionData.CompleteSwap, disabled: true });
 
     this.swapForm = this._fb.group({
       srcId: srcIdCtrl,
@@ -513,7 +522,7 @@ export class SwapSlotsComponent extends FeatureComponent<ResourceId> implements 
   executePhase2() {
     this._setupPhase2Executing();
 
-    if (this.swapForm.controls['revertSwap'].value === 'cancel') {
+    if (this.swapForm.controls['revertSwap'].value === Stage2OptionData.CancelSwap) {
       this._resetSlotConfig();
     } else {
       this._slotsSwap(true);

--- a/client/src/app/site/slots/swap-slots/swap-slots.component.ts
+++ b/client/src/app/site/slots/swap-slots/swap-slots.component.ts
@@ -86,7 +86,7 @@ export class SwapSlotsComponent extends FeatureComponent<ResourceId> implements 
   public showPreviewChanges = true;
 
   public showPhase2Controls = false;
-  public phase2DropDownOptions: DropDownElement<boolean>[];
+  public phase2DropDownOptions: DropDownElement<string>[];
   public previewLink: string;
   public showPreviewLink = false;
 
@@ -146,12 +146,12 @@ export class SwapSlotsComponent extends FeatureComponent<ResourceId> implements 
     this.phase2DropDownOptions = [
       {
         displayLabel: this._translateService.instant(PortalResources.completeSwap),
-        value: false,
+        value: 'complete',
         default: true,
       },
       {
         displayLabel: this._translateService.instant(PortalResources.cancelSwap),
-        value: true,
+        value: 'cancel',
         default: false,
       },
     ];
@@ -329,7 +329,7 @@ export class SwapSlotsComponent extends FeatureComponent<ResourceId> implements 
 
     const multiPhaseCtrl = this._fb.control({ value: false, disabled: true });
 
-    const revertSwapCtrl = this._fb.control({ value: false, disabled: true });
+    const revertSwapCtrl = this._fb.control({ value: 'complete', disabled: true });
 
     this.swapForm = this._fb.group({
       srcId: srcIdCtrl,
@@ -513,7 +513,7 @@ export class SwapSlotsComponent extends FeatureComponent<ResourceId> implements 
   executePhase2() {
     this._setupPhase2Executing();
 
-    if (this.swapForm.controls['revertSwap'].value) {
+    if (this.swapForm.controls['revertSwap'].value === 'cancel') {
       this._resetSlotConfig();
     } else {
       this._slotsSwap(true);


### PR DESCRIPTION
Fixes AB#5561926

Part of the UI broke when using the 2 stage slot swap. The issue was due to how angular interpreted the boolean value of the drop down (translated it into a string), instead of trying to handle that in old code, decided to go with changing the data to string instead since it just powers controls and isn't saved anywhere