### PR TITLE
Disable FTP options IF disable policy is set

### DIFF
--- a/client-react/src/ApiHelpers/SiteService.ts
+++ b/client-react/src/ApiHelpers/SiteService.ts
@@ -3,7 +3,7 @@ import { AvailableStack } from '../models/available-stacks';
 import { CommonConstants } from '../utils/CommonConstants';
 import LogService from '../utils/LogService';
 import { ArmObj, ArmArray } from '../models/arm-obj';
-import { Site } from '../models/site/site';
+import { Site, PublishingCredentialPolicies } from '../models/site/site';
 import { SiteConfig, ArmAzureStorageMount } from '../models/site/config';
 import { SlotConfigNames } from '../models/site/slot-config-names';
 import { SiteLogsConfig } from '../models/site/logs-config';
@@ -238,5 +238,14 @@ export default class SiteService {
   public static getPublishingCredentials = (resourceId: string) => {
     const id = `${resourceId}/config/publishingcredentials/list`;
     return MakeArmCall<ArmObj<PublishingCredentials>>({ method: 'POST', resourceId: id, commandName: 'getPublishingCredentials' });
+  };
+
+  public static getBasicPublishingCredentialsPolicies = (resourceId: string) => {
+    const id = `${resourceId}/basicPublishingCredentialsPolicies`;
+    return MakeArmCall<ArmObj<PublishingCredentialPolicies>>({
+      method: 'GET',
+      resourceId: id,
+      commandName: 'getBasicPublishingCredentialsPolicies',
+    });
   };
 }

--- a/client-react/src/models/site/site.ts
+++ b/client-react/src/models/site/site.ts
@@ -133,3 +133,12 @@ export enum AppOs {
 }
 
 export type AppOsType = AppOs.linux | AppOs.windows;
+
+export interface CredentialPolicy {
+  allow: boolean;
+}
+
+export interface PublishingCredentialPolicies {
+  ftp: CredentialPolicy;
+  scm: CredentialPolicy;
+}

--- a/client-react/src/pages/app/app-settings/AppSettings.types.ts
+++ b/client-react/src/pages/app/app-settings/AppSettings.types.ts
@@ -35,7 +35,7 @@ export interface AppSettingsFormValues {
   azureStorageMounts: FormAzureStorageMounts[];
   virtualApplications: VirtualApplication[];
   currentlySelectedStack: string;
-  basicPublishingCredentialsPolicies: ArmObj<PublishingCredentialPolicies>;
+  basicPublishingCredentialsPolicies: ArmObj<PublishingCredentialPolicies> | null;
   references?: AppSettingsReferences;
 }
 

--- a/client-react/src/pages/app/app-settings/AppSettings.types.ts
+++ b/client-react/src/pages/app/app-settings/AppSettings.types.ts
@@ -35,8 +35,8 @@ export interface AppSettingsFormValues {
   azureStorageMounts: FormAzureStorageMounts[];
   virtualApplications: VirtualApplication[];
   currentlySelectedStack: string;
-  references?: AppSettingsReferences;
   basicPublishingCredentialsPolicies: ArmObj<PublishingCredentialPolicies>;
+  references?: AppSettingsReferences;
 }
 
 export interface FormState {

--- a/client-react/src/pages/app/app-settings/AppSettings.types.ts
+++ b/client-react/src/pages/app/app-settings/AppSettings.types.ts
@@ -2,7 +2,7 @@ import { FormikProps } from 'formik';
 import { AvailableStack } from '../../../models/available-stacks';
 import { AzureStorageMount, SiteConfig, VirtualApplication } from '../../../models/site/config';
 import { ArmObj } from '../../../models/arm-obj';
-import { Site } from '../../../models/site/site';
+import { Site, PublishingCredentialPolicies } from '../../../models/site/site';
 import { HostStatus } from '../../../models/functions/host-status';
 
 export interface Permissions {
@@ -36,6 +36,7 @@ export interface AppSettingsFormValues {
   virtualApplications: VirtualApplication[];
   currentlySelectedStack: string;
   references?: AppSettingsReferences;
+  basicPublishingCredentialsPolicies: ArmObj<PublishingCredentialPolicies>;
 }
 
 export interface FormState {

--- a/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
@@ -226,7 +226,9 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
           appSettings: applicationSettings.metadata.success ? applicationSettings.data : null,
           slotConfigNames: slotConfigNames.data,
           azureStorageMounts: azureStorageMounts.metadata.success ? azureStorageMounts.data : null,
-          basicPublishingCredentialsPolicies: basicPublishingCredentialsPolicies.data,
+          basicPublishingCredentialsPolicies: basicPublishingCredentialsPolicies.metadata.success
+            ? basicPublishingCredentialsPolicies.data
+            : null,
         }),
       });
     }

--- a/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
@@ -122,10 +122,20 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
   };
 
   const fetchData = async () => {
-    const [site, { webConfig, metadata, connectionStrings, applicationSettings, slotConfigNames, azureStorageMounts }] = await Promise.all([
+    const [site, basicPublishingCredentialsPolicies, applicationSettingsResponse] = await Promise.all([
       siteContext.fetchSite(resourceId),
+      SiteService.getBasicPublishingCredentialsPolicies(resourceId),
       fetchApplicationSettingValues(resourceId),
     ]);
+
+    const {
+      webConfig,
+      metadata,
+      connectionStrings,
+      applicationSettings,
+      slotConfigNames,
+      azureStorageMounts,
+    } = applicationSettingsResponse;
 
     let loadingFailed =
       armCallFailed(site) ||
@@ -216,6 +226,7 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
           appSettings: applicationSettings.metadata.success ? applicationSettings.data : null,
           slotConfigNames: slotConfigNames.data,
           azureStorageMounts: azureStorageMounts.metadata.success ? azureStorageMounts.data : null,
+          basicPublishingCredentialsPolicies: basicPublishingCredentialsPolicies.data,
         }),
       });
     }

--- a/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
+++ b/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
@@ -2,7 +2,7 @@ import SiteService from '../../../ApiHelpers/SiteService';
 import { AppSettingsFormValues, FormAppSetting, FormConnectionString, FormAzureStorageMounts } from './AppSettings.types';
 import { sortBy, isEqual } from 'lodash-es';
 import { ArmObj } from '../../../models/arm-obj';
-import { Site } from '../../../models/site/site';
+import { Site, PublishingCredentialPolicies } from '../../../models/site/site';
 import { SiteConfig, ArmAzureStorageMount, ConnStringInfo, VirtualApplication, KeyVaultReference } from '../../../models/site/config';
 import { SlotConfigNames } from '../../../models/site/slot-config-names';
 import { NameValuePair } from '../../../models/name-value-pair';
@@ -47,13 +47,24 @@ interface StateToFormParams {
   azureStorageMounts: ArmObj<ArmAzureStorageMount> | null;
   slotConfigNames: ArmObj<SlotConfigNames> | null;
   metadata: ArmObj<KeyValue<string>> | null;
+  basicPublishingCredentialsPolicies: ArmObj<PublishingCredentialPolicies>;
 }
 export const convertStateToForm = (props: StateToFormParams): AppSettingsFormValues => {
-  const { site, config, appSettings, connectionStrings, azureStorageMounts, slotConfigNames, metadata } = props;
+  const {
+    site,
+    config,
+    appSettings,
+    connectionStrings,
+    azureStorageMounts,
+    slotConfigNames,
+    metadata,
+    basicPublishingCredentialsPolicies,
+  } = props;
   const formAppSetting = getFormAppSetting(appSettings, slotConfigNames);
 
   return {
     site,
+    basicPublishingCredentialsPolicies,
     config: getCleanedConfig(config),
     appSettings: formAppSetting,
     connectionStrings: getFormConnectionStrings(connectionStrings, slotConfigNames),

--- a/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
+++ b/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
@@ -47,7 +47,7 @@ interface StateToFormParams {
   azureStorageMounts: ArmObj<ArmAzureStorageMount> | null;
   slotConfigNames: ArmObj<SlotConfigNames> | null;
   metadata: ArmObj<KeyValue<string>> | null;
-  basicPublishingCredentialsPolicies: ArmObj<PublishingCredentialPolicies>;
+  basicPublishingCredentialsPolicies: ArmObj<PublishingCredentialPolicies> | null;
 }
 export const convertStateToForm = (props: StateToFormParams): AppSettingsFormValues => {
   const {

--- a/client-react/src/pages/app/app-settings/GeneralSettings/Platform.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/Platform.tsx
@@ -9,6 +9,7 @@ import { ScenarioService } from '../../../../utils/scenario-checker/scenario.ser
 import { AppSettingsFormValues } from '../AppSettings.types';
 import { PermissionsContext, SiteContext } from '../Contexts';
 import { Links } from '../../../../utils/FwLinks';
+import DropdownNoFormik from '../../../../components/form-controls/DropDownnoFormik';
 
 const Platform: React.FC<FormikProps<AppSettingsFormValues>> = props => {
   const site = useContext(SiteContext);
@@ -20,6 +21,12 @@ const Platform: React.FC<FormikProps<AppSettingsFormValues>> = props => {
   const platformOptionEnable = scenarioChecker.checkScenario(ScenarioIds.enablePlatform64, { site });
   const websocketsEnable = scenarioChecker.checkScenario(ScenarioIds.webSocketsEnabled, { site });
   const alwaysOnEnable = scenarioChecker.checkScenario(ScenarioIds.enableAlwaysOn, { site });
+
+  const disableFtp = () =>
+    props.values.basicPublishingCredentialsPolicies &&
+    props.values.basicPublishingCredentialsPolicies.properties.ftp &&
+    !props.values.basicPublishingCredentialsPolicies.properties.ftp.allow;
+
   return (
     <div>
       {scenarioChecker.checkScenario(ScenarioIds.platform64BitSupported, { site }).status !== 'disabled' && (
@@ -63,30 +70,50 @@ const Platform: React.FC<FormikProps<AppSettingsFormValues>> = props => {
           ]}
         />
       )}
-      <Field
-        name="config.properties.ftpsState"
-        dirty={values.config.properties.ftpsState !== initialValues.config.properties.ftpsState}
-        component={Dropdown}
-        infoBubbleMessage={t('ftpsInfoMessage')}
-        learnMoreLink={Links.ftpInfo}
-        label={t('ftpState')}
-        id="app-settings-ftps-state"
-        disabled={disableAllControls}
-        options={[
-          {
-            key: 'AllAllowed',
-            text: t('allAllowed'),
-          },
-          {
-            key: 'FtpsOnly',
-            text: t('ftpsOnly'),
-          },
-          {
-            key: 'Disabled',
-            text: t('disabled'),
-          },
-        ]}
-      />
+
+      {disableFtp() ? (
+        <DropdownNoFormik
+          onChange={() => {}}
+          infoBubbleMessage={t('ftpDisabledByPolicy')}
+          learnMoreLink={Links.ftpDisabledByPolicyLink}
+          label={t('ftpState')}
+          id="app-settings-ftps-state"
+          disabled={true}
+          defaultSelectedKey={'Disabled'}
+          options={[
+            {
+              key: 'Disabled',
+              text: t('disabled'),
+            },
+          ]}
+        />
+      ) : (
+        <Field
+          name="config.properties.ftpsState"
+          dirty={values.config.properties.ftpsState !== initialValues.config.properties.ftpsState}
+          component={Dropdown}
+          infoBubbleMessage={t('ftpsInfoMessage')}
+          learnMoreLink={Links.ftpInfo}
+          label={t('ftpState')}
+          id="app-settings-ftps-state"
+          disabled={disableAllControls}
+          options={[
+            {
+              key: 'AllAllowed',
+              text: t('allAllowed'),
+            },
+            {
+              key: 'FtpsOnly',
+              text: t('ftpsOnly'),
+            },
+            {
+              key: 'Disabled',
+              text: t('disabled'),
+            },
+          ]}
+        />
+      )}
+
       {scenarioChecker.checkScenario(ScenarioIds.addHTTPSwitch, { site }).status !== 'disabled' && (
         <Field
           name="config.properties.http20Enabled"

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
@@ -131,10 +131,15 @@ export default class DeploymentCenterData {
       'github',
       providerToken.accessToken,
       providerToken.refreshToken,
-      providerToken.environment);
-  }
+      providerToken.environment
+    );
+  };
 
   public getUserSourceControls = () => {
     return ProviderService.getUserSourceControls();
-  }
+  };
+
+  public getBasicPublishingCredentialsPolicies = (resourceId: string) => {
+    return SiteService.getBasicPublishingCredentialsPolicies(resourceId);
+  };
 }

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterContext.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterContext.ts
@@ -3,6 +3,7 @@ import { ArmSiteDescriptor } from '../../../utils/resourceDescriptors';
 import { ArmObj } from '../../../models/arm-obj';
 import { SiteConfig } from '../../../models/site/config';
 import { KeyValue } from '../../../models/portal-models';
+import { PublishingCredentialPolicies } from '../../../models/site/site';
 
 export interface IDeploymentCenterContext {
   resourceId: string;
@@ -18,6 +19,7 @@ export interface IDeploymentCenterContext {
   siteDescriptor?: ArmSiteDescriptor;
   applicationSettings?: ArmObj<KeyValue<string>>;
   configMetadata?: ArmObj<KeyValue<string>>;
+  basicPublishingCredentialsPolicies?: PublishingCredentialPolicies;
 }
 
 export const DeploymentCenterContext = React.createContext<IDeploymentCenterContext>({} as IDeploymentCenterContext);

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterDataLoader.tsx
@@ -35,6 +35,7 @@ import { SiteConfig } from '../../../models/site/config';
 import { KeyValue } from '../../../models/portal-models';
 import { DeploymentCenterCodeFormBuilder } from './code/DeploymentCenterCodeFormBuilder';
 import { SourceControl } from '../../../models/provider';
+import { PublishingCredentialPolicies } from '../../../models/site/site';
 
 export interface DeploymentCenterDataLoaderProps {
   resourceId: string;
@@ -82,6 +83,9 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
   const [dropBoxToken, setDropBoxToken] = useState<string>('');
   const [bitBucketToken, setBitBucketToken] = useState<string>('');
   const [gitHubToken, setGitHubToken] = useState<string>('');
+  const [basicPublishingCredentialsPolicies, setBasicPublishingCredentialsPolicies] = useState<PublishingCredentialPolicies | undefined>(
+    undefined
+  );
 
   const deploymentCenterContainerFormBuilder = new DeploymentCenterContainerFormBuilder(t);
   const deploymentCenterCodeFormBuilder = new DeploymentCenterCodeFormBuilder(t);
@@ -120,11 +124,12 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
     setIsLoading(true);
     const writePermissionRequest = portalContext.hasPermission(resourceId, [RbacConstants.writeScope]);
     const getPublishingUserRequest = deploymentCenterData.getPublishingUser();
+    const getUserSourceControlsRequest = deploymentCenterData.getUserSourceControls();
     const getContainerLogsRequest = deploymentCenterData.fetchContainerLogs(resourceId);
     const getSiteConfigRequest = deploymentCenterData.getSiteConfig(resourceId);
     const getDeploymentsRequest = deploymentCenterData.getSiteDeployments(resourceId);
     const getConfigMetadataRequest = deploymentCenterData.getConfigMetadata(resourceId);
-    const getUserSourceControlsRequest = deploymentCenterData.getUserSourceControls();
+    const getBasicPublishingCredentialsPoliciesRequest = deploymentCenterData.getBasicPublishingCredentialsPolicies(resourceId);
 
     const [
       writePermissionResponse,
@@ -134,6 +139,7 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
       deploymentsResponse,
       configMetadataResponse,
       userSourceControlsResponse,
+      basicPublishingCredentialsPoliciesResponse,
     ] = await Promise.all([
       writePermissionRequest,
       getPublishingUserRequest,
@@ -142,10 +148,15 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
       getDeploymentsRequest,
       getConfigMetadataRequest,
       getUserSourceControlsRequest,
+      getBasicPublishingCredentialsPoliciesRequest,
     ]);
 
     if (userSourceControlsResponse.metadata.success) {
       setUserControlTokens(userSourceControlsResponse.data);
+    }
+
+    if (basicPublishingCredentialsPoliciesResponse.metadata.success) {
+      setBasicPublishingCredentialsPolicies(basicPublishingCredentialsPoliciesResponse.data.properties);
     }
 
     setSiteDescriptor(new ArmSiteDescriptor(resourceId));
@@ -302,6 +313,7 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
         dropBoxToken,
         bitBucketToken,
         gitHubToken,
+        basicPublishingCredentialsPolicies,
         refresh,
       }}>
       {isContainerApp(siteStateContext.site) ? (

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
@@ -14,6 +14,7 @@ import TextField from '../../../components/form-controls/TextField';
 import CustomBanner from '../../../components/CustomBanner/CustomBanner';
 import { DeploymentCenterContext } from './DeploymentCenterContext';
 import CustomFocusTrapCallout from '../../../components/CustomCallout/CustomFocusTrapCallout';
+import { Links } from '../../../utils/FwLinks';
 
 type PasswordFieldType = 'password' | undefined;
 
@@ -74,147 +75,162 @@ const DeploymentCenterFtps: React.FC<
     setShowBlockedBanner(false);
   };
 
-  return (
-    <>
-      {isLoading ? (
-        getProgressIndicator()
-      ) : (
-        <div className={deploymentCenterContent}>
-          {deploymentCenterContext && !deploymentCenterContext.hasWritePermission && showBlockedBanner && (
-            <div className={deploymentCenterInfoBannerDiv}>
-              <CustomBanner
-                message={t('deploymentCenterFtpsWritePermissionRequired')}
-                type={MessageBarType.blocked}
-                onDismiss={closeBlockedBanner}
-              />
-            </div>
-          )}
+  const disableFtp = () =>
+    deploymentCenterContext.basicPublishingCredentialsPolicies &&
+    deploymentCenterContext.basicPublishingCredentialsPolicies.ftp &&
+    !deploymentCenterContext.basicPublishingCredentialsPolicies.ftp.allow;
 
-          <p>{t('deploymentCenterFtpsDescription')}</p>
-          <TextFieldNoFormik
-            id="deployment-center-ftps-endpoint"
-            label={t('deploymentCenterFtpsEndpointLabel')}
-            widthOverride="100%"
-            value={ftpsEndpoint}
-            copyButton={true}
-            disabled={true}
-          />
-
-          <h3>{t('deploymentCenterFtpsApplicationScopeTitle')}</h3>
-          <p>{t('deploymentCenterFtpsApplicationScopeDescription')}</p>
-
-          <TextFieldNoFormik
-            id="deployment-center-ftps-application-username"
-            label={t('deploymentCenterFtpsUsernameLabel')}
-            widthOverride="100%"
-            value={publishingProfile && publishingProfile.userName}
-            copyButton={true}
-            disabled={true}
-          />
-
-          <TextFieldNoFormik
-            id="deployment-center-ftps-application-password"
-            label={t('deploymentCenterFtpsPasswordLabel')}
-            widthOverride="100%"
-            value={publishingProfile && publishingProfile.userPWD}
-            copyButton={true}
-            disabled={true}
-            type={applicationPasswordType}
-            additionalControls={[
-              <ActionButton
-                id="deployment-center-ftps-application-password-visibility-toggle"
-                key="deployment-center-ftps-application-password-visibility-toggle"
-                className={additionalTextFieldControl}
-                ariaLabel={
-                  applicationPasswordType === 'password' ? t('showApplicationPasswordAriaLabel') : t('hideApplicationPasswordAriaLabel')
-                }
-                onClick={toggleShowApplicationPassword}
-                iconProps={{ iconName: applicationPasswordType === 'password' ? 'RedEye' : 'Hide' }}>
-                {applicationPasswordType === 'password' ? t('show') : t('hide')}
-              </ActionButton>,
-              <ActionButton
-                id="deployment-center-ftps-application-password-reset"
-                key="deployment-center-ftps-application-password-reset"
-                className={additionalTextFieldControl}
-                ariaLabel={t('resetPublishProfileAriaLabel')}
-                onClick={toggleResetCalloutVisibility}
-                iconProps={{ iconName: 'refresh' }}>
-                {t('reset')}
-              </ActionButton>,
-            ]}
-          />
-
-          <CustomFocusTrapCallout
-            target="#deployment-center-ftps-application-password-reset"
-            onDismissFunction={toggleResetCalloutVisibility}
-            setInitialFocus={true}
-            hidden={isResetCalloutHidden}
-            title={t('resetPublishProfileConfirmationTitle')}
-            description={t('resetPublishProfileConfirmationDescription')}
-            primaryButtonTitle={t('reset')}
-            primaryButtonFunction={resetApplicationPasswordFromCallout}
-            defaultButtonTitle={t('cancel')}
-            defaultButtonFunction={toggleResetCalloutVisibility}
-          />
-
-          <h3>{t('deploymentCenterFtpsUserScopeTitle')}</h3>
-          <p>{t('deploymentCenterFtpsUserScopeDescription').format(sampleWebProviderDomainUsername)}</p>
-
-          <Field
-            id="deployment-center-ftps-provider-username"
-            name="publishingUsername"
-            component={TextField}
-            widthOverride="60%"
-            label={t('deploymentCenterFtpsUsernameLabel')}
-          />
-
-          <Field
-            id="deployment-center-ftps-provider-password"
-            name="publishingPassword"
-            component={TextField}
-            widthOverride="60%"
-            label={t('deploymentCenterFtpsPasswordLabel')}
-            type={providerPasswordType}
-            additionalControls={[
-              <ActionButton
-                id="deployment-center-ftps-provider-password-visibility-toggle"
-                key="deployment-center-ftps-provider-password-visibility-toggle"
-                className={additionalTextFieldControl}
-                ariaLabel={providerPasswordType === 'password' ? t('showProviderPasswordAriaLabel') : t('hideProviderPasswordAriaLabel')}
-                onClick={toggleShowProviderPassword}
-                iconProps={{ iconName: providerPasswordType === 'password' ? 'RedEye' : 'Hide' }}>
-                {providerPasswordType === 'password' ? t('show') : t('hide')}
-              </ActionButton>,
-            ]}
-          />
-
-          <Field
-            id="deployment-center-ftps-provider-confirm-password"
-            name="publishingConfirmPassword"
-            component={TextField}
-            widthOverride="60%"
-            label={t('deploymentCenterFtpsConfirmPasswordLabel')}
-            type={providerConfirmPasswordType}
-            additionalControls={[
-              <ActionButton
-                id="deployment-center-ftps-provider-confirm-password-visibility-toggle"
-                key="deployment-center-ftps-provider-confirm-password-visibility-toggle"
-                className={additionalTextFieldControl}
-                ariaLabel={
-                  providerConfirmPasswordType === 'password'
-                    ? t('showProviderConfirmPasswordAriaLabel')
-                    : t('hideProviderConfirmPasswordAriaLabel')
-                }
-                onClick={toggleShowProviderConfirmPassword}
-                iconProps={{ iconName: providerConfirmPasswordType === 'password' ? 'RedEye' : 'Hide' }}>
-                {providerConfirmPasswordType === 'password' ? t('show') : t('hide')}
-              </ActionButton>,
-            ]}
-          />
-        </div>
-      )}
-    </>
+  const getDisabledByFTPPolicyMessage = () => (
+    <div className={deploymentCenterContent}>
+      <CustomBanner message={t('ftpDisabledByPolicy')} type={MessageBarType.info} learnMoreLink={Links.ftpDisabledByPolicyLink} />
+    </div>
   );
+
+  const getCredentialsControls = () => {
+    return (
+      <div className={deploymentCenterContent}>
+        {deploymentCenterContext && !deploymentCenterContext.hasWritePermission && showBlockedBanner && (
+          <div className={deploymentCenterInfoBannerDiv}>
+            <CustomBanner
+              message={t('deploymentCenterFtpsWritePermissionRequired')}
+              type={MessageBarType.blocked}
+              onDismiss={closeBlockedBanner}
+            />
+          </div>
+        )}
+
+        <p>{t('deploymentCenterFtpsDescription')}</p>
+        <TextFieldNoFormik
+          id="deployment-center-ftps-endpoint"
+          label={t('deploymentCenterFtpsEndpointLabel')}
+          widthOverride="100%"
+          value={ftpsEndpoint}
+          copyButton={true}
+          disabled={true}
+        />
+
+        <h3>{t('deploymentCenterFtpsApplicationScopeTitle')}</h3>
+        <p>{t('deploymentCenterFtpsApplicationScopeDescription')}</p>
+
+        <TextFieldNoFormik
+          id="deployment-center-ftps-application-username"
+          label={t('deploymentCenterFtpsUsernameLabel')}
+          widthOverride="100%"
+          value={publishingProfile && publishingProfile.userName}
+          copyButton={true}
+          disabled={true}
+        />
+
+        <TextFieldNoFormik
+          id="deployment-center-ftps-application-password"
+          label={t('deploymentCenterFtpsPasswordLabel')}
+          widthOverride="100%"
+          value={publishingProfile && publishingProfile.userPWD}
+          copyButton={true}
+          disabled={true}
+          type={applicationPasswordType}
+          additionalControls={[
+            <ActionButton
+              id="deployment-center-ftps-application-password-visibility-toggle"
+              key="deployment-center-ftps-application-password-visibility-toggle"
+              className={additionalTextFieldControl}
+              ariaLabel={
+                applicationPasswordType === 'password' ? t('showApplicationPasswordAriaLabel') : t('hideApplicationPasswordAriaLabel')
+              }
+              onClick={toggleShowApplicationPassword}
+              iconProps={{ iconName: applicationPasswordType === 'password' ? 'RedEye' : 'Hide' }}>
+              {applicationPasswordType === 'password' ? t('show') : t('hide')}
+            </ActionButton>,
+            <ActionButton
+              id="deployment-center-ftps-application-password-reset"
+              key="deployment-center-ftps-application-password-reset"
+              className={additionalTextFieldControl}
+              ariaLabel={t('resetPublishProfileAriaLabel')}
+              onClick={toggleResetCalloutVisibility}
+              iconProps={{ iconName: 'refresh' }}>
+              {t('reset')}
+            </ActionButton>,
+          ]}
+        />
+
+        <CustomFocusTrapCallout
+          target="#deployment-center-ftps-application-password-reset"
+          onDismissFunction={toggleResetCalloutVisibility}
+          setInitialFocus={true}
+          hidden={isResetCalloutHidden}
+          title={t('resetPublishProfileConfirmationTitle')}
+          description={t('resetPublishProfileConfirmationDescription')}
+          primaryButtonTitle={t('reset')}
+          primaryButtonFunction={resetApplicationPasswordFromCallout}
+          defaultButtonTitle={t('cancel')}
+          defaultButtonFunction={toggleResetCalloutVisibility}
+        />
+
+        <h3>{t('deploymentCenterFtpsUserScopeTitle')}</h3>
+        <p>{t('deploymentCenterFtpsUserScopeDescription').format(sampleWebProviderDomainUsername)}</p>
+
+        <Field
+          id="deployment-center-ftps-provider-username"
+          name="publishingUsername"
+          component={TextField}
+          widthOverride="60%"
+          label={t('deploymentCenterFtpsUsernameLabel')}
+        />
+
+        <Field
+          id="deployment-center-ftps-provider-password"
+          name="publishingPassword"
+          component={TextField}
+          widthOverride="60%"
+          label={t('deploymentCenterFtpsPasswordLabel')}
+          type={providerPasswordType}
+          additionalControls={[
+            <ActionButton
+              id="deployment-center-ftps-provider-password-visibility-toggle"
+              key="deployment-center-ftps-provider-password-visibility-toggle"
+              className={additionalTextFieldControl}
+              ariaLabel={providerPasswordType === 'password' ? t('showProviderPasswordAriaLabel') : t('hideProviderPasswordAriaLabel')}
+              onClick={toggleShowProviderPassword}
+              iconProps={{ iconName: providerPasswordType === 'password' ? 'RedEye' : 'Hide' }}>
+              {providerPasswordType === 'password' ? t('show') : t('hide')}
+            </ActionButton>,
+          ]}
+        />
+
+        <Field
+          id="deployment-center-ftps-provider-confirm-password"
+          name="publishingConfirmPassword"
+          component={TextField}
+          widthOverride="60%"
+          label={t('deploymentCenterFtpsConfirmPasswordLabel')}
+          type={providerConfirmPasswordType}
+          additionalControls={[
+            <ActionButton
+              id="deployment-center-ftps-provider-confirm-password-visibility-toggle"
+              key="deployment-center-ftps-provider-confirm-password-visibility-toggle"
+              className={additionalTextFieldControl}
+              ariaLabel={
+                providerConfirmPasswordType === 'password'
+                  ? t('showProviderConfirmPasswordAriaLabel')
+                  : t('hideProviderConfirmPasswordAriaLabel')
+              }
+              onClick={toggleShowProviderConfirmPassword}
+              iconProps={{ iconName: providerConfirmPasswordType === 'password' ? 'RedEye' : 'Hide' }}>
+              {providerConfirmPasswordType === 'password' ? t('show') : t('hide')}
+            </ActionButton>,
+          ]}
+        />
+      </div>
+    );
+  };
+
+  if (isLoading) {
+    return getProgressIndicator();
+  } else if (disableFtp()) {
+    return getDisabledByFTPPolicyMessage();
+  } else {
+    return getCredentialsControls();
+  }
 };
 
 export default DeploymentCenterFtps;

--- a/client-react/src/utils/FwLinks.ts
+++ b/client-react/src/utils/FwLinks.ts
@@ -33,6 +33,7 @@ export const Links = {
   cronLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2117147&clcid=0x409',
   quickstartViewDocumentation: 'https://go.microsoft.com/fwlink/?linkid=2119201',
   bindingDirectionLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2121806&clcid=0x409',
+  ftpDisabledByPolicyLink: 'https://go.microsoft.com/fwlink/?linkid=2137907',
 };
 
 export const DeploymentCenterLinks = {

--- a/client/src/app/shared/models/arm/site.ts
+++ b/client/src/app/shared/models/arm/site.ts
@@ -50,3 +50,12 @@ export interface Site {
   possibleInboundIpAddresses: string;
   possibleOutboundIpAddresses: string;
 }
+
+export interface CredentialPolicy {
+  allow: boolean;
+}
+
+export interface PublishingCredentialPolicies {
+  ftp: CredentialPolicy;
+  scm: CredentialPolicy;
+}

--- a/client/src/app/shared/models/constants.ts
+++ b/client/src/app/shared/models/constants.ts
@@ -171,6 +171,7 @@ export class Links {
   public static apimUpsellLearnMore = 'https://go.microsoft.com/fwlink/?linkid=2104075';
   public static runtimeScaleMonitoringLearnMore = 'https://go.microsoft.com/fwlink/?linkid=2104710';
   public static pv2FlexStampInfoLearnMore = 'https://go.microsoft.com/fwlink/?linkid=2116583';
+  public static ftpDisabledByPolicyLink: 'https://go.microsoft.com/fwlink/?linkid=2137907';
 }
 
 export class Kinds {

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2135,4 +2135,5 @@ export class PortalResources {
   public static versionLabel = 'versionLabel';
   public static javaWebServer = 'javaWebServer';
   public static javaWebServerVersion = 'javaWebServerVersion';
+  public static ftpDisabledByPolicy = 'ftpDisabledByPolicy';
 }

--- a/client/src/app/shared/services/site.service.ts
+++ b/client/src/app/shared/services/site.service.ts
@@ -9,7 +9,7 @@ import { ArmArrayResult } from './../models/arm/arm-obj';
 import { ArmObj } from './../models/arm/arm-obj';
 import { AuthSettings } from './../models/arm/auth-settings';
 import { ConnectionStrings } from './../models/arm/connection-strings';
-import { Site } from './../models/arm/site';
+import { Site, PublishingCredentialPolicies } from './../models/arm/site';
 import { SiteConfig } from './../models/arm/site-config';
 import { SiteExtension } from './../models/arm/site-extension';
 import { SlotConfigNames } from './../models/arm/slot-config-names';
@@ -255,4 +255,12 @@ export class SiteService {
       .map(r => r.json());
     return this._client.execute({ resourceId: resourceId }, t => fetchSiteConfigMetadata);
   }
+
+  getBasicPublishingCredentialsPolicies = (resourceId: string): Result<ArmObj<PublishingCredentialPolicies>> => {
+    const getBasicPublishingCredentialsPolicies = this._cacheService
+      .getArm(`${resourceId}/basicPublishingCredentialsPolicies`, true)
+      .map(r => r.json());
+
+    return this._client.execute({ resourceId: resourceId }, t => getBasicPublishingCredentialsPolicies);
+  };
 }

--- a/client/src/app/site/deployment-center/provider-dashboards/credentials-dashboard/credentials-dashboard.component.html
+++ b/client/src/app/site/deployment-center/provider-dashboards/credentials-dashboard/credentials-dashboard.component.html
@@ -11,11 +11,11 @@
     <div class="credentials-description">{{ 'deploymentCredentialsDescription' | translate }}</div>
 </div>
 
-<info-box *ngIf="!ftpDisabledByPolicy" typeClass="info" [infoText]="'ftpDisabledByPolicy' | translate" [infoLink]="ftpDisabledInfoLink">
+<info-box *ngIf="ftpDisabledByPolicy" typeClass="info" [infoText]="'ftpDisabledByPolicy' | translate" [infoLink]="ftpDisabledInfoLink">
 </info-box>
 
-<command-bar *ngIf="ftpDisabledByPolicy">
-    <command displayText="{{ 'refresh' | translate }}" 
+<command-bar *ngIf="!ftpDisabledByPolicy">
+    <command displayText="{{ 'refresh' | translate }}"
         iconUrl="image/refresh.svg"
         (click)="refresh()"
         [disabled]="disableRefreshCommand"></command>
@@ -31,7 +31,7 @@
         [disabled]="disableResetPublishProfileCommand"></command>
 </command-bar>
 
-<div *ngIf="ftpDisabledByPolicy" class="credentials-container">
+<div *ngIf="!ftpDisabledByPolicy" class="credentials-container">
     <nav id="creds-tabs" role="tablist" #credsTabs>
         <ng-container *ngIf="localGit">
             <div class="site-tab-label" (click)="selectTab('localGit')" role="tab" id="site-tab-localGit" aria-controls="site-tab-content-localGit"
@@ -56,7 +56,7 @@
             <label class="setting-label" id="credentials-scope-label">{{ 'gitCloneUrlLabel' | translate }}</label>
             <copy-pre [content]="gitEndpoint" class="setting-value"></copy-pre>
         </div>
-        
+
         <div *ngIf="activeTab === 'ftps'"  class="settings-wrapper">
             <label class="setting-label" id="credentials-scope-label">{{ 'ftpsEndpoint' | translate }}</label>
             <copy-pre [content]="ftpsEndpoint" class="setting-value"></copy-pre>
@@ -89,7 +89,7 @@
               </div>
             </div>
         </div>
-        
+
         <div *ngIf="selectedScope === 'UserCredentials'" class="creds-tab">
             <div class="cred-desc">
                 <div class="desc-text">{{userCredsDesc}} <a class="link" target="_blank" [href]="learnMoreLink">{{'learnMore' | translate}}</a></div>

--- a/client/src/app/site/deployment-center/provider-dashboards/credentials-dashboard/credentials-dashboard.component.html
+++ b/client/src/app/site/deployment-center/provider-dashboards/credentials-dashboard/credentials-dashboard.component.html
@@ -11,7 +11,10 @@
     <div class="credentials-description">{{ 'deploymentCredentialsDescription' | translate }}</div>
 </div>
 
-<command-bar>
+<info-box *ngIf="!ftpDisabledByPolicy" typeClass="info" [infoText]="'ftpDisabledByPolicy' | translate" [infoLink]="ftpDisabledInfoLink">
+</info-box>
+
+<command-bar *ngIf="ftpDisabledByPolicy">
     <command displayText="{{ 'refresh' | translate }}" 
         iconUrl="image/refresh.svg"
         (click)="refresh()"
@@ -28,7 +31,7 @@
         [disabled]="disableResetPublishProfileCommand"></command>
 </command-bar>
 
-<div class="credentials-container">
+<div *ngIf="ftpDisabledByPolicy" class="credentials-container">
     <nav id="creds-tabs" role="tablist" #credsTabs>
         <ng-container *ngIf="localGit">
             <div class="site-tab-label" (click)="selectTab('localGit')" role="tab" id="site-tab-localGit" aria-controls="site-tab-content-localGit"

--- a/client/src/app/site/deployment-center/provider-dashboards/deployment-credentials/deployment-credentials.component.html
+++ b/client/src/app/site/deployment-center/provider-dashboards/deployment-credentials/deployment-credentials.component.html
@@ -1,8 +1,8 @@
 <div class="credentials-container" [class.container-padding]="standalone">
-  <info-box *ngIf="!ftpDisabledByPolicy" typeClass="info" [infoText]="'ftpDisabledByPolicy' | translate" [infoLink]="ftpDisabledInfoLink">
+  <info-box *ngIf="ftpDisabledByPolicy" typeClass="info" [infoText]="'ftpDisabledByPolicy' | translate" [infoLink]="ftpDisabledInfoLink">
   </info-box>
 
-  <nav *ngIf="ftpDisabledByPolicy" id="creds-tabs" role="tablist" #credsTabs>
+  <nav *ngIf="!ftpDisabledByPolicy" id="creds-tabs" role="tablist" #credsTabs>
     <div class="site-tab-label" (click)="selectTab('app')" role="tab" id="site-tab-app" aria-controls="site-tab-content-app"
       aria-selected="false" [attr.aria-label]="'appCreds' | translate" [class.inactive-label]="activeTab !== 'app'" [tabindex]="activeTab === 'app' ? 0 : -1"
       (keydown)="onKeyPress($event, 'app')">
@@ -19,7 +19,7 @@
     </div>
   </nav>
 
-  <ng-container *ngIf="ftpDisabledByPolicy && activeTab === 'app'">
+  <ng-container *ngIf="!ftpDisabledByPolicy && activeTab === 'app'">
     <div class="cred-desc">
       <div class="desc-text">{{'appCredsDesc' | translate}} <a class="link" target="_blank" [href]="learnMoreLink">{{'learnMore' | translate}}</a></div>
     </div>
@@ -39,7 +39,7 @@
       <span *ngIf="resetting" load-image="image/loader.svg" class="icon-small fa-spin"></span>
     </button>
   </ng-container>
-  <ng-container *ngIf="ftpDisabledByPolicy && activeTab === 'user'">
+  <ng-container *ngIf="!ftpDisabledByPolicy && activeTab === 'user'">
     <div class="cred-desc">
       <div class="desc-text">{{userCredsDesc}} <a class="link" target="_blank" [href]="learnMoreLink">{{'learnMore' | translate}}</a></div>
     </div>

--- a/client/src/app/site/deployment-center/provider-dashboards/deployment-credentials/deployment-credentials.component.html
+++ b/client/src/app/site/deployment-center/provider-dashboards/deployment-credentials/deployment-credentials.component.html
@@ -1,5 +1,8 @@
 <div class="credentials-container" [class.container-padding]="standalone">
-  <nav id="creds-tabs" role="tablist" #credsTabs>
+  <info-box *ngIf="!ftpDisabledByPolicy" typeClass="info" [infoText]="'ftpDisabledByPolicy' | translate" [infoLink]="ftpDisabledInfoLink">
+  </info-box>
+
+  <nav *ngIf="ftpDisabledByPolicy" id="creds-tabs" role="tablist" #credsTabs>
     <div class="site-tab-label" (click)="selectTab('app')" role="tab" id="site-tab-app" aria-controls="site-tab-content-app"
       aria-selected="false" [attr.aria-label]="'appCreds' | translate" [class.inactive-label]="activeTab !== 'app'" [tabindex]="activeTab === 'app' ? 0 : -1"
       (keydown)="onKeyPress($event, 'app')">
@@ -16,7 +19,7 @@
     </div>
   </nav>
 
-  <ng-container *ngIf="activeTab === 'app'">
+  <ng-container *ngIf="ftpDisabledByPolicy && activeTab === 'app'">
     <div class="cred-desc">
       <div class="desc-text">{{'appCredsDesc' | translate}} <a class="link" target="_blank" [href]="learnMoreLink">{{'learnMore' | translate}}</a></div>
     </div>
@@ -36,7 +39,7 @@
       <span *ngIf="resetting" load-image="image/loader.svg" class="icon-small fa-spin"></span>
     </button>
   </ng-container>
-  <ng-container *ngIf="activeTab === 'user'">
+  <ng-container *ngIf="ftpDisabledByPolicy && activeTab === 'user'">
     <div class="cred-desc">
       <div class="desc-text">{{userCredsDesc}} <a class="link" target="_blank" [href]="learnMoreLink">{{'learnMore' | translate}}</a></div>
     </div>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -6555,4 +6555,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="javaWebServerVersion" xml:space="preserve">
         <value>Java web server version</value>
     </data>
+    <data name="ftpDisabledByPolicy" xml:space="preserve">
+        <value>FTP is disabled by access policy.</value>
+    </data>
 </root>


### PR DESCRIPTION
Fixes AB#6735725

Currently users can use an API/CLI to set provider level policies to block FTP connections. In this case, regardless of what the config value is, we should show that the FTP option is disabled and hide the FTP credentials. App Service API team has created a resource level API which indicates the FTP policy that should be followed by the UX.

** Configuration **
![image](https://user-images.githubusercontent.com/493476/89075397-fa563280-d332-11ea-8fad-17d6e353c13d.png)

** Deployment Center **
![image](https://user-images.githubusercontent.com/493476/89075433-080bb800-d333-11ea-82f6-c13b568c9b63.png)

** Classic deployment center **
![image](https://user-images.githubusercontent.com/493476/89082239-3e9cff00-d342-11ea-8a8a-d23bb0d71fcc.png)

yes! the ftp url shows up... removing that is a lot more work than necessary:
![image](https://user-images.githubusercontent.com/493476/89082263-4bb9ee00-d342-11ea-8450-04b294979a15.png)


