### PR TITLE
[BYOS] Storage Mounts don't show dirty state on tab

### DIFF
--- a/client-react/src/pages/app/app-settings/Sections/PathMappingsPivot.tsx
+++ b/client-react/src/pages/app/app-settings/Sections/PathMappingsPivot.tsx
@@ -60,7 +60,8 @@ const PathMappingsPivot: React.FC<FormikProps<AppSettingsFormValues> & PathMappi
 export const pathMappingsDirty = (values: AppSettingsFormValues, initialValues: AppSettingsFormValues) => {
   return (
     !isEqual(values.virtualApplications, initialValues.virtualApplications) ||
-    !isEqual(values.config.properties.handlerMappings, initialValues.config.properties.handlerMappings)
+    !isEqual(values.config.properties.handlerMappings, initialValues.config.properties.handlerMappings) ||
+    !isEqual(values.azureStorageMounts, initialValues.azureStorageMounts)
   );
 };
 


### PR DESCRIPTION
Fixes AB#5536428

Before:
![image](https://user-images.githubusercontent.com/35281019/89355397-24c82880-d670-11ea-91f2-bef9ae07d822.png)

Fix:
![image](https://user-images.githubusercontent.com/35281019/89355489-58a34e00-d670-11ea-8299-2c1aeddedd44.png)
