### PR TITLE
Transition GitHub Action out of 'preview' mode

### DIFF
--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildRuntimeAndVersion.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildRuntimeAndVersion.tsx
@@ -14,7 +14,6 @@ import { WebAppCreateStack } from '../../../../models/available-stacks';
 import { getRuntimeStackSetting } from '../utility/DeploymentCenterUtility';
 import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
 import { deploymentCenterInfoBannerDiv } from '../DeploymentCenter.styles';
-import { RuntimeStacks } from '../../../../utils/stacks-utils';
 import { AppOs } from '../../../../models/site/site';
 
 const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterFieldProps<DeploymentCenterCodeFormData>> = props => {
@@ -82,18 +81,12 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
       const siteName = deploymentCenterContext.siteDescriptor.site;
       const slotName = deploymentCenterContext.siteDescriptor.slot;
       setShowMismatchWarningBar(true);
-      if (defaultStack.toLocaleLowerCase() === RuntimeStacks.aspnet) {
-        setStackMismatchMessage(
-          t('githubActionAspNetStackMismatchMessage', { appName: slotName ? `${siteName} (${slotName})` : siteName })
-        );
-      } else {
-        setStackMismatchMessage(
-          t('githubActionStackMismatchMessage', {
-            appName: slotName ? `${siteName} (${slotName})` : siteName,
-            stack: defaultStack,
-          })
-        );
-      }
+      setStackMismatchMessage(
+        t('githubActionStackMismatchMessage', {
+          appName: slotName ? `${siteName} (${slotName})` : siteName,
+          stack: defaultStack,
+        })
+      );
     } else {
       setStackMismatchMessage('');
     }
@@ -172,15 +165,9 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
       const siteName = deploymentCenterContext.siteDescriptor.site;
       const slotName = deploymentCenterContext.siteDescriptor.slot;
       setShowNotSupportedWarningBar(true);
-      if (defaultStack.toLocaleLowerCase() === RuntimeStacks.aspnet) {
-        setStackNotSupportedMessage(
-          t('githubActionAspNetStackNotSupportedMessage', { appName: slotName ? `${siteName} (${slotName})` : siteName })
-        );
-      } else {
-        setStackNotSupportedMessage(
-          t('githubActionStackNotSupportedMessage', { appName: slotName ? `${siteName} (${slotName})` : siteName, stack: defaultStack })
-        );
-      }
+      setStackNotSupportedMessage(
+        t('githubActionStackNotSupportedMessage', { appName: slotName ? `${siteName} (${slotName})` : siteName, stack: defaultStack })
+      );
     } else {
       setStackNotSupportedMessage('');
     }

--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
@@ -38,6 +38,8 @@ const getRuntimeStackForWindows = (siteConfig: ArmObj<SiteConfig>, configMetadat
     // defined constants.
     if (metadataStack === 'java') {
       return siteConfig.properties.javaVersion === JavaVersions.WindowsVersion8 ? RuntimeStacks.java8 : RuntimeStacks.java11;
+    } else if (metadataStack === 'dotnet') {
+      return RuntimeStacks.aspnet;
     } else {
       return metadataStack;
     }

--- a/client-react/src/pages/app/deployment-center/utility/GitHubActionUtility.ts
+++ b/client-react/src/pages/app/deployment-center/utility/GitHubActionUtility.ts
@@ -39,6 +39,9 @@ export const getWorkflowInformation = (
         content = getJavaJarGithubActionWorkflowDefinition(siteName, slotName, branch, isLinuxApp, secretName, runtimeStackVersion);
       }
       break;
+    case RuntimeStacks.aspnet:
+      content = getAspNetGithubActionWorkflowDefinition(siteName, slotName, branch, secretName, runtimeStackVersion);
+      break;
     default:
       throw Error(`Incorrect stack value '${runtimeStack}' provided.`);
   }
@@ -353,4 +356,54 @@ jobs:
         slot-name: '${slot}'
         publish-profile: \${{ secrets.${secretName} }}
         package: '\${{ github.workspace }}/target/*.war'`;
+};
+
+// TODO(michinoy): Need to implement templated github action workflow generation.
+// Current reference - https://github.com/Azure/actions-workflow-templates
+const getAspNetGithubActionWorkflowDefinition = (
+  siteName: string,
+  slotName: string,
+  branch: string,
+  secretName: string,
+  runtimeStackVersion: string
+) => {
+  const webAppName = slotName ? `${siteName}(${slotName})` : siteName;
+  const slot = slotName || 'production';
+
+  return `# Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
+# More GitHub Actions for Azure: https://github.com/Azure/actions
+
+name: Build and deploy WAR app to Azure Web App - ${webAppName}
+
+on:
+  push:
+    branches:
+      - ${branch}
+
+  jobs:
+    build-and-deploy:
+      runs-on: 'windows-latest'
+
+      steps:
+      - uses: actions/checkout@master
+
+      - name: Setup MSBuild path
+        uses: microsoft/setup-msbuild@v1.0.0
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1.0.2
+
+      - name: Restore NuGet packages
+        run: nuget restore
+
+      - name: Publish to folder
+        run: msbuild /p:Configuration=Release /p:DeployOnBuild=true /t:WebPublish /p:WebPublishMethod=FileSystem /p:publishUrl=./published/ /p:PackageAsSingleFile=false
+
+      - name: Deploy to Azure Web App
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: '${siteName}'
+          slot-name: '${slot}'
+          publish-profile: \${{ secrets.${secretName} }}
+          package: ./published/`;
 };

--- a/client-react/src/utils/stacks-utils.ts
+++ b/client-react/src/utils/stacks-utils.ts
@@ -36,7 +36,7 @@ export class JavaContainers {
 }
 
 export class RuntimeStacks {
-  public static aspnet = 'dotnet';
+  public static aspnet = 'asp.net';
   public static node = 'node';
   public static python = 'python';
   public static dotnetcore = 'dotnetcore';

--- a/client/src/app/shared/models/constants.ts
+++ b/client/src/app/shared/models/constants.ts
@@ -683,7 +683,7 @@ export class Pricing {
 }
 
 export class RuntimeStacks {
-  public static aspnet = 'dotnet';
+  public static aspnet = 'asp.net';
   public static node = 'node';
   public static python = 'python';
   public static dotnetcore = 'dotnetcore';

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1723,7 +1723,6 @@ export class PortalResources {
   public static addFunctionKey = 'addFunctionKey';
   public static functionKeyPropIsRequired = 'functionKeyPropIsRequired';
   public static functionKeyNamesUnique = 'functionKeyNamesUnique';
-  public static gitHubActionBuildServerTitle = 'gitHubActionBuildServerTitle';
   public static gitHubActionBuildServerDesc = 'gitHubActionBuildServerDesc';
   public static azureKeyVault = 'azureKeyVault';
   public static appConfigValue = 'appConfigValue';
@@ -1871,8 +1870,6 @@ export class PortalResources {
   public static deleteFunctionKeyNotificationFailed = 'deleteFunctionKeyNotificationFailed';
   public static deleteFunctionKeyNotificationSuccess = 'deleteFunctionKeyNotificationSuccess';
   public static disableFunctionTestTooltip = 'disableFunctionTestTooltip';
-  public static githubActionAspNetStackNotSupportedMessage = 'githubActionAspNetStackNotSupportedMessage';
-  public static githubActionAspNetStackMismatchMessage = 'githubActionAspNetStackMismatchMessage';
   public static gitHubActionWorkflowFileNameTitle = 'gitHubActionWorkflowFileNameTitle';
   public static noAppFilesWhileFunctionAppStopped = 'noAppFilesWhileFunctionAppStopped';
   public static noAppKeysWhileFunctionAppStopped = 'noAppKeysWhileFunctionAppStopped';

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-build-provider/step-build-provider.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-build-provider/step-build-provider.component.ts
@@ -29,7 +29,7 @@ export class StepBuildProviderComponent implements OnDestroy {
     },
     {
       id: 'github',
-      name: this._translateService.instant(PortalResources.gitHubActionBuildServerTitle),
+      name: this._translateService.instant(PortalResources.deploymentCenterCodeSettingsBuildGitHubAction),
       icon: 'image/deployment-center/GitHubLogo.svg',
       color: '#68217A',
       description: this._translateService.instant(PortalResources.gitHubActionBuildServerDesc),

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-complete/step-complete.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-complete/step-complete.component.ts
@@ -130,8 +130,8 @@ export class StepCompleteComponent {
             err && err.message
               ? err.message
               : err && err.json() && err.json().message
-                ? err && err.json() && err.json().message
-                : this._translateService.instant(PortalResources.settingupDeploymentFail);
+              ? err && err.json() && err.json().message
+              : this._translateService.instant(PortalResources.settingupDeploymentFail);
 
           this._portalService.stopNotification(notificationId, false, errorMessage);
           this._logService.error(LogCategories.cicd, '/step-complete', { resourceId: this.wizard.siteArm.id, error: err });
@@ -302,7 +302,7 @@ export class StepCompleteComponent {
     const items = [
       {
         label: this._translateService.instant(PortalResources.provider),
-        value: this._translateService.instant(PortalResources.gitHubActionBuildServerTitle),
+        value: this._translateService.instant(PortalResources.deploymentCenterCodeSettingsBuildGitHubAction),
       },
     ];
 

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/stack-selector/stack-selector.component.html
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/stack-selector/stack-selector.component.html
@@ -23,7 +23,7 @@
         </div>
     </div>
 
-    <div class="settings-wrapper">
+    <div *ngIf="showVersionSelector" class="settings-wrapper">
         <div class="setting-wrapper">
             <label id="github-action-configure-stackversion-label" class="setting-label">{{ 'runtimeStackVersion' | translate }} </label>
             <div class="setting-control-container">

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/stack-selector/stack-selector.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/stack-selector/stack-selector.component.ts
@@ -30,6 +30,7 @@ export class StackSelectorComponent implements OnDestroy {
   public stackMismatchMessage = '';
   public selectedRuntimeStack = '';
   public selectedRuntimeStackVersion = '';
+  public showVersionSelector = true;
 
   private _ngUnsubscribe$ = new Subject();
   private _runtimeStacks: WebAppCreateStack[] = [];
@@ -80,16 +81,10 @@ export class StackSelectorComponent implements OnDestroy {
 
       // NOTE(michinoy): Show a warning message if the user selects a stack which does not match what their app is configured with.
       if (this.wizard.stack && stackValue !== this.wizard.stack.toLocaleLowerCase() && !this.stackNotSupportedMessage) {
-        if (this.wizard.stack.toLocaleLowerCase() === RuntimeStacks.aspnet) {
-          this.stackMismatchMessage = this._translateService.instant(PortalResources.githubActionAspNetStackMismatchMessage, {
-            appName: this.wizard.slotName ? `${this.wizard.siteName} (${this.wizard.slotName})` : this.wizard.siteName,
-          });
-        } else {
-          this.stackMismatchMessage = this._translateService.instant(PortalResources.githubActionStackMismatchMessage, {
-            appName: this.wizard.slotName ? `${this.wizard.siteName} (${this.wizard.slotName})` : this.wizard.siteName,
-            stack: this.wizard.stack,
-          });
-        }
+        this.stackMismatchMessage = this._translateService.instant(PortalResources.githubActionStackMismatchMessage, {
+          appName: this.wizard.slotName ? `${this.wizard.siteName} (${this.wizard.slotName})` : this.wizard.siteName,
+          stack: this.wizard.stack,
+        });
       } else {
         this.stackMismatchMessage = '';
       }
@@ -138,10 +133,6 @@ export class StackSelectorComponent implements OnDestroy {
       if (appSelectedStack && appSelectedStack.length === 1) {
         this.stackNotSupportedMessage = '';
         this._runtimeStackStream$.next(appSelectedStack[0].value);
-      } else if (this.wizard.stack.toLocaleLowerCase() === RuntimeStacks.aspnet) {
-        this.stackNotSupportedMessage = this._translateService.instant(PortalResources.githubActionAspNetStackNotSupportedMessage, {
-          appName: this.wizard.slotName ? `${this.wizard.siteName} (${this.wizard.slotName})` : this.wizard.siteName,
-        });
       } else {
         this.stackNotSupportedMessage = this._translateService.instant(PortalResources.githubActionStackNotSupportedMessage, {
           appName: this.wizard.slotName ? `${this.wizard.siteName} (${this.wizard.slotName})` : this.wizard.siteName,
@@ -155,6 +146,8 @@ export class StackSelectorComponent implements OnDestroy {
 
   private _populateRuntimeStackVersionItems(stackValue: string) {
     if (stackValue) {
+      this.showVersionSelector = stackValue !== RuntimeStacks.aspnet;
+
       const runtimeStack = this._runtimeStacks.find(stack => stack.value.toLocaleLowerCase() === stackValue);
 
       this.runtimeStackVersionItems = runtimeStack.versions.map(version => ({

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-source-control/step-source-control.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-source-control/step-source-control.component.ts
@@ -389,7 +389,7 @@ export class StepSourceControlComponent {
     this.selectedProvider = card;
     const currentFormValues = this._wizardService.wizardValues;
     currentFormValues.sourceProvider = card.id;
-    currentFormValues.buildProvider = 'kudu'; // Not all providers are supported by VSTS, however all providers are supported by kudu so this is a safe default
+    currentFormValues.buildProvider = card.id == 'github' ? 'github' : 'kudu'; // Not all providers are supported by VSTS, however all providers are supported by kudu so this is a safe default
     this._wizardService.wizardValues = currentFormValues;
   }
 

--- a/client/src/app/site/deployment-center/deployment-center-setup/wizard-logic/deployment-center-state-manager.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/wizard-logic/deployment-center-state-manager.ts
@@ -215,6 +215,8 @@ export class DeploymentCenterStateManager implements OnDestroy {
       // defined constants.
       if (metadataStack === 'java') {
         this.stack = siteConfig.javaVersion === JavaVersions.WindowsVersion8 ? RuntimeStacks.java8 : RuntimeStacks.java11;
+      } else if (metadataStack === 'dotnet') {
+        this.stack = RuntimeStacks.aspnet;
       } else {
         this.stack = metadataStack;
       }

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -5340,9 +5340,6 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="functionKeyNamesUnique" xml:space="preserve">
         <value>Function key names must be unique</value>
     </data>
-    <data name="gitHubActionBuildServerTitle" xml:space="preserve">
-        <value>GitHub Actions (Preview)</value>
-    </data>
     <data name="gitHubActionBuildServerDesc" xml:space="preserve">
         <value>Automate your build, test, and deployment steps with GitHub Actions for free. This will add a YML workflow to your repository with steps to build and deploy your application to App Service.</value>
     </data>
@@ -5786,12 +5783,6 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     </data>
     <data name="disableFunctionTestTooltip" xml:space="preserve">
         <value>Test is only supported for HTTP triggered functions</value>
-    </data>
-    <data name="githubActionAspNetStackNotSupportedMessage" xml:space="preserve">
-        <value>The app '{{appName}}' is setup with stack 'ASP.NET' which is currently not supported in Deployment Center via GitHub Actions.</value>
-    </data>
-    <data name="githubActionAspNetStackMismatchMessage" xml:space="preserve">
-        <value>The app '{{appName}}' is currently configured for 'ASP.NET', which does not match current build selection. The app might not function correctly with current build selection.</value>
     </data>
     <data name="gitHubActionWorkflowFileNameTitle" xml:space="preserve">
         <value>GitHub Action Workflow Filename</value>

--- a/server/src/stacks/webapp/2020-05-01/stacks/create/aspDotnet.ts
+++ b/server/src/stacks/webapp/2020-05-01/stacks/create/aspDotnet.ts
@@ -20,7 +20,8 @@ export const aspDotnetCreateStack: WebAppCreateStack = {
           runtimeVersion: 'v4.0',
           sortOrder: 0,
           githubActionSettings: {
-            supported: false,
+            supported: true,
+            recommendedVersion: '3.1',
           },
         },
       ],
@@ -40,7 +41,8 @@ export const aspDotnetCreateStack: WebAppCreateStack = {
           runtimeVersion: 'v2.0',
           sortOrder: 0,
           githubActionSettings: {
-            supported: false,
+            supported: true,
+            recommendedVersion: '2.1',
           },
         },
       ],

--- a/server/src/stacks/webapp/2020-06-01/stacks/aspDotnet.ts
+++ b/server/src/stacks/webapp/2020-06-01/stacks/aspDotnet.ts
@@ -20,7 +20,8 @@ export const aspDotnetStack: WebAppStack<WebAppRuntimes> = {
                 isSupported: true,
               },
               gitHubActionSettings: {
-                isSupported: false,
+                isSupported: true,
+                supportedVersion: '3.1',
               },
             },
           },
@@ -42,7 +43,8 @@ export const aspDotnetStack: WebAppStack<WebAppRuntimes> = {
                 isSupported: true,
               },
               gitHubActionSettings: {
-                isSupported: false,
+                isSupported: true,
+                supportedVersion: '2.1',
               },
             },
           },

--- a/server/src/tests/Stacks/WebApp/2020-05-01/validations.ts
+++ b/server/src/tests/Stacks/WebApp/2020-05-01/validations.ts
@@ -46,12 +46,12 @@ export function validateConfigLinuxStackLength(stacks) {
 
 export function validateGithubActionStackLength(stacks) {
   expect(stacks).to.be.an('array');
-  expect(stacks.length).to.equal(5);
+  expect(stacks.length).to.equal(6);
 }
 
 export function validateGithubActionWindowsStackLength(stacks) {
   expect(stacks).to.be.an('array');
-  expect(stacks.length).to.equal(5);
+  expect(stacks.length).to.equal(6);
 }
 
 export function validateGithubActionLinuxStackLength(stacks) {


### PR DESCRIPTION
fixes AB#7881869
fixes AB#7816083

Remove the 'preview' tags from GitHub Action. This requires following changes:
1. Add ASP.NET Support
2. Move to webapp deploy action from v1 to v2
3. Remove the actual 'preview' tag