### PR TITLE
Update the angular traces to contain identifier fields in our clienTelemetery logs

### DIFF
--- a/client/src/app/shared/services/log.service.ts
+++ b/client/src/app/shared/services/log.service.ts
@@ -39,8 +39,7 @@ export class LogService {
     }
 
     // Always log traces to App Insights
-    const properties = data ? (typeof data === 'object' ? data : { message: data }) : null;
-    this._aiService.trackEvent(`/trace/${category}/${id}`, properties);
+    this._aiService.trackEvent(`/trace/${category}/${id}`, data);
 
     if (this._shouldLog(category, LogLevel.trace)) {
       console.error(`[${category}] - ${this._getDataString(data)}`);
@@ -55,8 +54,7 @@ export class LogService {
     const errorId = `/errors/${category}/${id}`;
 
     // Always log errors to App Insights
-    const properties = typeof data === 'object' ? data : { message: data };
-    this._aiService.trackEvent(errorId, properties);
+    this._aiService.trackEvent(errorId, data);
 
     if (this._shouldLog(category, LogLevel.error)) {
       console.error(`[${category}] - ${this._getDataString(data)}`);
@@ -71,8 +69,7 @@ export class LogService {
     const warningId = `/warnings/${category}/${id}`;
 
     // Always log warnings to App Insights
-    const properties = typeof data === 'object' ? data : { message: data };
-    this._aiService.trackEvent(warningId, properties);
+    this._aiService.trackEvent(warningId, data);
 
     if (this._shouldLog(category, LogLevel.warning)) {
       console.log(`%c[${category}] - ${this._getDataString(data)}`, 'color: #ff8c00');

--- a/client/src/app/shared/services/portal.service.ts
+++ b/client/src/app/shared/services/portal.service.ts
@@ -292,7 +292,7 @@ export class PortalService implements IPortalService {
   }
 
   hasPermission(resourceId: string, actions: string[]) {
-    this.logAction('portal-service', `has-permission: ${resourceId}`, null);
+    this.logAction('portal-service', 'has-permission', { resourceId });
     const operationId = Guid.newGuid();
 
     const payload: DataMessage<CheckPermissionRequest> = {
@@ -316,7 +316,7 @@ export class PortalService implements IPortalService {
   }
 
   hasLock(resourceId: string, type: LockType) {
-    this.logAction('portal-service', `has-lock: ${resourceId}`, null);
+    this.logAction('portal-service', 'has-lock', { resourceId });
     const operationId = Guid.newGuid();
 
     const payload: DataMessage<CheckLockRequest> = {


### PR DESCRIPTION
fixes AB#7927056
fixes AB#7927080

Currently we have either Ibiza sessionId OR AI autogenerated sessionId, so '927b92d7e0e040a4a7e9bfe33590d3d8' or 'pTuOd'
Also the resource Ids either start with /ng-min/feature or not. 

This PR will standardize the logs emitted by Angular similar to how the logs are emitted for React.