### PR TITLE
[Proxies] Update proxies experience to use VFS APIs

### DIFF
--- a/client/src/app/api/api-details/api-details.component.ts
+++ b/client/src/app/api/api-details/api-details.component.ts
@@ -19,6 +19,8 @@ import { NavigableComponent, ExtendedTreeViewInfo } from '../../shared/component
 import { SiteService } from '../../shared/services/site.service';
 import { PortalService } from '../../shared/services/portal.service';
 import { FunctionsVersionInfoHelper } from '../../shared/models/functions-version-info';
+import { PortalResources } from '../../shared/models/portal-resources';
+import { errorIds } from '../../shared/models/error-ids';
 
 @Component({
   selector: 'api-details',
@@ -80,6 +82,15 @@ export class ApiDetailsComponent extends NavigableComponent implements OnDestroy
           .concatMap(r => {
             if (r.isSuccessful) {
               this._runtimeVersion = FunctionsVersionInfoHelper.getRuntimeVersionString(r.result.properties.version);
+            } else {
+              this.showComponentError({
+                message:
+                  this._translateService.instant(PortalResources.error_functionRuntimeIsUnableToStart) +
+                  '\n' +
+                  r.result.properties.errors.reduce((a, b) => `${a}\n${b}`, '\n'),
+                errorId: errorIds.functionRuntimeIsUnableToStart,
+                resourceId: this.context.site.id,
+              });
             }
             return Observable.zip(
               this._functionAppService.getApiProxies(this.context, this._runtimeVersion),

--- a/client/src/app/api/api-new/api-new.component.ts
+++ b/client/src/app/api/api-new/api-new.component.ts
@@ -112,6 +112,15 @@ export class ApiNewComponent extends NavigableComponent {
           .concatMap(r => {
             if (r.isSuccessful) {
               this._runtimeVersion = FunctionsVersionInfoHelper.getRuntimeVersionString(r.result.properties.version);
+            } else {
+              this.showComponentError({
+                message:
+                  this._translateService.instant(PortalResources.error_functionRuntimeIsUnableToStart) +
+                  '\n' +
+                  r.result.properties.errors.reduce((a, b) => `${a}\n${b}`, '\n'),
+                errorId: errorIds.functionRuntimeIsUnableToStart,
+                resourceId: this.context.site.id,
+              });
             }
 
             // Should be okay to query app settings without checkout RBAC/locks since this component

--- a/client/src/app/api/api-new/api-new.component.ts
+++ b/client/src/app/api/api-new/api-new.component.ts
@@ -19,6 +19,7 @@ import { SiteService } from '../../shared/services/site.service';
 import { ArmObj } from 'app/shared/models/arm/arm-obj';
 import { FunctionService } from 'app/shared/services/function.service';
 import { PortalService } from '../../shared/services/portal.service';
+import { FunctionsVersionInfoHelper } from '../../shared/models/functions-version-info';
 
 @Component({
   selector: 'api-new',
@@ -39,6 +40,7 @@ export class ApiNewComponent extends NavigableComponent {
 
   private _proxiesNode: ProxiesNode;
   private _rrOverrideValue: any;
+  private _runtimeVersion: string;
 
   static validateUrl(): ValidatorFn {
     return (control: AbstractControl): { [key: string]: any } => {
@@ -101,19 +103,28 @@ export class ApiNewComponent extends NavigableComponent {
           this.appNode = <AppNode>this._proxiesNode.parent;
         }
 
-        return this._functionAppService.getAppContext(viewInfo.siteDescriptor.getTrimmedResourceId()).concatMap(context => {
-          // Should be okay to query app settings without checkout RBAC/locks since this component
-          // shouldn't load unless you have write access.
-          return Observable.zip(
-            this._functionService.getFunctions(context.site.id),
-            this._functionAppService.getApiProxies(context),
-            this._siteService.getAppSettings(context.site.id),
-            (f, p, a) => ({ fcs: f, proxies: p, appSettings: a, context: context })
-          );
-        });
+        return this._functionAppService
+          .getAppContext(viewInfo.siteDescriptor.getTrimmedResourceId())
+          .concatMap(context => {
+            this.context = context;
+            return this._siteService.getHostStatus(context.site.id);
+          })
+          .concatMap(r => {
+            if (r.isSuccessful) {
+              this._runtimeVersion = FunctionsVersionInfoHelper.getRuntimeVersionString(r.result.properties.version);
+            }
+
+            // Should be okay to query app settings without checkout RBAC/locks since this component
+            // shouldn't load unless you have write access.
+            return Observable.zip(
+              this._functionService.getFunctions(this.context.site.id),
+              this._functionAppService.getApiProxies(this.context, this._runtimeVersion),
+              this._siteService.getAppSettings(this.context.site.id),
+              (f, p, a) => ({ fcs: f, proxies: p, appSettings: a })
+            );
+          });
       })
       .do(res => {
-        this.context = res.context;
         if (res.fcs.isSuccessful) {
           this.functionsInfo = res.fcs.result.value;
         } else {
@@ -186,7 +197,7 @@ export class ApiNewComponent extends NavigableComponent {
       };
 
       this._functionAppService
-        .getApiProxies(this.context)
+        .getApiProxies(this.context, this._runtimeVersion)
         .takeUntil(this.ngUnsubscribe)
         .subscribe(proxies => {
           // TODO: [alrod] handle error
@@ -230,18 +241,20 @@ export class ApiNewComponent extends NavigableComponent {
 
           this.apiProxies.push(newApiProxy);
 
-          this._functionAppService.saveApiProxy(this.context, ApiProxy.toJson(this.apiProxies, this._translateService)).subscribe(() => {
-            this.clearBusy();
-            this._aiService.trackEvent('/actions/proxy/create');
-            if (this._proxiesNode) {
-              // If someone refreshed the app, it would created a new set of child nodes under the app node.
-              this._proxiesNode = <ProxiesNode>this.appNode.children.find(node => node.title === this._proxiesNode.title);
-              this._proxiesNode.addChild(newApiProxy);
-            } else {
-              // Ibizafication Experience, open the Proxy-List tab
-              this._portalService.closeSelf({ data: { ...newApiProxy } });
-            }
-          });
+          this._functionAppService
+            .saveApiProxy(this.context, ApiProxy.toJson(this.apiProxies, this._translateService), this._runtimeVersion)
+            .subscribe(() => {
+              this.clearBusy();
+              this._aiService.trackEvent('/actions/proxy/create');
+              if (this._proxiesNode) {
+                // If someone refreshed the app, it would created a new set of child nodes under the app node.
+                this._proxiesNode = <ProxiesNode>this.appNode.children.find(node => node.title === this._proxiesNode.title);
+                this._proxiesNode.addChild(newApiProxy);
+              } else {
+                // Ibizafication Experience, open the Proxy-List tab
+                this._portalService.closeSelf({ data: { ...newApiProxy } });
+              }
+            });
         });
     }
   }

--- a/client/src/app/shared/models/constants.ts
+++ b/client/src/app/shared/models/constants.ts
@@ -132,6 +132,7 @@ export class Regex {
   public static readonly errorLog: RegExp = /^(\d{4}-\d{2}-\d{2})[T\s](\d{2}:\d{2}:\d{2}\.\d+)\ (\[Error|ERROR)/;
   public static readonly warningLog: RegExp = /^(\d{4}-\d{2}-\d{2})[T\s](\d{2}:\d{2}:\d{2}\.\d+)\ (\[Warning|WARNING)/;
   public static readonly log: RegExp = /^(\d{4}-\d{2}-\d{2})[T\s](\d{2}:\d{2}:\d{2})/;
+  public static readonly runtimeVersion = /^[0-9]+./;
   /*
     1. Donot Start with /, \ or ~
     2. Donot have path in drive letter format eg: (C:/Windows)

--- a/client/src/app/shared/models/functions-version-info.ts
+++ b/client/src/app/shared/models/functions-version-info.ts
@@ -1,4 +1,4 @@
-import { FunctionAppVersion } from './../models/constants';
+import { FunctionAppVersion, Regex } from './../models/constants';
 
 export interface FunctionsVersionInfo {
   runtimeStable: string[];
@@ -41,5 +41,13 @@ export class FunctionsVersionInfoHelper {
     const path = generation === FunctionAppVersion.v1 ? 'admin/extensions/EventGridExtensionConfig' : 'runtime/webhooks/EventGrid';
 
     return `${mainSiteUrl.toLowerCase()}/${path}?functionName=${functionName}&code=${code}`;
+  }
+
+  public static getRuntimeVersionString(exactVersion: string) {
+    if (Regex.runtimeVersion.test(exactVersion)) {
+      const versionElements = exactVersion.split('.');
+      return `~${versionElements[0]}`;
+    }
+    return exactVersion;
   }
 }

--- a/client/src/app/shared/services/function-app.service.ts
+++ b/client/src/app/shared/services/function-app.service.ts
@@ -108,10 +108,8 @@ export class FunctionAppService {
   private retrieveProxies(context: FunctionAppContext, runtimeVersion: string): Observable<any> {
     const headers = this._armService.getHeaders();
     headers['Cache-Control'] = 'no-cache';
-    const url = this._armService.getArmUrl(
-      `${context.site.id}${context.urlTemplates.getProxiesVfsUrl(runtimeVersion, 'proxies.json')}`,
-      this._armService.antaresApiVersion20181101
-    );
+    const resourceId = `${context.site.id}${context.urlTemplates.getProxiesVfsUrl(runtimeVersion, 'proxies.json')}`;
+    const url = this._armService.getArmUrl(resourceId, this._armService.antaresApiVersion20181101);
 
     return this._cacheService.get(url, true, headers).catch(err =>
       err.status === 404
@@ -164,10 +162,8 @@ export class FunctionAppService {
   saveApiProxy(context: FunctionAppContext, jsonString: string, runtimeVersion): Result<Response> {
     const headers = this._armService.getHeaders();
     headers['Cache-Control'] = 'no-cache';
-    const url = this._armService.getArmUrl(
-      `${context.site.id}${context.urlTemplates.getProxiesVfsUrl(runtimeVersion, 'proxies.json')}`,
-      this._armService.antaresApiVersion20181101
-    );
+    const resourceId = `${context.site.id}${context.urlTemplates.getProxiesVfsUrl(runtimeVersion, 'proxies.json')}`;
+    const url = this._armService.getArmUrl(resourceId, this._armService.antaresApiVersion20181101);
 
     return this.getClient(context).execute({ resourceId: context.site.id }, t => this._cacheService.put(url, headers, jsonString));
   }
@@ -581,12 +577,10 @@ export class FunctionAppService {
 
   fireSyncTrigger(context: FunctionAppContext): void {
     if (ArmUtil.isLinuxDynamic(context.site)) {
-      this._cacheService
-        .postArm(`${context.site.id}/hostruntime/admin/host/synctriggers`, true)
-        .subscribe(
-          success => this._logService.verbose(LogCategories.syncTriggers, success),
-          error => this._logService.error(LogCategories.syncTriggers, '/sync-triggers-error', error)
-        );
+      this._cacheService.postArm(`${context.site.id}/hostruntime/admin/host/synctriggers`, true).subscribe(
+        success => this._logService.verbose(LogCategories.syncTriggers, success),
+        error => this._logService.error(LogCategories.syncTriggers, '/sync-triggers-error', error)
+      );
     } else {
       const url = context.urlTemplates.syncTriggersUrl;
       this.azure

--- a/client/src/app/shared/services/function-app.service.ts
+++ b/client/src/app/shared/services/function-app.service.ts
@@ -49,6 +49,7 @@ import { ApplicationSettings } from 'app/shared/models/arm/application-settings'
 import { ArmSiteDescriptor } from '../resourceDescriptors';
 import { FunctionService } from './function.service';
 import { AppSettingsHelper } from '../Utilities/application-settings-helper';
+import { ArmService } from './arm.service';
 
 type Result<T> = Observable<HttpResult<T>>;
 @Injectable()
@@ -64,6 +65,7 @@ export class FunctionAppService {
     private _siteService: SiteService,
     private _logService: LogService,
     private _functionService: FunctionService,
+    private _armService: ArmService,
     injector: Injector
   ) {
     this.runtime = new ConditionalHttpClient(
@@ -92,10 +94,10 @@ export class FunctionAppService {
     return context.urlTemplates.useNewUrls ? this.runtime : this.azure;
   }
 
-  getApiProxies(context: FunctionAppContext): Result<ApiProxy[]> {
+  getApiProxies(context: FunctionAppContext, runtimeVersion: string): Result<ApiProxy[]> {
     return this.getClient(context).execute({ resourceId: context.site.id } /*input*/, token =>
       Observable /*query*/.zip(
-        this.retrieveProxies(context, token),
+        this.retrieveProxies(context, runtimeVersion),
         this._cacheService.get('assets/schemas/proxies.json', false, this.portalHeaders(token)),
         (p, s) => ({ proxies: p, schema: s })
       )
@@ -103,8 +105,8 @@ export class FunctionAppService {
     );
   }
 
-  private retrieveProxies(context: FunctionAppContext, token: string): Observable<any> {
-    return this._cacheService.get(context.urlTemplates.proxiesJsonUrl, false, this.headers(token)).catch(err =>
+  private retrieveProxies(context: FunctionAppContext, runtimeVersion: string): Observable<any> {
+    return this._cacheService.getArm(context.urlTemplates.getProxiesVfsUrl(runtimeVersion, 'proxies.json')).catch(err =>
       err.status === 404
         ? Observable.throw({
             errorId: errorIds.proxyJsonNotFound,
@@ -152,12 +154,13 @@ export class FunctionAppService {
     return Observable.of(ApiProxy.fromJson(proxiesJson));
   }
 
-  saveApiProxy(context: FunctionAppContext, jsonString: string): Result<Response> {
-    const uri = context.urlTemplates.proxiesJsonUrl;
-    this._cacheService.clearCachePrefix(uri);
-
+  saveApiProxy(context: FunctionAppContext, jsonString: string, runtimeVersion): Result<Response> {
     return this.getClient(context).execute({ resourceId: context.site.id }, t =>
-      this._cacheService.put(uri, this.jsonHeaders(t, ['If-Match', '*']), jsonString)
+      this._cacheService.putArm(
+        context.urlTemplates.getProxiesVfsUrl(runtimeVersion, 'proxies.json'),
+        this._armService.antaresApiVersion20181101,
+        jsonString
+      )
     );
   }
 

--- a/client/src/app/shared/services/site.service.ts
+++ b/client/src/app/shared/services/site.service.ts
@@ -25,6 +25,7 @@ import { HostingEnvironment } from '../models/arm/hosting-environment';
 import { PublishingUser } from '../models/arm/publishing-users';
 import { Deployment, SourceControlData } from 'app/site/deployment-center/Models/deployment-data';
 import { AppSettingsHelper } from '../Utilities/application-settings-helper';
+import { HostStatus } from '../models/host-status';
 
 type Result<T> = Observable<HttpResult<T>>;
 
@@ -263,4 +264,10 @@ export class SiteService {
 
     return this._client.execute({ resourceId: resourceId }, t => getBasicPublishingCredentialsPolicies);
   };
+
+  getHostStatus(resourceId: string, force?: boolean): Result<ArmObj<HostStatus>> {
+    const getHostStatus = this._cacheService.postArm(`${resourceId}/host/default/properties/status`, force).map(r => r.json());
+
+    return this._client.execute({ resourceId: resourceId }, t => getHostStatus);
+  }
 }

--- a/client/src/app/shared/services/site.service.ts
+++ b/client/src/app/shared/services/site.service.ts
@@ -266,7 +266,7 @@ export class SiteService {
   };
 
   getHostStatus(resourceId: string, force?: boolean): Result<ArmObj<HostStatus>> {
-    const getHostStatus = this._cacheService.postArm(`${resourceId}/host/default/properties/status`, force).map(r => r.json());
+    const getHostStatus = this._cacheService.getArm(`${resourceId}/host/default/properties/status`, force).map(r => r.json());
 
     return this._client.execute({ resourceId: resourceId }, t => getHostStatus);
   }

--- a/client/src/app/shared/url-templates.ts
+++ b/client/src/app/shared/url-templates.ts
@@ -7,6 +7,7 @@ import { Injector } from '@angular/core';
 import { ArmObj } from 'app/shared/models/arm/arm-obj';
 import { Site, HostType } from 'app/shared/models/arm/site';
 import { runtimeIsV2, runtimeIsV3 } from './models/functions-version-info';
+import { FunctionAppVersion } from './models/constants';
 
 export class UrlTemplates {
   private configService: ConfigService;
@@ -80,6 +81,17 @@ export class UrlTemplates {
         : `${this.mainSiteUrl}/admin/vfs/site/wwwroot/proxies.json`;
     }
     return `${this.scmUrl}/api/vfs/site/wwwroot/proxies.json`;
+  }
+
+  getProxiesVfsUrl(runtimeVersion: string, endpoint: string): string {
+    switch (runtimeVersion) {
+      case FunctionAppVersion.v2:
+      case FunctionAppVersion.v3:
+        return `/hostruntime/admin/vfs/${endpoint}?relativePath=1`;
+      case FunctionAppVersion.v1:
+      default:
+        return `/extensions/api/vfs/site/wwwroot/${endpoint}`;
+    }
   }
 
   getFunctionUrl(functionName: string, functionEntity?: string): string {

--- a/client/src/app/shared/url-templates.ts
+++ b/client/src/app/shared/url-templates.ts
@@ -7,7 +7,7 @@ import { Injector } from '@angular/core';
 import { ArmObj } from 'app/shared/models/arm/arm-obj';
 import { Site, HostType } from 'app/shared/models/arm/site';
 import { runtimeIsV2, runtimeIsV3 } from './models/functions-version-info';
-import { FunctionAppVersion } from './models/constants';
+import { FunctionAppRuntimeSetting } from './models/constants';
 
 export class UrlTemplates {
   private configService: ConfigService;
@@ -85,10 +85,10 @@ export class UrlTemplates {
 
   getProxiesVfsUrl(runtimeVersion: string, endpoint: string): string {
     switch (runtimeVersion) {
-      case FunctionAppVersion.v2:
-      case FunctionAppVersion.v3:
+      case FunctionAppRuntimeSetting.tilda2:
+      case FunctionAppRuntimeSetting.tilda3:
         return `/hostruntime/admin/vfs/${endpoint}?relativePath=1`;
-      case FunctionAppVersion.v1:
+      case FunctionAppRuntimeSetting.tilda1:
       default:
         return `/extensions/api/vfs/site/wwwroot/${endpoint}`;
     }


### PR DESCRIPTION
Fixes AB#7858844

In order to use the correct VFS API, we need the RuntimeVersion of the app, and thus the getHostStatus call. 