### PR TITLE
Get Deployment Center Preview ready for container based updates

### DIFF
--- a/client-react/src/SiteState.ts
+++ b/client-react/src/SiteState.ts
@@ -6,6 +6,8 @@ import { Site } from './models/site/site';
 export interface ISiteState {
   stopped: boolean;
   siteAppEditState: FunctionAppEditMode;
+  isLinuxApplication: boolean;
+  isContainerApplication: boolean;
   resourceId?: string;
   site?: ArmObj<Site>;
 }

--- a/client-react/src/SiteState.ts
+++ b/client-react/src/SiteState.ts
@@ -6,8 +6,8 @@ import { Site } from './models/site/site';
 export interface ISiteState {
   stopped: boolean;
   siteAppEditState: FunctionAppEditMode;
-  isLinuxApplication: boolean;
-  isContainerApplication: boolean;
+  isLinuxApp: boolean;
+  isContainerApp: boolean;
   resourceId?: string;
   site?: ArmObj<Site>;
 }

--- a/client-react/src/pages/app/SiteRouter.tsx
+++ b/client-react/src/pages/app/SiteRouter.tsx
@@ -233,7 +233,14 @@ const SiteRouter: React.FC<RouteComponentProps<SiteRouterProps>> = props => {
             return (
               value.token && (
                 <SiteStateContext.Provider
-                  value={{ site, siteAppEditState, stopped, resourceId, isLinuxApplication, isContainerApplication }}>
+                  value={{
+                    site,
+                    siteAppEditState,
+                    stopped,
+                    resourceId,
+                    isLinuxApp: isLinuxApplication,
+                    isContainerApp: isContainerApplication,
+                  }}>
                   <Router>
                     {/* NOTE(michinoy): The paths should be always all lowercase. */}
 

--- a/client-react/src/pages/app/SiteRouter.tsx
+++ b/client-react/src/pages/app/SiteRouter.tsx
@@ -75,6 +75,8 @@ const SiteRouter: React.FC<RouteComponentProps<SiteRouterProps>> = props => {
   const [site, setSite] = useState<ArmObj<Site> | undefined>(undefined);
   const [stopped, setStopped] = useState(false);
   const [siteAppEditState, setSiteAppEditState] = useState<FunctionAppEditMode>(FunctionAppEditMode.ReadWrite);
+  const [isLinuxApplication, setIsLinuxApplication] = useState<boolean>(false);
+  const [isContainerApplication, setIsContainerApplication] = useState<boolean>(false);
 
   const getSiteStateFromSiteData = (site: ArmObj<Site>): FunctionAppEditMode | undefined => {
     if (isLinuxDynamic(site)) {
@@ -210,6 +212,8 @@ const SiteRouter: React.FC<RouteComponentProps<SiteRouterProps>> = props => {
       if (siteResponse.metadata.success) {
         setSite(siteResponse.data);
         setStopped(siteResponse.data.properties.state.toLocaleLowerCase() === CommonConstants.SiteStates.stopped);
+        setIsLinuxApplication(isLinuxApp(siteResponse.data));
+        setIsContainerApplication(isContainerApp(siteResponse.data));
       }
       setSiteAppEditState(functionAppEditMode);
     }
@@ -228,7 +232,8 @@ const SiteRouter: React.FC<RouteComponentProps<SiteRouterProps>> = props => {
             setResourceId(value.token && value.resourceId);
             return (
               value.token && (
-                <SiteStateContext.Provider value={{ site, siteAppEditState, stopped, resourceId }}>
+                <SiteStateContext.Provider
+                  value={{ site, siteAppEditState, stopped, resourceId, isLinuxApplication, isContainerApplication }}>
                   <Router>
                     {/* NOTE(michinoy): The paths should be always all lowercase. */}
 

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -1,5 +1,4 @@
-import { ArmObj, ArmArray } from '../../../models/arm-obj';
-import { PublishingCredentials, PublishingUser, PublishingProfile } from '../../../models/site/publish';
+import { ArmArray } from '../../../models/arm-obj';
 import { FormikProps } from 'formik';
 import * as Yup from 'yup';
 import { ScmType, BuildProvider } from '../../../models/site/config';
@@ -47,9 +46,17 @@ export enum WorkflowFileDeleteOptions {
   Delete = 'Delete',
 }
 
-export type DeploymentCenterContainerProps = DeploymentCenterContainerLogsProps & DeploymentCenterFtpsProps;
+export interface DeploymentCenterDataLoaderProps {
+  resourceId: string;
+}
 
-export type DeploymentCenterCodeProps = DeploymentCenterCodeLogsProps & DeploymentCenterFtpsProps;
+export interface RefreshableComponent {
+  refresh: () => void;
+}
+
+export type DeploymentCenterContainerProps = DeploymentCenterContainerLogsProps & DeploymentCenterFtpsProps & RefreshableComponent;
+
+export type DeploymentCenterCodeProps = DeploymentCenterCodeLogsProps & DeploymentCenterFtpsProps & RefreshableComponent;
 
 export type DeploymentCenterYupValidationSchemaType<
   T = DeploymentCenterContainerFormData | DeploymentCenterCodeFormData
@@ -126,15 +133,10 @@ export interface DeploymentCenterGitHubWorkflowConfigPreviewProps {
 
 export interface DeploymentCenterFtpsProps {
   isLoading: boolean;
-  resetApplicationPassword: () => void;
-  publishingCredentials?: ArmObj<PublishingCredentials>;
-  publishingUser?: ArmObj<PublishingUser>;
-  publishingProfile?: PublishingProfile;
 }
 
 export interface DeploymentCenterFormProps<T = DeploymentCenterContainerFormData | DeploymentCenterCodeFormData> {
   isLoading: boolean;
-  showPublishProfilePanel: () => void;
   formData?: DeploymentCenterFormData<T>;
   formValidationSchema?: DeploymentCenterYupValidationSchemaType<T>;
 }
@@ -159,7 +161,6 @@ export interface DeploymentCenterCommandBarProps {
 
 export interface DeploymentCenterCodeCommandBarProps extends DeploymentCenterFieldProps<DeploymentCenterCodeFormData> {
   isLoading: boolean;
-  showPublishProfilePanel: () => void;
   refresh: () => void;
 }
 

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterContext.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterContext.ts
@@ -3,13 +3,10 @@ import { ArmSiteDescriptor } from '../../../utils/resourceDescriptors';
 import { ArmObj } from '../../../models/arm-obj';
 import { SiteConfig } from '../../../models/site/config';
 import { KeyValue } from '../../../models/portal-models';
-import { PublishingCredentialPolicies } from '../../../models/site/site';
 
 export interface IDeploymentCenterContext {
   resourceId: string;
   hasWritePermission: boolean;
-  isContainerApplication: boolean;
-  isLinuxApplication: boolean;
   oneDriveToken: string;
   dropBoxToken: string;
   bitbucketToken: string;
@@ -19,7 +16,6 @@ export interface IDeploymentCenterContext {
   siteDescriptor?: ArmSiteDescriptor;
   applicationSettings?: ArmObj<KeyValue<string>>;
   configMetadata?: ArmObj<KeyValue<string>>;
-  basicPublishingCredentialsPolicies?: PublishingCredentialPolicies;
 }
 
 export const DeploymentCenterContext = React.createContext<IDeploymentCenterContext>({} as IDeploymentCenterContext);

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
@@ -15,6 +15,7 @@ import CustomBanner from '../../../components/CustomBanner/CustomBanner';
 import { DeploymentCenterContext } from './DeploymentCenterContext';
 import CustomFocusTrapCallout from '../../../components/CustomCallout/CustomFocusTrapCallout';
 import { Links } from '../../../utils/FwLinks';
+import { DeploymentCenterPublishingContext } from './DeploymentCenterPublishingContext';
 
 type PasswordFieldType = 'password' | undefined;
 
@@ -22,7 +23,11 @@ const DeploymentCenterFtps: React.FC<
   DeploymentCenterFtpsProps & DeploymentCenterFieldProps<DeploymentCenterContainerFormData | DeploymentCenterCodeFormData>
 > = props => {
   const { t } = useTranslation();
-  const { publishingProfile, publishingUser, resetApplicationPassword, isLoading } = props;
+  const deploymentCenterContext = useContext(DeploymentCenterContext);
+  const deploymentCenterPublishingContext = useContext(DeploymentCenterPublishingContext);
+
+  const { isLoading } = props;
+  const { publishingProfile, publishingUser, resetApplicationPassword } = deploymentCenterPublishingContext;
 
   const [applicationPasswordType, setApplicationPasswordType] = useState<PasswordFieldType>('password');
   const [providerPasswordType, setProviderPasswordType] = useState<PasswordFieldType>('password');
@@ -32,7 +37,6 @@ const DeploymentCenterFtps: React.FC<
 
   const ftpsEndpoint = publishingProfile && publishingProfile.publishUrl.toLocaleLowerCase().replace('ftp:/', 'ftps:/');
   const webProviderUsername = publishingUser && publishingUser.properties.publishingUserName;
-  const deploymentCenterContext = useContext(DeploymentCenterContext);
 
   const siteDescriptor = deploymentCenterContext && deploymentCenterContext.siteDescriptor;
   const sampleAppNameDomain =
@@ -76,9 +80,9 @@ const DeploymentCenterFtps: React.FC<
   };
 
   const disableFtp = () =>
-    deploymentCenterContext.basicPublishingCredentialsPolicies &&
-    deploymentCenterContext.basicPublishingCredentialsPolicies.ftp &&
-    !deploymentCenterContext.basicPublishingCredentialsPolicies.ftp.allow;
+    deploymentCenterPublishingContext.basicPublishingCredentialsPolicies &&
+    deploymentCenterPublishingContext.basicPublishingCredentialsPolicies.ftp &&
+    !deploymentCenterPublishingContext.basicPublishingCredentialsPolicies.ftp.allow;
 
   const getDisabledByFTPPolicyMessage = () => (
     <div className={deploymentCenterContent}>

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterPublishingContext.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterPublishingContext.ts
@@ -1,0 +1,17 @@
+import React from 'react';
+import { PublishingCredentialPolicies } from '../../../models/site/site';
+import { ArmObj } from '../../../models/arm-obj';
+import { PublishingCredentials, PublishingUser, PublishingProfile } from '../../../models/site/publish';
+
+export interface IDeploymentCenterPublishingContext {
+  showPublishProfilePanel: () => void;
+  resetApplicationPassword: () => void;
+  basicPublishingCredentialsPolicies?: PublishingCredentialPolicies;
+  publishingCredentials?: ArmObj<PublishingCredentials>;
+  publishingUser?: ArmObj<PublishingUser>;
+  publishingProfile?: PublishingProfile;
+}
+
+export const DeploymentCenterPublishingContext = React.createContext<IDeploymentCenterPublishingContext>(
+  {} as IDeploymentCenterPublishingContext
+);

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildConfiguredView.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildConfiguredView.tsx
@@ -23,7 +23,7 @@ const DeploymentCenterCodeBuildConfiguredView: React.FC<{}> = () => {
   const siteStateContext = useContext(SiteStateContext);
 
   const fetchData = async () => {
-    const appOs = siteStateContext.isLinuxApplication ? AppOs.linux : AppOs.windows;
+    const appOs = siteStateContext.isLinuxApp ? AppOs.linux : AppOs.windows;
     const runtimeStacksResponse = await deploymentCenterData.getRuntimeStacks(appOs);
 
     if (runtimeStacksResponse.metadata.success) {
@@ -53,7 +53,7 @@ const DeploymentCenterCodeBuildConfiguredView: React.FC<{}> = () => {
     const defaultStackAndVersionKeys: RuntimeStackSetting =
       deploymentCenterContext.siteConfig && deploymentCenterContext.configMetadata && deploymentCenterContext.applicationSettings
         ? getRuntimeStackSetting(
-            siteStateContext.isLinuxApplication,
+            siteStateContext.isLinuxApp,
             deploymentCenterContext.siteConfig,
             deploymentCenterContext.configMetadata,
             deploymentCenterContext.applicationSettings

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildConfiguredView.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildConfiguredView.tsx
@@ -11,6 +11,7 @@ import { getRuntimeStackSetting } from '../utility/DeploymentCenterUtility';
 import { useTranslation } from 'react-i18next';
 import ReactiveFormControl from '../../../../components/form-controls/ReactiveFormControl';
 import { ScmType } from '../../../../models/site/config';
+import { SiteStateContext } from '../../../../SiteState';
 
 const DeploymentCenterCodeBuildConfiguredView: React.FC<{}> = () => {
   const { t } = useTranslation();
@@ -19,11 +20,11 @@ const DeploymentCenterCodeBuildConfiguredView: React.FC<{}> = () => {
 
   const deploymentCenterData = new DeploymentCenterData();
   const deploymentCenterContext = useContext(DeploymentCenterContext);
+  const siteStateContext = useContext(SiteStateContext);
 
   const fetchData = async () => {
-    const runtimeStacksResponse = await deploymentCenterData.getRuntimeStacks(
-      deploymentCenterContext.isLinuxApplication ? AppOs.linux : AppOs.windows
-    );
+    const appOs = siteStateContext.isLinuxApplication ? AppOs.linux : AppOs.windows;
+    const runtimeStacksResponse = await deploymentCenterData.getRuntimeStacks(appOs);
 
     if (runtimeStacksResponse.metadata.success) {
       setDefaultValues(runtimeStacksResponse.data);
@@ -52,7 +53,7 @@ const DeploymentCenterCodeBuildConfiguredView: React.FC<{}> = () => {
     const defaultStackAndVersionKeys: RuntimeStackSetting =
       deploymentCenterContext.siteConfig && deploymentCenterContext.configMetadata && deploymentCenterContext.applicationSettings
         ? getRuntimeStackSetting(
-            deploymentCenterContext.isLinuxApplication,
+            siteStateContext.isLinuxApplication,
             deploymentCenterContext.siteConfig,
             deploymentCenterContext.configMetadata,
             deploymentCenterContext.applicationSettings

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildRuntimeAndVersion.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildRuntimeAndVersion.tsx
@@ -45,7 +45,7 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
   };
 
   const fetchStacks = async () => {
-    const appOs = siteStateContext.isLinuxApplication ? AppOs.linux : AppOs.windows;
+    const appOs = siteStateContext.isLinuxApp ? AppOs.linux : AppOs.windows;
     const runtimeStacksResponse = await deploymentCenterData.getRuntimeStacks(appOs);
 
     if (runtimeStacksResponse.metadata.success) {
@@ -197,7 +197,7 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
     const defaultStackAndVersion: RuntimeStackSetting =
       deploymentCenterContext.siteConfig && deploymentCenterContext.configMetadata && deploymentCenterContext.applicationSettings
         ? getRuntimeStackSetting(
-            siteStateContext.isLinuxApplication,
+            siteStateContext.isLinuxApp,
             deploymentCenterContext.siteConfig,
             deploymentCenterContext.configMetadata,
             deploymentCenterContext.applicationSettings

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildRuntimeAndVersion.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildRuntimeAndVersion.tsx
@@ -15,6 +15,7 @@ import { getRuntimeStackSetting } from '../utility/DeploymentCenterUtility';
 import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
 import { deploymentCenterInfoBannerDiv } from '../DeploymentCenter.styles';
 import { AppOs } from '../../../../models/site/site';
+import { SiteStateContext } from '../../../../SiteState';
 
 const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterFieldProps<DeploymentCenterCodeFormData>> = props => {
   const { formProps } = props;
@@ -32,7 +33,7 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
   const [showMismatchWarningBar, setShowMismatchWarningBar] = useState(true);
 
   const deploymentCenterContext = useContext(DeploymentCenterContext);
-
+  const siteStateContext = useContext(SiteStateContext);
   const deploymentCenterData = new DeploymentCenterData();
 
   const closeStackNotSupportedWarningBanner = () => {
@@ -44,9 +45,8 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
   };
 
   const fetchStacks = async () => {
-    const runtimeStacksResponse = await deploymentCenterData.getRuntimeStacks(
-      deploymentCenterContext.isLinuxApplication ? AppOs.linux : AppOs.windows
-    );
+    const appOs = siteStateContext.isLinuxApplication ? AppOs.linux : AppOs.windows;
+    const runtimeStacksResponse = await deploymentCenterData.getRuntimeStacks(appOs);
 
     if (runtimeStacksResponse.metadata.success) {
       setRuntimeStacksData(runtimeStacksResponse.data);
@@ -197,7 +197,7 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
     const defaultStackAndVersion: RuntimeStackSetting =
       deploymentCenterContext.siteConfig && deploymentCenterContext.configMetadata && deploymentCenterContext.applicationSettings
         ? getRuntimeStackSetting(
-            deploymentCenterContext.isLinuxApplication,
+            siteStateContext.isLinuxApplication,
             deploymentCenterContext.siteConfig,
             deploymentCenterContext.configMetadata,
             deploymentCenterContext.applicationSettings

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeCommandBar.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeCommandBar.tsx
@@ -54,7 +54,7 @@ const DeploymentCenterCodeCommandBar: React.FC<DeploymentCenterCodeCommandBarPro
       formProps.values.runtimeVersion,
       formProps.values.runtimeRecommendedVersion,
       branch,
-      siteStateContext.isLinuxApplication,
+      siteStateContext.isLinuxApp,
       formProps.values.gitHubPublishProfileSecretGuid,
       deploymentCenterContext.siteDescriptor ? deploymentCenterContext.siteDescriptor.site : '',
       deploymentCenterContext.siteDescriptor ? deploymentCenterContext.siteDescriptor.slot : ''

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeCommandBar.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeCommandBar.tsx
@@ -11,11 +11,15 @@ import { PortalContext } from '../../../../PortalContext';
 import { useTranslation } from 'react-i18next';
 import { DeploymentCenterConstants } from '../DeploymentCenterConstants';
 import { getErrorMessage } from '../../../../ApiHelpers/ArmHelper';
+import { SiteStateContext } from '../../../../SiteState';
+import { DeploymentCenterPublishingContext } from '../DeploymentCenterPublishingContext';
 
 const DeploymentCenterCodeCommandBar: React.FC<DeploymentCenterCodeCommandBarProps> = props => {
-  const { isLoading, showPublishProfilePanel, refresh, formProps } = props;
+  const { isLoading, refresh, formProps } = props;
   const { t } = useTranslation();
   const deploymentCenterContext = useContext(DeploymentCenterContext);
+  const deploymentCenterPublishingContext = useContext(DeploymentCenterPublishingContext);
+  const siteStateContext = useContext(SiteStateContext);
   const portalContext = useContext(PortalContext);
   const deploymentCenterData = new DeploymentCenterData();
 
@@ -50,7 +54,7 @@ const DeploymentCenterCodeCommandBar: React.FC<DeploymentCenterCodeCommandBarPro
       formProps.values.runtimeVersion,
       formProps.values.runtimeRecommendedVersion,
       branch,
-      deploymentCenterContext.isLinuxApplication,
+      siteStateContext.isLinuxApplication,
       formProps.values.gitHubPublishProfileSecretGuid,
       deploymentCenterContext.siteDescriptor ? deploymentCenterContext.siteDescriptor.site : '',
       deploymentCenterContext.siteDescriptor ? deploymentCenterContext.siteDescriptor.slot : ''
@@ -152,7 +156,7 @@ const DeploymentCenterCodeCommandBar: React.FC<DeploymentCenterCodeCommandBarPro
     <DeploymentCenterCommandBar
       saveFunction={saveFunction}
       discardFunction={discardFunction}
-      showPublishProfilePanel={showPublishProfilePanel}
+      showPublishProfilePanel={deploymentCenterPublishingContext.showPublishProfilePanel}
       refresh={refresh}
       isLoading={isLoading}
     />

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeDataLoader.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useContext, useState } from 'react';
+import { SiteStateContext } from '../../../../SiteState';
+import { DeploymentCenterContext } from '../DeploymentCenterContext';
+import { ArmArray } from '../../../../models/arm-obj';
+import {
+  DeploymentProperties,
+  DeploymentCenterFormData,
+  DeploymentCenterCodeFormData,
+  DeploymentCenterYupValidationSchemaType,
+  DeploymentCenterDataLoaderProps,
+} from '../DeploymentCenter.types';
+import DeploymentCenterData from '../DeploymentCenter.data';
+import { DeploymentCenterCodeFormBuilder } from '../code/DeploymentCenterCodeFormBuilder';
+import { useTranslation } from 'react-i18next';
+import { DeploymentCenterPublishingContext } from '../DeploymentCenterPublishingContext';
+import { getErrorMessage } from '../../../../ApiHelpers/ArmHelper';
+import DeploymentCenterCodeForm from './DeploymentCenterCodeForm';
+
+const DeploymentCenterCodeDataLoader: React.FC<DeploymentCenterDataLoaderProps> = props => {
+  const { resourceId } = props;
+  const { t } = useTranslation();
+
+  const siteStateContext = useContext(SiteStateContext);
+  const deploymentCenterContext = useContext(DeploymentCenterContext);
+  const deploymentCenterPublishingContext = useContext(DeploymentCenterPublishingContext);
+
+  const deploymentCenterData = new DeploymentCenterData();
+  const deploymentCenterCodeFormBuilder = new DeploymentCenterCodeFormBuilder(t);
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [deployments, setDeployments] = useState<ArmArray<DeploymentProperties> | undefined>(undefined);
+  const [deploymentsError, setDeploymentsError] = useState<string | undefined>(undefined);
+  const [codeFormData, setCodeFormData] = useState<DeploymentCenterFormData<DeploymentCenterCodeFormData> | undefined>(undefined);
+  const [codeFormValidationSchema, setCodeFormValidationSchema] = useState<
+    DeploymentCenterYupValidationSchemaType<DeploymentCenterCodeFormData> | undefined
+  >(undefined);
+
+  const fetchData = async () => {
+    const deploymentsResponse = await deploymentCenterData.getSiteDeployments(resourceId);
+
+    if (deploymentsResponse.metadata.success) {
+      setDeployments(deploymentsResponse.data);
+    } else {
+      const errorMessage = getErrorMessage(deploymentsResponse.metadata.error);
+      setDeploymentsError(
+        errorMessage ? t('deploymentCenterCodeDeploymentsFailedWithError').format(errorMessage) : t('deploymentCenterCodeDeploymentsFailed')
+      );
+    }
+
+    setIsLoading(false);
+  };
+
+  const generateForm = () => {
+    if (deploymentCenterContext.siteConfig) {
+      deploymentCenterCodeFormBuilder.setSiteConfig(deploymentCenterContext.siteConfig);
+    }
+
+    if (deploymentCenterContext.configMetadata) {
+      deploymentCenterCodeFormBuilder.setConfigMetadata(deploymentCenterContext.configMetadata);
+    }
+
+    if (deploymentCenterContext.applicationSettings) {
+      deploymentCenterCodeFormBuilder.setApplicationSettings(deploymentCenterContext.applicationSettings);
+    }
+
+    if (deploymentCenterPublishingContext.publishingUser) {
+      deploymentCenterCodeFormBuilder.setPublishingUser(deploymentCenterPublishingContext.publishingUser);
+    }
+
+    setCodeFormData(deploymentCenterCodeFormBuilder.generateFormData());
+    setCodeFormValidationSchema(deploymentCenterCodeFormBuilder.generateYupValidationSchema());
+  };
+
+  const refresh = () => {
+    setIsLoading(true);
+    fetchData();
+    deploymentCenterContext.refresh();
+  };
+
+  useEffect(() => {
+    fetchData();
+    generateForm();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [siteStateContext, deploymentCenterContext]);
+
+  return (
+    <DeploymentCenterCodeForm
+      deployments={deployments}
+      deploymentsError={deploymentsError}
+      formData={codeFormData}
+      formValidationSchema={codeFormValidationSchema}
+      isLoading={isLoading}
+      refresh={refresh}
+    />
+  );
+};
+
+export default DeploymentCenterCodeDataLoader;

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import { Formik, FormikProps } from 'formik';
 import { DeploymentCenterFormData, DeploymentCenterCodeFormProps, DeploymentCenterCodeFormData } from '../DeploymentCenter.types';
 import { KeyCodes } from 'office-ui-fabric-react';
@@ -7,12 +7,10 @@ import DeploymentCenterCodePivot from './DeploymentCenterCodePivot';
 import { useTranslation } from 'react-i18next';
 import ConfirmDialog from '../../../../components/ConfirmDialog/ConfirmDialog';
 import DeploymentCenterCodeCommandBar from './DeploymentCenterCodeCommandBar';
-import { DeploymentCenterContext } from '../DeploymentCenterContext';
 
 const DeploymentCenterCodeForm: React.FC<DeploymentCenterCodeFormProps> = props => {
   const { t } = useTranslation();
   const [isRefreshConfirmDialogVisible, setIsRefreshConfirmDialogVisible] = useState(false);
-  const deploymentCenterContext = useContext(DeploymentCenterContext);
 
   const onKeyDown = keyEvent => {
     if ((keyEvent.charCode || keyEvent.keyCode) === KeyCodes.enter) {
@@ -22,7 +20,7 @@ const DeploymentCenterCodeForm: React.FC<DeploymentCenterCodeFormProps> = props 
 
   const refreshFunction = () => {
     hideRefreshConfirmDialog();
-    deploymentCenterContext.refresh();
+    props.refresh();
   };
 
   const onSubmit = () => {
@@ -46,7 +44,6 @@ const DeploymentCenterCodeForm: React.FC<DeploymentCenterCodeFormProps> = props 
           <div id="deployment-center-command-bar" className={commandBarSticky}>
             <DeploymentCenterCodeCommandBar
               isLoading={props.isLoading}
-              showPublishProfilePanel={props.showPublishProfilePanel}
               refresh={() => setIsRefreshConfirmDialogVisible(true)}
               formProps={formProps}
             />

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodePivot.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodePivot.tsx
@@ -7,16 +7,7 @@ import DeploymentCenterCodeLogs from './DeploymentCenterCodeLogs';
 import DeploymentCenterCodeSettings from './DeploymentCenterCodeSettings';
 
 const DeploymentCenterCodePivot: React.FC<DeploymentCenterCodePivotProps> = props => {
-  const {
-    publishingCredentials,
-    publishingProfile,
-    publishingUser,
-    formProps,
-    resetApplicationPassword,
-    deployments,
-    deploymentsError,
-    isLoading,
-  } = props;
+  const { formProps, deployments, deploymentsError, isLoading } = props;
   const { t } = useTranslation();
   const [selectedKey, setSelectedKey] = useState<string>('logs');
 
@@ -55,14 +46,7 @@ const DeploymentCenterCodePivot: React.FC<DeploymentCenterCodePivotProps> = prop
         itemKey="ftps"
         headerText={t('deploymentCenterPivotItemFtpsHeaderText')}
         ariaLabel={t('deploymentCenterPivotItemFtpsAriaLabel')}>
-        <DeploymentCenterFtps
-          formProps={formProps}
-          resetApplicationPassword={resetApplicationPassword}
-          publishingCredentials={publishingCredentials}
-          publishingProfile={publishingProfile}
-          publishingUser={publishingUser}
-          isLoading={isLoading}
-        />
+        <DeploymentCenterFtps formProps={formProps} isLoading={isLoading} />
       </PivotItem>
     </Pivot>
   );

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
@@ -103,7 +103,7 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
           formProps.values.runtimeVersion,
           formProps.values.runtimeRecommendedVersion,
           formProps.values.branch,
-          siteStateContext.isLinuxApplication,
+          siteStateContext.isLinuxApp,
           formProps.values.gitHubPublishProfileSecretGuid,
           deploymentCenterContext.siteDescriptor.site,
           deploymentCenterContext.siteDescriptor.slot

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
@@ -19,6 +19,7 @@ import { getWorkflowFileName } from '../utility/DeploymentCenterUtility';
 import DeploymentCenterCodeSourceKuduConfiguredView from './DeploymentCenterCodeSourceKuduConfiguredView';
 import { DeploymentCenterLinks } from '../../../../utils/FwLinks';
 import { learnMoreLinkStyle } from '../../../../components/form-controls/formControl.override.styles';
+import { SiteStateContext } from '../../../../SiteState';
 
 const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<DeploymentCenterCodeFormData>> = props => {
   const { formProps } = props;
@@ -26,6 +27,7 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
   const [showInfoBanner, setShowInfoBanner] = useState(true);
 
   const deploymentCenterContext = useContext(DeploymentCenterContext);
+  const siteStateContext = useContext(SiteStateContext);
 
   const [githubActionExistingWorkflowContents, setGithubActionExistingWorkflowContents] = useState<string>('');
   const [workflowFilePath, setWorkflowFilePath] = useState<string>('');
@@ -101,7 +103,7 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
           formProps.values.runtimeVersion,
           formProps.values.runtimeRecommendedVersion,
           formProps.values.branch,
-          deploymentCenterContext.isLinuxApplication,
+          siteStateContext.isLinuxApplication,
           formProps.values.gitHubPublishProfileSecretGuid,
           deploymentCenterContext.siteDescriptor.site,
           deploymentCenterContext.siteDescriptor.slot

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDataLoader.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useContext, useState } from 'react';
+import { SiteStateContext } from '../../../../SiteState';
+import { DeploymentCenterContext } from '../DeploymentCenterContext';
+import {
+  DeploymentCenterFormData,
+  DeploymentCenterContainerFormData,
+  DeploymentCenterYupValidationSchemaType,
+  DeploymentCenterDataLoaderProps,
+} from '../DeploymentCenter.types';
+import DeploymentCenterData from '../DeploymentCenter.data';
+import { DeploymentCenterPublishingContext } from '../DeploymentCenterPublishingContext';
+import { DeploymentCenterContainerFormBuilder } from '../container/DeploymentCenterContainerFormBuilder';
+import { useTranslation } from 'react-i18next';
+import { getErrorMessage } from '../../../../ApiHelpers/ArmHelper';
+import DeploymentCenterContainerForm from './DeploymentCenterContainerForm';
+
+const DeploymentCenterContainerDataLoader: React.FC<DeploymentCenterDataLoaderProps> = props => {
+  const { resourceId } = props;
+  const { t } = useTranslation();
+
+  const siteStateContext = useContext(SiteStateContext);
+  const deploymentCenterContext = useContext(DeploymentCenterContext);
+  const deploymentCenterPublishingContext = useContext(DeploymentCenterPublishingContext);
+
+  const deploymentCenterData = new DeploymentCenterData();
+  const deploymentCenterContainerFormBuilder = new DeploymentCenterContainerFormBuilder(t);
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [logs, setLogs] = useState<string | undefined>(undefined);
+
+  const [containerFormData, setContainerFormData] = useState<DeploymentCenterFormData<DeploymentCenterContainerFormData> | undefined>(
+    undefined
+  );
+  const [containerFormValidationSchema, setContainerFormValidationSchema] = useState<
+    DeploymentCenterYupValidationSchemaType<DeploymentCenterContainerFormData> | undefined
+  >(undefined);
+
+  const fetchData = async () => {
+    const containerLogsResponse = await deploymentCenterData.fetchContainerLogs(resourceId);
+
+    if (containerLogsResponse.metadata.success) {
+      setLogs(containerLogsResponse.data);
+    } else {
+      const errorMessage = getErrorMessage(containerLogsResponse.metadata.error);
+      setLogs(
+        errorMessage ? t('deploymentCenterContainerLogsFailedWithError').format(errorMessage) : t('deploymentCenterContainerLogsFailed')
+      );
+    }
+
+    setIsLoading(false);
+  };
+
+  const generateForm = () => {
+    if (deploymentCenterContext.siteConfig) {
+      deploymentCenterContainerFormBuilder.setSiteConfig(deploymentCenterContext.siteConfig);
+    }
+
+    if (deploymentCenterContext.configMetadata) {
+      deploymentCenterContainerFormBuilder.setConfigMetadata(deploymentCenterContext.configMetadata);
+    }
+
+    if (deploymentCenterContext.applicationSettings) {
+      deploymentCenterContainerFormBuilder.setApplicationSettings(deploymentCenterContext.applicationSettings);
+    }
+
+    if (deploymentCenterPublishingContext.publishingUser) {
+      deploymentCenterContainerFormBuilder.setPublishingUser(deploymentCenterPublishingContext.publishingUser);
+    }
+
+    setContainerFormData(deploymentCenterContainerFormBuilder.generateFormData());
+    setContainerFormValidationSchema(deploymentCenterContainerFormBuilder.generateYupValidationSchema());
+  };
+
+  const refresh = () => {
+    setIsLoading(true);
+    fetchData();
+    deploymentCenterContext.refresh();
+  };
+
+  useEffect(() => {
+    fetchData();
+    generateForm();
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [siteStateContext, deploymentCenterContext]);
+
+  return (
+    <DeploymentCenterContainerForm
+      logs={logs}
+      formData={containerFormData}
+      formValidationSchema={containerFormValidationSchema}
+      isLoading={isLoading}
+      refresh={refresh}
+    />
+  );
+};
+
+export default DeploymentCenterContainerDataLoader;

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -7,12 +7,13 @@ import { commandBarSticky, pivotContent } from '../DeploymentCenter.styles';
 import DeploymentCenterContainerPivot from './DeploymentCenterContainerPivot';
 import ConfirmDialog from '../../../../components/ConfirmDialog/ConfirmDialog';
 import { useTranslation } from 'react-i18next';
-import { DeploymentCenterContext } from '../DeploymentCenterContext';
+import { DeploymentCenterPublishingContext } from '../DeploymentCenterPublishingContext';
 
 const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps> = props => {
   const { t } = useTranslation();
+  const deploymentCenterPublishingContext = useContext(DeploymentCenterPublishingContext);
+
   const [isRefreshConfirmDialogVisible, setIsRefreshConfirmDialogVisible] = useState(false);
-  const deploymentCenterContext = useContext(DeploymentCenterContext);
 
   const onKeyDown = keyEvent => {
     if ((keyEvent.charCode || keyEvent.keyCode) === KeyCodes.enter) {
@@ -30,7 +31,7 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
 
   const refreshFunction = () => {
     hideRefreshConfirmDialog();
-    deploymentCenterContext.refresh();
+    props.refresh();
   };
 
   const onSubmit = () => {
@@ -55,7 +56,7 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
             <DeploymentCenterCommandBar
               saveFunction={saveFunction}
               discardFunction={discardFunction}
-              showPublishProfilePanel={props.showPublishProfilePanel}
+              showPublishProfilePanel={deploymentCenterPublishingContext.showPublishProfilePanel}
               refresh={() => setIsRefreshConfirmDialogVisible(true)}
               isLoading={props.isLoading}
             />

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPivot.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPivot.tsx
@@ -7,7 +7,7 @@ import { DeploymentCenterContainerPivotProps } from '../DeploymentCenter.types';
 import DeploymentCenterContainerLogs from './DeploymentCenterContainerLogs';
 
 const DeploymentCenterContainerPivot: React.FC<DeploymentCenterContainerPivotProps> = props => {
-  const { logs, publishingCredentials, publishingProfile, publishingUser, formProps, resetApplicationPassword, isLoading } = props;
+  const { logs, formProps, isLoading } = props;
   const { t } = useTranslation();
 
   return (
@@ -21,14 +21,7 @@ const DeploymentCenterContainerPivot: React.FC<DeploymentCenterContainerPivotPro
       </PivotItem>
 
       <PivotItem headerText={t('deploymentCenterPivotItemFtpsHeaderText')} ariaLabel={t('deploymentCenterPivotItemFtpsAriaLabel')}>
-        <DeploymentCenterFtps
-          formProps={formProps}
-          resetApplicationPassword={resetApplicationPassword}
-          publishingCredentials={publishingCredentials}
-          publishingProfile={publishingProfile}
-          publishingUser={publishingUser}
-          isLoading={isLoading}
-        />
+        <DeploymentCenterFtps formProps={formProps} isLoading={isLoading} />
       </PivotItem>
     </Pivot>
   );

--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubConfiguredView.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubConfiguredView.tsx
@@ -189,7 +189,7 @@ const DeploymentCenterGitHubConfiguredView: React.FC<DeploymentCenterGitHubConfi
           </div>
         </ReactiveFormControl>
       )}
-      {siteStateContext.isContainerApplication ? (
+      {siteStateContext.isContainerApp ? (
         <h3>{t('deploymentCenterContainerGitHubActionsTitle')}</h3>
       ) : (
         <h3>{t('deploymentCenterCodeGitHubTitle')}</h3>

--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubConfiguredView.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubConfiguredView.tsx
@@ -12,6 +12,7 @@ import { AuthorizationResult, DeploymentCenterGitHubConfiguredViewProps } from '
 import GitHubService from '../../../../ApiHelpers/GitHubService';
 import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
 import DeploymentCenterGitHubDisconnect from './DeploymentCenterGitHubDisconnect';
+import { SiteStateContext } from '../../../../SiteState';
 
 const DeploymentCenterGitHubConfiguredView: React.FC<DeploymentCenterGitHubConfiguredViewProps> = props => {
   const { t } = useTranslation();
@@ -24,6 +25,7 @@ const DeploymentCenterGitHubConfiguredView: React.FC<DeploymentCenterGitHubConfi
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   const deploymentCenterContext = useContext(DeploymentCenterContext);
+  const siteStateContext = useContext(SiteStateContext);
   const deploymentCenterData = new DeploymentCenterData();
 
   const getSourceControlDetails = async () => {
@@ -187,7 +189,7 @@ const DeploymentCenterGitHubConfiguredView: React.FC<DeploymentCenterGitHubConfi
           </div>
         </ReactiveFormControl>
       )}
-      {deploymentCenterContext.isContainerApplication ? (
+      {siteStateContext.isContainerApplication ? (
         <h3>{t('deploymentCenterContainerGitHubActionsTitle')}</h3>
       ) : (
         <h3>{t('deploymentCenterCodeGitHubTitle')}</h3>

--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubProvider.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubProvider.tsx
@@ -55,9 +55,7 @@ const DeploymentCenterGitHubProvider: React.FC<DeploymentCenterGitHubProviderPro
 
   return (
     <>
-      <h3>
-        {siteStateContext.isContainerApplication ? t('deploymentCenterContainerGitHubActionsTitle') : t('deploymentCenterCodeGitHubTitle')}
-      </h3>
+      <h3>{siteStateContext.isContainerApp ? t('deploymentCenterContainerGitHubActionsTitle') : t('deploymentCenterCodeGitHubTitle')}</h3>
 
       <DeploymentCenterGitHubAccount {...props} />
 

--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubProvider.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubProvider.tsx
@@ -2,14 +2,14 @@ import React, { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import DeploymentCenterGitHubAccount from './DeploymentCenterGitHubAccount';
 import { DeploymentCenterGitHubProviderProps } from '../DeploymentCenter.types';
-import { DeploymentCenterContext } from '../DeploymentCenterContext';
 import { IDropdownOption } from 'office-ui-fabric-react';
 import Dropdown from '../../../../components/form-controls/DropDown';
 import { Field } from 'formik';
+import { SiteStateContext } from '../../../../SiteState';
 
 const DeploymentCenterGitHubProvider: React.FC<DeploymentCenterGitHubProviderProps> = props => {
   const { t } = useTranslation();
-  const deploymentCenterContext = useContext(DeploymentCenterContext);
+  const siteStateContext = useContext(SiteStateContext);
 
   const {
     formProps,
@@ -56,49 +56,51 @@ const DeploymentCenterGitHubProvider: React.FC<DeploymentCenterGitHubProviderPro
   return (
     <>
       <h3>
-        {deploymentCenterContext.isContainerApplication ? t('deploymentCenterContainerGitHubActionsTitle') : t('deploymentCenterCodeGitHubTitle')}
+        {siteStateContext.isContainerApplication ? t('deploymentCenterContainerGitHubActionsTitle') : t('deploymentCenterCodeGitHubTitle')}
       </h3>
 
       <DeploymentCenterGitHubAccount {...props} />
 
-      {accountUser && accountUser.login && <>
-        <Field
-          id="deployment-center-settings-organization-option"
-          label={t('deploymentCenterOAuthOrganization')}
-          placeholder={t('deploymentCenterOAuthOrganizationPlaceholder')}
-          name="org"
-          component={Dropdown}
-          displayInVerticalLayout={true}
-          options={organizationOptions}
-          selectedKey={selectedOrg}
-          required={true}
-          onChange={onOrganizationChange}
-        />
-        <Field
-          id="deployment-center-settings-repository-option"
-          label={t('deploymentCenterOAuthRepository')}
-          placeholder={t('deploymentCenterOAuthRepositoryPlaceholder')}
-          name="repo"
-          component={Dropdown}
-          displayInVerticalLayout={true}
-          options={repositoryOptions}
-          selectedKey={selectedRepo}
-          required={true}
-          onChange={onRepositoryChange}
-        />
-        <Field
-          id="deployment-center-settings-branch-option"
-          label={t('deploymentCenterOAuthBranch')}
-          placeholder={t('deploymentCenterOAuthBranchPlaceholder')}
-          name="branch"
-          component={Dropdown}
-          displayInVerticalLayout={true}
-          options={branchOptions}
-          selectedKey={selectedBranch}
-          required={true}
-          onChange={onBranchChange}
-        />
-      </>}
+      {accountUser && accountUser.login && (
+        <>
+          <Field
+            id="deployment-center-settings-organization-option"
+            label={t('deploymentCenterOAuthOrganization')}
+            placeholder={t('deploymentCenterOAuthOrganizationPlaceholder')}
+            name="org"
+            component={Dropdown}
+            displayInVerticalLayout={true}
+            options={organizationOptions}
+            selectedKey={selectedOrg}
+            required={true}
+            onChange={onOrganizationChange}
+          />
+          <Field
+            id="deployment-center-settings-repository-option"
+            label={t('deploymentCenterOAuthRepository')}
+            placeholder={t('deploymentCenterOAuthRepositoryPlaceholder')}
+            name="repo"
+            component={Dropdown}
+            displayInVerticalLayout={true}
+            options={repositoryOptions}
+            selectedKey={selectedRepo}
+            required={true}
+            onChange={onRepositoryChange}
+          />
+          <Field
+            id="deployment-center-settings-branch-option"
+            label={t('deploymentCenterOAuthBranch')}
+            placeholder={t('deploymentCenterOAuthBranchPlaceholder')}
+            name="branch"
+            component={Dropdown}
+            displayInVerticalLayout={true}
+            options={branchOptions}
+            selectedKey={selectedBranch}
+            required={true}
+            onChange={onBranchChange}
+          />
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
While going through and understanding the changes needed to enable the container scenario, I realized that currently at the top level we a very tightly coupled with container and code scenarios. This PR does not contain any addition or removal of functionality, but only re-structing of things. The restructure has caused three major changes:

1. Moving the FTP credentials and publishing profile data and functions which are shared in ALL scenarios to its own context - PublishingContext.

2. Introducing CodeDataLoader and ContainerDataLoader. Currently parent dataloader was making network calls for both code and container scenarios and also building the formdata and yup validation schema for both. With this change, it is first decided the type of app we are working with and only going down that path.

3. DeploymentCenterContext object now is specifically for code and container, deployment and settings related shared context. The linux and container checks have been moved up to the siteStateContext which will benefit other features. And as mentioned in the point #1 above, the publishing data is moved strictly in the publishing context.

This change is needed to make the upcoming changes for container related scenario digestible. 