### PR TITLE
AB#5992610 [S145] Update Elastic Premium prices to use new meterIds in spec picker keeping the multiplier hardcoded

### DIFF
--- a/client/src/app/shared/models/serverFarmSku.ts
+++ b/client/src/app/shared/models/serverFarmSku.ts
@@ -61,7 +61,11 @@ export class SkuCode {
     EP1: 'EP1',
     EP2: 'EP2',
     EP3: 'EP3',
-    EPCPU: 'EP-C',
-    EPMemory: 'EP-M',
+    EP1CPU: 'EP1-C',
+    EP1Memory: 'EP1-M',
+    EP2CPU: 'EP2-C',
+    EP2Memory: 'EP2-M',
+    EP3CPU: 'EP3-C',
+    EP3Memory: 'EP3-M',
   };
 }

--- a/client/src/app/site/spec-picker/price-spec-manager/elastic-premium-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/elastic-premium-plan-price-spec.ts
@@ -96,13 +96,13 @@ export class ElasticPremiumSmallPlanPriceSpec extends ElasticPremiumPlanPriceSpe
     id: this.skuCode,
     firstParty: [
       {
-        id: SkuCode.ElasticPremium.EPCPU,
-        quantity: (Pricing.secondsInAzureMonth * this._ep1CpuCore) / 100,
+        id: SkuCode.ElasticPremium.EP1CPU,
+        quantity: Pricing.hoursInAzureMonth * this._ep1CpuCore,
         resourceId: null,
       },
       {
-        id: SkuCode.ElasticPremium.EPMemory,
-        quantity: (Pricing.secondsInAzureMonth * this._ep1Memory) / 100,
+        id: SkuCode.ElasticPremium.EP1Memory,
+        quantity: Pricing.hoursInAzureMonth * this._ep1Memory,
         resourceId: null,
       },
     ],
@@ -126,13 +126,13 @@ export class ElasticPremiumMediumPlanPriceSpec extends ElasticPremiumPlanPriceSp
     id: this.skuCode,
     firstParty: [
       {
-        id: SkuCode.ElasticPremium.EPCPU,
-        quantity: (Pricing.secondsInAzureMonth * this._ep2CpuCore) / 100,
+        id: SkuCode.ElasticPremium.EP2CPU,
+        quantity: Pricing.hoursInAzureMonth * this._ep2CpuCore,
         resourceId: null,
       },
       {
-        id: SkuCode.ElasticPremium.EPMemory,
-        quantity: (Pricing.secondsInAzureMonth * this._ep2Memory) / 100,
+        id: SkuCode.ElasticPremium.EP2Memory,
+        quantity: Pricing.hoursInAzureMonth * this._ep2Memory,
         resourceId: null,
       },
     ],
@@ -156,13 +156,13 @@ export class ElasticPremiumLargePlanPriceSpec extends ElasticPremiumPlanPriceSpe
     id: this.skuCode,
     firstParty: [
       {
-        id: SkuCode.ElasticPremium.EPCPU,
-        quantity: (Pricing.secondsInAzureMonth * this._ep3CpuCore) / 100,
+        id: SkuCode.ElasticPremium.EP3CPU,
+        quantity: Pricing.hoursInAzureMonth * this._ep3CpuCore,
         resourceId: null,
       },
       {
-        id: SkuCode.ElasticPremium.EPMemory,
-        quantity: (Pricing.secondsInAzureMonth * this._ep3Memory) / 100,
+        id: SkuCode.ElasticPremium.EP3Memory,
+        quantity: Pricing.hoursInAzureMonth * this._ep3Memory,
         resourceId: null,
       },
     ],


### PR DESCRIPTION
Fixes AB#5992610

Before:
![image](https://user-images.githubusercontent.com/14221995/90545880-24369400-e13e-11ea-8dbd-ef6b8b7a18fa.png)



After:
![image](https://user-images.githubusercontent.com/14221995/90545851-184ad200-e13e-11ea-93b9-227cf54d6c3e.png)
