### PR TITLE
Wire up the container forms with GitHub Action workflow process

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -74,6 +74,7 @@ export interface DeploymentCenterCommonFormData {
   org: string;
   repo: string;
   branch: string;
+  gitHubPublishProfileSecretGuid: string;
 }
 
 export interface DeploymentCenterContainerFormData {
@@ -89,6 +90,8 @@ export interface DeploymentCenterContainerFormData {
   command: string;
   cicd: boolean;
   scmType: ScmType;
+  gitHubContainerUsernameSecretGuid: string;
+  gitHubContainerPasswordSecretGuid: string;
 }
 
 export interface DeploymentCenterCodeFormData {
@@ -97,7 +100,6 @@ export interface DeploymentCenterCodeFormData {
   runtimeStack: string;
   runtimeVersion: string;
   runtimeRecommendedVersion: string;
-  gitHubPublishProfileSecretGuid: string;
 }
 
 export interface DeploymentCenterFieldProps<T = DeploymentCenterContainerFormData | DeploymentCenterCodeFormData> {
@@ -126,10 +128,11 @@ export interface DeploymentCenterCommitLogsProps {
 }
 
 export interface DeploymentCenterGitHubWorkflowConfigPreviewProps {
-  isPreviewFileButtonEnabled: () => boolean;
-  getPreviewPanelContent: () => JSX.Element | undefined;
-  setShowInfoBanner: (showInfoBanner: boolean) => void;
-  workflowFilePath: string;
+  isPreviewFileButtonDisabled: boolean;
+  workflowFilePath?: string;
+  workflowFileContent?: string;
+  panelMessage?: string;
+  panelMessageType?: MessageBarType;
 }
 
 export interface DeploymentCenterFtpsProps {
@@ -274,7 +277,15 @@ export interface RuntimeStackSetting {
   runtimeVersion: string;
 }
 
-export class WorkflowInformation {
+export class ContainerWorkflowInformation {
+  fileName: string;
+  content: string;
+  publishingProfileSecretName: string;
+  containerUsernameSecretName: string;
+  containerPasswordSecretName: string;
+}
+
+export class CodeWorkflowInformation {
   fileName: string;
   secretName: string;
   content: string;

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
@@ -26,6 +26,7 @@ export abstract class DeploymentCenterFormBuilder {
       org: '',
       repo: '',
       branch: '',
+      gitHubPublishProfileSecretGuid: '',
     };
   }
 
@@ -54,6 +55,7 @@ export abstract class DeploymentCenterFormBuilder {
       org: Yup.mixed().notRequired(),
       repo: Yup.mixed().notRequired(),
       branch: Yup.mixed().notRequired(),
+      gitHubPublishProfileSecretGuid: Yup.mixed().notRequired(),
     };
   }
 

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeCommandBar.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeCommandBar.tsx
@@ -5,7 +5,7 @@ import { GitHubCommit, GitHubActionWorkflowRequestContent } from '../../../../mo
 import { DeploymentCenterContext } from '../DeploymentCenterContext';
 import DeploymentCenterData from '../DeploymentCenter.data';
 import { BuildProvider, ScmType } from '../../../../models/site/config';
-import { getWorkflowInformation } from '../utility/GitHubActionUtility';
+import { getCodeAppWorkflowInformation } from '../utility/GitHubActionUtility';
 import { getArmToken, getWorkflowFilePath } from '../utility/DeploymentCenterUtility';
 import { PortalContext } from '../../../../PortalContext';
 import { useTranslation } from 'react-i18next';
@@ -49,7 +49,7 @@ const DeploymentCenterCodeCommandBar: React.FC<DeploymentCenterCodeCommandBarPro
     const repo = `${formProps.values.org}/${formProps.values.repo}`;
     const branch = formProps.values.branch || 'master';
 
-    const workflowInformation = getWorkflowInformation(
+    const workflowInformation = getCodeAppWorkflowInformation(
       formProps.values.runtimeStack,
       formProps.values.runtimeVersion,
       formProps.values.runtimeRecommendedVersion,

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeFormBuilder.ts
@@ -11,7 +11,6 @@ export class DeploymentCenterCodeFormBuilder extends DeploymentCenterFormBuilder
       runtimeStack: '',
       runtimeVersion: '',
       runtimeRecommendedVersion: '',
-      gitHubPublishProfileSecretGuid: '',
       ...this.generateCommonFormData(),
     };
   }
@@ -23,7 +22,6 @@ export class DeploymentCenterCodeFormBuilder extends DeploymentCenterFormBuilder
       runtimeStack: Yup.mixed().notRequired(),
       runtimeVersion: Yup.mixed().notRequired(),
       runtimeRecommendedVersion: Yup.mixed().notRequired(),
-      gitHubPublishProfileSecretGuid: Yup.mixed().notRequired(),
       ...this.generateCommonFormYupValidationSchema(),
     });
   }

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
@@ -48,12 +48,18 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
 
   useEffect(() => {
     if (deploymentCenterContext.siteDescriptor) {
+      const runtimeInfoAvailable =
+        formProps.values.runtimeStack && formProps.values.runtimeVersion && formProps.values.runtimeRecommendedVersion;
+
       if (formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig) {
         setPanelMessage(t('githubActionWorkflowOptionUseExistingMessage'));
         setWorkflowFileContent(githubActionExistingWorkflowContents);
       } else if (formProps.values.workflowOption === WorkflowOption.UseAvailableWorkflowConfigs) {
         setPanelMessage(t('githubActionWorkflowOptionUseExistingMessageWithoutPreview'));
-      } else if (formProps.values.workflowOption === WorkflowOption.Add || formProps.values.workflowOption === WorkflowOption.Overwrite) {
+      } else if (
+        (formProps.values.workflowOption === WorkflowOption.Add || formProps.values.workflowOption === WorkflowOption.Overwrite) &&
+        runtimeInfoAvailable
+      ) {
         const information = getCodeAppWorkflowInformation(
           formProps.values.runtimeStack,
           formProps.values.runtimeVersion,
@@ -72,18 +78,22 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
   }, [
     siteStateContext.isLinuxApp,
     deploymentCenterContext.siteDescriptor,
-    formProps.values.workflowOption,
     formProps.values.runtimeStack,
     formProps.values.runtimeVersion,
     formProps.values.runtimeRecommendedVersion,
     formProps.values.branch,
+    formProps.values.workflowOption,
   ]);
 
   useEffect(() => {
+    const runtimeInfoOmissionAllowed =
+      formProps.values.workflowOption === WorkflowOption.UseAvailableWorkflowConfigs ||
+      formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig;
+
     const formFilled =
-      (formProps.values.workflowOption === WorkflowOption.Add || formProps.values.workflowOption === WorkflowOption.Overwrite) &&
-      formProps.values.runtimeStack &&
-      formProps.values.runtimeVersion;
+      formProps.values.workflowOption !== WorkflowOption.None &&
+      (formProps.values.runtimeStack || runtimeInfoOmissionAllowed) &&
+      (formProps.values.runtimeVersion || runtimeInfoOmissionAllowed);
 
     setIsPreviewFileButtonDisabled(formProps.values.workflowOption === WorkflowOption.None || !formFilled);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
@@ -10,27 +10,27 @@ import DeploymentCenterCodeSourceAndBuild from './DeploymentCenterCodeSourceAndB
 import DeploymentCenterGitHubWorkflowConfigSelector from '../github-provider/DeploymentCenterGitHubWorkflowConfigSelector';
 import DeploymentCenterGitHubWorkflowConfigPreview from '../github-provider/DeploymentCenterGitHubWorkflowConfigPreview';
 import DeploymentCenterCodeBuildRuntimeAndVersion from './DeploymentCenterCodeBuildRuntimeAndVersion';
-import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
-import { deploymentCenterConsole, panelBanner } from '../DeploymentCenter.styles';
-import { MessageBarType, Link } from 'office-ui-fabric-react';
 import { useTranslation } from 'react-i18next';
-import { getWorkflowInformation } from '../utility/GitHubActionUtility';
+import { getCodeAppWorkflowInformation } from '../utility/GitHubActionUtility';
 import { getWorkflowFileName } from '../utility/DeploymentCenterUtility';
 import DeploymentCenterCodeSourceKuduConfiguredView from './DeploymentCenterCodeSourceKuduConfiguredView';
 import { DeploymentCenterLinks } from '../../../../utils/FwLinks';
 import { learnMoreLinkStyle } from '../../../../components/form-controls/formControl.override.styles';
 import { SiteStateContext } from '../../../../SiteState';
+import { Link } from 'office-ui-fabric-react';
 
 const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<DeploymentCenterCodeFormData>> = props => {
   const { formProps } = props;
   const { t } = useTranslation();
-  const [showInfoBanner, setShowInfoBanner] = useState(true);
 
   const deploymentCenterContext = useContext(DeploymentCenterContext);
   const siteStateContext = useContext(SiteStateContext);
 
   const [githubActionExistingWorkflowContents, setGithubActionExistingWorkflowContents] = useState<string>('');
   const [workflowFilePath, setWorkflowFilePath] = useState<string>('');
+  const [isPreviewFileButtonDisabled, setIsPreviewFileButtonDisabled] = useState(false);
+  const [workflowFileContent, setWorkflowFileContent] = useState('');
+  const [panelMessage, setPanelMessage] = useState('');
 
   const isGitHubSource = formProps.values.sourceProvider === ScmType.GitHub;
   const isBitbucketSource = formProps.values.sourceProvider === ScmType.BitbucketGit;
@@ -46,59 +46,15 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
     formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig ||
     formProps.values.workflowOption === WorkflowOption.UseAvailableWorkflowConfigs;
 
-  const closeInfoBanner = () => {
-    setShowInfoBanner(false);
-  };
-
-  const isPreviewFileButtonEnabled = () => {
-    if (
-      formProps.values.workflowOption === WorkflowOption.UseAvailableWorkflowConfigs ||
-      formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig
-    ) {
-      return true;
-    }
-    if (formProps.values.workflowOption === WorkflowOption.Add || formProps.values.workflowOption === WorkflowOption.Overwrite) {
-      if (formProps.values.runtimeStack && formProps.values.runtimeVersion) {
-        return true;
-      }
-    }
-
-    return false;
-  };
-
-  const getPreviewPanelContent = () => {
+  useEffect(() => {
     if (deploymentCenterContext.siteDescriptor) {
       if (formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig) {
-        return (
-          <>
-            {showInfoBanner && (
-              <div className={panelBanner}>
-                <CustomBanner
-                  message={t('githubActionWorkflowOptionUseExistingMessage')}
-                  type={MessageBarType.info}
-                  onDismiss={closeInfoBanner}
-                />
-              </div>
-            )}
-            <pre className={deploymentCenterConsole}>{githubActionExistingWorkflowContents}</pre>
-          </>
-        );
+        setPanelMessage(t('githubActionWorkflowOptionUseExistingMessage'));
+        setWorkflowFileContent(githubActionExistingWorkflowContents);
       } else if (formProps.values.workflowOption === WorkflowOption.UseAvailableWorkflowConfigs) {
-        return (
-          <>
-            {showInfoBanner && (
-              <div className={panelBanner}>
-                <CustomBanner
-                  message={t('githubActionWorkflowOptionUseExistingMessageWithoutPreview')}
-                  type={MessageBarType.info}
-                  onDismiss={closeInfoBanner}
-                />
-              </div>
-            )}
-          </>
-        );
+        setPanelMessage(t('githubActionWorkflowOptionUseExistingMessageWithoutPreview'));
       } else if (formProps.values.workflowOption === WorkflowOption.Add || formProps.values.workflowOption === WorkflowOption.Overwrite) {
-        const information = getWorkflowInformation(
+        const information = getCodeAppWorkflowInformation(
           formProps.values.runtimeStack,
           formProps.values.runtimeVersion,
           formProps.values.runtimeRecommendedVersion,
@@ -108,23 +64,30 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
           deploymentCenterContext.siteDescriptor.site,
           deploymentCenterContext.siteDescriptor.slot
         );
-        return (
-          <>
-            {showInfoBanner && (
-              <div className={panelBanner}>
-                <CustomBanner
-                  message={t('githubActionWorkflowOptionOverwriteIfConfigExists')}
-                  type={MessageBarType.info}
-                  onDismiss={closeInfoBanner}
-                />
-              </div>
-            )}
-            <pre className={deploymentCenterConsole}>{information.content}</pre>
-          </>
-        );
+        setPanelMessage(t('githubActionWorkflowOptionOverwriteIfConfigExists'));
+        setWorkflowFileContent(information.content);
       }
     }
-  };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    siteStateContext.isLinuxApp,
+    deploymentCenterContext.siteDescriptor,
+    formProps.values.workflowOption,
+    formProps.values.runtimeStack,
+    formProps.values.runtimeVersion,
+    formProps.values.runtimeRecommendedVersion,
+    formProps.values.branch,
+  ]);
+
+  useEffect(() => {
+    const formFilled =
+      (formProps.values.workflowOption === WorkflowOption.Add || formProps.values.workflowOption === WorkflowOption.Overwrite) &&
+      formProps.values.runtimeStack &&
+      formProps.values.runtimeVersion;
+
+    setIsPreviewFileButtonDisabled(formProps.values.workflowOption === WorkflowOption.None || !formFilled);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formProps.values.workflowOption, formProps.values.runtimeStack, formProps.values.runtimeVersion]);
 
   useEffect(() => {
     if (
@@ -179,10 +142,10 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
                   />
                   {!isUsingExistingOrAvailableWorkflowConfig && <DeploymentCenterCodeBuildRuntimeAndVersion formProps={formProps} />}
                   <DeploymentCenterGitHubWorkflowConfigPreview
-                    getPreviewPanelContent={getPreviewPanelContent}
-                    setShowInfoBanner={setShowInfoBanner}
-                    isPreviewFileButtonEnabled={isPreviewFileButtonEnabled}
+                    isPreviewFileButtonDisabled={isPreviewFileButtonDisabled}
                     workflowFilePath={workflowFilePath}
+                    workflowFileContent={workflowFileContent}
+                    panelMessage={panelMessage}
                   />
                 </>
               )}

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
@@ -11,7 +11,7 @@ import DeploymentCenterGitHubWorkflowConfigSelector from '../github-provider/Dep
 import DeploymentCenterGitHubWorkflowConfigPreview from '../github-provider/DeploymentCenterGitHubWorkflowConfigPreview';
 import DeploymentCenterCodeBuildRuntimeAndVersion from './DeploymentCenterCodeBuildRuntimeAndVersion';
 import { useTranslation } from 'react-i18next';
-import { getCodeAppWorkflowInformation } from '../utility/GitHubActionUtility';
+import { getCodeAppWorkflowInformation, isWorkflowOptionExistingOrAvailable } from '../utility/GitHubActionUtility';
 import { getWorkflowFileName } from '../utility/DeploymentCenterUtility';
 import DeploymentCenterCodeSourceKuduConfiguredView from './DeploymentCenterCodeSourceKuduConfiguredView';
 import { DeploymentCenterLinks } from '../../../../utils/FwLinks';
@@ -43,9 +43,7 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
     deploymentCenterContext.siteConfig &&
     (deploymentCenterContext.siteConfig.properties.scmType === ScmType.GitHubAction ||
       deploymentCenterContext.siteConfig.properties.scmType === ScmType.GitHub);
-  const isUsingExistingOrAvailableWorkflowConfig =
-    formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig ||
-    formProps.values.workflowOption === WorkflowOption.UseAvailableWorkflowConfigs;
+  const isUsingExistingOrAvailableWorkflowConfig = isWorkflowOptionExistingOrAvailable(formProps.values.workflowOption);
 
   const isBitbucketSource = formProps.values.sourceProvider === ScmType.BitbucketGit;
   const isBitbucketSetup =
@@ -97,8 +95,7 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
 
     const formFilled =
       formProps.values.workflowOption !== WorkflowOption.None &&
-      (formProps.values.runtimeStack || runtimeInfoOmissionAllowed) &&
-      (formProps.values.runtimeVersion || runtimeInfoOmissionAllowed);
+      ((formProps.values.runtimeStack && formProps.values.runtimeVersion) || runtimeInfoOmissionAllowed);
 
     setIsPreviewFileButtonDisabled(formProps.values.workflowOption === WorkflowOption.None || !formFilled);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { DeploymentCenterContainerAcrSettingsProps, WorkflowOption } from '../DeploymentCenter.types';
+import { DeploymentCenterContainerAcrSettingsProps } from '../DeploymentCenter.types';
 import { Field } from 'formik';
 import { useTranslation } from 'react-i18next';
 import Dropdown from '../../../../components/form-controls/DropDown';
@@ -7,6 +7,7 @@ import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
 import { IDropdownOption } from 'office-ui-fabric-react';
 import TextField from '../../../../components/form-controls/TextField';
 import { ScmType } from '../../../../models/site/config';
+import { isWorkflowOptionExistingOrAvailable } from '../utility/GitHubActionUtility';
 
 const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAcrSettingsProps> = props => {
   const {
@@ -56,10 +57,7 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
   };
 
   useEffect(() => {
-    setIsUsingExistingOrAvailableWorkflowConfig(
-      formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig ||
-        formProps.values.workflowOption === WorkflowOption.UseAvailableWorkflowConfigs
-    );
+    setIsUsingExistingOrAvailableWorkflowConfig(isWorkflowOptionExistingOrAvailable(formProps.values.workflowOption));
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formProps.values.workflowOption]);

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrSettings.tsx
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
-import { DeploymentCenterContainerAcrSettingsProps } from '../DeploymentCenter.types';
+import React, { useState, useEffect } from 'react';
+import { DeploymentCenterContainerAcrSettingsProps, WorkflowOption } from '../DeploymentCenter.types';
 import { Field } from 'formik';
 import { useTranslation } from 'react-i18next';
 import Dropdown from '../../../../components/form-controls/DropDown';
 import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
 import { IDropdownOption } from 'office-ui-fabric-react';
 import TextField from '../../../../components/form-controls/TextField';
+import { ScmType } from '../../../../models/site/config';
 
 const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAcrSettingsProps> = props => {
   const {
@@ -23,6 +24,8 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
   const [selectedRegistry, setSelectedRegistry] = useState<string>('');
   const [selectedImage, setSelectedImage] = useState<string>('');
   const [selectedTag, setSelectedTag] = useState<string>('');
+  const [isUsingExistingOrAvailableWorkflowConfig, setIsUsingExistingOrAvailableWorkflowConfig] = useState(false);
+  const [isGitHubAction, setIsGitHubAction] = useState(false);
 
   const onRegistryChange = (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption) => {
     setSelectedRegistry(option.key.toString());
@@ -52,6 +55,29 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
     formProps.setFieldValue('tag', option.key.toString());
   };
 
+  useEffect(() => {
+    setIsUsingExistingOrAvailableWorkflowConfig(
+      formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig ||
+        formProps.values.workflowOption === WorkflowOption.UseAvailableWorkflowConfigs
+    );
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formProps.values.workflowOption]);
+
+  useEffect(() => {
+    setIsGitHubAction(formProps.values.scmType === ScmType.GitHubAction);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formProps.values.scmType]);
+
+  // NOTE(michinoy): In case of GitHub Action, we will always need to get the user credentials for their ACR
+  // registry. This is because the workflow would need to use those credentials to push the images and app service
+  // would use the same credentials to pull the images.
+  // Also with GitHub Action, the image tag is not needed from the user as the workflow will generate the tag and push
+  // that to the users site config.
+  // Now in case if the user chooses to use an existing workflow file in their repo, we would still need to get the
+  // target registry url, username, and password to update the app settings, but no workflow update is needed.
+
   return (
     <>
       {acrStatusMessage && acrStatusMessageType && <CustomBanner type={acrStatusMessageType} message={acrStatusMessage} />}
@@ -66,26 +92,32 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
         selectedKey={selectedRegistry}
         onChange={onRegistryChange}
       />
-      <Field
-        id="container-acr-image"
-        label={t('containerACRImage')}
-        name="image"
-        component={Dropdown}
-        displayInVerticalLayout={true}
-        options={acrImageOptions}
-        selectedKey={selectedImage}
-        onChange={onImageChange}
-      />
-      <Field
-        id="container-acr-tag"
-        label={t('containerACRTag')}
-        name="tag"
-        component={Dropdown}
-        displayInVerticalLayout={true}
-        options={acrTagOptions}
-        selectedKey={selectedTag}
-        onChange={onTagChange}
-      />
+
+      {isGitHubAction && !isUsingExistingOrAvailableWorkflowConfig && (
+        <Field
+          id="container-acr-image"
+          label={t('containerACRImage')}
+          name="image"
+          component={Dropdown}
+          displayInVerticalLayout={true}
+          options={acrImageOptions}
+          selectedKey={selectedImage}
+          onChange={onImageChange}
+        />
+      )}
+
+      {!isGitHubAction && (
+        <Field
+          id="container-acr-tag"
+          label={t('containerACRTag')}
+          name="tag"
+          component={Dropdown}
+          displayInVerticalLayout={true}
+          options={acrTagOptions}
+          selectedKey={selectedTag}
+          onChange={onTagChange}
+        />
+      )}
 
       <Field id="container-acr-startUpFile" name="command" component={TextField} label={t('containerStartupFile')} />
     </>

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDockeHubSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDockeHubSettings.tsx
@@ -1,14 +1,45 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Field } from 'formik';
 import TextField from '../../../../components/form-controls/TextField';
 import { useTranslation } from 'react-i18next';
 import { IChoiceGroupOptionProps } from 'office-ui-fabric-react';
-import { ContainerDockerAccessTypes, DeploymentCenterFieldProps, DeploymentCenterContainerFormData } from '../DeploymentCenter.types';
+import {
+  ContainerDockerAccessTypes,
+  DeploymentCenterFieldProps,
+  DeploymentCenterContainerFormData,
+  WorkflowOption,
+} from '../DeploymentCenter.types';
 import Dropdown from '../../../../components/form-controls/DropDown';
+import { ScmType } from '../../../../models/site/config';
 
 const DeploymentCenterContainerDockerHubSettings: React.FC<DeploymentCenterFieldProps<DeploymentCenterContainerFormData>> = props => {
   const { formProps } = props;
   const { t } = useTranslation();
+
+  const [isUsingExistingOrAvailableWorkflowConfig, setIsUsingExistingOrAvailableWorkflowConfig] = useState(false);
+  const [isGitHubAction, setIsGitHubAction] = useState(false);
+  const [isPrivateConfiguration, setIsPrivateConfiguration] = useState(false);
+
+  useEffect(() => {
+    setIsPrivateConfiguration(formProps.values.dockerAccessType === ContainerDockerAccessTypes.private);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formProps.values.dockerAccessType]);
+
+  useEffect(() => {
+    setIsUsingExistingOrAvailableWorkflowConfig(
+      formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig ||
+        formProps.values.workflowOption === WorkflowOption.UseAvailableWorkflowConfigs
+    );
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formProps.values.workflowOption]);
+
+  useEffect(() => {
+    setIsGitHubAction(formProps.values.scmType === ScmType.GitHubAction);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formProps.values.scmType]);
 
   const accessTypes: IChoiceGroupOptionProps[] = [
     {
@@ -21,30 +52,52 @@ const DeploymentCenterContainerDockerHubSettings: React.FC<DeploymentCenterField
     },
   ];
 
+  // NOTE(michinoy): In case of GitHub Action, we will always need to get the user credentials for their
+  // DockerHub. This is because the workflow would need to use those credentials to push the images and app service
+  // would use the same credentials to pull the images.
+  // Also with GitHub Action, the image tag is not needed from the user as the workflow will generate the tag and push
+  // that to the users site config.
+  // Now in case if the user chooses to use an existing workflow file in their repo, we would still need to get the
+  // target registry url, username, and password to update the app settings, but no workflow update is needed.
+
   return (
     <>
-      <Field
-        id="container-dockerHub-imageAndTag"
-        name="imageAndTag"
-        component={TextField}
-        label={t('containerImageAndTag')}
-        placeholder={t('containerImageAndTagPlaceholder')}
-      />
+      {!isGitHubAction && (
+        <Field
+          id="container-dockerHub-accessType"
+          name="dockerAccessType"
+          component={Dropdown}
+          options={accessTypes}
+          label={t('containerRepositoryAccess')}
+        />
+      )}
 
-      <Field
-        id="container-dockerHub-accessType"
-        name="dockerAccessType"
-        component={Dropdown}
-        options={accessTypes}
-        label={t('containerRepositoryAccess')}
-      />
-
-      {formProps && formProps.values.dockerAccessType === ContainerDockerAccessTypes.private && (
+      {(isPrivateConfiguration || isGitHubAction) && (
         <>
           <Field id="container-dockerHub-username" name="username" component={TextField} label={t('containerLogin')} />
 
           <Field id="container-dockerHub-password" name="password" component={TextField} label={t('containerPassword')} />
         </>
+      )}
+
+      {isGitHubAction && !isUsingExistingOrAvailableWorkflowConfig && (
+        <Field
+          id="container-dockerHub-image"
+          name="image"
+          component={TextField}
+          label={t('containerImage')}
+          placeholder={t('containerImagePlaceholder')}
+        />
+      )}
+
+      {!isGitHubAction && (
+        <Field
+          id="container-dockerHub-imageAndTag"
+          name="imageAndTag"
+          component={TextField}
+          label={t('containerImageAndTag')}
+          placeholder={t('containerImageAndTagPlaceholder')}
+        />
       )}
 
       <Field id="container-dockerHub-startUpFile" name="command" component={TextField} label={t('containerStartupFile')} />

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDockeHubSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDockeHubSettings.tsx
@@ -3,14 +3,10 @@ import { Field } from 'formik';
 import TextField from '../../../../components/form-controls/TextField';
 import { useTranslation } from 'react-i18next';
 import { IChoiceGroupOptionProps } from 'office-ui-fabric-react';
-import {
-  ContainerDockerAccessTypes,
-  DeploymentCenterFieldProps,
-  DeploymentCenterContainerFormData,
-  WorkflowOption,
-} from '../DeploymentCenter.types';
+import { ContainerDockerAccessTypes, DeploymentCenterFieldProps, DeploymentCenterContainerFormData } from '../DeploymentCenter.types';
 import Dropdown from '../../../../components/form-controls/DropDown';
 import { ScmType } from '../../../../models/site/config';
+import { isWorkflowOptionExistingOrAvailable } from '../utility/GitHubActionUtility';
 
 const DeploymentCenterContainerDockerHubSettings: React.FC<DeploymentCenterFieldProps<DeploymentCenterContainerFormData>> = props => {
   const { formProps } = props;
@@ -27,10 +23,7 @@ const DeploymentCenterContainerDockerHubSettings: React.FC<DeploymentCenterField
   }, [formProps.values.dockerAccessType]);
 
   useEffect(() => {
-    setIsUsingExistingOrAvailableWorkflowConfig(
-      formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig ||
-        formProps.values.workflowOption === WorkflowOption.UseAvailableWorkflowConfigs
-    );
+    setIsUsingExistingOrAvailableWorkflowConfig(isWorkflowOptionExistingOrAvailable(formProps.values.workflowOption));
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formProps.values.workflowOption]);

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -26,6 +26,8 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
       password: '',
       command: '',
       cicd: false,
+      gitHubContainerPasswordSecretGuid: '',
+      gitHubContainerUsernameSecretGuid: '',
       ...this.generateCommonFormData(),
     };
   }
@@ -44,6 +46,8 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
       password: Yup.mixed().notRequired(),
       command: Yup.mixed().notRequired(),
       cicd: Yup.mixed().notRequired(),
+      gitHubContainerPasswordSecretGuid: Yup.mixed().notRequired(),
+      gitHubContainerUsernameSecretGuid: Yup.mixed().notRequired(),
       ...this.generateCommonFormYupValidationSchema(),
     });
   }

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPrivateRegistrySettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPrivateRegistrySettings.tsx
@@ -2,8 +2,9 @@ import React, { useState, useEffect } from 'react';
 import { Field } from 'formik';
 import TextField from '../../../../components/form-controls/TextField';
 import { useTranslation } from 'react-i18next';
-import { DeploymentCenterFieldProps, DeploymentCenterContainerFormData, WorkflowOption } from '../DeploymentCenter.types';
+import { DeploymentCenterFieldProps, DeploymentCenterContainerFormData } from '../DeploymentCenter.types';
 import { ScmType } from '../../../../models/site/config';
+import { isWorkflowOptionExistingOrAvailable } from '../utility/GitHubActionUtility';
 
 const DeploymentCenterContainerPrivateRegistrySettings: React.FC<DeploymentCenterFieldProps<DeploymentCenterContainerFormData>> = props => {
   const { formProps } = props;
@@ -13,10 +14,7 @@ const DeploymentCenterContainerPrivateRegistrySettings: React.FC<DeploymentCente
   const [isGitHubAction, setIsGitHubAction] = useState(false);
 
   useEffect(() => {
-    setIsUsingExistingOrAvailableWorkflowConfig(
-      formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig ||
-        formProps.values.workflowOption === WorkflowOption.UseAvailableWorkflowConfigs
-    );
+    setIsUsingExistingOrAvailableWorkflowConfig(isWorkflowOptionExistingOrAvailable(formProps.values.workflowOption));
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formProps.values.workflowOption]);

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPrivateRegistrySettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPrivateRegistrySettings.tsx
@@ -1,11 +1,39 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Field } from 'formik';
 import TextField from '../../../../components/form-controls/TextField';
 import { useTranslation } from 'react-i18next';
-import { DeploymentCenterFieldProps, DeploymentCenterContainerFormData } from '../DeploymentCenter.types';
+import { DeploymentCenterFieldProps, DeploymentCenterContainerFormData, WorkflowOption } from '../DeploymentCenter.types';
+import { ScmType } from '../../../../models/site/config';
 
 const DeploymentCenterContainerPrivateRegistrySettings: React.FC<DeploymentCenterFieldProps<DeploymentCenterContainerFormData>> = props => {
+  const { formProps } = props;
   const { t } = useTranslation();
+
+  const [isUsingExistingOrAvailableWorkflowConfig, setIsUsingExistingOrAvailableWorkflowConfig] = useState(false);
+  const [isGitHubAction, setIsGitHubAction] = useState(false);
+
+  useEffect(() => {
+    setIsUsingExistingOrAvailableWorkflowConfig(
+      formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig ||
+        formProps.values.workflowOption === WorkflowOption.UseAvailableWorkflowConfigs
+    );
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formProps.values.workflowOption]);
+
+  useEffect(() => {
+    setIsGitHubAction(formProps.values.scmType === ScmType.GitHubAction);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formProps.values.scmType]);
+
+  // NOTE(michinoy): In case of GitHub Action, we will always need to get the user credentials for their private
+  // registry. This is because the workflow would need to use those credentials to push the images and app service
+  // would use the same credentials to pull the images.
+  // Also with GitHub Action, the image tag is not needed from the user as the workflow will generate the tag and push
+  // that to the users site config.
+  // Now in case if the user chooses to use an existing workflow file in their repo, we would still need to get the
+  // target registry url, username, and password to update the app settings, but no workflow update is needed.
 
   return (
     <>
@@ -17,17 +45,29 @@ const DeploymentCenterContainerPrivateRegistrySettings: React.FC<DeploymentCente
         placeholder={t('containerServerURLPlaceholder')}
       />
 
-      <Field
-        id="container-privateRegistry-imageAndTag"
-        name="imageAndTag"
-        component={TextField}
-        label={t('containerImageAndTag')}
-        placeholder={t('containerImageAndTagPlaceholder')}
-      />
-
       <Field id="container-privateRegistry-username" name="username" component={TextField} label={t('containerLogin')} />
 
       <Field id="container-privateRegistry-password" name="password" component={TextField} label={t('containerPassword')} />
+
+      {isGitHubAction && !isUsingExistingOrAvailableWorkflowConfig && (
+        <Field
+          id="container-privateRegistry-image"
+          name="image"
+          component={TextField}
+          label={t('containerImage')}
+          placeholder={t('containerImagePlaceholder')}
+        />
+      )}
+
+      {!isGitHubAction && (
+        <Field
+          id="container-privateRegistry-imageAndTag"
+          name="imageAndTag"
+          component={TextField}
+          label={t('containerImageAndTag')}
+          placeholder={t('containerImageAndTagPlaceholder')}
+        />
+      )}
 
       <Field id="container-privateRegistry-startUpFile" name="command" component={TextField} label={t('containerStartupFile')} />
     </>

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettings.tsx
@@ -1,25 +1,159 @@
-import React from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import DeploymentCenterContainerSource from './DeploymentCenterContainerSource';
-import { ContainerRegistrySources, DeploymentCenterFieldProps, DeploymentCenterContainerFormData } from '../DeploymentCenter.types';
+import {
+  ContainerRegistrySources,
+  DeploymentCenterFieldProps,
+  DeploymentCenterContainerFormData,
+  WorkflowOption,
+} from '../DeploymentCenter.types';
 import { ScmType } from '../../../../models/site/config';
 import DeploymentCenterContainerRegistrySettings from './DeploymentCenterContainerRegistrySettings';
 import DeploymentCenterContainerDockerHubSettings from './DeploymentCenterContainerDockeHubSettings';
 import DeploymentCenterContainerPrivateRegistrySettings from './DeploymentCenterContainerPrivateRegistrySettings';
 import DeploymentCenterGitHubDataLoader from '../github-provider/DeploymentCenterGitHubDataLoader';
 import DeploymentCenterContainerAcrDataLoader from './DeploymentCenterContainerAcrDataLoader';
+import DeploymentCenterGitHubWorkflowConfigSelector from '../github-provider/DeploymentCenterGitHubWorkflowConfigSelector';
+import DeploymentCenterGitHubWorkflowConfigPreview from '../github-provider/DeploymentCenterGitHubWorkflowConfigPreview';
+import { DeploymentCenterContext } from '../DeploymentCenterContext';
+import { useTranslation } from 'react-i18next';
+import { getWorkflowFileName } from '../utility/DeploymentCenterUtility';
+import { Guid } from '../../../../utils/Guid';
+import { getContainerAppWorkflowInformation } from '../utility/GitHubActionUtility';
 
 const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<DeploymentCenterContainerFormData>> = props => {
   const { formProps } = props;
+  const { t } = useTranslation();
+  const [githubActionExistingWorkflowContents, setGithubActionExistingWorkflowContents] = useState<string>('');
+  const [workflowFilePath, setWorkflowFilePath] = useState<string>('');
+  const [isPreviewFileButtonDisabled, setIsPreviewFileButtonDisabled] = useState(false);
+  const [workflowFileContent, setWorkflowFileContent] = useState('');
+  const [panelMessage, setPanelMessage] = useState('');
+
+  const deploymentCenterContext = useContext(DeploymentCenterContext);
+
   const isGitHubActionEnabled = formProps.values.scmType === ScmType.GitHubAction;
   const isAcrConfigured = formProps.values.registrySource === ContainerRegistrySources.acr;
   const isDockerHubConfigured = formProps.values.registrySource === ContainerRegistrySources.docker;
   const isPrivateRegistryConfigured = formProps.values.registrySource === ContainerRegistrySources.privateRegistry;
 
+  useEffect(() => {
+    if (deploymentCenterContext.siteDescriptor) {
+      if (formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig) {
+        setPanelMessage(t('githubActionWorkflowOptionUseExistingMessage'));
+        setWorkflowFileContent(githubActionExistingWorkflowContents);
+      } else if (formProps.values.workflowOption === WorkflowOption.UseAvailableWorkflowConfigs) {
+        setPanelMessage(t('githubActionWorkflowOptionUseExistingMessageWithoutPreview'));
+      } else if (formProps.values.workflowOption === WorkflowOption.Add || formProps.values.workflowOption === WorkflowOption.Overwrite) {
+        const information = getContainerAppWorkflowInformation(
+          formProps.values.serverUrl,
+          formProps.values.image,
+          formProps.values.branch,
+          formProps.values.gitHubPublishProfileSecretGuid,
+          formProps.values.gitHubContainerUsernameSecretGuid,
+          formProps.values.gitHubContainerPasswordSecretGuid,
+          deploymentCenterContext.siteDescriptor.site,
+          deploymentCenterContext.siteDescriptor.slot
+        );
+        setPanelMessage(t('githubActionWorkflowOptionOverwriteIfConfigExists'));
+        setWorkflowFileContent(information.content);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    deploymentCenterContext.siteDescriptor,
+    formProps.values.workflowOption,
+    formProps.values.serverUrl,
+    formProps.values.image,
+    formProps.values.branch,
+  ]);
+
+  useEffect(() => {
+    const imageOmissionAllowed =
+      formProps.values.workflowOption === WorkflowOption.UseAvailableWorkflowConfigs ||
+      formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig;
+
+    const formFilled =
+      formProps.values.workflowOption !== WorkflowOption.None &&
+      formProps.values.serverUrl &&
+      formProps.values.username &&
+      formProps.values.password &&
+      (formProps.values.image || imageOmissionAllowed);
+
+    setIsPreviewFileButtonDisabled(formProps.values.workflowOption === WorkflowOption.None || !formFilled);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    formProps.values.workflowOption,
+    formProps.values.serverUrl,
+    formProps.values.username,
+    formProps.values.password,
+    formProps.values.image,
+  ]);
+
+  useEffect(() => {
+    if (
+      deploymentCenterContext.siteDescriptor &&
+      (formProps.values.workflowOption === WorkflowOption.UseExistingWorkflowConfig ||
+        formProps.values.workflowOption === WorkflowOption.Add ||
+        formProps.values.workflowOption === WorkflowOption.Overwrite)
+    ) {
+      const workflowFileName = getWorkflowFileName(
+        formProps.values.branch,
+        deploymentCenterContext.siteDescriptor.site,
+        deploymentCenterContext.siteDescriptor.slot
+      );
+      setWorkflowFilePath(`.github/workflows/${workflowFileName}`);
+    } else {
+      setWorkflowFilePath('');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formProps.values.workflowOption]);
+
+  useEffect(() => {
+    // NOTE(michinoy): In case of having GitHub Action based integrate for containers
+    // the container registry username and password need to be added as secrets on
+    // the GitHub repo.
+    if (formProps.values.scmType === ScmType.GitHubAction) {
+      formProps.setFieldValue(
+        'gitHubPublishProfileSecretGuid',
+        Guid.newGuid()
+          .toLowerCase()
+          .replace(/[-]/g, '')
+      );
+
+      formProps.setFieldValue(
+        'gitHubContainerUsernameSecretGuid',
+        Guid.newGuid()
+          .toLowerCase()
+          .replace(/[-]/g, '')
+      );
+
+      formProps.setFieldValue(
+        'gitHubContainerPasswordSecretGuid',
+        Guid.newGuid()
+          .toLowerCase()
+          .replace(/[-]/g, '')
+      );
+    } else {
+      formProps.setFieldValue('gitHubPublishProfileSecretGuid', '');
+      formProps.setFieldValue('gitHubContainerUsernameSecretGuid', '');
+      formProps.setFieldValue('gitHubContainerPasswordSecretGuid', '');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formProps.values.scmType]);
+
   return (
     <>
       <DeploymentCenterContainerSource />
 
-      {isGitHubActionEnabled && <DeploymentCenterGitHubDataLoader formProps={formProps} />}
+      {isGitHubActionEnabled && (
+        <>
+          <DeploymentCenterGitHubDataLoader formProps={formProps} />{' '}
+          <DeploymentCenterGitHubWorkflowConfigSelector
+            formProps={formProps}
+            setGithubActionExistingWorkflowContents={setGithubActionExistingWorkflowContents}
+          />
+        </>
+      )}
 
       <DeploymentCenterContainerRegistrySettings {...props} />
 
@@ -28,6 +162,15 @@ const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<Dep
       {isDockerHubConfigured && <DeploymentCenterContainerDockerHubSettings {...props} />}
 
       {isPrivateRegistryConfigured && <DeploymentCenterContainerPrivateRegistrySettings {...props} />}
+
+      {isGitHubActionEnabled && (
+        <DeploymentCenterGitHubWorkflowConfigPreview
+          isPreviewFileButtonDisabled={isPreviewFileButtonDisabled}
+          workflowFilePath={workflowFilePath}
+          workflowFileContent={workflowFileContent}
+          panelMessage={panelMessage}
+        />
+      )}
     </>
   );
 };

--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubWorkflowConfig.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubWorkflowConfig.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import { DeploymentCenterFieldProps } from '../DeploymentCenter.types';
-
-const DeploymentCenterGitHubWorkflowConfig: React.FC<DeploymentCenterFieldProps> = props => {
-  return <></>;
-};
-
-export default DeploymentCenterGitHubWorkflowConfig;

--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubWorkflowConfigPreview.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubWorkflowConfigPreview.tsx
@@ -1,23 +1,24 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DeploymentCenterGitHubWorkflowConfigPreviewProps } from '../DeploymentCenter.types';
-import { PanelType, DefaultButton } from 'office-ui-fabric-react';
+import { PanelType, DefaultButton, MessageBarType } from 'office-ui-fabric-react';
 import CustomPanel from '../../../../components/CustomPanel/CustomPanel';
+import { panelBanner, deploymentCenterConsole } from '../DeploymentCenter.styles';
+import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
 
 const DeploymentCenterGitHubWorkflowConfigPreview: React.FC<DeploymentCenterGitHubWorkflowConfigPreviewProps> = props => {
-  const { isPreviewFileButtonEnabled, getPreviewPanelContent, setShowInfoBanner, workflowFilePath } = props;
+  const { isPreviewFileButtonDisabled, workflowFilePath, workflowFileContent, panelMessage } = props;
   const { t } = useTranslation();
 
   const [isPreviewPanelOpen, setIsPreviewPanelOpen] = useState<boolean>(false);
+  const [showInfoBanner, setShowInfoBanner] = useState(true);
+
+  const closeInfoBanner = () => {
+    setShowInfoBanner(false);
+  };
 
   const dismissPreviewPanel = () => {
     setIsPreviewPanelOpen(false);
-  };
-
-  const showWorkflowFilePath = () => {
-    if (workflowFilePath) {
-      return <p>{`${t('deploymentCenterWorkflowConfigsFilePathLabel')}: ${workflowFilePath}`}</p>;
-    }
   };
 
   return (
@@ -30,13 +31,20 @@ const DeploymentCenterGitHubWorkflowConfigPreview: React.FC<DeploymentCenterGitH
           setIsPreviewPanelOpen(true);
           setShowInfoBanner(true);
         }}
-        disabled={!isPreviewFileButtonEnabled()}
+        disabled={isPreviewFileButtonDisabled}
       />
       {isPreviewPanelOpen && (
         <CustomPanel isOpen={isPreviewPanelOpen} onDismiss={dismissPreviewPanel} type={PanelType.medium}>
           <h1>{t('deploymentCenterSettingsWorkflowConfigTitle')}</h1>
-          {showWorkflowFilePath()}
-          {getPreviewPanelContent()}
+          {workflowFilePath && <p>{`${t('deploymentCenterWorkflowConfigsFilePathLabel')}: ${workflowFilePath}`}</p>}
+
+          {showInfoBanner && panelMessage && (
+            <div className={panelBanner}>
+              <CustomBanner message={panelMessage} type={MessageBarType.info} onDismiss={closeInfoBanner} />
+            </div>
+          )}
+
+          {workflowFileContent && <pre className={deploymentCenterConsole}>{workflowFileContent}</pre>}
         </CustomPanel>
       )}
     </>

--- a/client-react/src/pages/app/deployment-center/utility/GitHubActionUtility.ts
+++ b/client-react/src/pages/app/deployment-center/utility/GitHubActionUtility.ts
@@ -1,6 +1,10 @@
-import { CodeWorkflowInformation, ContainerWorkflowInformation } from '../DeploymentCenter.types';
+import { CodeWorkflowInformation, ContainerWorkflowInformation, WorkflowOption } from '../DeploymentCenter.types';
 import { RuntimeStacks, JavaContainers } from '../../../../utils/stacks-utils';
 import { getWorkflowFileName } from './DeploymentCenterUtility';
+
+export const isWorkflowOptionExistingOrAvailable = (workflowOption: string): boolean => {
+  return workflowOption === WorkflowOption.UseExistingWorkflowConfig || workflowOption === WorkflowOption.UseAvailableWorkflowConfigs;
+};
 
 export const getContainerAppWorkflowInformation = (
   serverUrl: string,

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2144,4 +2144,6 @@ export class PortalResources {
   public static detail = 'detail';
   public static detailDescription = 'detailDescription';
   public static developInPortal = 'developInPortal';
+  public static containerImage = 'containerImage';
+  public static containerImagePlaceholder = 'containerImagePlaceholder';
 }

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -6582,4 +6582,10 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="developInPortal" xml:space="preserve">
         <value>Develop in portal</value>
     </data>
+    <data name="containerImage" xml:space="preserve">
+        <value>Image name</value>
+    </data>
+    <data name="containerImagePlaceholder" xml:space="preserve">
+        <value>E.g. nginx</value>
+    </data>
 </root>


### PR DESCRIPTION
This PR wires up the GitHub Action workflow process with the existing container forms. Following are the overall states/scenarios:

No GitHub action
Gather the serverUrl, username, password, image, and tag

![image](https://user-images.githubusercontent.com/493476/90714066-b2546c80-e25b-11ea-819b-9e0f0e4a30a2.png)

GitHub branch is clean, no workflows exist
Gather the serverurl, username, password, and image

![image](https://user-images.githubusercontent.com/493476/90714139-d912a300-e25b-11ea-85ab-735af2647aab.png)

GitHub branch has workflows, but overwrite option is selected
Gather the serverurl, username, password, and image

![image](https://user-images.githubusercontent.com/493476/90714190-f6477180-e25b-11ea-8708-b90745d254a7.png)

GitHub branch has workflow, but use existing or use available option is selected
Gather the serverurl, username, and password

![image](https://user-images.githubusercontent.com/493476/90714222-065f5100-e25c-11ea-9077-2836632d580b.png)


In case of ACR - the serverurl and credentials are mapped via the registry dropdown

![image](https://user-images.githubusercontent.com/493476/90714261-20009880-e25c-11ea-9311-dacb425f5efc.png)

In case of dockerhub, the server url is assumed to be index.docker.io.

![image](https://user-images.githubusercontent.com/493476/90714296-34dd2c00-e25c-11ea-83e9-07e95341fa98.png)

With the preview side panel

![image](https://user-images.githubusercontent.com/493476/90714332-49b9bf80-e25c-11ea-8f5b-9af859ab22f5.png)

