### PR TITLE
HOTFIX: reset the default provider in classic deployment center to kudu

### DIFF
--- a/client/src/app/site/deployment-center/deployment-center-setup/step-source-control/step-source-control.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-source-control/step-source-control.component.ts
@@ -389,7 +389,7 @@ export class StepSourceControlComponent {
     this.selectedProvider = card;
     const currentFormValues = this._wizardService.wizardValues;
     currentFormValues.sourceProvider = card.id;
-    currentFormValues.buildProvider = card.id == 'github' ? 'github' : 'kudu'; // Not all providers are supported by VSTS, however all providers are supported by kudu so this is a safe default
+    currentFormValues.buildProvider = 'kudu'; // Not all providers are supported by VSTS, however all providers are supported by kudu so this is a safe default
     this._wizardService.wizardValues = currentFormValues;
   }
 


### PR DESCRIPTION
There was a bug reported earlier where for linux ASP function apps the deployment center is trying to query for githubAction workflows. This is currently not supported for FunctionApps. For now setting the default value for build provider back to kudu to be on the safe side as that option is universally operational.