### PR TITLE
Add continuous deployment option for non-github action based setup.

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -25,6 +25,11 @@ export enum ContainerDockerAccessTypes {
   private = 'private',
 }
 
+export enum ContinuousDeploymentOption {
+  on = 'on',
+  off = 'off',
+}
+
 export enum DeploymentStatus {
   Pending,
   Building,
@@ -94,6 +99,7 @@ export interface DeploymentCenterContainerFormData {
   scmType: ScmType;
   gitHubContainerUsernameSecretGuid: string;
   gitHubContainerPasswordSecretGuid: string;
+  continuousDeploymentOption: ContinuousDeploymentOption;
 }
 
 export interface DeploymentCenterCodeFormData {

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerContinuousDeploymentSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerContinuousDeploymentSettings.tsx
@@ -22,6 +22,30 @@ const DeploymentCenterContainerContinuousDeploymentSettings: React.FC<
     setWebhookFieldType(!webhookFieldType ? 'password' : undefined);
   };
 
+  const additionalWebhookControls = () => {
+    return [
+      <ActionButton
+        id="continuous-deployment-webhook-visibility-toggle"
+        key="continuous-deployment-webhook-visibility-toggle"
+        className={additionalTextFieldControl}
+        onClick={toggleShowWebhook}
+        iconProps={{ iconName: webhookFieldType === 'password' ? 'RedEye' : 'Hide' }}>
+        {webhookFieldType === 'password' ? t('show') : t('hide')}
+      </ActionButton>,
+    ];
+  };
+
+  const continuousDeploymentOptions = [
+    {
+      key: ContinuousDeploymentOption.on,
+      text: t('on'),
+    },
+    {
+      key: ContinuousDeploymentOption.off,
+      text: t('off'),
+    },
+  ];
+
   useEffect(() => {
     if (
       deploymentCenterPublishingContext &&
@@ -36,21 +60,11 @@ const DeploymentCenterContainerContinuousDeploymentSettings: React.FC<
   return (
     <>
       <Field
-        id="continuous-deployment-enabled"
+        id="continuous-deployment-option"
         label={t('continuousDeployment')}
-        name="continuousDeployment"
-        defaultSelectedKey={props.formProps.values.continuousDeploymentOption}
+        name="continuousDeploymentOption"
         component={RadioButton}
-        options={[
-          {
-            key: ContinuousDeploymentOption.on,
-            text: t('on'),
-          },
-          {
-            key: ContinuousDeploymentOption.off,
-            text: t('off'),
-          },
-        ]}
+        options={continuousDeploymentOptions}
       />
 
       <TextFieldNoFormik
@@ -60,16 +74,7 @@ const DeploymentCenterContainerContinuousDeploymentSettings: React.FC<
         copyButton={true}
         disabled={true}
         type={webhookFieldType}
-        additionalControls={[
-          <ActionButton
-            id="continuous-deployment-webhook-visibility-toggle"
-            key="continuous-deployment-webhook-visibility-toggle"
-            className={additionalTextFieldControl}
-            onClick={toggleShowWebhook}
-            iconProps={{ iconName: webhookFieldType === 'password' ? 'RedEye' : 'Hide' }}>
-            {webhookFieldType === 'password' ? t('show') : t('hide')}
-          </ActionButton>,
-        ]}
+        additionalControls={additionalWebhookControls()}
       />
     </>
   );

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerContinuousDeploymentSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerContinuousDeploymentSettings.tsx
@@ -1,0 +1,78 @@
+import React, { useContext, useState, useEffect } from 'react';
+import { DeploymentCenterFieldProps, DeploymentCenterContainerFormData, ContinuousDeploymentOption } from '../DeploymentCenter.types';
+import { Field } from 'formik';
+import { useTranslation } from 'react-i18next';
+import RadioButton from '../../../../components/form-controls/RadioButton';
+import TextFieldNoFormik from '../../../../components/form-controls/TextFieldNoFormik';
+import { DeploymentCenterPublishingContext } from '../DeploymentCenterPublishingContext';
+import { additionalTextFieldControl } from '../DeploymentCenter.styles';
+import { ActionButton } from 'office-ui-fabric-react';
+
+type WebhookFieldType = 'password' | undefined;
+
+const DeploymentCenterContainerContinuousDeploymentSettings: React.FC<
+  DeploymentCenterFieldProps<DeploymentCenterContainerFormData>
+> = props => {
+  const { t } = useTranslation();
+  const deploymentCenterPublishingContext = useContext(DeploymentCenterPublishingContext);
+  const [webhookFieldType, setWebhookFieldType] = useState<WebhookFieldType>('password');
+  const [webhookUrl, setWebhookUrl] = useState<string>('');
+
+  const toggleShowWebhook = () => {
+    setWebhookFieldType(!webhookFieldType ? 'password' : undefined);
+  };
+
+  useEffect(() => {
+    if (
+      deploymentCenterPublishingContext &&
+      deploymentCenterPublishingContext.publishingCredentials &&
+      deploymentCenterPublishingContext.publishingCredentials.properties.scmUri
+    ) {
+      setWebhookUrl(`${deploymentCenterPublishingContext.publishingCredentials.properties.scmUri}/docker/hook`);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deploymentCenterPublishingContext.publishingCredentials]);
+
+  return (
+    <>
+      <Field
+        id="continuous-deployment-enabled"
+        label={t('continuousDeployment')}
+        name="continuousDeployment"
+        defaultSelectedKey={props.formProps.values.continuousDeploymentOption}
+        component={RadioButton}
+        options={[
+          {
+            key: ContinuousDeploymentOption.on,
+            text: t('on'),
+          },
+          {
+            key: ContinuousDeploymentOption.off,
+            text: t('off'),
+          },
+        ]}
+      />
+
+      <TextFieldNoFormik
+        id="continuous-deployment-webhook"
+        label={t('containerWebhookUrl')}
+        value={webhookUrl}
+        copyButton={true}
+        disabled={true}
+        type={webhookFieldType}
+        additionalControls={[
+          <ActionButton
+            id="continuous-deployment-webhook-visibility-toggle"
+            key="continuous-deployment-webhook-visibility-toggle"
+            className={additionalTextFieldControl}
+            onClick={toggleShowWebhook}
+            iconProps={{ iconName: webhookFieldType === 'password' ? 'RedEye' : 'Hide' }}>
+            {webhookFieldType === 'password' ? t('show') : t('hide')}
+          </ActionButton>,
+        ]}
+      />
+    </>
+  );
+};
+
+export default DeploymentCenterContainerContinuousDeploymentSettings;

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -6,6 +6,7 @@ import {
   ContainerDockerAccessTypes,
   DeploymentCenterYupValidationSchemaType,
   DeploymentCenterContainerFormData,
+  ContinuousDeploymentOption,
 } from '../DeploymentCenter.types';
 import { CommonConstants } from '../../../../utils/CommonConstants';
 import * as Yup from 'yup';
@@ -28,6 +29,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
       cicd: false,
       gitHubContainerPasswordSecretGuid: '',
       gitHubContainerUsernameSecretGuid: '',
+      continuousDeploymentOption: ContinuousDeploymentOption.off,
       ...this.generateCommonFormData(),
     };
   }
@@ -48,6 +50,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
       cicd: Yup.mixed().notRequired(),
       gitHubContainerPasswordSecretGuid: Yup.mixed().notRequired(),
       gitHubContainerUsernameSecretGuid: Yup.mixed().notRequired(),
+      continuousDeploymentOption: Yup.mixed().required(),
       ...this.generateCommonFormYupValidationSchema(),
     });
   }

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettings.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from 'react-i18next';
 import { getWorkflowFileName } from '../utility/DeploymentCenterUtility';
 import { Guid } from '../../../../utils/Guid';
 import { getContainerAppWorkflowInformation } from '../utility/GitHubActionUtility';
+import DeploymentCenterContainerContinuousDeploymentSettings from './DeploymentCenterContainerContinuousDeploymentSettings';
 
 const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<DeploymentCenterContainerFormData>> = props => {
   const { formProps } = props;
@@ -171,6 +172,8 @@ const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<Dep
           panelMessage={panelMessage}
         />
       )}
+
+      {!isGitHubActionEnabled && <DeploymentCenterContainerContinuousDeploymentSettings {...props} />}
     </>
   );
 };


### PR DESCRIPTION
Customers will have an option to setup a continuous deployment pipeline if they choose to do so without having to use github actions.

![image](https://user-images.githubusercontent.com/493476/91528569-d4359b00-e8bc-11ea-818e-bb510cd0fd4f.png)

The option is available for all container source types. But it is not available if you choose to setup deployments via github actions.

![image](https://user-images.githubusercontent.com/493476/91528780-f8917780-e8bc-11ea-96d9-d4506eaa8caf.png)
