### PR TITLE
[DeploymentCenterV2] Persist the form state of each registry source

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -84,20 +84,38 @@ export interface DeploymentCenterCommonFormData {
   externalPassword?: string;
 }
 
-export interface DeploymentCenterContainerFormData {
+export interface AcrFormData {
+  acrLoginServer: string;
+  acrImage: string;
+  acrTag: string;
+  acrUsername: string;
+  acrPassword: string;
+  acrComposeYml: string;
+  acrResourceId: string;
+  acrLocation: string;
+}
+
+export interface DockerHubFormData {
+  dockerHubAccessType: ContainerDockerAccessTypes;
+  dockerHubImageAndTag: string;
+  dockerHubUsername: string;
+  dockerHubPassword: string;
+  dockerHubComposeYml: string;
+}
+
+export interface PrivateRegistryFormData {
+  privateRegistryServerUrl: string;
+  privateRegistryImageAndTag: string;
+  privateRegistryUsername: string;
+  privateRegistryPassword: string;
+  privateRegistryComposeYml: string;
+}
+
+export interface DeploymentCenterContainerFormData extends AcrFormData, DockerHubFormData, PrivateRegistryFormData {
   option: ContainerOptions;
   registrySource: ContainerRegistrySources;
-  dockerAccessType: ContainerDockerAccessTypes;
-  serverUrl: string;
-  image: string;
-  tag: string;
-  imageAndTag: string; // NOTE(michinoy): In some container forms Image and Tags are separate fields and in others they are same.
-  username: string;
-  password: string;
-  command: string;
   scmType: ScmType;
-  acrResourceId: string;
-  acrResourceLocation: string;
+  command: string;
   gitHubContainerUsernameSecretGuid: string;
   gitHubContainerPasswordSecretGuid: string;
   continuousDeploymentOption: ContinuousDeploymentOption;
@@ -344,8 +362,8 @@ export interface DeploymentCenterBitbucketProviderProps<T = DeploymentCenterCont
 }
 
 export interface DeploymentCenterContainerAcrSettingsProps extends DeploymentCenterFieldProps<DeploymentCenterContainerFormData> {
-  fetchImages: (loginServer: string, resourceId: string) => void;
-  fetchTags: (loginServer: string, image: string) => void;
+  fetchImages: (loginServer: string) => void;
+  fetchTags: (image: string) => void;
   acrRegistryOptions: IDropdownOption[];
   acrImageOptions: IDropdownOption[];
   acrTagOptions: IDropdownOption[];

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrSettings.tsx
@@ -4,62 +4,16 @@ import { Field } from 'formik';
 import { useTranslation } from 'react-i18next';
 import Dropdown from '../../../../components/form-controls/DropDown';
 import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
-import { IDropdownOption } from 'office-ui-fabric-react';
 import TextField from '../../../../components/form-controls/TextField';
 import { ScmType } from '../../../../models/site/config';
 import { isWorkflowOptionExistingOrAvailable } from '../utility/GitHubActionUtility';
 
 const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAcrSettingsProps> = props => {
-  const {
-    fetchImages,
-    fetchTags,
-    acrRegistryOptions,
-    acrImageOptions,
-    acrTagOptions,
-    acrStatusMessage,
-    acrStatusMessageType,
-    formProps,
-  } = props;
+  const { acrRegistryOptions, acrImageOptions, acrTagOptions, acrStatusMessage, acrStatusMessageType, formProps } = props;
   const { t } = useTranslation();
 
-  const [selectedRegistry, setSelectedRegistry] = useState<string>('');
-  const [selectedImage, setSelectedImage] = useState<string>('');
-  const [selectedTag, setSelectedTag] = useState<string>('');
   const [isUsingExistingOrAvailableWorkflowConfig, setIsUsingExistingOrAvailableWorkflowConfig] = useState(false);
   const [isGitHubAction, setIsGitHubAction] = useState(false);
-
-  const onRegistryChange = (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption) => {
-    setSelectedRegistry(option.key.toString());
-    const [loginServer, resourceId, location] = option.key.toString().split(':');
-    const serverUrl = `https://${loginServer}`;
-    formProps.setFieldValue('serverUrl', serverUrl.toLocaleLowerCase());
-    formProps.setFieldValue('acrResourceId', resourceId.toLocaleLowerCase());
-    formProps.setFieldValue('acrResourceLocation', location);
-
-    setSelectedImage('');
-    formProps.setFieldValue('image', '');
-
-    setSelectedTag('');
-    formProps.setFieldValue('tag', '');
-
-    fetchImages(loginServer, resourceId);
-  };
-
-  const onImageChange = (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption) => {
-    setSelectedImage(option.key.toString());
-    formProps.setFieldValue('image', option.key.toString());
-
-    setSelectedTag('');
-    formProps.setFieldValue('tag', '');
-
-    const loginServer = formProps.values.serverUrl.replace('https://', '');
-    fetchTags(loginServer, option.key.toString());
-  };
-
-  const onTagChange = async (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption) => {
-    setSelectedTag(option.key.toString());
-    formProps.setFieldValue('tag', option.key.toString());
-  };
 
   useEffect(() => {
     setIsUsingExistingOrAvailableWorkflowConfig(isWorkflowOptionExistingOrAvailable(formProps.values.workflowOption));
@@ -88,24 +42,22 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
       <Field
         id="container-acr-repository"
         label={t('containerACRRegistry')}
-        name="serverUrl"
+        name="acrLoginServer"
+        defaultSelectedKey={formProps.values.acrLoginServer}
         component={Dropdown}
         displayInVerticalLayout={true}
         options={acrRegistryOptions}
-        selectedKey={selectedRegistry}
-        onChange={onRegistryChange}
       />
 
       {!isUsingExistingOrAvailableWorkflowConfig && (
         <Field
           id="container-acr-image"
           label={t('containerACRImage')}
-          name="image"
+          name="acrImage"
+          defaultSelectedKey={formProps.values.acrImage}
           component={Dropdown}
           displayInVerticalLayout={true}
           options={acrImageOptions}
-          selectedKey={selectedImage}
-          onChange={onImageChange}
         />
       )}
 
@@ -113,12 +65,11 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
         <Field
           id="container-acr-tag"
           label={t('containerACRTag')}
-          name="tag"
+          name="acrTag"
+          defaultSelectedKey={formProps.values.acrTag}
           component={Dropdown}
           displayInVerticalLayout={true}
           options={acrTagOptions}
-          selectedKey={selectedTag}
-          onChange={onTagChange}
         />
       )}
 

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDockeHubSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDockeHubSettings.tsx
@@ -17,10 +17,10 @@ const DeploymentCenterContainerDockerHubSettings: React.FC<DeploymentCenterField
   const [isPrivateConfiguration, setIsPrivateConfiguration] = useState(false);
 
   useEffect(() => {
-    setIsPrivateConfiguration(formProps.values.dockerAccessType === ContainerDockerAccessTypes.private);
+    setIsPrivateConfiguration(formProps.values.dockerHubAccessType === ContainerDockerAccessTypes.private);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formProps.values.dockerAccessType]);
+  }, [formProps.values.dockerHubAccessType]);
 
   useEffect(() => {
     setIsUsingExistingOrAvailableWorkflowConfig(isWorkflowOptionExistingOrAvailable(formProps.values.workflowOption));
@@ -58,7 +58,7 @@ const DeploymentCenterContainerDockerHubSettings: React.FC<DeploymentCenterField
       {!isGitHubAction && (
         <Field
           id="container-dockerHub-accessType"
-          name="dockerAccessType"
+          name="dockerHubAccessType"
           component={Dropdown}
           options={accessTypes}
           label={t('containerRepositoryAccess')}
@@ -67,31 +67,23 @@ const DeploymentCenterContainerDockerHubSettings: React.FC<DeploymentCenterField
 
       {(isPrivateConfiguration || isGitHubAction) && (
         <>
-          <Field id="container-dockerHub-username" name="username" component={TextField} label={t('containerLogin')} />
+          <Field id="container-dockerHub-username" name="dockerHubUsername" component={TextField} label={t('containerLogin')} />
 
-          <Field id="container-dockerHub-password" name="password" component={TextField} label={t('containerPassword')} />
+          <Field id="container-dockerHub-password" name="dockerHubPassword" component={TextField} label={t('containerPassword')} />
         </>
       )}
 
-      {isGitHubAction && !isUsingExistingOrAvailableWorkflowConfig && (
-        <Field
-          id="container-dockerHub-image"
-          name="image"
-          component={TextField}
-          label={t('containerImage')}
-          placeholder={t('containerImagePlaceholder')}
-        />
-      )}
-
-      {!isGitHubAction && (
-        <Field
-          id="container-dockerHub-imageAndTag"
-          name="imageAndTag"
-          component={TextField}
-          label={t('containerImageAndTag')}
-          placeholder={t('containerImageAndTagPlaceholder')}
-        />
-      )}
+      <Field
+        id="container-dockerHub-imageAndTag"
+        name="dockerHubImageAndTag"
+        component={TextField}
+        label={isGitHubAction && !isUsingExistingOrAvailableWorkflowConfig ? t('containerImage') : t('containerImageAndTag')}
+        placeholder={
+          isGitHubAction && !isUsingExistingOrAvailableWorkflowConfig
+            ? t('containerImagePlaceholder')
+            : t('containerImageAndTagPlaceholder')
+        }
+      />
 
       <Field id="container-dockerHub-startUpFile" name="command" component={TextField} label={t('containerStartupFile')} />
     </>

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -96,9 +96,8 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
 
   private _getContainerOption(): ContainerOptions {
     const fxVersion = this._siteConfig.properties.linuxFxVersion || this._siteConfig.properties.windowsFxVersion;
-    const fxVersionParts = fxVersion ? fxVersion.split('|') : [];
 
-    if (fxVersionParts[0].toLocaleLowerCase() === DeploymentCenterConstants.composePrefix) {
+    if (this._isComposeContainerOption(fxVersion)) {
       return ContainerOptions.compose;
     } else {
       return ContainerOptions.docker;
@@ -106,7 +105,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
   }
 
   private _getContainerRegistrySource(): ContainerRegistrySources {
-    const serverUrl = this._getServerUrl().toLocaleLowerCase();
+    const serverUrl = this._getServerUrl();
 
     if (this._isServerUrlAcr(serverUrl)) {
       return ContainerRegistrySources.acr;
@@ -119,7 +118,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
 
   private _getServerUrl(): string {
     const value = this._applicationSettings && this._applicationSettings.properties[DeploymentCenterConstants.serverUrlSetting];
-    return value ? value : '';
+    return value.toLocaleLowerCase() ? value : '';
   }
 
   private _getUsername(): string {
@@ -151,7 +150,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
       throw Error(`Incorrect fxVersion set in the site config: ${fxVersion}`);
     }
 
-    if (fxVersionParts[0].toLocaleLowerCase() === DeploymentCenterConstants.composePrefix.toLocaleLowerCase()) {
+    if (this._isComposeContainerOption(fxVersion)) {
       return {
         server: '',
         image: '',
@@ -248,10 +247,15 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
   }
 
   private _isServerUrlAcr(serverUrl: string): boolean {
-    return !!serverUrl && serverUrl.toLocaleLowerCase().indexOf(DeploymentCenterConstants.acrUriHost) > -1;
+    return !!serverUrl && serverUrl.indexOf(DeploymentCenterConstants.acrUriHost) > -1;
   }
 
   private _isServerUrlDockerHub(serverUrl: string): boolean {
-    return !!serverUrl && serverUrl.toLocaleLowerCase().indexOf(DeploymentCenterConstants.dockerHubUrl) > -1;
+    return !!serverUrl && serverUrl.indexOf(DeploymentCenterConstants.dockerHubUrl) > -1;
+  }
+
+  private _isComposeContainerOption(fxVersion: string): boolean {
+    const fxVersionParts = fxVersion ? fxVersion.split('|') : [];
+    return fxVersionParts[0].toLocaleLowerCase() === DeploymentCenterConstants.composePrefix.toLocaleLowerCase();
   }
 }

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -7,30 +7,40 @@ import {
   DeploymentCenterYupValidationSchemaType,
   DeploymentCenterContainerFormData,
   ContinuousDeploymentOption,
+  AcrFormData,
+  DockerHubFormData,
+  PrivateRegistryFormData,
 } from '../DeploymentCenter.types';
-import { CommonConstants } from '../../../../utils/CommonConstants';
 import * as Yup from 'yup';
 import { DeploymentCenterFormBuilder } from '../DeploymentCenterFormBuilder';
+import { DeploymentCenterConstants } from '../DeploymentCenterConstants';
+
+interface FxVersionParts {
+  containerOption: ContainerOptions;
+  server: string;
+  image: string;
+  tag: string;
+  composeYml: string;
+}
 
 export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBuilder {
   public generateFormData(): DeploymentCenterFormData<DeploymentCenterContainerFormData> {
+    const fxVersionParts = this._getFxVersionParts();
+    const serverUrl = this._getServerUrl();
+    const username = this._getUsername();
+    const password = this._getPassword();
+
     return {
       scmType: this._siteConfig ? this._siteConfig.properties.scmType : ScmType.None,
-      option: ContainerOptions.docker,
+      option: this._getContainerOption(),
       registrySource: this._getContainerRegistrySource(),
-      dockerAccessType: ContainerDockerAccessTypes.public,
-      serverUrl: '',
-      image: '',
-      tag: '',
-      imageAndTag: '',
-      username: '',
-      password: '',
-      command: '',
-      acrResourceId: '',
-      acrResourceLocation: '',
+      command: this._getCommand(),
       gitHubContainerPasswordSecretGuid: '',
       gitHubContainerUsernameSecretGuid: '',
       continuousDeploymentOption: ContinuousDeploymentOption.off,
+      ...this._getAcrFormData(serverUrl, username, password, fxVersionParts),
+      ...this._getDockerHubFormData(serverUrl, username, password, fxVersionParts),
+      ...this._getPrivateRegistryFormData(serverUrl, username, password, fxVersionParts),
       ...this.generateCommonFormData(),
     };
   }
@@ -40,32 +50,203 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
       scmType: Yup.mixed().required(),
       option: Yup.mixed().notRequired(),
       registrySource: Yup.mixed().notRequired(),
-      dockerAccessType: Yup.mixed().notRequired(),
-      serverUrl: Yup.mixed().notRequired(),
-      image: Yup.mixed().notRequired(),
-      tag: Yup.mixed().notRequired(),
-      imageAndTag: Yup.mixed().notRequired(),
-      username: Yup.mixed().notRequired(),
-      password: Yup.mixed().notRequired(),
       command: Yup.mixed().notRequired(),
-      acrResourceId: Yup.mixed().notRequired(),
-      acrResourceLocation: Yup.mixed().notRequired(),
       gitHubContainerPasswordSecretGuid: Yup.mixed().notRequired(),
       gitHubContainerUsernameSecretGuid: Yup.mixed().notRequired(),
       continuousDeploymentOption: Yup.mixed().required(),
+      ...this._getAcrFormValidationSchema(),
+      ...this._getDockerHubFormValidationSchema(),
+      ...this._getPrivateRegistryFormValidationSchema(),
       ...this.generateCommonFormYupValidationSchema(),
     });
   }
 
-  private _getContainerRegistrySource(): ContainerRegistrySources {
-    const serverUrl = this._applicationSettings && this._applicationSettings[CommonConstants.ContainerConstants.serverUrlSetting];
+  private _getAcrFormValidationSchema(): Yup.ObjectSchemaDefinition<AcrFormData> {
+    return {
+      acrLoginServer: Yup.mixed().notRequired(),
+      acrImage: Yup.mixed().notRequired(),
+      acrTag: Yup.mixed().notRequired(),
+      acrComposeYml: Yup.mixed().notRequired(),
+      acrUsername: Yup.mixed().notRequired(),
+      acrPassword: Yup.mixed().notRequired(),
+      acrResourceId: Yup.mixed().notRequired(),
+      acrLocation: Yup.mixed().notRequired(),
+    };
+  }
 
-    if (serverUrl && serverUrl.indexOf(CommonConstants.ContainerConstants.acrUriHost) > -1) {
+  private _getDockerHubFormValidationSchema(): Yup.ObjectSchemaDefinition<DockerHubFormData> {
+    return {
+      dockerHubImageAndTag: Yup.mixed().notRequired(),
+      dockerHubComposeYml: Yup.mixed().notRequired(),
+      dockerHubAccessType: Yup.mixed().notRequired(),
+      dockerHubUsername: Yup.mixed().notRequired(),
+      dockerHubPassword: Yup.mixed().notRequired(),
+    };
+  }
+
+  private _getPrivateRegistryFormValidationSchema(): Yup.ObjectSchemaDefinition<PrivateRegistryFormData> {
+    return {
+      privateRegistryServerUrl: Yup.mixed().notRequired(),
+      privateRegistryImageAndTag: Yup.mixed().notRequired(),
+      privateRegistryComposeYml: Yup.mixed().notRequired(),
+      privateRegistryUsername: Yup.mixed().notRequired(),
+      privateRegistryPassword: Yup.mixed().notRequired(),
+    };
+  }
+
+  private _getContainerOption(): ContainerOptions {
+    const fxVersion = this._siteConfig.properties.linuxFxVersion || this._siteConfig.properties.windowsFxVersion;
+    const fxVersionParts = fxVersion ? fxVersion.split('|') : [];
+
+    if (fxVersionParts[0].toLocaleLowerCase() === DeploymentCenterConstants.composePrefix) {
+      return ContainerOptions.compose;
+    } else {
+      return ContainerOptions.docker;
+    }
+  }
+
+  private _getContainerRegistrySource(): ContainerRegistrySources {
+    const serverUrl = this._getServerUrl().toLocaleLowerCase();
+
+    if (serverUrl && serverUrl.indexOf(DeploymentCenterConstants.acrUriHost) > -1) {
       return ContainerRegistrySources.acr;
-    } else if (serverUrl && serverUrl.indexOf(CommonConstants.ContainerConstants.dockerHubUrl) > -1) {
+    } else if (serverUrl && serverUrl.indexOf(DeploymentCenterConstants.dockerHubUrl) > -1) {
       return ContainerRegistrySources.docker;
     } else {
       return ContainerRegistrySources.privateRegistry;
+    }
+  }
+
+  private _getServerUrl(): string {
+    const value = this._applicationSettings && this._applicationSettings.properties[DeploymentCenterConstants.serverUrlSetting];
+    return value ? value : '';
+  }
+
+  private _getUsername(): string {
+    const value = this._applicationSettings && this._applicationSettings.properties[DeploymentCenterConstants.usernameSetting];
+    return value ? value : '';
+  }
+
+  private _getPassword(): string {
+    const value = this._applicationSettings && this._applicationSettings.properties[DeploymentCenterConstants.passwordSetting];
+    return value ? value : '';
+  }
+
+  private _getCommand(): string {
+    return this._siteConfig && this._siteConfig.properties.appCommandLine ? this._siteConfig.properties.appCommandLine : '';
+  }
+
+  private _getFxVersionParts(): FxVersionParts {
+    // NOTE(michinoy): Depending on the OS you would either have linuxFxVersion or windowsFxVersion.
+    // Depending on the container option (single/docker or compose) the fxVersion value could either contain
+    // the registry source or an encoded yml file (yeah I know!). Following are some examples:
+    // compose fxVersion: COMPOSE|<base64Encoded string>
+    // docker fxVersion with serverPath: DOCKER|<serverPath>/<imageName>:<tag>
+    // docker fxVersion without serverPath: DOCKER|<imageName>:<tag>
+    // docker fxVersion without tag: DOCKER|<image>
+    const fxVersion = this._siteConfig.properties.linuxFxVersion || this._siteConfig.properties.windowsFxVersion;
+    const fxVersionParts = fxVersion.split('|');
+
+    if (fxVersionParts.length < 2) {
+      throw Error(`Incorrect fxVersion set in the site config: ${fxVersion}`);
+    }
+
+    if (fxVersionParts[0].toLocaleLowerCase() === DeploymentCenterConstants.composePrefix.toLocaleLowerCase()) {
+      return {
+        server: '',
+        image: '',
+        tag: '',
+        containerOption: ContainerOptions.compose,
+        composeYml: btoa(fxVersionParts[1]),
+      };
+    } else {
+      const registryParts = fxVersionParts[1].split(':');
+      const imageParts = registryParts[0].split('/');
+      const tag = registryParts[1] ? registryParts[1] : '';
+      const image = imageParts.length > 1 ? imageParts[1] : imageParts[0];
+      const server = imageParts.length > 1 ? imageParts[0] : '';
+
+      return {
+        server,
+        image,
+        tag,
+        containerOption: ContainerOptions.docker,
+        composeYml: '',
+      };
+    }
+  }
+
+  private _getAcrFormData(serverUrl: string, username: string, password: string, fxVersionParts: FxVersionParts): AcrFormData {
+    if (serverUrl.toLocaleLowerCase().indexOf(DeploymentCenterConstants.acrUriHost) > -1) {
+      return {
+        acrLoginServer: fxVersionParts.server.toLocaleLowerCase(),
+        acrImage: fxVersionParts.image,
+        acrTag: fxVersionParts.tag,
+        acrComposeYml: fxVersionParts.composeYml,
+        acrUsername: username,
+        acrPassword: password,
+        acrResourceId: '',
+        acrLocation: '',
+      };
+    } else {
+      return {
+        acrLoginServer: '',
+        acrImage: '',
+        acrTag: '',
+        acrComposeYml: '',
+        acrUsername: '',
+        acrPassword: '',
+        acrResourceId: '',
+        acrLocation: '',
+      };
+    }
+  }
+
+  private _getDockerHubFormData(serverUrl: string, username: string, password: string, fxVersionParts: FxVersionParts): DockerHubFormData {
+    if (serverUrl.toLocaleLowerCase() === DeploymentCenterConstants.dockerHubUrl) {
+      return {
+        dockerHubImageAndTag: fxVersionParts.tag ? `${fxVersionParts.image}:${fxVersionParts.tag}` : fxVersionParts.image,
+        dockerHubComposeYml: fxVersionParts.composeYml,
+        dockerHubAccessType: username && password ? ContainerDockerAccessTypes.private : ContainerDockerAccessTypes.public,
+        dockerHubUsername: username,
+        dockerHubPassword: password,
+      };
+    } else {
+      return {
+        dockerHubImageAndTag: '',
+        dockerHubComposeYml: '',
+        dockerHubAccessType: ContainerDockerAccessTypes.public,
+        dockerHubUsername: '',
+        dockerHubPassword: '',
+      };
+    }
+  }
+
+  private _getPrivateRegistryFormData(
+    serverUrl: string,
+    username: string,
+    password: string,
+    fxVersionParts: FxVersionParts
+  ): PrivateRegistryFormData {
+    if (
+      serverUrl.toLocaleLowerCase().indexOf(DeploymentCenterConstants.acrUriHost) === -1 &&
+      serverUrl.toLocaleLowerCase() !== DeploymentCenterConstants.dockerHubUrl
+    ) {
+      return {
+        privateRegistryServerUrl: serverUrl,
+        privateRegistryImageAndTag: fxVersionParts.tag ? `${fxVersionParts.image}:${fxVersionParts.tag}` : fxVersionParts.image,
+        privateRegistryComposeYml: fxVersionParts.composeYml,
+        privateRegistryUsername: username,
+        privateRegistryPassword: password,
+      };
+    } else {
+      return {
+        privateRegistryServerUrl: '',
+        privateRegistryImageAndTag: '',
+        privateRegistryComposeYml: '',
+        privateRegistryUsername: '',
+        privateRegistryPassword: '',
+      };
     }
   }
 }

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -108,9 +108,9 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
   private _getContainerRegistrySource(): ContainerRegistrySources {
     const serverUrl = this._getServerUrl().toLocaleLowerCase();
 
-    if (serverUrl && serverUrl.indexOf(DeploymentCenterConstants.acrUriHost) > -1) {
+    if (this._isServerUrlAcr(serverUrl)) {
       return ContainerRegistrySources.acr;
-    } else if (serverUrl && serverUrl.indexOf(DeploymentCenterConstants.dockerHubUrl) > -1) {
+    } else if (this._isServerUrlDockerHub(serverUrl)) {
       return ContainerRegistrySources.docker;
     } else {
       return ContainerRegistrySources.privateRegistry;
@@ -177,7 +177,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
   }
 
   private _getAcrFormData(serverUrl: string, username: string, password: string, fxVersionParts: FxVersionParts): AcrFormData {
-    if (serverUrl.toLocaleLowerCase().indexOf(DeploymentCenterConstants.acrUriHost) > -1) {
+    if (this._isServerUrlAcr(serverUrl)) {
       return {
         acrLoginServer: fxVersionParts.server.toLocaleLowerCase(),
         acrImage: fxVersionParts.image,
@@ -203,7 +203,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
   }
 
   private _getDockerHubFormData(serverUrl: string, username: string, password: string, fxVersionParts: FxVersionParts): DockerHubFormData {
-    if (serverUrl.toLocaleLowerCase() === DeploymentCenterConstants.dockerHubUrl) {
+    if (this._isServerUrlDockerHub(serverUrl)) {
       return {
         dockerHubImageAndTag: fxVersionParts.tag ? `${fxVersionParts.image}:${fxVersionParts.tag}` : fxVersionParts.image,
         dockerHubComposeYml: fxVersionParts.composeYml,
@@ -228,10 +228,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
     password: string,
     fxVersionParts: FxVersionParts
   ): PrivateRegistryFormData {
-    if (
-      serverUrl.toLocaleLowerCase().indexOf(DeploymentCenterConstants.acrUriHost) === -1 &&
-      serverUrl.toLocaleLowerCase() !== DeploymentCenterConstants.dockerHubUrl
-    ) {
+    if (this._isServerUrlAcr(serverUrl) && this._isServerUrlDockerHub(serverUrl)) {
       return {
         privateRegistryServerUrl: serverUrl,
         privateRegistryImageAndTag: fxVersionParts.tag ? `${fxVersionParts.image}:${fxVersionParts.tag}` : fxVersionParts.image,
@@ -248,5 +245,13 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
         privateRegistryPassword: '',
       };
     }
+  }
+
+  private _isServerUrlAcr(serverUrl: string): boolean {
+    return !!serverUrl && serverUrl.toLocaleLowerCase().indexOf(DeploymentCenterConstants.acrUriHost) > -1;
+  }
+
+  private _isServerUrlDockerHub(serverUrl: string): boolean {
+    return !!serverUrl && serverUrl.toLocaleLowerCase().indexOf(DeploymentCenterConstants.dockerHubUrl) > -1;
   }
 }

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPrivateRegistrySettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPrivateRegistrySettings.tsx
@@ -37,35 +37,27 @@ const DeploymentCenterContainerPrivateRegistrySettings: React.FC<DeploymentCente
     <>
       <Field
         id="container-privateRegistry-serverUrl"
-        name="serverUrl"
+        name="privateRegistryServerUrl"
         component={TextField}
         label={t('containerServerURL')}
         placeholder={t('containerServerURLPlaceholder')}
       />
 
-      <Field id="container-privateRegistry-username" name="username" component={TextField} label={t('containerLogin')} />
+      <Field id="container-privateRegistry-username" name="privateRegistryUsername" component={TextField} label={t('containerLogin')} />
 
-      <Field id="container-privateRegistry-password" name="password" component={TextField} label={t('containerPassword')} />
+      <Field id="container-privateRegistry-password" name="privateRegistryPassword" component={TextField} label={t('containerPassword')} />
 
-      {isGitHubAction && !isUsingExistingOrAvailableWorkflowConfig && (
-        <Field
-          id="container-privateRegistry-image"
-          name="image"
-          component={TextField}
-          label={t('containerImage')}
-          placeholder={t('containerImagePlaceholder')}
-        />
-      )}
-
-      {!isGitHubAction && (
-        <Field
-          id="container-privateRegistry-imageAndTag"
-          name="imageAndTag"
-          component={TextField}
-          label={t('containerImageAndTag')}
-          placeholder={t('containerImageAndTagPlaceholder')}
-        />
-      )}
+      <Field
+        id="container-privateRegistry-imageAndTag"
+        name="privateRegistryImageAndTag"
+        component={TextField}
+        label={isGitHubAction && !isUsingExistingOrAvailableWorkflowConfig ? t('containerImage') : t('containerImageAndTag')}
+        placeholder={
+          isGitHubAction && !isUsingExistingOrAvailableWorkflowConfig
+            ? t('containerImagePlaceholder')
+            : t('containerImageAndTagPlaceholder')
+        }
+      />
 
       <Field id="container-privateRegistry-startUpFile" name="command" component={TextField} label={t('containerStartupFile')} />
     </>

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -118,25 +118,6 @@ export class CommonConstants {
 
   public static readonly newLine = '\n';
 
-  public static ContainerConstants = {
-    dockerHubUrl: 'https://index.docker.io',
-    microsoftMcrUrl: 'https://mcr.microsoft.com',
-    acrUriBody: 'azurecr',
-    acrUriHost: 'azurecr.io',
-    imageNameSetting: 'DOCKER_CUSTOM_IMAGE_NAME',
-    serverUrlSetting: 'DOCKER_REGISTRY_SERVER_URL',
-    usernameSetting: 'DOCKER_REGISTRY_SERVER_USERNAME',
-    passwordSetting: 'DOCKER_REGISTRY_SERVER_PASSWORD',
-    runCommandSetting: 'DOCKER_CUSTOM_IMAGE_RUN_COMMAND',
-    appServiceStorageSetting: 'WEBSITES_ENABLE_APP_SERVICE_STORAGE',
-    enableCISetting: 'DOCKER_ENABLE_CI',
-    containerWinRmEnabled: 'CONTAINER_WINRM_ENABLED',
-    createAcrFwLink: 'https://go.microsoft.com/fwlink/?linkid=852293',
-    singleContainerQSLink: 'https://go.microsoft.com/fwlink/?linkid=873144',
-    dockerComposeQSLink: 'https://go.microsoft.com/fwlink/?linkid=873149',
-    kubeQSLink: 'https://go.microsoft.com/fwlink/?linkid=873150',
-  };
-
   public static AppKeys = {
     master: 'master',
     eventGridV1: 'eventgridextensionconfig_extension',


### PR DESCRIPTION
There are three types of registry sources - acr, dockerHub, and privateRegistry. Each have their own way of forming serverUrl, username, password, image, and tag. Initially I had implemented a common form data to be used across all three sources. Now from past experience, users tend to switch between each source while setting up and expect the whatever values they have selected in each source is persisted till they save. Due to this requirement, we need to have separate formdata properties for each of the sources. Thus this PR.