### PR TITLE
Add the readonly view for github action based container setup

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -174,7 +174,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
 
   private _getServerUrl(): string {
     const value = this._applicationSettings && this._applicationSettings.properties[DeploymentCenterConstants.serverUrlSetting];
-    return value.toLocaleLowerCase() ? value : '';
+    return value ? value.toLocaleLowerCase() : '';
   }
 
   private _getUsername(): string {

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettings.tsx
@@ -22,7 +22,7 @@ import { getContainerAppWorkflowInformation } from '../utility/GitHubActionUtili
 import DeploymentCenterContainerContinuousDeploymentSettings from './DeploymentCenterContainerContinuousDeploymentSettings';
 import { DeploymentCenterConstants } from '../DeploymentCenterConstants';
 import DeploymentCenterGitHubConfiguredView from '../github-provider/DeploymentCenterGitHubConfiguredView';
-import DeploymentCenterContainerSettingsConfiguredView from './DeploymentCenterContainerSettingsConfiguredView';
+import DeploymentCenterContainerSettingsReadOnlyView from './DeploymentCenterContainerSettingsReadOnlyView';
 
 const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<DeploymentCenterContainerFormData>> = props => {
   const { formProps } = props;
@@ -32,7 +32,7 @@ const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<Dep
   const [isPreviewFileButtonDisabled, setIsPreviewFileButtonDisabled] = useState(false);
   const [workflowFileContent, setWorkflowFileContent] = useState('');
   const [panelMessage, setPanelMessage] = useState('');
-  const [showConfiguredView, setShowConfiguredView] = useState(false);
+  const [showGitHubActionReadOnlyView, setShowGitHubActionReadOnlyView] = useState(false);
 
   // NOTE(michinoy): The serverUrl, image, username, and password are retrieved from  one of three sources:
   // acr, dockerHub, or privateRegistry.
@@ -45,7 +45,7 @@ const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<Dep
 
   const deploymentCenterContext = useContext(DeploymentCenterContext);
 
-  const isGitHubActionEnabled = formProps.values.scmType === ScmType.GitHubAction;
+  const isGitHubActionSelected = formProps.values.scmType === ScmType.GitHubAction;
   const isAcrConfigured = formProps.values.registrySource === ContainerRegistrySources.acr;
   const isDockerHubConfigured = formProps.values.registrySource === ContainerRegistrySources.docker;
   const isPrivateRegistryConfigured = formProps.values.registrySource === ContainerRegistrySources.privateRegistry;
@@ -210,18 +210,18 @@ const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<Dep
       deploymentCenterContext.siteConfig &&
       deploymentCenterContext.siteConfig.properties.scmType === ScmType.GitHubAction
     ) {
-      setShowConfiguredView(true);
+      setShowGitHubActionReadOnlyView(true);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deploymentCenterContext.siteConfig]);
 
-  const setupView = () => {
+  const renderSetupView = () => {
     return (
       <>
         <DeploymentCenterContainerSource />
 
-        {isGitHubActionEnabled && (
+        {isGitHubActionSelected && (
           <>
             <DeploymentCenterGitHubDataLoader formProps={formProps} />{' '}
             <DeploymentCenterGitHubWorkflowConfigSelector
@@ -239,7 +239,7 @@ const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<Dep
 
         {isPrivateRegistryConfigured && <DeploymentCenterContainerPrivateRegistrySettings {...props} />}
 
-        {isGitHubActionEnabled && (
+        {isGitHubActionSelected && (
           <DeploymentCenterGitHubWorkflowConfigPreview
             isPreviewFileButtonDisabled={isPreviewFileButtonDisabled}
             workflowFilePath={workflowFilePath}
@@ -248,21 +248,21 @@ const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<Dep
           />
         )}
 
-        {!isGitHubActionEnabled && <DeploymentCenterContainerContinuousDeploymentSettings {...props} />}
+        {!isGitHubActionSelected && <DeploymentCenterContainerContinuousDeploymentSettings {...props} />}
       </>
     );
   };
 
-  const configuredView = () => {
+  const renderGitHubActionReadOnlyView = () => {
     return (
       <>
         <DeploymentCenterGitHubConfiguredView isGitHubActionsSetup={true} />
-        <DeploymentCenterContainerSettingsConfiguredView />
+        <DeploymentCenterContainerSettingsReadOnlyView />
       </>
     );
   };
 
-  return showConfiguredView ? configuredView() : setupView();
+  return showGitHubActionReadOnlyView ? renderGitHubActionReadOnlyView() : renderSetupView();
 };
 
 export default DeploymentCenterContainerSettings;

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettingsConfiguredView.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettingsConfiguredView.tsx
@@ -1,0 +1,60 @@
+import React, { useContext, useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { DeploymentCenterContext } from '../DeploymentCenterContext';
+import ReactiveFormControl from '../../../../components/form-controls/ReactiveFormControl';
+import { DeploymentCenterConstants } from '../DeploymentCenterConstants';
+import { SiteStateContext } from '../../../../SiteState';
+
+const DeploymentCenterContainerSettingsConfiguredView: React.FC<{}> = props => {
+  const { t } = useTranslation();
+  const deploymentCenterContext = useContext(DeploymentCenterContext);
+  const siteStateContext = useContext(SiteStateContext);
+  const [serverUrl, setServerUrl] = useState<string>(t('loading'));
+  const [username, setUsername] = useState<string>(t('loading'));
+  const [imageAndTag, setImageAndTag] = useState<string>(t('loading'));
+
+  useEffect(() => {
+    if (deploymentCenterContext && deploymentCenterContext.applicationSettings) {
+      const appSettings = deploymentCenterContext.applicationSettings.properties;
+      setServerUrl(appSettings[DeploymentCenterConstants.serverUrlSetting]);
+      setUsername(appSettings[DeploymentCenterConstants.usernameSetting]);
+    }
+
+    if (siteStateContext && deploymentCenterContext && deploymentCenterContext.siteConfig) {
+      const fxVersion = siteStateContext.isLinuxApp
+        ? deploymentCenterContext.siteConfig.properties.linuxFxVersion
+        : deploymentCenterContext.siteConfig.properties.windowsFxVersion;
+
+      const fxVersionParts = fxVersion.split('|');
+      const imageAndTagParts = fxVersionParts[1] ? fxVersionParts[1].split('/') : [];
+
+      setImageAndTag(imageAndTagParts.length > 1 ? imageAndTagParts[1] : imageAndTagParts[0]);
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deploymentCenterContext.applicationSettings, deploymentCenterContext.siteConfig, siteStateContext]);
+
+  return (
+    <>
+      <h3>{t('deploymentCenterContainerRegistrySettingsTitle')}</h3>
+
+      <ReactiveFormControl id="deployment-center-container-settings-build" label={t('deploymentCenterSettingsBuildLabel')}>
+        <div>{t('deploymentCenterCodeSettingsBuildGitHubAction')}</div>
+      </ReactiveFormControl>
+
+      <ReactiveFormControl id="deployment-center-container-settings-serverUrl" label={t('containerServerURL')}>
+        <div>{serverUrl}</div>
+      </ReactiveFormControl>
+
+      <ReactiveFormControl id="deployment-center-container-settings-username" label={t('containerLogin')}>
+        <div>{username}</div>
+      </ReactiveFormControl>
+
+      <ReactiveFormControl id="deployment-center-container-settings-imageAndTag" label={t('containerImageAndTag')}>
+        <div>{imageAndTag}</div>
+      </ReactiveFormControl>
+    </>
+  );
+};
+
+export default DeploymentCenterContainerSettingsConfiguredView;

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettingsReadOnlyView.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettingsReadOnlyView.tsx
@@ -5,7 +5,7 @@ import ReactiveFormControl from '../../../../components/form-controls/ReactiveFo
 import { DeploymentCenterConstants } from '../DeploymentCenterConstants';
 import { SiteStateContext } from '../../../../SiteState';
 
-const DeploymentCenterContainerSettingsConfiguredView: React.FC<{}> = props => {
+const DeploymentCenterContainerSettingsReadOnlyView: React.FC<{}> = props => {
   const { t } = useTranslation();
   const deploymentCenterContext = useContext(DeploymentCenterContext);
   const siteStateContext = useContext(SiteStateContext);
@@ -57,4 +57,4 @@ const DeploymentCenterContainerSettingsConfiguredView: React.FC<{}> = props => {
   );
 };
 
-export default DeploymentCenterContainerSettingsConfiguredView;
+export default DeploymentCenterContainerSettingsReadOnlyView;


### PR DESCRIPTION
If the container is wired up via GitHub Action. Than on reload the page should load the readonly view with an option to disconnect rather than an editable form.

![image](https://user-images.githubusercontent.com/493476/92339553-9d554700-f06b-11ea-832f-a0f12b33e890.png)

![image](https://user-images.githubusercontent.com/493476/92339570-ac3bf980-f06b-11ea-9056-b099bd47bc63.png)
