### PR TITLE
Auto populate pre-selected fields for GitHub provider on tab switching

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -84,6 +84,8 @@ export interface DeploymentCenterCommonFormData {
   externalRepoType: RepoTypeOptions;
   externalUsername?: string;
   externalPassword?: string;
+  gitHubUser?: GitHubUser;
+  bitBuckerUser?: BitbucketUser;
 }
 
 export interface AcrFormData {

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
@@ -30,6 +30,8 @@ export abstract class DeploymentCenterFormBuilder {
       org: '',
       repo: '',
       branch: '',
+      gitHubUser: undefined,
+      bitBucketUser: undefined,
       gitHubPublishProfileSecretGuid: '',
       externalRepoType: RepoTypeOptions.Public,
     };
@@ -87,6 +89,8 @@ export abstract class DeploymentCenterFormBuilder {
           ? !!value
           : true;
       }),
+      gitHubUser: Yup.mixed().notRequired(),
+      bitBucketUser: Yup.mixed().notRequired(),
       gitHubPublishProfileSecretGuid: Yup.mixed().notRequired(),
       externalUsername: Yup.mixed().test('externalUsernameRequired', this._t('deploymentCenterFieldRequiredMessage'), function(value) {
         return this.parent.externalRepoType === RepoTypeOptions.Private ? !!value : true;

--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubProvider.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubProvider.tsx
@@ -1,8 +1,7 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import DeploymentCenterGitHubAccount from './DeploymentCenterGitHubAccount';
 import { DeploymentCenterGitHubProviderProps } from '../DeploymentCenter.types';
-import { IDropdownOption } from 'office-ui-fabric-react';
 import Dropdown from '../../../../components/form-controls/DropDown';
 import { Field } from 'formik';
 import { SiteStateContext } from '../../../../SiteState';
@@ -14,8 +13,6 @@ const DeploymentCenterGitHubProvider: React.FC<DeploymentCenterGitHubProviderPro
   const {
     formProps,
     accountUser,
-    fetchRepositoryOptions,
-    fetchBranchOptions,
     organizationOptions,
     repositoryOptions,
     branchOptions,
@@ -23,38 +20,6 @@ const DeploymentCenterGitHubProvider: React.FC<DeploymentCenterGitHubProviderPro
     loadingRepositories,
     loadingBranches,
   } = props;
-
-  const [selectedOrg, setSelectedOrg] = useState<string>('');
-  const [selectedRepo, setSelectedRepo] = useState<string>('');
-  const [selectedBranch, setSelectedBranch] = useState<string>('');
-
-  const onOrganizationChange = (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption) => {
-    setSelectedOrg(option.key.toString());
-    formProps.setFieldValue('org', option.text);
-
-    setSelectedRepo('');
-    formProps.setFieldValue('repo', '');
-
-    setSelectedBranch('');
-    formProps.setFieldValue('branch', '');
-
-    fetchRepositoryOptions(option.key.toString());
-  };
-
-  const onRepositoryChange = (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption) => {
-    setSelectedRepo(option.text);
-    formProps.setFieldValue('repo', option.key.toString());
-
-    setSelectedBranch('');
-    formProps.setFieldValue('branch', '');
-
-    fetchBranchOptions(formProps.values.org, option.text);
-  };
-
-  const onBranchChange = async (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption) => {
-    setSelectedBranch(option.text);
-    formProps.setFieldValue('branch', option.key.toString());
-  };
 
   return (
     <>
@@ -69,12 +34,11 @@ const DeploymentCenterGitHubProvider: React.FC<DeploymentCenterGitHubProviderPro
             label={t('deploymentCenterOAuthOrganization')}
             placeholder={t('deploymentCenterOAuthOrganizationPlaceholder')}
             name="org"
+            defaultSelectedKey={formProps.values.org}
             component={Dropdown}
             displayInVerticalLayout={true}
             options={organizationOptions}
-            selectedKey={selectedOrg}
             required={true}
-            onChange={onOrganizationChange}
             isLoading={loadingOrganizations}
           />
           <Field
@@ -85,9 +49,8 @@ const DeploymentCenterGitHubProvider: React.FC<DeploymentCenterGitHubProviderPro
             component={Dropdown}
             displayInVerticalLayout={true}
             options={repositoryOptions}
-            selectedKey={selectedRepo}
+            defaultSelectedKey={formProps.values.repo}
             required={true}
-            onChange={onRepositoryChange}
             isLoading={loadingRepositories}
           />
           <Field
@@ -98,9 +61,8 @@ const DeploymentCenterGitHubProvider: React.FC<DeploymentCenterGitHubProviderPro
             component={Dropdown}
             displayInVerticalLayout={true}
             options={branchOptions}
-            selectedKey={selectedBranch}
+            defaultSelectedKey={formProps.values.branch}
             required={true}
-            onChange={onBranchChange}
             isLoading={loadingBranches}
           />
         </>

--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubWorkflowConfigSelector.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubWorkflowConfigSelector.tsx
@@ -14,7 +14,6 @@ const DeploymentCenterGitHubWorkflowConfigSelector: React.FC<DeploymentCenterGit
   const { formProps, setGithubActionExistingWorkflowContents } = props;
   const { t } = useTranslation();
 
-  const [selectedWorkflowConfigOption, setSelectedWorkflowConfigOption] = useState<WorkflowOption | undefined>(undefined);
   const [showWorkflowConfigDropdown, setShowWorkflowConfigDropdown] = useState<boolean>(false);
   const [workflowConfigDropdownOptions, setWorkflowConfigDropdownOptions] = useState<IDropdownOption[] | undefined>(undefined);
   const [workflowFileExistsWarningMessage, setWorkflowFileExistsWarningMessage] = useState<string | undefined>(undefined);
@@ -47,11 +46,6 @@ const DeploymentCenterGitHubWorkflowConfigSelector: React.FC<DeploymentCenterGit
 
   const closeWarningBanner = () => {
     setShowWarningBanner(false);
-  };
-
-  const onWorkflowOptionChange = (event: React.FormEvent<HTMLDivElement>, option: WorkflowDropdownOption) => {
-    setSelectedWorkflowConfigOption(option.workflowOption);
-    formProps.setFieldValue('workflowOption', option.workflowOption);
   };
 
   const fetchWorkflowConfiguration = async (org: string, repo: string, branch: string) => {
@@ -113,7 +107,6 @@ const DeploymentCenterGitHubWorkflowConfigSelector: React.FC<DeploymentCenterGit
       } else {
         setShowWarningBanner(false);
         setWorkflowFileExistsWarningMessage(undefined);
-        setSelectedWorkflowConfigOption(WorkflowOption.Add);
         formProps.setFieldValue('workflowOption', WorkflowOption.Add);
       }
     }
@@ -122,13 +115,11 @@ const DeploymentCenterGitHubWorkflowConfigSelector: React.FC<DeploymentCenterGit
 
   useEffect(() => {
     setShowWorkflowConfigDropdown(false);
-    setSelectedWorkflowConfigOption(WorkflowOption.None);
-    formProps.setFieldValue('workflowOption', WorkflowOption.None);
-    if (formProps.values.branch !== '') {
+    if (formProps.values.org && formProps.values.repo && formProps.values.branch) {
       fetchWorkflowConfiguration(formProps.values.org, formProps.values.repo, formProps.values.branch);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formProps.values.branch]);
+  }, [formProps.values.org, formProps.values.repo, formProps.values.branch]);
 
   return (
     <>
@@ -150,12 +141,11 @@ const DeploymentCenterGitHubWorkflowConfigSelector: React.FC<DeploymentCenterGit
             label={t('githubActionWorkflowOption')}
             placeholder={t('deploymentCenterSettingsGitHubActionWorkflowOptionPlaceholder')}
             name="workflowOption"
+            defaultSelectedKey={formProps.values.workflowOption}
             component={Dropdown}
             displayInVerticalLayout={true}
             options={workflowConfigDropdownOptions}
-            selectedKey={selectedWorkflowConfigOption}
             required={true}
-            onChange={onWorkflowOptionChange}
           />
         </>
       )}


### PR DESCRIPTION
Preserve the selected dropdown values when switching between tabs.

![Screen-Recording-2020-09-09-at-1](https://user-images.githubusercontent.com/493476/92567091-0ab2d480-f232-11ea-8258-d97e93fcef8b.gif)
