### PR TITLE
[Deployment Center V2] Showing Java 8 stack and runtime

### DIFF
--- a/client-react/src/utils/stacks-utils.ts
+++ b/client-react/src/utils/stacks-utils.ts
@@ -26,7 +26,7 @@ export const getStacksSummaryForDropdown = (stack: WebAppStack | FunctionAppStac
 export class JavaVersions {
   public static WindowsVersion8 = '1.8';
   public static WindowsVersion11 = '11';
-  public static LinuxVersion8 = 'java8';
+  public static LinuxVersion8 = 'jre8';
   public static LinuxVersion11 = 'java11';
 }
 


### PR DESCRIPTION
Fixes AB#8195697
Fixes AB#8196063

Default Stack:
![image](https://user-images.githubusercontent.com/35281019/92658967-53a76f00-f2ac-11ea-9ba8-46bae26437df.png)

Configured View:
![image](https://user-images.githubusercontent.com/35281019/92659043-789be200-f2ac-11ea-9a75-c38e6052b6cd.png)
