### PR TITLE
Implement workaround in case the original source controls API fails.

### DIFF
--- a/client-react/src/ApiHelpers/SiteService.ts
+++ b/client-react/src/ApiHelpers/SiteService.ts
@@ -139,7 +139,7 @@ export default class SiteService {
       method: 'PATCH',
       resourceId: `${resourceId}/config/web`,
       body: body,
-      commandName: 'updatePathSiteConfig',
+      commandName: 'patchSiteConfig',
       apiVersion: CommonConstants.ApiVersions.antaresApiVersion20181101,
     });
   };
@@ -162,6 +162,21 @@ export default class SiteService {
   public static fetchMetadata = async (resourceId: string) => {
     const id = `${resourceId}/config/metadata/list`;
     const result = await MakeArmCall<ArmObj<KeyValue<string>>>({ resourceId: id, commandName: 'fetchMetadata', method: 'POST' });
+    LogService.trackEvent('site-service', 'metadataLoaded', {
+      success: result.metadata.success,
+      resultCount: result.data && Object.keys(result.data.properties).length,
+    });
+    return result;
+  };
+
+  public static updateMetadata = async (resourceId: string, properties: KeyValue<string>) => {
+    const id = `${resourceId}/config/metadata`;
+    const result = await MakeArmCall<any>({
+      resourceId: id,
+      commandName: 'updateMetadata',
+      method: 'PUT',
+      body: { properties },
+    });
     LogService.trackEvent('site-service', 'metadataLoaded', {
       success: result.metadata.success,
       resultCount: result.data && Object.keys(result.data.properties).length,

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
@@ -13,6 +13,7 @@ import OneDriveService from '../../../ApiHelpers/OneDriveService';
 import ACRService from '../../../ApiHelpers/ACRService';
 import { ACRWebhookPayload } from '../../../models/acr';
 import { SiteConfig } from '../../../models/site/config';
+import { KeyValue } from '../../../models/portal-models';
 
 export default class DeploymentCenterData {
   public fetchContainerLogs = (resourceId: string) => {
@@ -49,6 +50,10 @@ export default class DeploymentCenterData {
 
   public getConfigMetadata = (resourceId: string) => {
     return SiteService.fetchMetadata(resourceId);
+  };
+
+  public updateConfigMetadata = (resourceId: string, properties: KeyValue<string>) => {
+    return SiteService.updateMetadata(resourceId, properties);
   };
 
   public getSiteDeployments = (resourceId: string) => {


### PR DESCRIPTION
After a ton of discussion with @ehamai we found a solution where we can simple update the metadata and scmtype for a site with the source control information. This allows the source controls and site config APIs to return the correct payload post-save. It also preserves the user data for future disconnect scenarios. 

With this change once the source controls api is fixed, we can simply remove the change.

![workaround](https://user-images.githubusercontent.com/493476/92877664-3b287900-f3c0-11ea-8a4f-cf2e67ea66c6.gif)
