### PR TITLE
[DO NOT SQUASH] Cherry-pick recent changes for deployment center fixes

### DIFF
--- a/client-react/src/ApiHelpers/SiteService.ts
+++ b/client-react/src/ApiHelpers/SiteService.ts
@@ -139,7 +139,7 @@ export default class SiteService {
       method: 'PATCH',
       resourceId: `${resourceId}/config/web`,
       body: body,
-      commandName: 'updatePathSiteConfig',
+      commandName: 'patchSiteConfig',
       apiVersion: CommonConstants.ApiVersions.antaresApiVersion20181101,
     });
   };
@@ -162,6 +162,21 @@ export default class SiteService {
   public static fetchMetadata = async (resourceId: string) => {
     const id = `${resourceId}/config/metadata/list`;
     const result = await MakeArmCall<ArmObj<KeyValue<string>>>({ resourceId: id, commandName: 'fetchMetadata', method: 'POST' });
+    LogService.trackEvent('site-service', 'metadataLoaded', {
+      success: result.metadata.success,
+      resultCount: result.data && Object.keys(result.data.properties).length,
+    });
+    return result;
+  };
+
+  public static updateMetadata = async (resourceId: string, properties: KeyValue<string>) => {
+    const id = `${resourceId}/config/metadata`;
+    const result = await MakeArmCall<any>({
+      resourceId: id,
+      commandName: 'updateMetadata',
+      method: 'PUT',
+      body: { properties },
+    });
     LogService.trackEvent('site-service', 'metadataLoaded', {
       success: result.metadata.success,
       resultCount: result.data && Object.keys(result.data.properties).length,

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
@@ -13,6 +13,7 @@ import OneDriveService from '../../../ApiHelpers/OneDriveService';
 import ACRService from '../../../ApiHelpers/ACRService';
 import { ACRWebhookPayload } from '../../../models/acr';
 import { SiteConfig } from '../../../models/site/config';
+import { KeyValue } from '../../../models/portal-models';
 
 export default class DeploymentCenterData {
   public fetchContainerLogs = (resourceId: string) => {
@@ -49,6 +50,10 @@ export default class DeploymentCenterData {
 
   public getConfigMetadata = (resourceId: string) => {
     return SiteService.fetchMetadata(resourceId);
+  };
+
+  public updateConfigMetadata = (resourceId: string, properties: KeyValue<string>) => {
+    return SiteService.updateMetadata(resourceId, properties);
   };
 
   public getSiteDeployments = (resourceId: string) => {

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -40,6 +40,8 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
   const { t } = useTranslation();
 
   const [isRefreshConfirmDialogVisible, setIsRefreshConfirmDialogVisible] = useState(false);
+  const [isDiscardConfirmDialogVisible, setIsDiscardConfirmDialogVisible] = useState(false);
+
   const deploymentCenterContext = useContext(DeploymentCenterContext);
   const deploymentCenterPublishingContext = useContext(DeploymentCenterPublishingContext);
   const portalContext = useContext(PortalContext);
@@ -523,6 +525,10 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
     setIsRefreshConfirmDialogVisible(false);
   };
 
+  const hideDiscardConfirmDialog = () => {
+    setIsDiscardConfirmDialogVisible(false);
+  };
+
   return (
     <Formik
       initialValues={props.formData}
@@ -536,7 +542,7 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
           <div id="deployment-center-command-bar" className={commandBarSticky}>
             <DeploymentCenterCommandBar
               saveFunction={formProps.submitForm}
-              discardFunction={formProps.resetForm}
+              discardFunction={() => setIsDiscardConfirmDialogVisible(true)}
               showPublishProfilePanel={deploymentCenterPublishingContext.showPublishProfilePanel}
               refresh={() => setIsRefreshConfirmDialogVisible(true)}
               isLoading={props.isLoading}
@@ -557,6 +563,24 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
               content={t('deploymentCenterDataLossMessage')}
               hidden={!isRefreshConfirmDialogVisible}
               onDismiss={hideRefreshConfirmDialog}
+            />
+
+            <ConfirmDialog
+              primaryActionButton={{
+                title: t('ok'),
+                onClick: () => {
+                  formProps.resetForm();
+                  hideDiscardConfirmDialog();
+                },
+              }}
+              defaultActionButton={{
+                title: t('cancel'),
+                onClick: hideDiscardConfirmDialog,
+              }}
+              title={t('deploymentCenterDiscardConfirmTitle')}
+              content={t('deploymentCenterDataLossMessage')}
+              hidden={!isDiscardConfirmDialogVisible}
+              onDismiss={hideDiscardConfirmDialog}
             />
           </>
           <div className={pivotContent}>

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettings.tsx
@@ -100,12 +100,15 @@ const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<Dep
   }, [formProps.values.registrySource, formProps.values.acrLoginServer, formProps.values.privateRegistryServerUrl]);
 
   useEffect(() => {
-    if (formProps.values.registrySource === ContainerRegistrySources.acr) {
+    if (formProps.values.registrySource === ContainerRegistrySources.acr && formProps.values.acrImage) {
       setImage(formProps.values.acrImage);
-    } else if (formProps.values.registrySource === ContainerRegistrySources.privateRegistry) {
+    } else if (
+      formProps.values.registrySource === ContainerRegistrySources.privateRegistry &&
+      formProps.values.privateRegistryImageAndTag
+    ) {
       const imageAndTagParts = formProps.values.privateRegistryImageAndTag.split(':');
       setImage(imageAndTagParts[0]);
-    } else {
+    } else if (formProps.values.dockerHubImageAndTag) {
       const imageAndTagParts = formProps.values.dockerHubImageAndTag.split(':');
       setImage(imageAndTagParts[0]);
     }

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSource.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSource.tsx
@@ -46,6 +46,7 @@ const DeploymentCenterContainerSource: React.FC<{}> = props => {
         component={RadioButton}
         displayInVerticalLayout={true}
         options={options}
+        defaultSelectedKey={ScmType.None}
         required={true}
       />
     </>


### PR DESCRIPTION
There are three separate commits in this file:

Fixing the discard button for deployment center preview:
https://github.com/Azure/azure-functions-ux/commit/c7652c649d273465a12e767bc737e47717c4e300

Implementing the API workaround for deployment center preview:
https://github.com/Azure/azure-functions-ux/commit/a24925c0c632095fe549bf0b7482032c10ddb719

Hotfixing the API workaround for deployment center classic:
https://github.com/Azure/azure-functions-ux/commit/da67fb3ec058f17d929fc84735a57aacdc11a5b7

When pushing this change to the release-s148 branch we should make sure to NOT squash and preserve individual commits.