### PR TITLE
Update the workflow content preview and generation logic

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -160,8 +160,8 @@ export interface DeploymentCenterCommitLogsProps {
 
 export interface DeploymentCenterGitHubWorkflowConfigPreviewProps {
   isPreviewFileButtonDisabled: boolean;
+  getWorkflowFileContent: () => string;
   workflowFilePath?: string;
-  workflowFileContent?: string;
   panelMessage?: string;
   panelMessageType?: MessageBarType;
 }

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -54,7 +54,7 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
 
   const getServerUrl = (values: DeploymentCenterFormData<DeploymentCenterContainerFormData>): string => {
     if (values.registrySource === ContainerRegistrySources.acr) {
-      return `https://${values.acrLoginServer}'`;
+      return `https://${values.acrLoginServer}`;
     } else if (values.registrySource === ContainerRegistrySources.privateRegistry) {
       return values.privateRegistryServerUrl;
     } else {

--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubWorkflowConfigPreview.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubWorkflowConfigPreview.tsx
@@ -7,7 +7,7 @@ import { panelBanner, deploymentCenterConsole } from '../DeploymentCenter.styles
 import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
 
 const DeploymentCenterGitHubWorkflowConfigPreview: React.FC<DeploymentCenterGitHubWorkflowConfigPreviewProps> = props => {
-  const { isPreviewFileButtonDisabled, workflowFilePath, workflowFileContent, panelMessage } = props;
+  const { isPreviewFileButtonDisabled, getWorkflowFileContent, workflowFilePath, panelMessage } = props;
   const { t } = useTranslation();
 
   const [isPreviewPanelOpen, setIsPreviewPanelOpen] = useState<boolean>(false);
@@ -20,6 +20,8 @@ const DeploymentCenterGitHubWorkflowConfigPreview: React.FC<DeploymentCenterGitH
   const dismissPreviewPanel = () => {
     setIsPreviewPanelOpen(false);
   };
+
+  const workflowFileContent = getWorkflowFileContent();
 
   return (
     <>

--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubWorkflowConfigSelector.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubWorkflowConfigSelector.tsx
@@ -77,6 +77,8 @@ const DeploymentCenterGitHubWorkflowConfigSelector: React.FC<DeploymentCenterGit
         getWorkflowConfigurationRequest,
       ]);
 
+      setGithubActionExistingWorkflowContents('');
+
       if (appWorkflowConfigurationResponse.metadata.success) {
         setShowWarningBanner(true);
         setWorkflowFileExistsWarningMessage(
@@ -88,8 +90,6 @@ const DeploymentCenterGitHubWorkflowConfigSelector: React.FC<DeploymentCenterGit
 
         if (appWorkflowConfigurationResponse.data.content) {
           setGithubActionExistingWorkflowContents(atob(appWorkflowConfigurationResponse.data.content));
-        } else {
-          setGithubActionExistingWorkflowContents('');
         }
 
         setWorkflowConfigDropdownOptions(overwriteOrUseExistingOptions);


### PR DESCRIPTION
This is pretty much doing the same thing as before except in some cases the content remained "sticky" depending on which useEffects got fired. So in this change, the useEffects affect the "Preview" button enablement/disablement.. but once the Workflow Preview panel opens, it calls the parent component to generate and return the contents. With this the panel is always computing the latest content structure based on the parent component selections. So there is 100% accuracy.