### PR TITLE
AB#7664885 Updating console to use '\' instead of 'site\wwwroot' as root directory for Xenon appst

### DIFF
--- a/client/src/app/site/console/shared/components/abstract.windows.component.ts
+++ b/client/src/app/site/console/shared/components/abstract.windows.component.ts
@@ -30,7 +30,7 @@ export abstract class AbstractWindowsComponent extends AbstractConsoleComponent 
       const header = this.getHeader();
       const body = {
         command: 'cd',
-        dir: 'site\\wwwroot',
+        dir: this.site.properties.hyperV ? '\\' : 'site\\wwwroot',
       };
       const res = this.consoleService.send(HttpMethods.POST, uri, JSON.stringify(body), header);
       res.subscribe(data => {


### PR DESCRIPTION
Fixes [AB#7664885](https://msazure.visualstudio.com/Antares/_workitems/edit/7664885)