### PR TITLE
[CRI] Create Host Key with UntrackedArmObj request

### DIFF
--- a/client-react/src/ApiHelpers/AppKeysService.ts
+++ b/client-react/src/ApiHelpers/AppKeysService.ts
@@ -1,5 +1,5 @@
-import { AppKeysInfo, AppKeysTypes } from '../pages/app/functions/app-keys/AppKeys.types';
 import { UntrackedArmObj } from '../models/arm-obj';
+import { AppKeysInfo, AppKeysTypes } from '../pages/app/functions/app-keys/AppKeys.types';
 import MakeArmCall from './ArmHelper';
 
 export default class AppKeyService {

--- a/client-react/src/ApiHelpers/AppKeysService.ts
+++ b/client-react/src/ApiHelpers/AppKeysService.ts
@@ -1,5 +1,5 @@
 import { AppKeysInfo, AppKeysTypes } from '../pages/app/functions/app-keys/AppKeys.types';
-import { ArmObj } from '../models/arm-obj';
+import { UntrackedArmObj } from '../models/arm-obj';
 import MakeArmCall from './ArmHelper';
 
 export default class AppKeyService {
@@ -15,14 +15,12 @@ export default class AppKeyService {
   public static createKey = (resourceId: string, keyType: AppKeysTypes, keyName: string, keyValue: string) => {
     const body = {
       id: '',
-      location: '',
-      name: '',
       properties: keyName && keyValue ? { name: keyName, value: keyValue } : {},
     };
 
     const id = `${resourceId}/host/default/${keyType}/${keyName}`;
 
-    return MakeArmCall<ArmObj<{ name?: string; value?: string }>>({
+    return MakeArmCall<UntrackedArmObj<{ name?: string; value?: string }>>({
       resourceId: id,
       commandName: 'createAppKey',
       method: 'PUT',


### PR DESCRIPTION
Fixes AB#8308705

Host key is an untracked resource and can use the untracked resource object to inherit parent location