### PR TITLE
Changing Dropdown Size

### DIFF
--- a/client-react/src/theme/CustomOfficeFabric/AzurePortal/Dropdown.styles.ts
+++ b/client-react/src/theme/CustomOfficeFabric/AzurePortal/Dropdown.styles.ts
@@ -150,7 +150,7 @@ export const DropDownStyles = props => {
     dropdownItemHeader: [
       globalClassnames.dropdownItemHeader,
       {
-        ...fonts.medium,
+        ...fonts.smallPlus,
         fontWeight: 'bold',
         color: semanticColors.hyperlinkText,
         height: DROPDOWN_ITEMHEIGHT,

--- a/client-react/src/theme/CustomOfficeFabric/AzurePortal/Dropdown.styles.ts
+++ b/client-react/src/theme/CustomOfficeFabric/AzurePortal/Dropdown.styles.ts
@@ -52,7 +52,7 @@ export const DropDownStyles = props => {
   const dropdownItemStyle: IStyle = [
     GlobalClassNames.dropdownItem,
     {
-      ...fonts.small,
+      ...fonts.medium,
       backgroundColor: 'transparent',
       boxSizing: 'border-box',
       color: semanticColors.textColor,
@@ -88,7 +88,7 @@ export const DropDownStyles = props => {
     ],
     dropdown: [
       {
-        ...fonts.small,
+        ...fonts.medium,
         color: semanticColors.textColor,
         selectors: {
           [`&:hover .${globalClassnames.title}`]: [{ borderColor: semanticColors.standardControlOutlineHover }],
@@ -150,7 +150,7 @@ export const DropDownStyles = props => {
     dropdownItemHeader: [
       globalClassnames.dropdownItemHeader,
       {
-        ...fonts.small,
+        ...fonts.medium,
         fontWeight: 'bold',
         color: semanticColors.hyperlinkText,
         height: DROPDOWN_ITEMHEIGHT,


### PR DESCRIPTION
Fixes AB#8180317

This will also affect other places where Dropdown is used (Configuration, etc.)
Open to making the headers one size smaller... which would change the blue part to look like
![image](https://user-images.githubusercontent.com/35281019/93819480-9e13de80-fc10-11ea-95c4-52d12b12224c.png)


Before:
![image](https://user-images.githubusercontent.com/35281019/93819209-4d03ea80-fc10-11ea-986e-4acab6ba20da.png)

After:
![image](https://user-images.githubusercontent.com/35281019/93819058-11692080-fc10-11ea-8a2f-0a3c901507ac.png)

![image](https://user-images.githubusercontent.com/35281019/93819117-2c3b9500-fc10-11ea-9f77-410c1a3c0727.png)

