### PR TITLE
Adding server-evaluated global config for React experiences

### DIFF
--- a/client-react/public/index.html
+++ b/client-react/public/index.html
@@ -21,6 +21,24 @@
   <noscript>
     You need to enable JavaScript to run this app.
   </noscript>
+
+  <!-- This script block is replaced during Node initialization when run from within Azure.  See home.service.prod.tsx -->
+  <!-- NOTE - IF YOU CHANGE THIS SCRIPT BLOCK, MAKE SURE YOU VALIDATE THAT THE VALUES ARE REPLACED PROPERLY
+       AFTER DEPLOYING TO AZURE FOR ALL CLOUDS SINCE IT HAS DEPENDENCIES ON HAVING PROPER CONFIGURATION
+       FOR EACH DEPLOYMENT PIPELINE -->
+  <script type="text/javascript" id="appsvcConfig">
+window.appsvc = {
+  version: '',
+  env: {
+    hostName: '',
+    appName: '',
+    azureResourceManagerEndpoint: '',
+    cloud: 'public',
+    acceptedOriginsSuffix: ['portal.azure.com']
+  },
+};
+  </script>
+
   <div id="root"></div>
   <!--
       This HTML file is a template.

--- a/server/src/home/home/home.service.dev.tsx
+++ b/server/src/home/home/home.service.dev.tsx
@@ -14,7 +14,7 @@ export class HomeServiceDev extends HomeService {
   getAngularHomeHtml = (optimized?: string) => {
     const html = ReactDOMServer.renderToString(
       <Home
-        {...this.configService.staticConfig}
+        {...this.configService.staticAngularConfig}
         version={this.configService.get('VERSION')}
         versionConfig={null}
         clientOptimizationsOff={!!(optimized && optimized.toLowerCase() === 'false')}

--- a/server/src/home/home/home.service.prod.tsx
+++ b/server/src/home/home/home.service.prod.tsx
@@ -6,32 +6,30 @@ import { HomeService } from './home.service.base';
 import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 import { Home } from './views/home';
+import { LoggingService } from '../../shared/logging/logging.service';
 @Injectable()
 export class HomeServiceProd extends HomeService implements OnModuleInit {
   protected angularConfig: any = null;
   protected reactHtml: string = '';
-  constructor(private configService: ConfigService) {
+  constructor(private _configService: ConfigService, private _logService: LoggingService) {
     super();
   }
   async onModuleInit() {
-    const currentVersion = this.configService.get('VERSION');
+    const currentVersion = this._configService.get('VERSION');
     const configFileLoc = normalize(join(__dirname, '..', '..', 'public', 'ng-min', `${currentVersion}.json`));
     if (await exists(configFileLoc)) {
       const config = JSON.parse(await readFile(configFileLoc, { encoding: 'utf8' }));
       this.angularConfig = config;
     }
-    const reactHtmlFile = normalize(join(__dirname, '..', '..', 'public', 'react', `index.react.html`));
-    if (await exists(reactHtmlFile)) {
-      const html = await readFile(reactHtmlFile, { encoding: 'utf8' });
-      this.reactHtml = html;
-    }
+
+    await this._initializeReactHtml();
   }
 
   getAngularHomeHtml = (optimized?: string) => {
     const html = ReactDOMServer.renderToString(
       <Home
-        {...this.configService.staticConfig}
-        version={this.configService.get('VERSION')}
+        {...this._configService.staticAngularConfig}
+        version={this._configService.get('VERSION')}
         versionConfig={this.angularConfig}
         clientOptimizationsOff={!!(optimized && optimized.toLowerCase() === 'false')}
       />
@@ -42,4 +40,32 @@ export class HomeServiceProd extends HomeService implements OnModuleInit {
   getReactHomeHtml = () => {
     return this.reactHtml;
   };
+
+  // We need to add environment-specific settings by transforming the global config that gets injected into the
+  // main index.html file which loads React.
+  private async _initializeReactHtml() {
+    const reactHtmlFilePath = normalize(join(__dirname, '..', '..', 'public', 'react', `index.react.html`));
+    let newHtml: string;
+
+    if (await exists(reactHtmlFilePath)) {
+      const html = await readFile(reactHtmlFilePath, { encoding: 'utf8' });
+
+      // I experimented with using XML parsers but it turns out that this was actually simpler and just as reliable for our limited use case.
+      const scriptTagRegex = /<script type="text\/javascript" id="appsvcConfig">(.*?)<\/script>/i;
+      const scriptTagFormat = `<script type="text/javascript" id="appsvcConfig">{0}</script>`;
+
+      try {
+        const configString = `window.appsvc = ${JSON.stringify(this._configService.staticReactConfig)}`;
+        const newScriptTagString = scriptTagFormat.replace('{0}', configString);
+        newHtml = html.replace(scriptTagRegex, newScriptTagString);
+        this._logService.trackEvent('React-Transform', { success: 'true', error: null });
+      } catch (e) {
+        this._logService.trackEvent('React-Transform', { success: 'false', error: e });
+        this._logService.error('Failed to transform React index.html file', e);
+
+        throw e;
+      }
+    }
+    this.reactHtml = newHtml;
+  }
 }

--- a/server/src/home/home/views/home.tsx
+++ b/server/src/home/home/views/home.tsx
@@ -3,7 +3,7 @@ import { Head as AzureHead } from './azure/Head';
 import { Body as AzureBody } from './azure/Body';
 import { Head as LocalHead } from './local/Head';
 import { Body as LocalBody } from './local/Body';
-import { HomeConfig } from 'src/types/config';
+import { AngularHomeConfig } from 'src/types/config';
 declare global {
   namespace JSX {
     interface IntrinsicElements {
@@ -12,7 +12,7 @@ declare global {
   }
 }
 
-export const Home = (props: HomeConfig) => {
+export const Home = (props: AngularHomeConfig) => {
   return (
     <html lang="en">
       <head title="Azure Functions">

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -43,6 +43,8 @@ async function bootstrap() {
     });
   }
 
+  // This only applies to local development.  In Azure the CORS rules defined on the app takes precedence
+  app.enableCors();
   app.useStaticAssets(join(__dirname, 'public'));
   app.useStaticAssets(join(__dirname, 'public', 'react'));
   app.use(

--- a/server/src/shared/config/config.service.ts
+++ b/server/src/shared/config/config.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import * as dotenv from 'dotenv';
 import { HttpService } from '../../shared/http/http.service';
-import { StaticConfig } from '../../types/config';
+import { CloudType, StaticAngularConfig, StaticReactConfig } from '../../types/config';
 export const KeyvaultApiVersion = '2016-10-01';
 export const KeyvaultUri = 'https://vault.azure.net';
 
@@ -23,7 +23,7 @@ export class ConfigService implements OnModuleInit {
     return process.env[key];
   }
 
-  get staticConfig(): StaticConfig {
+  get staticAngularConfig(): StaticAngularConfig {
     return {
       config: {
         env: {
@@ -42,6 +42,25 @@ export class ConfigService implements OnModuleInit {
       },
     };
   }
+
+  get staticReactConfig(): StaticReactConfig {
+    const acceptedOriginsString = process.env.APPSVC_ACCEPTED_ORIGINS_SUFFIX;
+    let acceptedOrigins: string[] = [];
+    if (acceptedOriginsString) {
+      acceptedOrigins = acceptedOriginsString.split(',');
+    }
+
+    return {
+      env: {
+        appName: process.env.WEBSITE_SITE_NAME,
+        hostName: process.env.WEBSITE_HOSTNAME,
+        cloud: process.env.APPSVC_CLOUD as CloudType,
+        acceptedOriginsSuffix: acceptedOrigins,
+      },
+      version: process.env.VERSION,
+    };
+  }
+
   private async getAADTokenFromMSI(endpoint: string, secret: string, resource: string) {
     const apiVersion = '2017-09-01';
 

--- a/server/src/types/config.ts
+++ b/server/src/types/config.ts
@@ -1,4 +1,4 @@
-export interface StaticConfig {
+export interface StaticAngularConfig {
   config: {
     env: {
       runtimeType: 'Azure' | 'OnPrem' | 'Standalone';
@@ -16,8 +16,24 @@ export interface StaticConfig {
   };
 }
 
-export interface HomeConfig extends StaticConfig {
+export interface AngularHomeConfig extends StaticAngularConfig {
   version: string;
   versionConfig: string;
   clientOptimizationsOff: boolean;
+}
+
+export type CloudType = 'onprem' | 'public' | 'fairfax' | 'mooncake' | 'blackforest' | 'usnat' | 'ussec';
+
+export interface ReactEnvironment {
+  hostName: string;
+  azureResourceManagerEndpoint?: string;
+  armToken?: string;
+  appName: string;
+  cloud: CloudType;
+  acceptedOriginsSuffix: string[];
+}
+
+export interface StaticReactConfig {
+  env: ReactEnvironment;
+  version: string;
 }


### PR DESCRIPTION
The change here is to allow us to inject server-side information into a global config object for React similar to how we do it for Angular-based experiences.  

For local development, we already load a static index.html file but now it will also have default values for Azure development.  For apps deployed to Azure, this static index.html file will get transformed in-memory when the Node process starts up to contain app setting values which are configured on each web app hosting fusion.  This implies that we'll also have to update our deployment pipelines to inject this information as app settings.

Once we have all of the server-side changes deployed world-wide for this sprint, then it should be safe to add client-side dependencies on the new global config.