### PR TITLE
Mark node and php version as null on saving config when these values are empty

### DIFF
--- a/client-react/src/models/site/config.ts
+++ b/client-react/src/models/site/config.ts
@@ -28,9 +28,9 @@ export interface SiteConfig {
   numberOfWorkers: number;
   defaultDocuments: string[];
   netFrameworkVersion: string;
-  phpVersion: string;
+  phpVersion: string | null;
   pythonVersion: string;
-  nodeVersion: string;
+  nodeVersion: string | null;
   windowsFxVersion: string;
   linuxFxVersion: string;
   minTlsVersion: string;

--- a/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
+++ b/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
@@ -377,6 +377,16 @@ export function getConfigWithStackSettings(config: SiteConfig, values: AppSettin
     configCopy.javaContainerVersion = '';
     configCopy.javaVersion = '';
   }
+
+  // NOTE (krmitta): We need to explicitly mark node and php versions as null,
+  // whenever these are empty since it prevents the backend from disabling the alwaysOn property.
+  if (configCopy.phpVersion === '') {
+    configCopy.phpVersion = null;
+  }
+
+  if (configCopy.nodeVersion === '') {
+    configCopy.nodeVersion = null;
+  }
   return configCopy;
 }
 


### PR DESCRIPTION
Fixes AB#8280577

![image](https://user-images.githubusercontent.com/11722204/93926922-ff998300-fccc-11ea-8759-458b7960b96e.png)
