### PR TITLE
Fix the container hint text, dockerhub render, and show detailed error messages.

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDockerHubSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDockerHubSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Field } from 'formik';
 import TextField from '../../../../components/form-controls/TextField';
 import { useTranslation } from 'react-i18next';
@@ -6,10 +6,12 @@ import { IChoiceGroupOptionProps } from 'office-ui-fabric-react';
 import { ContainerDockerAccessTypes, DeploymentCenterFieldProps, DeploymentCenterContainerFormData } from '../DeploymentCenter.types';
 import Dropdown from '../../../../components/form-controls/DropDown';
 import { ScmType } from '../../../../models/site/config';
+import { SiteStateContext } from '../../../../SiteState';
 
 const DeploymentCenterContainerDockerHubSettings: React.FC<DeploymentCenterFieldProps<DeploymentCenterContainerFormData>> = props => {
   const { formProps } = props;
   const { t } = useTranslation();
+  const siteStateContext = useContext(SiteStateContext);
 
   const [isGitHubAction, setIsGitHubAction] = useState(false);
   const [isPrivateConfiguration, setIsPrivateConfiguration] = useState(false);
@@ -84,7 +86,7 @@ const DeploymentCenterContainerDockerHubSettings: React.FC<DeploymentCenterField
         name="dockerHubImageAndTag"
         component={TextField}
         label={t('containerImageAndTag')}
-        placeholder={t('containerImageAndTagPlaceholder')}
+        placeholder={siteStateContext.isLinuxApp ? t('containerImageAndTagPlaceholder') : t('containerImageAndTagPlaceholderForWindows')}
         required={true}
       />
 

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -294,7 +294,19 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
 
       portalContext.stopNotification(notificationId, true, t('savingContainerConfigurationSuccess'));
     } else {
-      portalContext.stopNotification(notificationId, false, t('savingContainerConfigurationFailed'));
+      let errorMessage = !updateAppSettingsResponse.success ? getErrorMessage(updateAppSettingsResponse.error) : '';
+
+      errorMessage = !errorMessage && !updateSiteConfigResponse.success ? getErrorMessage(updateSiteConfigResponse.error) : '';
+
+      if (errorMessage) {
+        portalContext.stopNotification(
+          notificationId,
+          false,
+          t('savingContainerConfigurationFailedWithStatusMessage').format(errorMessage)
+        );
+      } else {
+        portalContext.stopNotification(notificationId, false, t('savingContainerConfigurationFailed'));
+      }
     }
   };
 
@@ -475,17 +487,31 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
     const notificationId = portalContext.startNotification(t('savingContainerConfiguration'), t('savingContainerConfiguration'));
 
     const updateGitHubActionSettingsResponse = await updateGitHubActionSettings(values);
+    let containerConfigurationSucceeded = true;
+    let errorMessage = '';
 
     if (updateGitHubActionSettingsResponse.success) {
       const updateApplicationPropertiesResponse = await updateApplicationProperties(values);
 
-      if (updateApplicationPropertiesResponse.success) {
-        portalContext.stopNotification(notificationId, true, t('savingContainerConfigurationSuccess'));
+      if (!updateApplicationPropertiesResponse.success) {
+        errorMessage = getErrorMessage(updateApplicationPropertiesResponse.error);
+      }
+    } else {
+      errorMessage = getErrorMessage(updateGitHubActionSettingsResponse.error);
+    }
+
+    if (containerConfigurationSucceeded) {
+      portalContext.stopNotification(notificationId, true, t('savingContainerConfigurationSuccess'));
+    } else {
+      if (errorMessage) {
+        portalContext.stopNotification(
+          notificationId,
+          false,
+          t('savingContainerConfigurationFailedWithStatusMessage').format(errorMessage)
+        );
       } else {
         portalContext.stopNotification(notificationId, false, t('savingContainerConfigurationFailed'));
       }
-    } else {
-      portalContext.stopNotification(notificationId, false, t('savingContainerConfigurationFailed'));
     }
   };
 

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -255,8 +255,11 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
     // The image and/or tags could definitely have /'s. The username is a separate field on the form, so image and tag should not have that.
     // In this case, remove the serverInfo and/or username from the FxVersion and compute the image and tag by splitting on :.
 
-    const serverAndUsernamePrefix = `${DeploymentCenterConstants.dockerHubServerUrlHost}/${appSettingUsername}/`;
-    const usernamePrefix = `${appSettingUsername}/`;
+    const serverAndUsernamePrefix = appSettingUsername
+      ? `${DeploymentCenterConstants.dockerHubServerUrlHost}/${appSettingUsername}/`
+      : `${DeploymentCenterConstants.dockerHubServerUrlHost}/`;
+
+    const usernamePrefix = appSettingUsername ? `${appSettingUsername}/` : '';
 
     let imageAndTagInfo = registryInfo
       .toLocaleLowerCase()

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPrivateRegistrySettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPrivateRegistrySettings.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Field } from 'formik';
 import TextField from '../../../../components/form-controls/TextField';
 import { useTranslation } from 'react-i18next';
+import { SiteStateContext } from '../../../../SiteState';
 
 const DeploymentCenterContainerPrivateRegistrySettings: React.FC<{}> = props => {
   const { t } = useTranslation();
+  const siteStateContext = useContext(SiteStateContext);
 
   // NOTE(michinoy): In case of GitHub Action, we will always need to get the user credentials for their private
   // registry. This is because the workflow would need to use those credentials to push the images and app service
@@ -40,7 +42,7 @@ const DeploymentCenterContainerPrivateRegistrySettings: React.FC<{}> = props => 
         name="privateRegistryImageAndTag"
         component={TextField}
         label={t('containerImageAndTag')}
-        placeholder={t('containerImageAndTagPlaceholder')}
+        placeholder={siteStateContext.isLinuxApp ? t('containerImageAndTagPlaceholder') : t('containerImageAndTagPlaceholderForWindows')}
         required={true}
       />
 

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1268,6 +1268,7 @@ export class PortalResources {
   public static containerImageSource = 'containerImageSource';
   public static containerImageAndTag = 'containerImageAndTag';
   public static containerImageAndTagPlaceholder = 'containerImageAndTagPlaceholder';
+  public static containerImageAndTagPlaceholderForWindows = 'containerImageAndTagPlaceholderForWindows';
   public static containerACRMissingErrorMessage = 'containerACRMissingErrorMessage';
   public static containerRepositoryAccess = 'containerRepositoryAccess';
   public static containerRepositoryPublic = 'containerRepositoryPublic';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -3944,6 +3944,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="containerImageAndTagPlaceholder" xml:space="preserve">
         <value>E.g. nginx:latest</value>
     </data>
+    <data name="containerImageAndTagPlaceholderForWindows" xml:space="preserve">
+        <value>E.g. microsoft/iis:latest</value>
+    </data>
     <data name="containerACRMissingErrorMessage" xml:space="preserve">
         <value>To get started, first create an Azure Container Registry and add an image.</value>
     </data>


### PR DESCRIPTION
Hint text updated for windows containers
![image](https://user-images.githubusercontent.com/493476/95270828-3b663980-07f1-11eb-9d4c-5eeff01b285e.png)

The slash is preserved for docker hub images
![image](https://user-images.githubusercontent.com/493476/95270949-897b3d00-07f1-11eb-96ef-74c0b50d6ec4.png)

There is a detailed error message being shown
![image](https://user-images.githubusercontent.com/493476/95271009-ae6fb000-07f1-11eb-9b37-df1c9955560f.png)
