### PR TITLE
AB#8559682 [Fusion] Pass in Fabric Icon CDN Endpoint from query string into initializeIcons() in F:\repos\azure-functions-ux\client-react\src\index.tsx

### DIFF
--- a/client-react/src/index.tsx
+++ b/client-react/src/index.tsx
@@ -7,9 +7,10 @@ import { lightTheme } from './theme/light';
 import { loadTheme } from '@uifabric/styling';
 import 'react-app-polyfill/ie11';
 import LogService from './utils/LogService';
+import Url from './utils/url';
 
 LogService.initialize();
-initializeIcons();
+initializeIcons(Url.getParameterByName(null, 'officeFabricIconsCdn') || undefined);
 loadTheme(lightTheme); // make sure we load a custom theme before anything else, custom theme has custom semantic colors
 
 LogService.startTrackPage('shell');

--- a/client-react/src/react-app-env.d.ts
+++ b/client-react/src/react-app-env.d.ts
@@ -26,6 +26,7 @@ interface AppSvc {
   cdn?: string;
   cacheBreakQuery?: string;
   frameId?: string;
+  officeFabricIconsCdn?: string;
 }
 
 declare global {


### PR DESCRIPTION
Fixes AB#8559682

**NOTE:**
We need to pass in the baseUrl (cdn endpoint) for Fabric icons so that the icons are fetched correctly for airgapped clouds. When we don't pass any input, Fabric uses the default CDN endpoint which works only for non-airgapped clouds.
I will send a separate PR on Ibiza side to set the new query string based on environment in FunctionsIframeUrlResolver. If not set or not passed in, Fusion will behave same as it currently does. No dependency between the two.