### PR TITLE
Adding server-side logging for storage controller

### DIFF
--- a/client-react/src/ApiHelpers/HttpClient.ts
+++ b/client-react/src/ApiHelpers/HttpClient.ts
@@ -4,7 +4,19 @@ import { Guid } from '../utils/Guid';
 import { KeyValue } from '../models/portal-models';
 import Url from '../utils/url';
 
+export class WellKnownHeaders {
+  static readonly REQUEST_ID = 'x-ms-client-request-id';
+  static readonly SESSION_ID = 'x-ms-client-session-id';
+}
+
 export const sendHttpRequest = <T>(options: AxiosRequestConfig) => {
+  options.headers = options.headers ? options.headers : {};
+
+  options.headers[WellKnownHeaders.SESSION_ID] = window.appsvc && window.appsvc.sessionId;
+  if (!options.headers[WellKnownHeaders.REQUEST_ID]) {
+    options.headers[WellKnownHeaders.REQUEST_ID] = Guid.newGuid();
+  }
+
   return axios({
     ...options,
     validateStatus: () => true, // never throw error

--- a/client-react/src/portal-communicator.ts
+++ b/client-react/src/portal-communicator.ts
@@ -105,6 +105,7 @@ export default class PortalCommunicator {
 
       window.appsvc = {
         version: '',
+        sessionId: '',
         env: {
           hostName: '',
           appName: '',
@@ -120,6 +121,7 @@ export default class PortalCommunicator {
             startupInfo.iframeAppName = response.data.appName;
             window.appsvc = {
               version: response.data.version,
+              sessionId: '',
               env: {
                 hostName: response.data.hostName,
                 appName: response.data.appName,
@@ -444,6 +446,7 @@ export default class PortalCommunicator {
       this.setStartupInfo(startupInfo);
 
       if (window.appsvc) {
+        window.appsvc.sessionId = startupInfo.sessionId;
         window.appsvc.env.azureResourceManagerEndpoint = startupInfo.armEndpoint;
         window.appsvc.resourceId = startupInfo.resourceId;
         window.appsvc.feature = startupInfo.featureInfo && startupInfo.featureInfo.feature;

--- a/client-react/src/react-app-env.d.ts
+++ b/client-react/src/react-app-env.d.ts
@@ -21,6 +21,7 @@ interface Environment {
 interface AppSvc {
   env: Environment;
   version: string;
+  sessionId: string;
   resourceId?: string;
   feature?: string;
   cdn?: string;

--- a/client-react/src/utils/LogService.ts
+++ b/client-react/src/utils/LogService.ts
@@ -153,13 +153,14 @@ export default class LogService {
 
     const identifiers = window.appsvc
       ? JSON.stringify({
-        hostName: window.appsvc.env && window.appsvc.env.hostName,
-        appName: window.appsvc.env && window.appsvc.env.appName,
-        version: window.appsvc.version,
-        resourceId: window.appsvc.resourceId,
-        feature: window.appsvc.feature,
-        frameId: window.appsvc.frameId,
-      })
+          hostName: window.appsvc.env && window.appsvc.env.hostName,
+          appName: window.appsvc.env && window.appsvc.env.appName,
+          version: window.appsvc.version,
+          resourceId: window.appsvc.resourceId,
+          feature: window.appsvc.feature,
+          frameId: window.appsvc.frameId,
+          sessionId: window.appsvc.sessionId,
+        })
       : '';
 
     return {

--- a/server/src/shared/http/wellknownheaders.ts
+++ b/server/src/shared/http/wellknownheaders.ts
@@ -1,0 +1,4 @@
+export class WellKnownHeaders {
+  static readonly REQUEST_ID = 'x-ms-client-request-id';
+  static readonly SESSION_ID = 'x-ms-client-session-id';
+}

--- a/server/src/storage/storage.controller.ts
+++ b/server/src/storage/storage.controller.ts
@@ -1,12 +1,14 @@
-import { Controller, Post, Body, HttpException } from '@nestjs/common';
+import { Controller, Post, Body, HttpException, Headers } from '@nestjs/common';
+import { WellKnownHeaders } from '../shared/http/wellknownheaders';
+import { LoggingService } from '../shared/logging/logging.service';
 import { StorageService } from './storage.service';
 
 @Controller('api')
 export class StorageController {
-  constructor(private storageService: StorageService) {}
+  constructor(private storageService: StorageService, private logService: LoggingService) {}
 
   @Post('getStorageContainers')
-  getStorageContainers(@Body('accountName') accountName, @Body('accessKey') accessKey) {
+  async getStorageContainers(@Headers() headers, @Body('accountName') accountName, @Body('accessKey') accessKey) {
     if (!accountName) {
       throw new HttpException('Header must contain Storage Connection String', 400);
     }
@@ -14,17 +16,63 @@ export class StorageController {
       throw new HttpException('Header must contain Storage Connection Container Name', 400);
     }
 
-    return this.storageService.getStorageContainers(accountName, accessKey);
+    try {
+      return await this.storageService.getStorageContainers(accountName, accessKey);
+    } catch (e) {
+      // Task 8646582: Add server-side global exception handler to consistently log sessionId and requestId
+      this.logService.error(
+        {
+          error: e,
+          requestId: headers[WellKnownHeaders.REQUEST_ID],
+          sessionId: headers[WellKnownHeaders.SESSION_ID],
+        },
+        'Failed to get storage containers'
+      );
+
+      throw new HttpException(`Failed to get storage containers: ${this._getErrorMessage(e)}`, this._getStatusCode(e));
+    }
   }
 
   @Post('getStorageFileShares')
-  getStorageFileShares(@Body('accountName') accountName, @Body('accessKey') accessKey) {
+  async getStorageFileShares(@Headers() headers, @Body('accountName') accountName, @Body('accessKey') accessKey) {
     if (!accountName) {
       throw new HttpException('Header must contain Storage Connection String', 400);
     }
     if (!accessKey) {
       throw new HttpException('Header must contain Storage Connection Container Name', 400);
     }
-    return this.storageService.getFileShares(accountName, accessKey);
+
+    try {
+      return await this.storageService.getFileShares(accountName, accessKey);
+    } catch (e) {
+      // Task 8646582: Add server-side global exception handler to consistently log sessionId and requestId
+      this.logService.error(
+        {
+          error: e,
+          requestId: headers[WellKnownHeaders.REQUEST_ID],
+          sessionId: headers[WellKnownHeaders.SESSION_ID],
+        },
+        'Failed to get file shares'
+      );
+
+      throw new HttpException(`Failed to get file shares: ${this._getErrorMessage(e)}`, this._getStatusCode(e));
+    }
+  }
+
+  private _getErrorMessage(e: any) {
+    let message = '';
+    if (!e) {
+      return message;
+    } else if (e.body) {
+      message = `${e.body.Code} - ${e.body.message}`;
+    } else if (e.message) {
+      message = `${e.message}`;
+    }
+
+    return message;
+  }
+
+  private _getStatusCode(e: any) {
+    return e && e.statusCode ? e.statusCode : 500;
   }
 }


### PR DESCRIPTION
Adding better logging to our storage APIs on the server as well as returning a better http code and message if possible.  

Also adding standard headers for all HTTP requests from the client to include requestId and sessionId.