### PR TITLE
AB#8665326 [I2][Spec Picker][Fusion] Add Support for IV2 skus

### DIFF
--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2223,4 +2223,5 @@ export class PortalResources {
   public static uploadingFileSuccessWithName = 'uploadingFileSuccessWithName';
   public static uploadingFileFailureWithName = 'uploadingFileFailureWithName';
   public static earlyAccessTemplate = 'earlyAccessTemplate';
+  public static pricing_iv2NotAvailable = 'pricing_iv2NotAvailable';
 }

--- a/client/src/app/shared/models/serverFarmSku.ts
+++ b/client/src/app/shared/models/serverFarmSku.ts
@@ -11,6 +11,7 @@ export class Tier {
   public static readonly elasticPremium = 'ElasticPremium';
   public static readonly elasticIsolated = 'ElasticIsolated';
   public static readonly premiumV3 = 'PremiumV3';
+  public static readonly isolatedV2 = 'IsolatedV2';
 }
 
 export class SkuCode {
@@ -74,5 +75,11 @@ export class SkuCode {
     P1V3: 'P1V3',
     P2V3: 'P2V3',
     P3V3: 'P3V3',
+  };
+
+  public static readonly IsolatedV2 = {
+    I1V2: 'I1V2',
+    I2V2: 'I2V2',
+    I3V2: 'I3V2',
   };
 }

--- a/client/src/app/site/spec-picker/price-spec-manager/isolatedv2-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/isolatedv2-plan-price-spec.ts
@@ -1,14 +1,17 @@
 import { Injector } from '@angular/core';
-import { Kinds, Links, Pricing } from './../../../shared/models/constants';
-import { Tier, SkuCode } from './../../../shared/models/serverFarmSku';
+import { Kinds, Links, Pricing } from '../../../shared/models/constants';
+import { Tier, SkuCode } from '../../../shared/models/serverFarmSku';
 import { PortalResources } from '../../../shared/models/portal-resources';
 import { AseService } from '../../../shared/services/ase.service';
-import { NationalCloudEnvironment } from './../../../shared/services/scenario/national-cloud.environment';
-import { AppKind } from './../../../shared/Utilities/app-kind';
+import { NationalCloudEnvironment } from '../../../shared/services/scenario/national-cloud.environment';
+import { AppKind } from '../../../shared/Utilities/app-kind';
 import { PriceSpec, PriceSpecInput } from './price-spec';
+import { PlanService } from './../../../shared/services/plan.service';
+import { ResourceId, Sku } from '../../../shared/models/arm/arm-obj';
+import { Observable } from 'rxjs/Rx';
 
-export abstract class IsolatedPlanPriceSpec extends PriceSpec {
-  tier = Tier.isolated;
+export abstract class IsolatedV2PlanPriceSpec extends PriceSpec {
+  tier = Tier.isolatedV2;
 
   featureItems = [
     {
@@ -60,11 +63,32 @@ export abstract class IsolatedPlanPriceSpec extends PriceSpec {
   cssClass = 'spec isolated-spec';
 
   private _aseService: AseService;
+  private _planService: PlanService;
 
   constructor(injector: Injector) {
     super(injector);
 
     this._aseService = injector.get(AseService);
+    this._planService = injector.get(PlanService);
+  }
+
+  protected _matchSku(sku: Sku): boolean {
+    return sku.tier.toLocaleLowerCase() === this.tier.toLocaleLowerCase() && sku.name.indexOf('v2') > -1;
+  }
+
+  private _checkIfSkuEnabledOnStamp(resourceId: ResourceId) {
+    if (this.state !== 'hidden') {
+      return this._planService.getAvailableSkusForPlan(resourceId).do(availableSkus => {
+        this.state = availableSkus.find(s => this._matchSku(s.sku)) ? 'enabled' : 'disabled';
+
+        if (this.state === 'disabled') {
+          this.disabledMessage = this._ts.instant(PortalResources.pricing_iv2NotAvailable);
+          this.disabledInfoLink = ''; // TODO(shimedh): Get link from Christina.
+        }
+      });
+    }
+
+    return Observable.of(null);
   }
 
   runInitialization(input: PriceSpecInput) {
@@ -81,38 +105,42 @@ export abstract class IsolatedPlanPriceSpec extends PriceSpec {
         return this._aseService.getAse(input.plan.properties.hostingEnvironmentProfile.id).do(r => {
           // If the call to get the ASE fails (maybe due to RBAC), then we can't confirm ASE v1 or v2 or v3
           // but we'll let them see the isolated card anyway.  The plan update will probably fail in
-          // the back-end if it's ASE v1, but at least we allow real ASE v2 customers who don't have
+          // the back-end if it's ASE v1, but at least we allow real ASE v3 customers who don't have
           // ASE permissions to scale their plan.
-          // We don't want to show Isolated sku's for IsolatedV2 plans.
-          if (r.isSuccessful && r.result.kind && r.result.kind.toLowerCase().indexOf(Kinds.aseV2.toLowerCase()) === -1) {
+          if (r.isSuccessful && r.result.kind && r.result.kind.toLowerCase().indexOf(Kinds.aseV3.toLowerCase()) === -1) {
             this.state = 'hidden';
           }
         });
       }
+
+      return this._checkIfSkuEnabledOnStamp(input.plan.id).switchMap(_ => {
+        return this.checkIfDreamspark(input.subscriptionId);
+      });
     } else if (
       input.specPickerInput.data &&
-      (!input.specPickerInput.data.allowAseV2Creation ||
+      (!input.specPickerInput.data.allowAseV3Creation ||
         input.specPickerInput.data.isXenon ||
         input.specPickerInput.data.hyperV ||
         (input.specPickerInput.data.isNewFunctionAppCreate && input.specPickerInput.data.isElastic))
     ) {
       this.state = 'hidden';
+      return this.checkIfDreamspark(input.subscriptionId);
     }
 
-    return this.checkIfDreamspark(input.subscriptionId);
+    return Observable.of(null);
   }
 }
 
-export class IsolatedSmallPlanPriceSpec extends IsolatedPlanPriceSpec {
-  skuCode = SkuCode.Isolated.I1;
-  legacySkuName = 'small_isolated';
+export class IsolatedV2SmallPlanPriceSpec extends IsolatedV2PlanPriceSpec {
+  skuCode = SkuCode.IsolatedV2.I1V2;
+  legacySkuName = SkuCode.IsolatedV2.I1V2;
   topLevelFeatures = [
-    this._ts.instant(PortalResources.pricing_ACU).format('210'),
-    this._ts.instant(PortalResources.pricing_memory).format('3.5'),
+    this._ts.instant(PortalResources.pricing_ACU).format('390'),
+    this._ts.instant(PortalResources.pricing_memory).format('8'),
     this._ts.instant(PortalResources.pricing_dSeriesComputeEquivalent),
   ];
 
-  meterFriendlyName = 'Isolated Small App Service Hours';
+  meterFriendlyName = 'IsolatedV2 Small App Service Hours';
 
   specResourceSet = {
     id: this.skuCode,
@@ -126,16 +154,16 @@ export class IsolatedSmallPlanPriceSpec extends IsolatedPlanPriceSpec {
   };
 }
 
-export class IsolatedMediumPlanPriceSpec extends IsolatedPlanPriceSpec {
-  skuCode = SkuCode.Isolated.I2;
-  legacySkuName = 'medium_isolated';
+export class IsolatedV2MediumPlanPriceSpec extends IsolatedV2PlanPriceSpec {
+  skuCode = SkuCode.IsolatedV2.I2V2;
+  legacySkuName = SkuCode.IsolatedV2.I2V2;
   topLevelFeatures = [
-    this._ts.instant(PortalResources.pricing_ACU).format('420'),
-    this._ts.instant(PortalResources.pricing_memory).format('7'),
+    this._ts.instant(PortalResources.pricing_ACU).format('780'),
+    this._ts.instant(PortalResources.pricing_memory).format('16'),
     this._ts.instant(PortalResources.pricing_dSeriesComputeEquivalent),
   ];
 
-  meterFriendlyName = 'Isolated Medium App Service Hours';
+  meterFriendlyName = 'IsolatedV2 Medium App Service Hours';
 
   specResourceSet = {
     id: this.skuCode,
@@ -149,16 +177,16 @@ export class IsolatedMediumPlanPriceSpec extends IsolatedPlanPriceSpec {
   };
 }
 
-export class IsolatedLargePlanPriceSpec extends IsolatedPlanPriceSpec {
-  skuCode = SkuCode.Isolated.I3;
-  legacySkuName = 'large_isolated';
+export class IsolatedV2LargePlanPriceSpec extends IsolatedV2PlanPriceSpec {
+  skuCode = SkuCode.IsolatedV2.I3V2;
+  legacySkuName = SkuCode.IsolatedV2.I3V2;
   topLevelFeatures = [
-    this._ts.instant(PortalResources.pricing_ACU).format('840'),
-    this._ts.instant(PortalResources.pricing_memory).format('14'),
+    this._ts.instant(PortalResources.pricing_ACU).format('1560'),
+    this._ts.instant(PortalResources.pricing_memory).format('32'),
     this._ts.instant(PortalResources.pricing_dSeriesComputeEquivalent),
   ];
 
-  meterFriendlyName = 'Isolated Large App Service Hours';
+  meterFriendlyName = 'IsolatedV2 Large App Service Hours';
 
   specResourceSet = {
     id: this.skuCode,

--- a/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
@@ -70,6 +70,7 @@ export interface PlanSpecPickerData {
   isNewFunctionAppCreate?: boolean; // NOTE(shimedh): We need this additional flag temporarily to make it work with old and new FunctionApp creates.
   // Since old creates always shows elastic premium sku's along with other sku's.
   // However, in new full screen creates it would be based on the plan type selected which will determing isElastic boolean value.
+  allowAseV3Creation?: boolean; // NOTE(shimedh): Adding for future use. We have not enabled new app in new ASEv3 scenario from Portal.
 }
 
 export type ApplyButtonState = 'enabled' | 'disabled';

--- a/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
@@ -70,7 +70,7 @@ export interface PlanSpecPickerData {
   isNewFunctionAppCreate?: boolean; // NOTE(shimedh): We need this additional flag temporarily to make it work with old and new FunctionApp creates.
   // Since old creates always shows elastic premium sku's along with other sku's.
   // However, in new full screen creates it would be based on the plan type selected which will determing isElastic boolean value.
-  allowAseV3Creation?: boolean; // NOTE(shimedh): Adding for future use. We have not enabled new app in new ASEv3 scenario from Portal.
+  allowAseV3Creation?: boolean; // NOTE(shimedh): This will be set for new ASP creating in existing ASEv3. It will later also be used for new app in new ASEv3 scenario from webapp create (will be enabled for GA).
 }
 
 export type ApplyButtonState = 'enabled' | 'disabled';
@@ -575,7 +575,7 @@ export class PlanPriceSpecManager {
     if (this._isUpdateScenario(inputs)) {
       this._stampIpAddresses = null;
       return this._planService.getServerFarmSites(inputs.id, true).switchMap(response => {
-        if (response.isSuccessful) {
+        if (response.isSuccessful && response.result.value.length > 0) {
           this._stampIpAddresses = {
             inboundIpAddress: response.result.value[0].properties.inboundIpAddress,
             outboundIpAddresses: response.result.value[0].properties.outboundIpAddresses,

--- a/client/src/app/site/spec-picker/price-spec-manager/premiumv2-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premiumv2-plan-price-spec.ts
@@ -65,7 +65,7 @@ export abstract class PremiumV2PlanPriceSpec extends DV2SeriesPriceSpec {
   }
 
   protected _matchSku(sku: Sku): boolean {
-    return sku.name.indexOf('v2') > -1;
+    return sku.tier.toLocaleLowerCase() === this.tier.toLocaleLowerCase() && sku.name.indexOf('v2') > -1;
   }
 
   protected _shouldHideForNewPlan(data: PlanSpecPickerData): boolean {

--- a/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
@@ -8,6 +8,7 @@ import { PremiumV2SmallPlanPriceSpec, PremiumV2MediumPlanPriceSpec, PremiumV2Lar
 import { PremiumSmallPlanPriceSpec, PremiumMediumPlanPriceSpec, PremiumLargePlanPriceSpec } from './premium-plan-price-spec';
 import { IsolatedSmallPlanPriceSpec, IsolatedMediumPlanPriceSpec, IsolatedLargePlanPriceSpec } from './isolated-plan-price-spec';
 import { PremiumV3SmallPlanPriceSpec, PremiumV3MediumPlanPriceSpec, PremiumV3LargePlanPriceSpec } from './premiumv3-plan-price-spec';
+import { IsolatedV2SmallPlanPriceSpec, IsolatedV2MediumPlanPriceSpec, IsolatedV2LargePlanPriceSpec } from './isolatedv2-plan-price-spec';
 import {
   PremiumContainerSmallPriceSpec,
   PremiumContainerMediumPriceSpec,
@@ -275,6 +276,9 @@ export class IsolatedSpecGroup extends PriceSpecGroup {
     new IsolatedSmallPlanPriceSpec(this.injector),
     new IsolatedMediumPlanPriceSpec(this.injector),
     new IsolatedLargePlanPriceSpec(this.injector),
+    new IsolatedV2SmallPlanPriceSpec(this.injector),
+    new IsolatedV2MediumPlanPriceSpec(this.injector),
+    new IsolatedV2LargePlanPriceSpec(this.injector),
   ];
 
   additionalSpecs = [];

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -6819,4 +6819,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="earlyAccessTemplate" xml:space="preserve">
         <value>{0} (Early Access)</value>
     </data>
+    <data name="pricing_iv2NotAvailable" xml:space="preserve">
+        <value>Isolated V2 is not supported for this scale unit. Please consider redeploying or cloning your app.</value>
+    </data>
 </root>


### PR DESCRIPTION
Fixes AB#8665326

**Note: **
**Not supported scenario -> new app in new ASEv3**

**Scenarios:**
1. Existing ASEv3 resource -> only show IV2 sku's
![image](https://user-images.githubusercontent.com/14221995/97239474-f0fd2a80-17a8-11eb-92fe-4457603ccf65.png)

2. Existing ASEv2 resource -> only show Isolated sku's
![image](https://user-images.githubusercontent.com/14221995/97240897-b72e2300-17ac-11eb-8b7b-24cbbb4952ef.png)


3. Create new ASP in existing ASEv3 -> only show IV2 sku's (screenshot will be available once I make the Ibiza side changes which will include setting allowAseV3Creation flag and passing to specpicker. This flag will also be used for new app in new ase scenario when supported)

4. Create new ASP in existing ASEv2 -> only show Isolated sku's (existing scenario. See screenshot below where we don't show IV2 skus)
![image](https://user-images.githubusercontent.com/14221995/97241108-52bf9380-17ad-11eb-9057-1735304f4814.png)


