### PR TITLE
Introduce .net 5 for classic and preview deployment center. (#5523)

### DIFF
--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
@@ -41,14 +41,7 @@ const getRuntimeStackForWindows = (configMetadata: ArmObj<KeyValue<string>>) => 
   if (configMetadata.properties['CURRENT_STACK']) {
     const metadataStack = configMetadata.properties['CURRENT_STACK'].toLowerCase();
 
-    // NOTE(michinoy): Java is special, so need to handle it carefully. Also in this case, use
-    // the string 'java' rather than any of the constants defined as it is not related to any of the
-    // defined constants.
-    if (metadataStack === 'dotnet') {
-      return RuntimeStacks.aspnet;
-    } else {
-      return metadataStack;
-    }
+    return metadataStack === 'dotnet' ? RuntimeStacks.aspnet : metadataStack;
   } else {
     return '';
   }
@@ -91,7 +84,9 @@ const getRuntimeStackForLinux = (siteConfig: ArmObj<SiteConfig>) => {
   if (runtimeStack === JavaContainers.JavaSE || runtimeStack === JavaContainers.Tomcat || runtimeStack === JavaContainers.JBoss) {
     return RuntimeStacks.java;
   } else {
-    return runtimeStack;
+    // NOTE(michinoy): So it seems that in the stack API the stack value is 'asp.net', whereas from site config, the stack identifier is
+    // 'dotnetcore'. Due to this mismatch, we need to hard code the conversion on the client side.
+    return siteConfig.properties.linuxFxVersion.toLocaleLowerCase() === 'dotnetcore|5.0' ? RuntimeStacks.aspnet : runtimeStack;
   }
 };
 

--- a/client-react/src/pages/app/deployment-center/utility/GitHubActionUtility.ts
+++ b/client-react/src/pages/app/deployment-center/utility/GitHubActionUtility.ts
@@ -154,7 +154,11 @@ export const getCodeAppWorkflowInformation = (
       }
       break;
     case RuntimeStacks.aspnet:
-      content = getAspNetGithubActionWorkflowDefinition(siteName, slotName, repoBranch, secretName, runtimeStackVersion);
+      // NOTE(michinoy): In case of version 5, generate the dotnet core workflow file.
+      content =
+        runtimeVersion === '5' || runtimeVersion.toLocaleLowerCase() === 'v5.0'
+          ? getDotnetCoreGithubActionWorkflowDefinition(siteName, slotName, repoBranch, isLinuxApp, secretName, runtimeStackVersion)
+          : getAspNetGithubActionWorkflowDefinition(siteName, slotName, repoBranch, secretName, runtimeStackVersion);
       break;
     default:
       throw Error(`Incorrect stack value '${runtimeStack}' provided.`);

--- a/client-react/src/utils/stacks-utils.ts
+++ b/client-react/src/utils/stacks-utils.ts
@@ -244,7 +244,7 @@ export const JavaContainers = {
 
 export const RuntimeStacks = {
   java: 'java',
-  aspnet: 'asp.net',
+  aspnet: 'aspnet',
   node: 'node',
   python: 'python',
   dotnetcore: 'dotnetcore',

--- a/client/src/app/shared/models/constants.ts
+++ b/client/src/app/shared/models/constants.ts
@@ -655,6 +655,7 @@ export class FeatureFlags {
   public static EnableAIOnNationalCloud = 'EnableAIOnNationalCloud';
   public static EnablePv2Experiment = 'EnablePv2Experiment';
   public static DisablePv2Experiment = 'DisablePv2Experiment';
+  public static showHiddenStacks = 'showHiddenStacks';
 }
 
 export class SupportedFeatures {

--- a/client/src/app/shared/services/runtimestack.service.ts
+++ b/client/src/app/shared/services/runtimestack.service.ts
@@ -3,7 +3,8 @@ import { ConditionalHttpClient, Result } from '../conditional-http-client';
 import { CacheService } from './cache.service';
 import { UserService } from './user.service';
 import { WebAppCreateStack } from '../models/stacks';
-import { Constants, ARMApiVersions } from '../models/constants';
+import { Constants, ARMApiVersions, FeatureFlags } from '../models/constants';
+import { Url } from '../Utilities/url';
 
 @Injectable()
 export class RuntimeStackService {
@@ -16,7 +17,9 @@ export class RuntimeStackService {
   public getWebAppGitHubActionStacks(os: 'linux' | 'windows'): Result<WebAppCreateStack[]> {
     const getWebAppGitHubActionStacks = this._cacheService
       .post(
-        `${Constants.serviceHost}stacks/webAppGitHubActionStacks?api-version=${ARMApiVersions.stacksApiVersion20200501}&os=${os}`,
+        `${Constants.serviceHost}stacks/webAppGitHubActionStacks?api-version=${
+          ARMApiVersions.stacksApiVersion20200501
+        }&os=${os}&removeHiddenStacks=${!this._isShowHiddenStackFlagPassed()}`,
         false,
         null,
         null
@@ -25,4 +28,9 @@ export class RuntimeStackService {
 
     return this._client.execute({ resourceId: null }, t => getWebAppGitHubActionStacks);
   }
+
+  private _isShowHiddenStackFlagPassed = () => {
+    const flagValue = Url.getFeatureValue(FeatureFlags.showHiddenStacks);
+    return flagValue && flagValue.toLocaleLowerCase() === 'true';
+  };
 }

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/stack-selector/stack-selector.component.html
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/stack-selector/stack-selector.component.html
@@ -23,7 +23,7 @@
         </div>
     </div>
 
-    <div *ngIf="showVersionSelector" class="settings-wrapper">
+    <div class="settings-wrapper">
         <div class="setting-wrapper">
             <label id="github-action-configure-stackversion-label" class="setting-label">{{ 'runtimeStackVersion' | translate }} </label>
             <div class="setting-control-container">

--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/stack-selector/stack-selector.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-github/stack-selector/stack-selector.component.ts
@@ -4,7 +4,7 @@ import { DeploymentCenterStateManager } from '../../../wizard-logic/deployment-c
 import { RuntimeStackService } from 'app/shared/services/runtimestack.service';
 import { WebAppCreateStack } from 'app/shared/models/stacks';
 import { LogService } from 'app/shared/services/log.service';
-import { LogCategories, Os, RuntimeStacks } from 'app/shared/models/constants';
+import { LogCategories, Os } from 'app/shared/models/constants';
 import { DropDownElement } from 'app/shared/models/drop-down-element';
 import { RequiredValidator } from 'app/shared/validators/requiredValidator';
 import { TranslateService } from '@ngx-translate/core';
@@ -30,7 +30,6 @@ export class StackSelectorComponent implements OnDestroy {
   public stackMismatchMessage = '';
   public selectedRuntimeStack = '';
   public selectedRuntimeStackVersion = '';
-  public showVersionSelector = true;
 
   private _ngUnsubscribe$ = new Subject();
   private _runtimeStacks: WebAppCreateStack[] = [];
@@ -146,8 +145,6 @@ export class StackSelectorComponent implements OnDestroy {
 
   private _populateRuntimeStackVersionItems(stackValue: string) {
     if (stackValue) {
-      this.showVersionSelector = stackValue !== RuntimeStacks.aspnet;
-
       const runtimeStack = this._runtimeStacks.find(stack => stack.value.toLocaleLowerCase() === stackValue);
 
       this.runtimeStackVersionItems = runtimeStack.versions.map(version => ({

--- a/client/src/app/site/deployment-center/deployment-center-setup/wizard-logic/deployment-center-state-manager.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/wizard-logic/deployment-center-state-manager.ts
@@ -239,6 +239,8 @@ export class DeploymentCenterStateManager implements OnDestroy {
       this.stackVersion = siteConfig.pythonVersion;
     } else if (this.stack === RuntimeStacks.java8 || this.stack === RuntimeStacks.java11) {
       this.stackVersion = `${siteConfig.javaVersion}|${siteConfig.javaContainer}|${siteConfig.javaContainerVersion}`;
+    } else if (this.stack === RuntimeStacks.aspnet && !!siteConfig.netFrameworkVersion) {
+      this.stackVersion == siteConfig.netFrameworkVersion;
     } else if (this.stack === '') {
       this.stackVersion = '';
     }
@@ -258,7 +260,9 @@ export class DeploymentCenterStateManager implements OnDestroy {
         this.stack = '';
       }
     } else {
-      this.stack = runtimeStack;
+      // NOTE(michinoy): So it seems that in the stack API the stack value is 'aspnet', whereas from site config, the stack identifier is
+      // 'dotnetcore'. Due to this mismatch, we need to hard code the conversion on the client side.
+      this.stack = siteConfig.linuxFxVersion.toLocaleLowerCase() === 'dotnetcore|5.0' ? RuntimeStacks.aspnet : runtimeStack;
     }
 
     this.stackVersion = !!siteConfig.linuxFxVersion ? siteConfig.linuxFxVersion : '';

--- a/client/src/app/site/deployment-center/deployment-center-setup/wizard-logic/github.service.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/wizard-logic/github.service.ts
@@ -185,7 +185,11 @@ export class GithubService implements OnDestroy {
         }
         break;
       case RuntimeStacks.aspnet:
-        content = this._getAspNetGithubActionWorkflowDefinition(siteName, slotName, branch, secretName, runtimeStackVersion);
+        // NOTE(michinoy): In case of version 5, generate the dotnet core workflow file.
+        content =
+          buildSettings.runtimeStackVersion === '5' || buildSettings.runtimeStackVersion.toLocaleLowerCase() === 'v5.0'
+            ? this._getDotnetCoreGithubActionWorkflowDefinition(siteName, slotName, branch, isLinuxApp, secretName, runtimeStackVersion)
+            : this._getAspNetGithubActionWorkflowDefinition(siteName, slotName, branch, secretName, runtimeStackVersion);
         break;
       default:
         throw Error(`Incorrect stack value '${buildSettings.runtimeStack}' provided.`);

--- a/server/src/stacks/2020-05-01/service/StackService.ts
+++ b/server/src/stacks/2020-05-01/service/StackService.ts
@@ -146,7 +146,7 @@ export class StacksService20200501 {
     return stacks;
   }
 
-  getWebAppGitHubActionStacks(os?: 'linux' | 'windows'): WebAppCreateStack[] {
+  getWebAppGitHubActionStacks(os?: 'linux' | 'windows', removeHidden?: boolean): WebAppCreateStack[] {
     const stacks = this.getWebAppCreateStacks(os);
 
     // remove all supported platforms which are not github action supported.
@@ -154,7 +154,7 @@ export class StacksService20200501 {
       stack.versions.forEach(version =>
         ArrayUtil.remove<WebAppCreateStackVersionPlatform>(
           version.supportedPlatforms,
-          platform => !platform.githubActionSettings || !platform.githubActionSettings.supported
+          platform => !platform.githubActionSettings || !platform.githubActionSettings.supported || (removeHidden && platform.isHidden)
         )
       )
     );

--- a/server/src/stacks/2020-05-01/stacks/web-app-stacks/create/AspDotnet.ts
+++ b/server/src/stacks/2020-05-01/stacks/web-app-stacks/create/AspDotnet.ts
@@ -6,6 +6,41 @@ export const aspDotnetCreateStack: WebAppCreateStack = {
   sortOrder: 0,
   versions: [
     {
+      displayText: '.NET 5',
+      value: '5',
+      sortOrder: 0,
+      supportedPlatforms: [
+        {
+          os: 'windows',
+          isPreview: false,
+          isDeprecated: false,
+          isHidden: true,
+          applicationInsightsEnabled: false,
+          remoteDebuggingEnabled: false,
+          runtimeVersion: 'v5.0',
+          sortOrder: 0,
+          githubActionSettings: {
+            supported: true,
+            recommendedVersion: '5.0.x',
+          },
+        },
+        {
+          os: 'linux',
+          isPreview: false,
+          isDeprecated: false,
+          isHidden: true,
+          applicationInsightsEnabled: false,
+          remoteDebuggingEnabled: false,
+          runtimeVersion: 'DOTNETCORE|5.0',
+          sortOrder: 0,
+          githubActionSettings: {
+            supported: true,
+            recommendedVersion: '5.0.x',
+          },
+        },
+      ],
+    },
+    {
       displayText: 'ASP.NET V4.8',
       value: 'V4.8',
       sortOrder: 0,

--- a/server/src/stacks/stacks.controller.ts
+++ b/server/src/stacks/stacks.controller.ts
@@ -131,12 +131,18 @@ export class StacksController {
   }
 
   @Post('webAppGitHubActionStacks')
-  webAppGitHubActionStacks(@Query('api-version') apiVersion: string, @Query('os') os?: 'linux' | 'windows') {
+  webAppGitHubActionStacks(
+    @Query('api-version') apiVersion: string,
+    @Query('os') os?: 'linux' | 'windows',
+    @Query('removeHiddenStacks') removeHiddenStacks?: string
+  ) {
     validateApiVersion(apiVersion, [Versions.version20200501]);
     validateOs(os);
 
+    const removeHidden = removeHiddenStacks && removeHiddenStacks.toLowerCase() === 'true';
+
     if (apiVersion === Versions.version20200501) {
-      return this._stackService20200501.getWebAppGitHubActionStacks(os);
+      return this._stackService20200501.getWebAppGitHubActionStacks(os, removeHidden);
     }
   }
 

--- a/server/src/tests/Stacks/2020-05-01/web-app/validations.ts
+++ b/server/src/tests/Stacks/2020-05-01/web-app/validations.ts
@@ -56,7 +56,7 @@ export function validateGithubActionWindowsStackLength(stacks) {
 
 export function validateGithubActionLinuxStackLength(stacks) {
   expect(stacks).to.be.an('array');
-  expect(stacks.length).to.equal(5);
+  expect(stacks.length).to.equal(6);
 }
 
 export function validateASPCreateStack(stacks) {
@@ -65,7 +65,7 @@ export function validateASPCreateStack(stacks) {
   expect(aspStack.displayText).to.equal('ASP.NET');
   expect(aspStack.value).to.equal('ASP.NET');
   expect(aspStack.sortOrder).to.equal(0);
-  expect(aspStack.versions.length).to.equal(2);
+  expect(aspStack.versions.length).to.equal(3);
   expect(aspStack).to.deep.equal(aspDotnetCreateStack);
 }
 


### PR DESCRIPTION
* initial changes

* enable dotnet 5 in deployment center.

* update some stuff.

* address some of the PR comments.

* update test cases

* Add the concept of showing hidden stacks in the old api version.