### PR TITLE
AB#8710702 [Fusion] Isolated v2 cards show the wrong vm series - match PV3 since underneath they are the same

### DIFF
--- a/client/src/app/site/spec-picker/price-spec-manager/isolatedv2-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/isolatedv2-plan-price-spec.ts
@@ -135,9 +135,9 @@ export class IsolatedV2SmallPlanPriceSpec extends IsolatedV2PlanPriceSpec {
   skuCode = SkuCode.IsolatedV2.I1V2;
   legacySkuName = SkuCode.IsolatedV2.I1V2;
   topLevelFeatures = [
-    this._ts.instant(PortalResources.pricing_ACU).format('390'),
-    this._ts.instant(PortalResources.pricing_memory).format('8'),
-    this._ts.instant(PortalResources.pricing_dSeriesComputeEquivalent),
+    this._ts.instant(PortalResources.pricing_ACU_Pv3).format(195),
+    this._ts.instant(PortalResources.pricing_memory).format(8),
+    this._ts.instant(PortalResources.pricing_vCores).format(2),
   ];
 
   meterFriendlyName = 'IsolatedV2 Small App Service Hours';
@@ -158,9 +158,9 @@ export class IsolatedV2MediumPlanPriceSpec extends IsolatedV2PlanPriceSpec {
   skuCode = SkuCode.IsolatedV2.I2V2;
   legacySkuName = SkuCode.IsolatedV2.I2V2;
   topLevelFeatures = [
-    this._ts.instant(PortalResources.pricing_ACU).format('780'),
-    this._ts.instant(PortalResources.pricing_memory).format('16'),
-    this._ts.instant(PortalResources.pricing_dSeriesComputeEquivalent),
+    this._ts.instant(PortalResources.pricing_ACU_Pv3).format(195),
+    this._ts.instant(PortalResources.pricing_memory).format(16),
+    this._ts.instant(PortalResources.pricing_vCores).format(4),
   ];
 
   meterFriendlyName = 'IsolatedV2 Medium App Service Hours';
@@ -181,9 +181,9 @@ export class IsolatedV2LargePlanPriceSpec extends IsolatedV2PlanPriceSpec {
   skuCode = SkuCode.IsolatedV2.I3V2;
   legacySkuName = SkuCode.IsolatedV2.I3V2;
   topLevelFeatures = [
-    this._ts.instant(PortalResources.pricing_ACU).format('1560'),
-    this._ts.instant(PortalResources.pricing_memory).format('32'),
-    this._ts.instant(PortalResources.pricing_dSeriesComputeEquivalent),
+    this._ts.instant(PortalResources.pricing_ACU_Pv3).format(195),
+    this._ts.instant(PortalResources.pricing_memory).format(32),
+    this._ts.instant(PortalResources.pricing_vCores).format(8),
   ];
 
   meterFriendlyName = 'IsolatedV2 Large App Service Hours';


### PR DESCRIPTION
Fixes AB#8710702

**NOTE: There is no price as billing meters are not ready yet.**

Before:
![image](https://user-images.githubusercontent.com/14221995/97911528-3fa64980-1d00-11eb-93f0-9728ac82fc74.png)


After:
![image](https://user-images.githubusercontent.com/14221995/97911431-1685b900-1d00-11eb-84a9-66ab311de18c.png)
