### PR TITLE
AB#7062492 Consider removing S2/ S3 form SKU Picker for new ASP since P1v2 and P2v2 offer better perf at the same price point

### DIFF
--- a/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
@@ -251,6 +251,9 @@ export class ProdSpecGroup extends PriceSpecGroup {
           level: BannerMessageLevel.INFO,
         };
       }
+
+      // NOTE(shimedh): We don't want to show S2 and S3 sku'd in create scenario since P1v2 and P2v2 offer better perf at the same price point.
+      this.additionalSpecs.splice(0, 2);
     }
 
     const isPartOfPv2Experiment = FlightingUtil.checkSubscriptionInFlight(input.subscriptionId, FlightingUtil.Features.Pv2Experimentation);


### PR DESCRIPTION
Fixes AB#7062492 

**Create scenario:**
Before:
![image](https://user-images.githubusercontent.com/14221995/97933233-f7e6e880-1d26-11eb-9ee7-e93739784700.png)


After:
![image](https://user-images.githubusercontent.com/14221995/97933140-c1a96900-1d26-11eb-8b4e-37b5f14747ac.png)


**Existing ASP -> scale up scenario - NO change**
Before:
![image](https://user-images.githubusercontent.com/14221995/97933269-1947d480-1d27-11eb-9eaa-422d74fea548.png)

After:
![image](https://user-images.githubusercontent.com/14221995/97933304-37add000-1d27-11eb-8d98-8f7b7e990832.png)
