### PR TITLE
[GitHub Actions\Create] Get client id from configservice

### DIFF
--- a/server/src/deployment-center/github/github.controller.ts
+++ b/server/src/deployment-center/github/github.controller.ts
@@ -185,6 +185,11 @@ export class GithubController {
     }
   }
 
+  @Get('auth/github/createClientId')
+  clientId() {
+    return { client_id: this.configService.get('GITHUB_FOR_CREATES_CLIENT_ID') };
+  }
+
   @Post('auth/github/generateCreateAccessToken')
   @HttpCode(200)
   async generateAccessToken(


### PR DESCRIPTION
Fixes AB#8782760