### PR TITLE
AB#8826878 [Spec picker] Revert the experiment to hide S2 and S3 skus

### DIFF
--- a/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
@@ -259,8 +259,6 @@ export class ProdSpecGroup extends PriceSpecGroup {
     // NOTE(michinoy): The OS type determines whether standard small plan is recommended or additional pricing tier.
     // NOTE(shimedh): If subscription is part of PV2 experiment flighting we always add standard small plan in additional pricing tier irrespective of OS.
     if (isPartOfPv2Experiment) {
-      // NOTE(shimedh): We don't want to show S2 and S3 sku'd in create scenario since P1v2 and P2v2 offer better perf at the same price point.
-      this.additionalSpecs.splice(0, 2);
       this.additionalSpecs.unshift(new StandardSmallPlanPriceSpec(this.injector));
       this.portalService.logAction('specPicker', LogCategories.specPickerPv2Experiment, {
         subscriptionId: input.subscriptionId,


### PR DESCRIPTION
Fixes AB#8826878

![image](https://user-images.githubusercontent.com/14221995/99431354-7e6efe80-28bf-11eb-934e-a612b290ab0d.png)

![image](https://user-images.githubusercontent.com/14221995/99431477-af4f3380-28bf-11eb-8c71-e7f277f26fff.png)
