### PR TITLE
Set "recommendedVersion" for Node14 on Windows

### DIFF
--- a/server/src/stacks/2020-05-01/stacks/web-app-stacks/create/Node.ts
+++ b/server/src/stacks/2020-05-01/stacks/web-app-stacks/create/Node.ts
@@ -35,6 +35,7 @@ export const nodeCreateStack: WebAppCreateStack = {
           sortOrder: 1,
           githubActionSettings: {
             supported: true,
+            recommendedVersion: '14.x'
           },
         },
       ],

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
@@ -66,6 +66,7 @@ export const nodeStack: WebAppStack = {
               },
               gitHubActionSettings: {
                 isSupported: true,
+                supportedVersion: '14.x'
               },
               isEarlyAccess: true,
               endOfLifeDate: node14EOL,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
@@ -66,6 +66,7 @@ export const nodeStack: WebAppStack = {
               },
               gitHubActionSettings: {
                 isSupported: true,
+                supportedVersion: '14.x'
               },
               isEarlyAccess: true,
               endOfLifeDate: node14EOL,


### PR DESCRIPTION
Node 14 is working with our GitHub Actions flow. On Windows though, we need to make a small change. Right now the Windows workflow is setting the "version" param on the Node setup action to `14-lts`. The action does not understand this syntax.

![image](https://user-images.githubusercontent.com/18747768/99730015-a18ce000-2a70-11eb-8391-cb4fde68b37f.png)

So if we can update the Windows workflow to set `14.x` like the Linux one, then we're good to go:

![image](https://user-images.githubusercontent.com/18747768/99730264-fe889600-2a70-11eb-8dcb-2ed25d443d5b.png)

I *believe* this change will fix it, but will need Mitren to check that the DC will honor the "recommendedVerison" for Windows workflows.