### PR TITLE
[Stacks][Function App]Enable function app Python 3.9 in preview and hidden

### DIFF
--- a/server/src/stacks/2020-05-01/stacks/function-app-stacks/Python.ts
+++ b/server/src/stacks/2020-05-01/stacks/function-app-stacks/Python.ts
@@ -7,6 +7,30 @@ export const pythonStack: FunctionAppStack = {
   versions: [
     {
       sortOrder: 1,
+      displayText: '3.9',
+      value: '3.9',
+      isDefault: false,
+      supportedPlatforms: [
+        {
+          sortOrder: 0,
+          os: 'linux',
+          isPreview: true,
+          isDeprecated: false,
+          isHidden: true,
+          applicationInsightsEnabled: true,
+          runtimeVersion: 'Python|3.9',
+          appSettingsDictionary: {
+            FUNCTIONS_WORKER_RUNTIME: 'python',
+          },
+          siteConfigPropertiesDictionary: {
+            use32BitWorkerProcess: false,
+            linuxFxVersion: 'Python|3.9',
+          },
+        },
+      ],
+    },
+    {
+      sortOrder: 2,
       displayText: '3.8',
       value: '3.8',
       isDefault: false,
@@ -30,7 +54,7 @@ export const pythonStack: FunctionAppStack = {
       ],
     },
     {
-      sortOrder: 2,
+      sortOrder: 3,
       displayText: '3.7',
       value: '3.7',
       isDefault: true,
@@ -54,7 +78,7 @@ export const pythonStack: FunctionAppStack = {
       ],
     },
     {
-      sortOrder: 3,
+      sortOrder: 4,
       displayText: '3.6',
       value: '3.6',
       isDefault: false,

--- a/server/src/stacks/2020-06-01/stacks/function-app-stacks/Python.ts
+++ b/server/src/stacks/2020-06-01/stacks/function-app-stacks/Python.ts
@@ -10,6 +10,34 @@ export const pythonStack: FunctionAppStack = {
       value: '3',
       minorVersions: [
         {
+          displayText: 'Python 3.9',
+          value: '3.9',
+          stackSettings: {
+            linuxRuntimeSettings: {
+              runtimeVersion: 'Python|3.9',
+              remoteDebuggingSupported: false,
+              isPreview: true,
+              isHidden: true,
+              isDefault: false,
+              appInsightsSettings: {
+                isSupported: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '3.9',
+              },
+              appSettingsDictionary: {
+                FUNCTIONS_WORKER_RUNTIME: 'python',
+              },
+              siteConfigPropertiesDictionary: {
+                use32BitWorkerProcess: false,
+                linuxFxVersion: 'Python|3.9',
+              },
+              supportedFunctionsExtensionVersions: ['~3'],
+            },
+          },
+        },
+        {
           displayText: 'Python 3.8',
           value: '3.8',
           stackSettings: {

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Python.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Python.ts
@@ -10,6 +10,34 @@ export const pythonStack: FunctionAppStack = {
       value: '3',
       minorVersions: [
         {
+          displayText: 'Python 3.9',
+          value: '3.9',
+          stackSettings: {
+            linuxRuntimeSettings: {
+              runtimeVersion: 'Python|3.9',
+              remoteDebuggingSupported: false,
+              isPreview: true,
+              isHidden: true,
+              isDefault: false,
+              appInsightsSettings: {
+                isSupported: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '3.9',
+              },
+              appSettingsDictionary: {
+                FUNCTIONS_WORKER_RUNTIME: 'python',
+              },
+              siteConfigPropertiesDictionary: {
+                use32BitWorkerProcess: false,
+                linuxFxVersion: 'Python|3.9',
+              },
+              supportedFunctionsExtensionVersions: ['~3'],
+            },
+          },
+        },
+        {
           displayText: 'Python 3.8',
           value: '3.8',
           stackSettings: {

--- a/server/src/tests/Stacks/2020-05-01/function-app/validations.ts
+++ b/server/src/tests/Stacks/2020-05-01/function-app/validations.ts
@@ -44,7 +44,7 @@ export function validatePythonStack(stacks) {
   expect(pythonStack.displayText).to.equal('Python');
   expect(pythonStack.value).to.equal('python');
   expect(pythonStack.sortOrder).to.equal(2);
-  expect(pythonStack.versions.length).to.equal(3);
+  expect(pythonStack.versions.length).to.equal(4);
   expect(pythonStack).to.deep.equal(hardCodedPythonStack);
 }
 


### PR DESCRIPTION
cc: @pragnagopa 

We expect to release Python 3.9 for Azure Functions in December. This is a placeholder for the Python 3.9 stack in backend API.
Related PR:
[PragnaGopa Stack] https://github.com/pragnagopa/azure-functions-supported-runtime-stacks/pull/24
[Azure CLI] https://github.com/Azure/azure-cli/pull/16020