### PR TITLE
Task 8647397: Add iframe API in React to log to new telemetry class

### DIFF
--- a/client-react/src/components/ErrorLogger.tsx
+++ b/client-react/src/components/ErrorLogger.tsx
@@ -9,7 +9,7 @@ export default class ErrorLogger extends React.Component<{}, {}> {
   public context!: PortalCommunicator;
 
   public componentDidCatch(error, info) {
-    this.context.logMessage(LogEntryLevel.Error, error, info);
+    this.context.logMessageDeprecated(LogEntryLevel.Error, error, info);
   }
 
   public render() {

--- a/client-react/src/models/portal-models.ts
+++ b/client-react/src/models/portal-models.ts
@@ -84,8 +84,9 @@ export class Verbs {
 
   public static closeBlades = 'close-blades';
   public static closeSelf = 'close-self';
-  public static logAction = 'log-action';
-  public static logMessage = 'log-message';
+  public static log = 'log';
+  public static logActionDeprecated = 'log-action';
+  public static logMessageDeprecated = 'log-message';
   public static logTimerEvent = 'log-timer-event';
   public static setDirtyState = 'set-dirtystate'; // Deprecated
   public static updateDirtyState = 'update-dirtystate';

--- a/client-react/src/models/telemetry.ts
+++ b/client-react/src/models/telemetry.ts
@@ -1,0 +1,12 @@
+export type LogLevel = 'error' | 'warning' | 'info' | 'verbose';
+export interface LogData {
+  [key: string]: any;
+  message?: string;
+}
+export interface TelemetryInfo {
+  action: string; // The action being performed:  e.g. "initializing", "updatingConfig", "refreshingToken", etc...
+  actionModifier: string; // The status of that action: e.g. "started", "stopped", "succeeded", etc...
+  resourceId: string; // The resourceId of the resource you're logging for.
+  logLevel?: LogLevel; // If unspecified, this is defaulted to "info"
+  data?: string | LogData; // If a string, will get set as a LogData message property before logging
+}


### PR DESCRIPTION
For now, I'm opting to leave the React-side of the world as a direct call on the PortalCommunicator class.  I thought about introducing a new Telemetry class which wraps the communicator, but it doesn't seem to make as much sense in the React side of the world since it's just a passthrough to an existing Telemetry instance in the Ibiza side of the world.  So it would just be another layer of complication on-top of this already complicated problem.