### PR TITLE
[Deployment Center V2] Disable sync button for dev ops

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
@@ -39,6 +39,7 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
       (deploymentCenterContext.siteConfig &&
         (deploymentCenterContext.siteConfig.properties.scmType === ScmType.LocalGit ||
           deploymentCenterContext.siteConfig.properties.scmType === ScmType.GitHubAction ||
+          deploymentCenterContext.siteConfig.properties.scmType === ScmType.Vsts ||
           deploymentCenterContext.siteConfig.properties.scmType === ScmType.None))
     );
   };


### PR DESCRIPTION
Fixes AB#8564677

![image](https://user-images.githubusercontent.com/35281019/101096518-85ab3300-3574-11eb-85a7-0325dd198ac4.png)
 