### PR TITLE
AB#8965964 Hide free sku from spec picker for Linux FunctionApp creates

### DIFF
--- a/client/src/app/site/spec-picker/price-spec-manager/free-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/free-plan-price-spec.ts
@@ -80,6 +80,10 @@ export class FreePlanPriceSpec extends PriceSpec {
       isLinux = input.specPickerInput.data.isLinux;
       if (isLinux) {
         this.topLevelFeatures.shift();
+        // NOTE(shimedh): Linux FunctionApp's don't work on Free sku's. Hide Free sku for Linux FunctionApp create scenario.
+        if (input.specPickerInput.data.isFunctionApp) {
+          this.state = 'hidden';
+        }
       }
 
       if (


### PR DESCRIPTION
Fixes AB#8965964

Will send a PR separately on the Ibiza side to disable Linux for free subs and filtering out existing Free ASP from dropdown for Linux.


Linux FunctionApp create:
![image](https://user-images.githubusercontent.com/14221995/101964688-11513f00-3bc7-11eb-95ef-91302cec5459.png)

Windows FunctionApp create:
![image](https://user-images.githubusercontent.com/14221995/101964716-2cbc4a00-3bc7-11eb-924a-7c7152f48eca.png)

Linux WebApp create:
![image](https://user-images.githubusercontent.com/14221995/101964658-ef57bc80-3bc6-11eb-9b11-3f518a3753d0.png)


Windows WebApp create:
![image](https://user-images.githubusercontent.com/14221995/101964623-d2bb8480-3bc6-11eb-8c5b-f20958cc4f8c.png)
