### PR TITLE
[Stacks][Function App]Unhide function app Python 3.9

### DIFF
--- a/server/src/stacks/2020-05-01/stacks/function-app-stacks/Python.ts
+++ b/server/src/stacks/2020-05-01/stacks/function-app-stacks/Python.ts
@@ -16,7 +16,7 @@ export const pythonStack: FunctionAppStack = {
           os: 'linux',
           isPreview: true,
           isDeprecated: false,
-          isHidden: true,
+          isHidden: false,
           applicationInsightsEnabled: true,
           runtimeVersion: 'Python|3.9',
           appSettingsDictionary: {

--- a/server/src/stacks/2020-06-01/stacks/function-app-stacks/Python.ts
+++ b/server/src/stacks/2020-06-01/stacks/function-app-stacks/Python.ts
@@ -17,7 +17,7 @@ export const pythonStack: FunctionAppStack = {
               runtimeVersion: 'Python|3.9',
               remoteDebuggingSupported: false,
               isPreview: true,
-              isHidden: true,
+              isHidden: false,
               isDefault: false,
               appInsightsSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-06-01/stacks/function-app-stacks/Python.ts
+++ b/server/src/stacks/2020-06-01/stacks/function-app-stacks/Python.ts
@@ -17,7 +17,6 @@ export const pythonStack: FunctionAppStack = {
               runtimeVersion: 'Python|3.9',
               remoteDebuggingSupported: false,
               isPreview: true,
-              isHidden: false,
               isDefault: false,
               appInsightsSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Python.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Python.ts
@@ -17,7 +17,7 @@ export const pythonStack: FunctionAppStack = {
               runtimeVersion: 'Python|3.9',
               remoteDebuggingSupported: false,
               isPreview: true,
-              isHidden: true,
+              isHidden: false,
               isDefault: false,
               appInsightsSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Python.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Python.ts
@@ -17,7 +17,6 @@ export const pythonStack: FunctionAppStack = {
               runtimeVersion: 'Python|3.9',
               remoteDebuggingSupported: false,
               isPreview: true,
-              isHidden: false,
               isDefault: false,
               appInsightsSettings: {
                 isSupported: true,


### PR DESCRIPTION
We expect to release Python 3.9 for Azure Functions in preview mode early January, 2021
cc: @anirudhgarg @vrdmr @pragnagopa @stefanushinardi