### PR TITLE
Enable external git to have http based protocol.

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
@@ -85,7 +85,10 @@ export abstract class DeploymentCenterFormBuilder {
             : true;
         })
         .test('repositoryIsUrl', this._t('deploymentCenterExternalRepoMessage'), function(value) {
-          return this.parent.sourceProvider === ScmType.ExternalGit ? !!value && this.parent.repo.startsWith('https://') : true;
+          const parentRepoUrl = this.parent.repo ? this.parent.repo.toLocaleLowerCase() : '';
+          const urlIsPrefixedCorrectly = parentRepoUrl.startsWith('https://') || parentRepoUrl.startsWith('http://');
+
+          return this.parent.sourceProvider === ScmType.ExternalGit ? !!value && urlIsPrefixedCorrectly : true;
         }),
       branch: Yup.mixed().test('branchRequired', this._t('deploymentCenterFieldRequiredMessage'), function(value) {
         return this.parent.sourceProvider === ScmType.GitHubAction ||

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
@@ -118,9 +118,12 @@ const DeploymentCenterCodeForm: React.FC<DeploymentCenterCodeFormProps> = props 
         //(note: stpelleg): Local Git does not require a Repo Url
         return '';
       case ScmType.ExternalGit:
+        const repoUrlParts = values.repo.split('://');
+        const protocol = repoUrlParts[0];
+        const hostContents = repoUrlParts[1];
+
         if (values.externalUsername && values.externalPassword) {
-          const repoPath = values.repo.toLocaleLowerCase().replace('https://', '');
-          return `https://${values.externalUsername}:${values.externalPassword}@${repoPath}`;
+          return `${protocol}://${values.externalUsername}:${values.externalPassword}@${hostContents}`;
         }
         return values.repo;
       case ScmType.Vso:

--- a/client-react/src/pages/app/deployment-center/external-provider/DeploymentCenterExternalConfiguredView.tsx
+++ b/client-react/src/pages/app/deployment-center/external-provider/DeploymentCenterExternalConfiguredView.tsx
@@ -43,14 +43,22 @@ const DeploymentCenterExternalConfiguredView: React.FC<DeploymentCenterFieldProp
   };
 
   const processRepo = (repoUrl: string): void => {
-    const repoUrlPartsForUsername = repoUrl.replace('https://', '').split(':');
-    if (repoUrlPartsForUsername.length > 1) {
-      setExternalUsername(repoUrlPartsForUsername[0]);
-      const repoUrlPartsForRepo = repoUrl.split('@');
-      setRepo(`https://${repoUrlPartsForRepo[repoUrlPartsForRepo.length - 1]}`);
-    } else {
-      setRepo(repoUrl);
-    }
+    // NOTE(michinoy): There can be multiple variations of the URL:
+    // The protocol can be either https or http
+    // The host part can be - username@domain.net/path/name.git
+    //                        username:password@domain.net/path/name.git
+    //                        domain.net/path/name.git
+
+    const repoUrlParts = repoUrl.split('://');
+    const protocol = repoUrlParts[0];
+    const hostContents = repoUrlParts[1];
+    const hostContentParts = hostContents.split('@');
+    const domainContent = hostContentParts[1] ? hostContentParts[1] : hostContentParts[0];
+    const usernameAndPassword = hostContentParts[1] ? hostContentParts[0] : '';
+    const username = usernameAndPassword ? usernameAndPassword.split(':')[0] : '';
+
+    setExternalUsername(username);
+    setRepo(`${protocol}://${domainContent}`);
   };
 
   const getBranchLink = () => {


### PR DESCRIPTION
Turns out we have several existing apps with 'http' and the backend API allows this too.

Before:
![image](https://user-images.githubusercontent.com/493476/103424644-559a8400-4b62-11eb-9274-3b1dd50e2d8a.png)

After:
![image](https://user-images.githubusercontent.com/493476/103424658-60551900-4b62-11eb-8fd4-a9469b7d03fd.png)

