### PR TITLE
Hide logs for consumption linux function apps

### DIFF
--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodePivot.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodePivot.tsx
@@ -13,16 +13,23 @@ import { DeploymentCenterPublishingContext } from '../DeploymentCenterPublishing
 import { PortalContext } from '../../../../PortalContext';
 import { getTelemetryInfo } from '../utility/DeploymentCenterUtility';
 import { LogLevels } from '../../../../models/telemetry';
+import { ScenarioService } from '../../../../utils/scenario-checker/scenario.service';
+import { ScenarioIds } from '../../../../utils/scenario-checker/scenario-ids';
+import { SiteStateContext } from '../../../../SiteState';
 
 const DeploymentCenterCodePivot: React.FC<DeploymentCenterCodePivotProps> = props => {
   const { formProps, deployments, deploymentsError, isLoading, refreshLogs } = props;
   const { t } = useTranslation();
   const [selectedKey, setSelectedKey] = useState<string>('logs');
+  const [showLogsTab, setShowLogsTab] = useState(true);
 
   const deploymentCenterContext = useContext(DeploymentCenterContext);
   const deploymentCenterPublishingContext = useContext(DeploymentCenterPublishingContext);
+  const siteStateContext = useContext(SiteStateContext);
+
   const theme = useContext(ThemeContext);
   const portalContext = useContext(PortalContext);
+  const scenarioService = new ScenarioService(t);
 
   const isScmLocalGit = deploymentCenterContext.siteConfig && deploymentCenterContext.siteConfig.properties.scmType === ScmType.LocalGit;
 
@@ -66,20 +73,31 @@ const DeploymentCenterCodePivot: React.FC<DeploymentCenterCodePivotProps> = prop
     formProps.values.publishingConfirmPassword,
   ]);
 
+  useEffect(() => {
+    if (siteStateContext && siteStateContext.site) {
+      const scenarioStatus = scenarioService.checkScenario(ScenarioIds.deploymentCenterLogs, { site: siteStateContext.site }).status;
+      setShowLogsTab(scenarioStatus !== 'disabled');
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [siteStateContext]);
+
   return (
     <Pivot selectedKey={selectedKey} onLinkClick={onLinkClick}>
-      <PivotItem
-        itemKey="logs"
-        headerText={t('deploymentCenterPivotItemLogsHeaderText')}
-        ariaLabel={t('deploymentCenterPivotItemLogsAriaLabel')}>
-        <DeploymentCenterCodeLogs
-          goToSettings={goToSettingsOnClick}
-          deployments={deployments}
-          deploymentsError={deploymentsError}
-          isLoading={isLoading}
-          refreshLogs={refreshLogs}
-        />
-      </PivotItem>
+      {showLogsTab && (
+        <PivotItem
+          itemKey="logs"
+          headerText={t('deploymentCenterPivotItemLogsHeaderText')}
+          ariaLabel={t('deploymentCenterPivotItemLogsAriaLabel')}>
+          <DeploymentCenterCodeLogs
+            goToSettings={goToSettingsOnClick}
+            deployments={deployments}
+            deploymentsError={deploymentsError}
+            isLoading={isLoading}
+            refreshLogs={refreshLogs}
+          />
+        </PivotItem>
+      )}
 
       <PivotItem
         itemKey="settings"

--- a/client-react/src/utils/scenario-checker/dynamic-linux.environment.ts
+++ b/client-react/src/utils/scenario-checker/dynamic-linux.environment.ts
@@ -21,6 +21,13 @@ export class DynamicLinuxEnvironment extends Environment {
       },
     };
 
+    this.scenarioChecks[ScenarioIds.deploymentCenterLogs] = {
+      id: ScenarioIds.deploymentCenterLogs,
+      runCheck: () => {
+        return { status: 'disabled' };
+      },
+    };
+
     this.scenarioChecks[ScenarioIds.addMsi] = {
       id: ScenarioIds.addMsi,
       runCheck: () => {

--- a/client-react/src/utils/scenario-checker/scenario-ids.ts
+++ b/client-react/src/utils/scenario-checker/scenario-ids.ts
@@ -107,4 +107,5 @@ export class ScenarioIds {
   public static readonly xenonAppRuntimeStack = 'xenonAppRuntimeStack';
   public static readonly showAppInsightsLogs = 'showAppInsightsLogs';
   public static readonly showRuntimeVersionSetting = 'showRuntimeVersionSetting';
+  public static readonly deploymentCenterLogs = 'deploymentCenterLogs';
 }


### PR DESCRIPTION
fixes AB#9058474

We currently have an email thread with the function team to get a timeline on when this can be enabled. As of right now, the calls to fetch logs always fails.

non-consumption:
![image](https://user-images.githubusercontent.com/493476/103712728-6b97b280-4f6f-11eb-9280-1d4cdf9e0396.png)

consumption:
![image](https://user-images.githubusercontent.com/493476/103712755-7a7e6500-4f6f-11eb-81db-1fc2ca30ef15.png)
