### PR TITLE
Add an optional query string to the stacks api to filter out non-githubaction stacks

### DIFF
--- a/server/src/stacks/2020-10-01/service/FunctionAppUtility.ts
+++ b/server/src/stacks/2020-10-01/service/FunctionAppUtility.ts
@@ -7,7 +7,8 @@ export function filterFunctionAppStacks(
   os?: AppStackOs,
   removeHiddenStacks?: boolean,
   removeDeprecatedStacks?: boolean,
-  removePreviewStacks?: boolean
+  removePreviewStacks?: boolean,
+  removeNonGitHubActionStacks?: boolean
 ): FunctionAppStack[] {
   stacks.forEach((stack, i) => {
     stack.majorVersions.forEach((majorVersion, j) => {
@@ -24,6 +25,9 @@ export function filterFunctionAppStacks(
         }
         if (removePreviewStacks) {
           _removePreviewRuntimeSettings(stacks, i, j, k);
+        }
+        if (removeNonGitHubActionStacks) {
+          _removeNonGitHubActionRuntimeSettings(stacks, i, j, k);
         }
       });
 
@@ -87,6 +91,19 @@ function _removePreviewRuntimeSettings(stacks: FunctionAppStack[], i: number, j:
   }
 
   if (linuxRuntimeSettings && linuxRuntimeSettings.isPreview) {
+    delete stacks[i].majorVersions[j].minorVersions[k].stackSettings.linuxRuntimeSettings;
+  }
+}
+
+function _removeNonGitHubActionRuntimeSettings(stacks: FunctionAppStack[], i: number, j: number, k: number): void {
+  const windowsRuntimeSettings = stacks[i].majorVersions[j].minorVersions[k].stackSettings.windowsRuntimeSettings;
+  const linuxRuntimeSettings = stacks[i].majorVersions[j].minorVersions[k].stackSettings.linuxRuntimeSettings;
+
+  if (windowsRuntimeSettings && !windowsRuntimeSettings.gitHubActionSettings.isSupported) {
+    delete stacks[i].majorVersions[j].minorVersions[k].stackSettings.windowsRuntimeSettings;
+  }
+
+  if (linuxRuntimeSettings && !linuxRuntimeSettings.gitHubActionSettings.isSupported) {
     delete stacks[i].majorVersions[j].minorVersions[k].stackSettings.linuxRuntimeSettings;
   }
 }

--- a/server/src/stacks/2020-10-01/service/StackService.ts
+++ b/server/src/stacks/2020-10-01/service/StackService.ts
@@ -25,7 +25,8 @@ export class StacksService20201001 {
     stackValue?: FunctionAppStackValue,
     removeHiddenStacks?: boolean,
     removeDeprecatedStacks?: boolean,
-    removePreviewStacks?: boolean
+    removePreviewStacks?: boolean,
+    removeNonGitHubActionStacks?: boolean
   ): FunctionAppStack[] {
     const dotnetStackCopy = JSON.parse(JSON.stringify(dotnetFunctionAppStack));
     const nodeStackCopy = JSON.parse(JSON.stringify(nodeFunctionAppStack));
@@ -40,9 +41,9 @@ export class StacksService20201001 {
       stacks = [stacks.find(stack => stack.value === stackValue)];
     }
 
-    return this._hasNoFilterFlags(os, removeHiddenStacks, removeDeprecatedStacks, removePreviewStacks)
+    return this._hasNoFilterFlags(os, removeHiddenStacks, removeDeprecatedStacks, removePreviewStacks, removeNonGitHubActionStacks)
       ? stacks
-      : filterFunctionAppStacks(stacks, os, removeHiddenStacks, removeDeprecatedStacks, removePreviewStacks);
+      : filterFunctionAppStacks(stacks, os, removeHiddenStacks, removeDeprecatedStacks, removePreviewStacks, removeNonGitHubActionStacks);
   }
 
   getWebAppStacks(
@@ -50,7 +51,8 @@ export class StacksService20201001 {
     stackValue?: WebAppStackValue,
     removeHiddenStacks?: boolean,
     removeDeprecatedStacks?: boolean,
-    removePreviewStacks?: boolean
+    removePreviewStacks?: boolean,
+    removeNonGitHubActionStacks?: boolean
   ): WebAppStack[] {
     const dotnetStackCopy = JSON.parse(JSON.stringify(dotnetWebAppStack));
     const nodeStackCopy = JSON.parse(JSON.stringify(nodeWebAppStack));
@@ -74,17 +76,18 @@ export class StacksService20201001 {
       stacks = [stacks.find(stack => stack.value === stackValue)];
     }
 
-    return this._hasNoFilterFlags(os, removeHiddenStacks, removeDeprecatedStacks, removePreviewStacks)
+    return this._hasNoFilterFlags(os, removeHiddenStacks, removeDeprecatedStacks, removePreviewStacks, removeNonGitHubActionStacks)
       ? stacks
-      : filterWebAppStacks(stacks, os, removeHiddenStacks, removeDeprecatedStacks, removePreviewStacks);
+      : filterWebAppStacks(stacks, os, removeHiddenStacks, removeDeprecatedStacks, removePreviewStacks, removeNonGitHubActionStacks);
   }
 
   private _hasNoFilterFlags(
     os?: AppStackOs,
     removeHiddenStacks?: boolean,
     removeDeprecatedStacks?: boolean,
-    removePreviewStacks?: boolean
+    removePreviewStacks?: boolean,
+    removeNonGitHubActionStacks?: boolean
   ): boolean {
-    return !os && !removeHiddenStacks && !removeDeprecatedStacks && !removePreviewStacks;
+    return !os && !removeHiddenStacks && !removeDeprecatedStacks && !removePreviewStacks && !removeNonGitHubActionStacks;
   }
 }

--- a/server/src/stacks/2020-10-01/service/WebAppUtility.ts
+++ b/server/src/stacks/2020-10-01/service/WebAppUtility.ts
@@ -7,7 +7,8 @@ export function filterWebAppStacks(
   os?: AppStackOs,
   removeHiddenStacks?: boolean,
   removeDeprecatedStacks?: boolean,
-  removePreviewStacks?: boolean
+  removePreviewStacks?: boolean,
+  removeNonGitHubActionStacks?: boolean
 ): WebAppStack[] {
   stacks.forEach((stack, i) => {
     stack.majorVersions.forEach((majorVersion, j) => {
@@ -24,6 +25,9 @@ export function filterWebAppStacks(
         }
         if (removePreviewStacks) {
           _removePreviewRuntimeAndContainerSettings(stacks, i, j, k);
+        }
+        if (removeNonGitHubActionStacks) {
+          _removeNonGitHubActionRuntimeSettings(stacks, i, j, k);
         }
       });
 
@@ -125,5 +129,18 @@ function _removePreviewRuntimeAndContainerSettings(stacks: WebAppStack[], i: num
 
   if (linuxContainerSettings && linuxContainerSettings.isPreview) {
     delete stacks[i].majorVersions[j].minorVersions[k].stackSettings.linuxContainerSettings;
+  }
+}
+
+function _removeNonGitHubActionRuntimeSettings(stacks: WebAppStack[], i: number, j: number, k: number): void {
+  const windowsRuntimeSettings = stacks[i].majorVersions[j].minorVersions[k].stackSettings.windowsRuntimeSettings;
+  const linuxRuntimeSettings = stacks[i].majorVersions[j].minorVersions[k].stackSettings.linuxRuntimeSettings;
+
+  if (windowsRuntimeSettings && !windowsRuntimeSettings.gitHubActionSettings.isSupported) {
+    delete stacks[i].majorVersions[j].minorVersions[k].stackSettings.windowsRuntimeSettings;
+  }
+
+  if (linuxRuntimeSettings && !linuxRuntimeSettings.gitHubActionSettings.isSupported) {
+    delete stacks[i].majorVersions[j].minorVersions[k].stackSettings.linuxRuntimeSettings;
   }
 }

--- a/server/src/stacks/stacks.controller.ts
+++ b/server/src/stacks/stacks.controller.ts
@@ -16,6 +16,7 @@ import {
   validateRemoveDeprecatedStacks,
   validateRemovePreviewStacks,
   validateWebAppStack,
+  validateRemoveNonGitHubActionStacks,
 } from './validations';
 
 @Controller('stacks')
@@ -33,7 +34,8 @@ export class StacksController {
     @Query('stack') stack?: string,
     @Query('removeHiddenStacks') removeHiddenStacks?: string,
     @Query('removeDeprecatedStacks') removeDeprecatedStacks?: string,
-    @Query('removePreviewStacks') removePreviewStacks?: string
+    @Query('removePreviewStacks') removePreviewStacks?: string,
+    @Query('removeNonGitHubActionStacks') removeNonGitHubActionStacks?: string
   ) {
     validateApiVersion(apiVersion, [Versions.version20200601, Versions.version20201001]);
     validateOs(os);
@@ -41,10 +43,12 @@ export class StacksController {
     validateRemoveHiddenStacks(removeHiddenStacks);
     validateRemoveDeprecatedStacks(removeDeprecatedStacks);
     validateRemovePreviewStacks(removePreviewStacks);
+    validateRemoveNonGitHubActionStacks(removeNonGitHubActionStacks);
 
     const removeHidden = removeHiddenStacks && removeHiddenStacks.toLowerCase() === 'true';
     const removeDeprecated = removeDeprecatedStacks && removeDeprecatedStacks.toLowerCase() === 'true';
     const removePreview = removePreviewStacks && removePreviewStacks.toLowerCase() === 'true';
+    const removeNonGitHubAction = removeNonGitHubActionStacks && removeNonGitHubActionStacks.toLowerCase() === 'true';
 
     switch (apiVersion) {
       case Versions.version20200601: {
@@ -62,7 +66,8 @@ export class StacksController {
           stack as FunctionAppStack20201001Value,
           removeHidden,
           removeDeprecated,
-          removePreview
+          removePreview,
+          removeNonGitHubAction
         );
       }
     }
@@ -75,7 +80,8 @@ export class StacksController {
     @Query('stack') stack?: string,
     @Query('removeHiddenStacks') removeHiddenStacks?: string,
     @Query('removeDeprecatedStacks') removeDeprecatedStacks?: string,
-    @Query('removePreviewStacks') removePreviewStacks?: string
+    @Query('removePreviewStacks') removePreviewStacks?: string,
+    @Query('removeNonGitHubActionStacks') removeNonGitHubActionStacks?: string
   ) {
     validateApiVersion(apiVersion, [Versions.version20200601, Versions.version20201001]);
     validateOs(os);
@@ -83,10 +89,12 @@ export class StacksController {
     validateRemoveHiddenStacks(removeHiddenStacks);
     validateRemoveDeprecatedStacks(removeDeprecatedStacks);
     validateRemovePreviewStacks(removePreviewStacks);
+    validateRemoveNonGitHubActionStacks(removeNonGitHubActionStacks);
 
     const removeHidden = removeHiddenStacks && removeHiddenStacks.toLowerCase() === 'true';
     const removeDeprecated = removeDeprecatedStacks && removeDeprecatedStacks.toLowerCase() === 'true';
     const removePreview = removePreviewStacks && removePreviewStacks.toLowerCase() === 'true';
+    const removeNonGitHubAction = removeNonGitHubActionStacks && removeNonGitHubActionStacks.toLowerCase() === 'true';
 
     switch (apiVersion) {
       case Versions.version20200601: {
@@ -104,7 +112,8 @@ export class StacksController {
           stack as WebAppStack20201001Value,
           removeHidden,
           removeDeprecated,
-          removePreview
+          removePreview,
+          removeNonGitHubAction
         );
       }
     }

--- a/server/src/stacks/validations.ts
+++ b/server/src/stacks/validations.ts
@@ -100,3 +100,16 @@ export function validateRemovePreviewStacks(removePreviewStacks?: string) {
     );
   }
 }
+
+export function validateRemoveNonGitHubActionStacks(removeNonGitHubActionStacks?: string) {
+  if (
+    removeNonGitHubActionStacks &&
+    removeNonGitHubActionStacks.toLowerCase() !== 'true' &&
+    removeNonGitHubActionStacks.toLowerCase() !== 'false'
+  ) {
+    throw new HttpException(
+      `Incorrect removeNonGitHubActionStacks '${removeNonGitHubActionStacks}' provided. Allowed removeNonGitHubActionStacks values are 'true' or 'false'.`,
+      400
+    );
+  }
+}

--- a/server/src/tests/Stacks/2020-10-01/function-app/tests.ts
+++ b/server/src/tests/Stacks/2020-10-01/function-app/tests.ts
@@ -1,4 +1,5 @@
 import { StacksService20201001 } from '../../../../stacks/2020-10-01/service/StackService';
+import { validateGitHubActionStacks } from '../web-app/validations';
 import {
   validateAllStackLength,
   validateWindowsStacks,
@@ -181,6 +182,15 @@ describe('FunctionApp Stacks Test 2020-10-01', () => {
     it('should validate the Custom stack filter', done => {
       const stacks = stacksService.getFunctionAppStacks(undefined, 'custom');
       validateCustomStackFilter(stacks);
+      done();
+    });
+  });
+
+  // Test GitHub Action stacks
+  describe('Test remove non github action stacks', () => {
+    it('should validate only stacks supporting GitHub Action are returned', done => {
+      const stacks = stacksService.getFunctionAppStacks(undefined, undefined, undefined, undefined, undefined, true);
+      validateGitHubActionStacks(stacks);
       done();
     });
   });

--- a/server/src/tests/Stacks/2020-10-01/web-app/tests.ts
+++ b/server/src/tests/Stacks/2020-10-01/web-app/tests.ts
@@ -20,6 +20,7 @@ import {
   validateJavaFilter,
   validateJavaContainersInStacks,
   validateJavaContainersFilter,
+  validateGitHubActionStacks,
 } from './validations';
 
 const stacksService = new StacksService20201001();
@@ -201,6 +202,15 @@ describe('WebApp Stacks Test 2020-10-01', () => {
     it('should validate the Java Containers stack filter', done => {
       const stacks = stacksService.getWebAppStacks(undefined, 'javacontainers');
       validateJavaContainersFilter(stacks);
+      done();
+    });
+  });
+
+  // Test GitHub Action stacks
+  describe('Test remove non github action stacks', () => {
+    it('should validate only stacks supporting GitHub Action are returned', done => {
+      const stacks = stacksService.getWebAppStacks(undefined, undefined, undefined, undefined, undefined, true);
+      validateGitHubActionStacks(stacks);
       done();
     });
   });

--- a/server/src/tests/Stacks/2020-10-01/web-app/validations.ts
+++ b/server/src/tests/Stacks/2020-10-01/web-app/validations.ts
@@ -118,6 +118,11 @@ export function validateNotPreviewStacks(stacks) {
   validateStacksAreNotPreview(stacks);
 }
 
+export function validateGitHubActionStacks(stacks) {
+  expect(stacks).to.be.an('array');
+  expect(stacks.length).to.equal(5);
+}
+
 function validateNotPreviewStacksLength(stacks) {
   expect(stacks).to.be.an('array');
   expect(stacks.length).to.equal(7);

--- a/server/src/tests/Stacks/2020-10-01/web-app/validations.ts
+++ b/server/src/tests/Stacks/2020-10-01/web-app/validations.ts
@@ -118,11 +118,6 @@ export function validateNotPreviewStacks(stacks) {
   validateStacksAreNotPreview(stacks);
 }
 
-export function validateGitHubActionStacks(stacks) {
-  expect(stacks).to.be.an('array');
-  expect(stacks.length).to.equal(5);
-}
-
 function validateNotPreviewStacksLength(stacks) {
   expect(stacks).to.be.an('array');
   expect(stacks.length).to.equal(7);
@@ -280,4 +275,31 @@ function validateJavaContainersStack(javaContainersStack) {
   expect(javaContainersStack.preferredOs).to.equal(undefined);
   expect(javaContainersStack.majorVersions.length).to.equal(9);
   expect(javaContainersStack).to.deep.equal(hardCodedJavaContainersStack);
+}
+
+export function validateGitHubActionStacks(stacks) {
+  validateGitHubActionStacksLength(stacks);
+  validateGitHubActionStacksProperties(stacks);
+}
+
+function validateGitHubActionStacksLength(stacks) {
+  expect(stacks).to.be.an('array');
+  expect(stacks.length).to.equal(5);
+}
+
+function validateGitHubActionStacksProperties(stacks) {
+  stacks.forEach(stack => {
+    expect(stack.majorVersions).to.be.an('array');
+    stack.majorVersions.forEach(majorVersion => {
+      expect(majorVersion.minorVersions).to.be.an('array');
+      majorVersion.minorVersions.forEach(minorVersion => {
+        if (minorVersion.stackSettings.windowsRuntimeSettings) {
+          expect(minorVersion.stackSettings.windowsRuntimeSettings.gitHubActionSettings).to.have.property('isSupported', true);
+        }
+        if (minorVersion.stackSettings.linuxRuntimeSettings) {
+          expect(minorVersion.stackSettings.linuxRuntimeSettings.gitHubActionSettings).to.have.property('isSupported', true);
+        }
+      });
+    });
+  });
 }


### PR DESCRIPTION
Sample url - https://localhost:44400/stacks/functionAppStacks?os=windows&removeHiddenStacks=true&removeDeprecatedStacks=true&removeNonGitHubActionStacks=true&api-version=2020-10-01

Currently this is not used by the client, I will another PR that focuses on the client side changes. Also this is for stacks that are supported from 2020-10-01 API version.