### PR TITLE
AB#9219848 [Spec Picker] Hide free sku from spec picker for all (Linux as well as Windows) FunctionApp creates

### DIFF
--- a/client/src/app/site/spec-picker/price-spec-manager/free-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/free-plan-price-spec.ts
@@ -80,13 +80,11 @@ export class FreePlanPriceSpec extends PriceSpec {
       isLinux = input.specPickerInput.data.isLinux;
       if (isLinux) {
         this.topLevelFeatures.shift();
-        // NOTE(shimedh): Linux FunctionApp's don't work on Free sku's. Hide Free sku for Linux FunctionApp create scenario.
-        if (input.specPickerInput.data.isFunctionApp) {
-          this.state = 'hidden';
-        }
       }
 
+      // NOTE(shimedh): FunctionApp's don't work on Free sku's (Linux as well as Windows). Hide Free sku for Linux FunctionApp create scenario.
       if (
+        input.specPickerInput.data.isFunctionApp ||
         input.specPickerInput.data.hostingEnvironmentName ||
         input.specPickerInput.data.isXenon ||
         input.specPickerInput.data.hyperV ||


### PR DESCRIPTION
Fixes AB#9219848 

Will send a PR separately on the Ibiza side to allow only Consumption for Free and Dreamspark subscriptions for both Linux and Windows.