### PR TITLE
Handle dot net core stacks (need this after the API Version update)

### DIFF
--- a/client-react/src/pages/app/app-settings/GeneralSettings/WindowsStacks/DotNetStack.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/WindowsStacks/DotNetStack.tsx
@@ -121,6 +121,12 @@ const DotNetStack: React.SFC<StackProps> = props => {
   );
 };
 
+// NOTE (krmitta) - For dotnetcore we don't store any version on the backend,
+// so will be showing a single item - .NET Core under .NET stack to prevent from mis-leading the user.
+// We cannot have different .NET Core versions in the dropdown since we have no way of mapping a user to a particular version.
+// Thus, we are removing all the .NET Core versions from the stacks API response.
+// But if we had a valid windowsRuntimeSettings for one or more .NET Core stacks,
+// we simply add a default .NET Core majorVersion stack which needs to be hard-coded for this specific scenario.
 const mergeDotnetcoreStacks = (stack?: WebAppStack): WebAppStack | undefined => {
   if (!!stack) {
     const majorVersions = [...stack.majorVersions];

--- a/client-react/src/pages/app/app-settings/GeneralSettings/WindowsStacks/WindowsStacks.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/WindowsStacks/WindowsStacks.tsx
@@ -1,5 +1,5 @@
 import { Field, FormikProps } from 'formik';
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Dropdown from '../../../../../components/form-controls/DropDown';
 import { AppSettingsFormValues } from '../../AppSettings.types';
@@ -21,6 +21,8 @@ const WindowsStacks: React.FC<StackProps> = props => {
   const disableAllControls = readonly || !editable || saving;
   const javaSelected = values.currentlySelectedStack === RuntimeStacks.java;
   const showNonJavaAnyway = readonly && !javaSelected;
+
+  const [initialStackDropdownValue, setInitialStackDropdownValue] = useState<string | undefined>(undefined);
 
   const supportedStacks = useContext(WebAppStacksContext);
 
@@ -45,6 +47,17 @@ const WindowsStacks: React.FC<StackProps> = props => {
       });
   };
 
+  const setInitialDropdownValues = (values: AppSettingsFormValues) => {
+    setInitialStackDropdownValue(
+      values.currentlySelectedStack.toLowerCase() === RuntimeStacks.dotnetcore ? RuntimeStacks.dotnet : values.currentlySelectedStack
+    );
+  };
+
+  useEffect(() => {
+    setInitialDropdownValues(initialValues);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialValues.currentlySelectedStack]);
   return (
     <>
       <Field
@@ -56,8 +69,13 @@ const WindowsStacks: React.FC<StackProps> = props => {
         options={filterStackOptions()}
         label={t('stack')}
         id="app-settings-stack-dropdown"
+        defaultSelectedKey={initialStackDropdownValue}
       />
-      {values.currentlySelectedStack === RuntimeStacks.dotnet || showNonJavaAnyway ? <DotNetStack {...props} /> : null}
+      {values.currentlySelectedStack === RuntimeStacks.dotnet ||
+      values.currentlySelectedStack === RuntimeStacks.dotnetcore ||
+      showNonJavaAnyway ? (
+        <DotNetStack {...props} />
+      ) : null}
       {values.currentlySelectedStack === RuntimeStacks.php || showNonJavaAnyway ? <PhpStack {...props} /> : null}
       {values.currentlySelectedStack === RuntimeStacks.python || showNonJavaAnyway ? <PythonStack {...props} /> : null}
       {javaSelected ? <JavaStack {...props} /> : null}

--- a/client-react/src/utils/stacks-utils.tsx
+++ b/client-react/src/utils/stacks-utils.tsx
@@ -281,11 +281,11 @@ export const RuntimeStacks = {
 };
 
 export const defaultDotnetCoreMajorVersion = {
-  displayText: '.NET Core',
+  displayText: '.NET Core (3.1, 2.1)',
   value: '.NET Core',
   minorVersions: [
     {
-      displayText: '.NET Core',
+      displayText: '.NET Core (3.1, 2.1)',
       value: '.NET Core',
       stackSettings: {
         windowsRuntimeSettings: {

--- a/client-react/src/utils/stacks-utils.tsx
+++ b/client-react/src/utils/stacks-utils.tsx
@@ -277,4 +277,28 @@ export const RuntimeStacks = {
   php: 'php',
   powershell: 'powershell',
   dotnet: 'dotnet',
+  dotnetcore: 'dotnetcore',
+};
+
+export const defaultDotnetCoreMajorVersion = {
+  displayText: '.NET Core',
+  value: '.NET Core',
+  minorVersions: [
+    {
+      displayText: '.NET Core',
+      value: '.NET Core',
+      stackSettings: {
+        windowsRuntimeSettings: {
+          runtimeVersion: RuntimeStacks.dotnetcore,
+          remoteDebuggingSupported: false,
+          appInsightsSettings: {
+            isSupported: false,
+          },
+          gitHubActionSettings: {
+            isSupported: false,
+          },
+        },
+      },
+    },
+  ],
 };


### PR DESCRIPTION
With the recent Stacks API Update, `Dotnet` and `Dotnetcore` stacks are merged into one.

But on the backend we still shouldn't be updating `config.properties.netFrameworkVersion` in case of dotnetcore (instead only metadata needs to be updated), so this PR takes care of updating the metadata when dotnetcore is selected. 

Also, since we are not storing any version for dotnetcore, it is mis-leading to show different dotnetcore versions in the dropdown and also we won't be able to map the correct dropdown value (since there is no version property for dotnetcore).
The PR also takes care of this part, i.e. merging all the dotnetcore stacks version into one general dotnetcore stack item.