### PR TITLE
Additional logging and error messages for ACR scenarios.

### DIFF
--- a/client-react/src/ApiHelpers/ACRService.ts
+++ b/client-react/src/ApiHelpers/ACRService.ts
@@ -102,7 +102,7 @@ export default class ACRService {
       } else {
         nextLink = '';
         if (logger) {
-          logger(page, response.metadata.error);
+          logger(page, response);
         }
       }
 

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
@@ -5,9 +5,11 @@ import { DeploymentCenterContext } from '../DeploymentCenterContext';
 import { IDropdownOption, MessageBarType } from 'office-ui-fabric-react';
 import DeploymentCenterData from '../DeploymentCenter.data';
 import { getErrorMessage } from '../../../../ApiHelpers/ArmHelper';
-import { ACRCredential } from '../../../../models/acr';
+import { ACRCredential, ACRRepositories, ACRTags } from '../../../../models/acr';
 import { getTelemetryInfo } from '../utility/DeploymentCenterUtility';
 import { PortalContext } from '../../../../PortalContext';
+import { useTranslation } from 'react-i18next';
+import { HttpResponseObject } from '../../../../ArmHelper.types';
 
 interface RegistryIdentifiers {
   resourceId: string;
@@ -17,6 +19,8 @@ interface RegistryIdentifiers {
 
 const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProps<DeploymentCenterContainerFormData>> = props => {
   const { formProps } = props;
+  const { t } = useTranslation();
+
   const deploymentCenterData = new DeploymentCenterData();
   const deploymentCenterContext = useContext(DeploymentCenterContext);
   const portalContext = useContext(PortalContext);
@@ -48,37 +52,45 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
       portalContext.log(getTelemetryInfo('info', 'getAcrRegistries', 'submit'));
       const registriesResponse = await deploymentCenterData.getAcrRegistries(deploymentCenterContext.siteDescriptor.subscription);
       if (registriesResponse.metadata.success && registriesResponse.data) {
-        const adminEnabledRegistries = registriesResponse.data.value.filter(registry => registry.properties.adminUserEnabled);
-        const dropdownOptions: IDropdownOption[] = [];
+        if (registriesResponse.data.value.length > 0) {
+          const dropdownOptions: IDropdownOption[] = [];
 
-        adminEnabledRegistries.forEach(registry => {
-          registryIdentifiers.current[registry.properties.loginServer.toLocaleLowerCase()] = {
-            resourceId: registry.id,
-            location: registry.location,
-          };
+          registriesResponse.data.value.forEach(registry => {
+            registryIdentifiers.current[registry.properties.loginServer.toLocaleLowerCase()] = {
+              resourceId: registry.id,
+              location: registry.location,
+            };
 
-          dropdownOptions.push({
-            key: registry.properties.loginServer.toLocaleLowerCase(),
-            text: registry.name,
+            dropdownOptions.push({
+              key: registry.properties.loginServer.toLocaleLowerCase(),
+              text: registry.name,
+            });
           });
-        });
 
-        setAcrRegistryOptions(dropdownOptions);
+          setAcrRegistryOptions(dropdownOptions);
 
-        if (formProps.values.acrLoginServer) {
-          fetchRepositories(formProps.values.acrLoginServer);
+          if (formProps.values.acrLoginServer) {
+            fetchRepositories(formProps.values.acrLoginServer);
+          }
+        } else {
+          setAcrStatusMessage(
+            t('deploymentCenterContainerAcrRegistrieNotAvailable').format(deploymentCenterContext.siteDescriptor.subscription)
+          );
+          setAcrStatusMessageType(MessageBarType.warning);
         }
       } else {
         const errorMessage = getErrorMessage(registriesResponse.metadata.error);
-        if (errorMessage) {
-          setAcrStatusMessage(errorMessage);
-          setAcrStatusMessageType(MessageBarType.error);
-        }
+        const statusMessage = errorMessage
+          ? t('deploymentCenterContainerAcrFailedToLoadRegistriesWithError').format(errorMessage)
+          : t('deploymentCenterContainerAcrFailedToLoadRegistries');
+
+        setAcrStatusMessage(statusMessage);
+        setAcrStatusMessageType(MessageBarType.error);
 
         portalContext.log(
           getTelemetryInfo('error', 'registriesResponse', 'failed', {
             message: getErrorMessage(registriesResponse.metadata.error),
-            errorAsString: JSON.stringify(registriesResponse.metadata.error),
+            error: registriesResponse.metadata.error,
           })
         );
       }
@@ -100,38 +112,52 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
       const credentialsResponse = await deploymentCenterData.listAcrCredentials(selectedRegistryIdentifier.resourceId);
 
       if (credentialsResponse.metadata.success && credentialsResponse.data.passwords && credentialsResponse.data.passwords.length > 0) {
-        selectedRegistryIdentifier.credential = credentialsResponse.data;
+        registryIdentifiers.current[loginServer].credential = credentialsResponse.data;
       } else {
         const errorMessage = getErrorMessage(credentialsResponse.metadata.error);
-        if (errorMessage) {
-          setAcrStatusMessage(errorMessage);
-          setAcrStatusMessageType(MessageBarType.error);
-        }
+        const statusMessage = errorMessage
+          ? t('deploymentCenterContainerAcrFailedToLoadCredentialsWithError').format(errorMessage)
+          : t('deploymentCenterContainerAcrFailedToLoadCredentials');
+
+        setAcrStatusMessage(statusMessage);
+        setAcrStatusMessageType(MessageBarType.error);
 
         portalContext.log(
           getTelemetryInfo('error', 'credentialsResponse', 'failed', {
             message: getErrorMessage(credentialsResponse.metadata.error),
-            errorAsString: JSON.stringify(credentialsResponse.metadata.error),
+            error: credentialsResponse.metadata.error,
           })
         );
       }
     }
 
-    const credentials = selectedRegistryIdentifier.credential;
+    const credentials = registryIdentifiers.current[loginServer].credential;
 
     if (credentials) {
       const username = credentials.username;
       const password = credentials.passwords[0].value;
+      let failedNetworkCall = false;
+      let errorMessage = '';
 
       portalContext.log(getTelemetryInfo('info', 'getAcrRepositories', 'submit'));
-      const repositoriesResponse = await deploymentCenterData.getAcrRepositories(loginServer, username, password, (page, response) => {
-        portalContext.log(
-          getTelemetryInfo('error', 'getAcrRepositoriesResponse', 'failed', {
-            page: page,
-            errorAsString: response && response.metadata && response.metadata.error && JSON.stringify(response.metadata.error),
-          })
-        );
-      });
+      const repositoriesResponse = await deploymentCenterData.getAcrRepositories(
+        loginServer,
+        username,
+        password,
+        (page, response: HttpResponseObject<ACRRepositories>) => {
+          portalContext.log(
+            // NOTE(michinoy): 2021-02-04, Generally a bad idea to log the entire response object. But I am unable to identify what error is being returned,
+            // thus logging the entire response object.
+            getTelemetryInfo('error', 'getAcrRepositoriesResponse', 'failed', {
+              page: page,
+              error: response.metadata.error,
+            })
+          );
+
+          failedNetworkCall = response.metadata.success;
+          errorMessage = getErrorMessage(response.metadata.error);
+        }
+      );
 
       const repositoryOptions: IDropdownOption[] = [];
       repositoriesResponse.forEach(response => {
@@ -141,6 +167,15 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
             : [];
         repositoryOptions.push(...dropdownOptions);
       });
+
+      if (repositoryOptions.length === 0 && failedNetworkCall) {
+        const statusMessage = errorMessage
+          ? t('deploymentCenterContainerAcrFailedToLoadImagesWithError').format(errorMessage)
+          : t('deploymentCenterContainerAcrFailedToLoadImages');
+
+        setAcrStatusMessage(statusMessage);
+        setAcrStatusMessageType(MessageBarType.error);
+      }
 
       formProps.setFieldValue('acrResourceId', selectedRegistryIdentifier.resourceId);
       formProps.setFieldValue('acrLocation', selectedRegistryIdentifier.location);
@@ -168,16 +203,29 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
     if (credentials) {
       const username = credentials.username;
       const password = credentials.passwords[0].value;
+      let failedNetworkCall = false;
+      let errorMessage = '';
 
       portalContext.log(getTelemetryInfo('info', 'getAcrTags', 'submit'));
-      const tagsResponse = await deploymentCenterData.getAcrTags(loginServer, imageSelected, username, password, (page, response) => {
-        portalContext.log(
-          getTelemetryInfo('error', 'getAcrTagsResponse', 'failed', {
-            page: page,
-            errorAsString: response && response.metadata && response.metadata.error && JSON.stringify(response.metadata.error),
-          })
-        );
-      });
+      const tagsResponse = await deploymentCenterData.getAcrTags(
+        loginServer,
+        imageSelected,
+        username,
+        password,
+        (page, response: HttpResponseObject<ACRTags>) => {
+          portalContext.log(
+            // NOTE(michinoy): 2021-02-04, Generally a bad idea to log the entire response object. But I am unable to identify what error is being returned,
+            // thus logging the entire response object.
+            getTelemetryInfo('error', 'getAcrTagsResponse', 'failed', {
+              page: page,
+              error: response.metadata.error,
+            })
+          );
+
+          failedNetworkCall = response.metadata.success;
+          errorMessage = getErrorMessage(response.metadata.error);
+        }
+      );
 
       const tagOptions: IDropdownOption[] = [];
       tagsResponse.forEach(response => {
@@ -185,6 +233,15 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
           response && response.tags && response.tags.length > 0 ? response.tags.map(tag => ({ key: tag, text: tag })) : [];
         tagOptions.push(...dropdownOptions);
       });
+
+      if (tagOptions.length === 0 && failedNetworkCall) {
+        const statusMessage = errorMessage
+          ? t('deploymentCenterContainerAcrFailedToLoadTagsWithError').format(errorMessage)
+          : t('deploymentCenterContainerAcrFailedToLoadTags');
+
+        setAcrStatusMessage(statusMessage);
+        setAcrStatusMessageType(MessageBarType.error);
+      }
 
       setAcrTagOptions(tagOptions);
     }

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2255,4 +2255,14 @@ export class PortalResources {
   public static classicContainerSettingDeprecationMessage = 'classicContainerSettingDeprecationMessage';
   public static classicDeploymentCenterDeprecationMessage = 'classicDeploymentCenterDeprecationMessage';
   public static netVersionLabel = 'netVersionLabel';
+  public static deploymentCenterContainerAcrRegistrieNotAvailable = 'deploymentCenterContainerAcrRegistrieNotAvailable';
+  public static deploymentCenterContainerAcrFailedToLoadRegistriesWithError = 'deploymentCenterContainerAcrFailedToLoadRegistriesWithError';
+  public static deploymentCenterContainerAcrFailedToLoadRegistries = 'deploymentCenterContainerAcrFailedToLoadRegistries';
+  public static deploymentCenterContainerAcrFailedToLoadCredentialsWithError =
+    'deploymentCenterContainerAcrFailedToLoadCredentialsWithError';
+  public static deploymentCenterContainerAcrFailedToLoadCredentials = 'deploymentCenterContainerAcrFailedToLoadCredentials';
+  public static deploymentCenterContainerAcrFailedToLoadImagesWithError = 'deploymentCenterContainerAcrFailedToLoadImagesWithError';
+  public static deploymentCenterContainerAcrFailedToLoadImages = 'deploymentCenterContainerAcrFailedToLoadImages';
+  public static deploymentCenterContainerAcrFailedToLoadTagsWithError = 'deploymentCenterContainerAcrFailedToLoadTagsWithError';
+  public static deploymentCenterContainerAcrFailedToLoadTags = 'deploymentCenterContainerAcrFailedToLoadTags';
 }

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -6912,4 +6912,31 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="netVersionLabel" xml:space="preserve">
         <value>.NET version</value>
     </data>
+    <data name="deploymentCenterContainerAcrRegistrieNotAvailable" xml:space="preserve">
+        <value>No ACR Registeries are available in Subscription '{0}'.</value>
+    </data>
+    <data name="deploymentCenterContainerAcrFailedToLoadRegistriesWithError" xml:space="preserve">
+        <value>Failed to load ACR Registries - {0}.</value>
+    </data>
+    <data name="deploymentCenterContainerAcrFailedToLoadRegistries" xml:space="preserve">
+        <value>Failed to load ACR Registries.</value>
+    </data>
+    <data name="deploymentCenterContainerAcrFailedToLoadCredentialsWithError" xml:space="preserve">
+        <value>Failed to load ACR Credentials needed to load Images and Tags - {0}.</value>
+    </data>
+    <data name="deploymentCenterContainerAcrFailedToLoadCredentials" xml:space="preserve">
+        <value>Failed to load ACR Credentials needed to load Images and Tags.</value>
+    </data>
+    <data name="deploymentCenterContainerAcrFailedToLoadImagesWithError" xml:space="preserve">
+        <value>Failed to load ACR Images - {0}.</value>
+    </data>
+    <data name="deploymentCenterContainerAcrFailedToLoadImages" xml:space="preserve">
+        <value>Failed to load ACR Images</value>
+    </data>
+    <data name="deploymentCenterContainerAcrFailedToLoadTagsWithError" xml:space="preserve">
+        <value>Failed to load ACR Tags - {0}.</value>
+    </data>
+    <data name="deploymentCenterContainerAcrFailedToLoadTags" xml:space="preserve">
+        <value>Failed to load ACR Tags.</value>
+    </data>
 </root>


### PR DESCRIPTION
fixes AB#9258239
fixes AB#9266341
The only scenario that I am able to replicate is credential where the ACR registry is not admin enabled. For all the other ones, the error object in the logs is null and we are not showing the error message on the screen in case of a failure. This change updates our logging strategy and shows additional messages on the screen in case of failures. There really aren't any screenshots I can share, till I understand through logs how to identify these issues.