### PR TITLE
Mark PHP 7.2 as deprecated

### DIFF
--- a/server/src/stacks/2020-05-01/stacks/web-app-stacks/config/linux/Php.ts
+++ b/server/src/stacks/2020-05-01/stacks/web-app-stacks/config/linux/Php.ts
@@ -75,7 +75,7 @@ export const phpLinuxConfigStack: WebAppConfigStack = {
         ],
         applicationInsights: false,
         isPreview: false,
-        isDeprecated: false,
+        isDeprecated: true,
         isHidden: false,
       },
       {

--- a/server/src/stacks/2020-05-01/stacks/web-app-stacks/config/windows/Php.ts
+++ b/server/src/stacks/2020-05-01/stacks/web-app-stacks/config/windows/Php.ts
@@ -46,7 +46,7 @@ export const phpWindowsConfigStack: WebAppConfigStack = {
         minorVersions: [],
         applicationInsights: false,
         isPreview: false,
-        isDeprecated: false,
+        isDeprecated: true,
         isHidden: false,
       },
       {

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Php.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Php.ts
@@ -78,6 +78,7 @@ export const phpStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'PHP|7.2',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
@@ -89,6 +90,7 @@ export const phpStack: WebAppStack = {
             },
             windowsRuntimeSettings: {
               runtimeVersion: '7.2',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Php.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Php.ts
@@ -78,6 +78,7 @@ export const phpStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'PHP|7.2',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
@@ -89,6 +90,7 @@ export const phpStack: WebAppStack = {
             },
             windowsRuntimeSettings: {
               runtimeVersion: '7.2',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,


### PR DESCRIPTION
PHP 7.2 has reached EOL and Byron sent out reminders to customers to upgrade their sites to 7.4. ANT 93 will upgrade everyone from 7.2 to 7.4. The intent is to hide PHP 7.2 as an option on Windows and Linux.