### PR TITLE
Make the close (X) button tab-able and add an event handler for enter and spacebar.

### DIFF
--- a/client-react/src/components/CustomPanel/CustomPanel.styles.ts
+++ b/client-react/src/components/CustomPanel/CustomPanel.styles.ts
@@ -12,12 +12,15 @@ export const panelHeaderStyle = style({
       fontSize: '20px',
     },
 
-    svg: {
-      height: '12px',
-      width: '12px',
+    div: {
       float: 'right',
       marginTop: '18px',
       marginRight: '3px',
+    },
+
+    svg: {
+      height: '12px',
+      width: '12px',
       cursor: 'pointer',
     },
   },

--- a/client-react/src/components/CustomPanel/CustomPanel.tsx
+++ b/client-react/src/components/CustomPanel/CustomPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Panel as OfficePanel, IPanelProps, PanelType, Overlay } from 'office-ui-fabric-react';
+import { Panel as OfficePanel, IPanelProps, PanelType, Overlay, KeyCodes } from 'office-ui-fabric-react';
 import { ReactComponent as CloseSvg } from '../../images/Common/close.svg';
 import { useTranslation } from 'react-i18next';
 import { panelStyle, panelHeaderStyle, panelBodyStyle, closeButtonStyle } from './CustomPanel.styles';
@@ -26,10 +26,22 @@ const CustomPanel: React.SFC<CustomPanelProps & IPanelPropsReduced> = props => {
 
   const onRenderNavigationContent = panelProps => {
     const onClick = panelProps.onDismiss && (() => panelProps.onDismiss!());
+
+    const onKeyUp = event => {
+      if (event.keyCode === KeyCodes.enter || event.keyCode === KeyCodes.space) {
+        event.preventDefault();
+        if (panelProps.onDismiss) {
+          panelProps.onDismiss();
+        }
+      }
+    };
+
     return (
       <div className={panelHeaderStyle}>
         {headerText && <h3>{headerText}</h3>}
-        <CloseSvg onClick={onClick} role="button" aria-label={t('close')} className={closeButtonStyle(theme)} />
+        <div onKeyUp={onKeyUp} tabIndex={0}>
+          <CloseSvg onClick={onClick} role="button" aria-label={t('close')} className={closeButtonStyle(theme)} focusable="true" />
+        </div>
         {!!headerContent && headerContent}
       </div>
     );


### PR DESCRIPTION
fixes AB#8964875
fixes AB#8964940

The UX look and feel has not changed at all.
![image](https://user-images.githubusercontent.com/493476/107409772-5dced300-6ac1-11eb-9021-7bb258ae2abf.png)


![image](https://user-images.githubusercontent.com/493476/107409819-69ba9500-6ac1-11eb-8248-c050cdbe9029.png)


![image](https://user-images.githubusercontent.com/493476/107409927-8060ec00-6ac1-11eb-9a99-80b1f8eec057.png)
