### PR TITLE
New Java versions added in ANT 91, 92

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Java.ts
@@ -48,6 +48,43 @@ export const javaStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java 11.0.9',
+          value: '11.0.9',
+          stackSettings: {
+            linuxRuntimeSettings: {
+              // Note (allisonm): Runtime on Linux Java is determined by the Java container
+              runtimeVersion: '',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: false,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '11',
+              },
+              endOfLifeDate: java11EOL,
+            },
+          },
+        },
+        {
+          displayText: 'Java 11.0.8',
+          value: '11.0.8',
+          stackSettings: {
+            windowsRuntimeSettings: {
+              runtimeVersion: '11.0.8',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: false,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '11',
+              },
+              endOfLifeDate: java11EOL,
+            },
+          },
+        },
+        {
           displayText: 'Java 11.0.7',
           value: '11.0.7',
           stackSettings: {
@@ -205,6 +242,24 @@ export const javaStack: WebAppStack = {
             windowsRuntimeSettings: {
               runtimeVersion: '1.8',
               isAutoUpdate: true,
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: false,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '8',
+              },
+              endOfLifeDate: java8EOL,
+            },
+          },
+        },
+        {
+          displayText: 'Java 1.8.0_265',
+          value: '8.0.265',
+          stackSettings: {
+            windowsRuntimeSettings: {
+              runtimeVersion: '1.8.0_265',
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
@@ -578,6 +633,24 @@ export const javaStack: WebAppStack = {
             windowsRuntimeSettings: {
               runtimeVersion: '1.7',
               isAutoUpdate: true,
+              isDeprecated: true,
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: false,
+              },
+              gitHubActionSettings: {
+                isSupported: false,
+              },
+              endOfLifeDate: java7EOL,
+            },
+          },
+        },
+        {
+          displayText: 'Java 1.7.0_272',
+          value: '7.0.272',
+          stackSettings: {
+            windowsRuntimeSettings: {
+              runtimeVersion: '1.7.0_272_ZULU',
               isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
@@ -26,6 +26,16 @@ export const javaContainersStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java SE 11.0.9',
+          value: '11.0.9',
+          stackSettings: {
+            linuxContainerSettings: {
+              // Note (jafreebe): This doesn't have suffix of -java11 since setting to 11.0.8 prevents auto-updates
+              java11Runtime: 'JAVA|11.0.9',
+            },
+          },
+        },
+        {
           displayText: 'Java SE 11.0.7',
           value: '11.0.7',
           stackSettings: {
@@ -92,6 +102,18 @@ export const javaContainersStack: WebAppStack = {
       value: 'jbosseap',
       minorVersions: [
         {
+          displayText: 'JBoss EAP 7',
+          value: '7',
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: 'JBOSSEAP|7.2-java8',
+              java11Runtime: "JBOSSEAP|7-java11",
+              isPreview: true,
+              isAutoUpdate: true
+            },
+          },
+        },
+        {
           displayText: 'JBoss EAP 7.2',
           value: '7.2',
           stackSettings: {
@@ -99,8 +121,8 @@ export const javaContainersStack: WebAppStack = {
               java8Runtime: 'JBOSSEAP|7.2-java8',
               isPreview: true,
             },
-          },
-        },
+          }
+        }
       ],
     },
     {
@@ -121,6 +143,26 @@ export const javaContainersStack: WebAppStack = {
               java8Runtime: 'TOMCAT|9.0-jre8',
               isAutoUpdate: true,
             },
+          },
+        },
+        {
+          displayText: "Tomcat 9.0.41",
+          value: "9.0.41",
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: "TOMCAT|9.0.41-java8",
+              java11Runtime: "TOMCAT|9.0.41-java11"
+            }
+          }
+        },
+        {
+          displayText: 'Tomcat 9.0.38',
+          value: '9.0.38',
+          stackSettings: {
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '9.0.38',
+            }
           },
         },
         {
@@ -250,16 +292,6 @@ export const javaContainersStack: WebAppStack = {
           },
         },
         {
-          displayText: 'Tomcat 8.5.6',
-          value: '8.5.6',
-          stackSettings: {
-            windowsContainerSettings: {
-              javaContainer: 'TOMCAT',
-              javaContainerVersion: '8.5.6',
-            },
-          },
-        },
-        {
           displayText: 'Tomcat 8.5.57',
           value: '8.5.57',
           stackSettings: {
@@ -360,6 +392,16 @@ export const javaContainersStack: WebAppStack = {
             windowsContainerSettings: {
               javaContainer: 'TOMCAT',
               javaContainerVersion: '8.5.20',
+            },
+          },
+        },
+        {
+          displayText: 'Tomcat 8.5.6',
+          value: '8.5.6',
+          stackSettings: {
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '8.5.6',
             },
           },
         },

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
@@ -48,6 +48,25 @@ export const javaStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java 11.0.9',
+          value: '11.0.9',
+          stackSettings: {
+            linuxRuntimeSettings: {
+              // Note (allisonm): Runtime on Linux Java is determined by the Java container
+              runtimeVersion: '',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: false,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '11',
+              },
+              endOfLifeDate: java11EOL,
+            },
+          },
+        },
+        {
           displayText: 'Java 11.0.8',
           value: '11.0.8',
           stackSettings: {

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
@@ -48,6 +48,25 @@ export const javaStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java 11.0.8',
+          value: '11.0.8',
+          stackSettings: {
+            windowsRuntimeSettings: {
+              // Note (allisonm): ZULU suffix was removed after Java 11.0.5
+              runtimeVersion: '11.0.8',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: false,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '11',
+              },
+              endOfLifeDate: java11EOL,
+            },
+          },
+        },
+        {
           displayText: 'Java 11.0.7',
           value: '11.0.7',
           stackSettings: {
@@ -205,6 +224,24 @@ export const javaStack: WebAppStack = {
             windowsRuntimeSettings: {
               runtimeVersion: '1.8',
               isAutoUpdate: true,
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: false,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '8',
+              },
+              endOfLifeDate: java8EOL,
+            },
+          },
+        },
+        {
+          displayText: 'Java 1.8.0_265',
+          value: '8.0.265',
+          stackSettings: {
+            windowsRuntimeSettings: {
+              runtimeVersion: '1.8.0_265',
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
@@ -578,6 +615,24 @@ export const javaStack: WebAppStack = {
             windowsRuntimeSettings: {
               runtimeVersion: '1.7',
               isAutoUpdate: true,
+              isDeprecated: true,
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: false,
+              },
+              gitHubActionSettings: {
+                isSupported: false,
+              },
+              endOfLifeDate: java7EOL,
+            },
+          },
+        },
+        {
+          displayText: 'Java 1.7.0_272',
+          value: '7.0.272',
+          stackSettings: {
+            windowsRuntimeSettings: {
+              runtimeVersion: '1.7.0_272_ZULU',
               isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
@@ -71,7 +71,6 @@ export const javaStack: WebAppStack = {
           value: '11.0.8',
           stackSettings: {
             windowsRuntimeSettings: {
-              // Note (allisonm): ZULU suffix was removed after Java 11.0.5
               runtimeVersion: '11.0.8',
               remoteDebuggingSupported: false,
               appInsightsSettings: {

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -92,6 +92,18 @@ export const javaContainersStack: WebAppStack = {
       value: 'jbosseap',
       minorVersions: [
         {
+          displayText: "JBoss EAP 7",
+          value: "7",
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: "JBOSSEAP|7-java8",
+              java11Runtime: "JBOSSEAP|7-java11",
+              isAutoUpdate: true,
+              isPreview: true
+            }
+          }
+        },
+        {
           displayText: 'JBoss EAP 7.2',
           value: '7.2',
           stackSettings: {
@@ -121,6 +133,16 @@ export const javaContainersStack: WebAppStack = {
               java8Runtime: 'TOMCAT|9.0-jre8',
               isAutoUpdate: true,
             },
+          },
+        },
+        {
+          displayText: 'Tomcat 9.0.38',
+          value: '9.0.38',
+          stackSettings: {
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '9.0.38',
+            }
           },
         },
         {
@@ -257,6 +279,16 @@ export const javaContainersStack: WebAppStack = {
               javaContainer: 'TOMCAT',
               javaContainerVersion: '8.5.6',
             },
+          },
+        },
+        {
+          displayText: 'Tomcat 8.5.58',
+          value: '8.5.58',
+          stackSettings: {
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '8.5.58',
+            }
           },
         },
         {

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -26,6 +26,16 @@ export const javaContainersStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java SE 11.0.9',
+          value: '11.0.9',
+          stackSettings: {
+            linuxContainerSettings: {
+              // Note (allisonm): This doesn't have suffix of -java11 since setting to 11.0.7 prevents auto-updates
+              java11Runtime: 'JAVA|11.0.9',
+            },
+          },
+        },
+        {
           displayText: 'Java SE 11.0.7',
           value: '11.0.7',
           stackSettings: {
@@ -134,6 +144,16 @@ export const javaContainersStack: WebAppStack = {
               isAutoUpdate: true,
             },
           },
+        },
+        {
+          displayText: "Tomcat 9.0.41",
+          value: "9.0.41",
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: "TOMCAT|9.0.41-java8",
+              java11Runtime: "TOMCAT|9.0.41-java11"
+            }
+          }
         },
         {
           displayText: 'Tomcat 9.0.38',
@@ -279,6 +299,16 @@ export const javaContainersStack: WebAppStack = {
               javaContainer: 'TOMCAT',
               javaContainerVersion: '8.5.6',
             },
+          },
+        },
+        {
+          displayText: 'Tomcat 8.5.61',
+          value: '8.5.61',
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: "TOMCAT|8.5.61-java8",
+              java11Runtime: "TOMCAT|8.5.61-java11"
+            }
           },
         },
         {

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -30,7 +30,7 @@ export const javaContainersStack: WebAppStack = {
           value: '11.0.9',
           stackSettings: {
             linuxContainerSettings: {
-              // Note (allisonm): This doesn't have suffix of -java11 since setting to 11.0.7 prevents auto-updates
+              // Note (jafreebe): This doesn't have suffix of -java11 since setting to 11.0.8 prevents auto-updates
               java11Runtime: 'JAVA|11.0.9',
             },
           },
@@ -292,16 +292,6 @@ export const javaContainersStack: WebAppStack = {
           },
         },
         {
-          displayText: 'Tomcat 8.5.6',
-          value: '8.5.6',
-          stackSettings: {
-            windowsContainerSettings: {
-              javaContainer: 'TOMCAT',
-              javaContainerVersion: '8.5.6',
-            },
-          },
-        },
-        {
           displayText: 'Tomcat 8.5.61',
           value: '8.5.61',
           stackSettings: {
@@ -422,6 +412,16 @@ export const javaContainersStack: WebAppStack = {
             windowsContainerSettings: {
               javaContainer: 'TOMCAT',
               javaContainerVersion: '8.5.20',
+            },
+          },
+        },
+        {
+          displayText: 'Tomcat 8.5.6',
+          value: '8.5.6',
+          stackSettings: {
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '8.5.6',
             },
           },
         },


### PR DESCRIPTION
https://azure.github.io/AppService/2021/01/06/java-stacks-update.html

On Windows, this adds the following runtimes:

- Tomcat 9.0.38
- Tomcat 8.5.58
- Java 11.0.8
- Java 8.0.265
- Java 7.0.272

And on Linux...

- Auto Update for JBoss EAP 7.x on Java 8 and 11
- Java 11.0.9
- Tomcat 9.0.41
- Tomcat 8.5.61
