### PR TITLE
Remove ghost tab stop from configured view

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.styles.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.styles.ts
@@ -96,8 +96,8 @@ export const panelBanner = style({
 });
 
 export const disconnectLink = style({
+  display: 'block',
   marginTop: '5px',
-  width: '100%',
 });
 
 export const panelOverflowStyle = {

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
@@ -204,7 +204,7 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
           {!isTfsOrVsoSetup && <DeploymentCenterCodeBuildConfiguredView />}
         </>
       ) : (
-        <>
+        <div tabIndex={-1}>
           <DeploymentCenterCodeSourceAndBuild formProps={formProps} />
 
           {isGitHubActionsBuild && (
@@ -235,7 +235,7 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
             </>
           )}
           {isVstsBuild && <DeploymentCenterVstsBuildProvider />}
-        </>
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
fixes AB#8965071

Before:
![image](https://user-images.githubusercontent.com/493476/107585478-2c363480-6bb3-11eb-837c-76c0a260c156.png)


After:
![image](https://user-images.githubusercontent.com/493476/107585391-0315a400-6bb3-11eb-9bda-66de7a7db418.png)

Also the reflow is not affected
![image](https://user-images.githubusercontent.com/493476/107585578-5f78c380-6bb3-11eb-8a8b-7952c1326fc2.png)
