### PR TITLE
[DeploymentCenterV2] Refresh button moved to logs tab

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.styles.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.styles.ts
@@ -120,7 +120,6 @@ export const disconnectWorkflowInfoStyle = style({
 
 export const logsTimerStyle = style({
   marginTop: '10px',
-  fontSize: '10px',
 });
 
 export const closePublishProfileButtonStyle = style({

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -319,6 +319,7 @@ export interface DeploymentCenterGitHubWorkflowConfigSelectorProps<T = Deploymen
 
 export interface DeploymentCenterContainerLogsProps {
   isLoading: boolean;
+  refresh: () => void;
   logs?: string;
 }
 
@@ -374,19 +375,16 @@ export interface DeploymentCenterCommandBarProps {
   saveFunction: () => void;
   discardFunction: () => void;
   showPublishProfilePanel: () => void;
-  refresh: () => void;
   redeploy?: () => void;
 }
 
 export interface DeploymentCenterCodeCommandBarProps extends DeploymentCenterFieldProps<DeploymentCenterCodeFormData> {
   isLoading: boolean;
-  refresh: () => void;
   redeploy: () => void;
 }
 
 export interface DeploymentCenterContainerCommandBarProps extends DeploymentCenterFieldProps<DeploymentCenterContainerFormData> {
   isLoading: boolean;
-  refresh: () => void;
 }
 
 export interface DeploymentCenterPublishProfilePanelProps {

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
@@ -11,7 +11,7 @@ import { PortalContext } from '../../../PortalContext';
 import { getTelemetryInfo } from './utility/DeploymentCenterUtility';
 
 const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = props => {
-  const { saveFunction, discardFunction, showPublishProfilePanel, refresh, redeploy, isLoading, isDirty, isVstsBuildProvider } = props;
+  const { saveFunction, discardFunction, showPublishProfilePanel, redeploy, isLoading, isDirty, isVstsBuildProvider } = props;
   const { t } = useTranslation();
 
   const portalContext = useContext(PortalContext);
@@ -76,7 +76,6 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
       getDiscardButton(),
       getBrowseButton(),
       getManagePublishProfileButton(),
-      getRefreshButton(),
     ];
 
     if (!siteStateContext.isContainerApp) {
@@ -106,11 +105,6 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
   const onManagePublishProfileButtonClick = () => {
     portalContext.log(getTelemetryInfo('info', 'managePublishProfileButton', 'clicked'));
     showPublishProfilePanel();
-  };
-
-  const onRefreshButtonClick = () => {
-    portalContext.log(getTelemetryInfo('info', 'refreshButton', 'clicked'));
-    refresh();
   };
 
   const onRedeployClick = () => {
@@ -177,19 +171,6 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
       ariaLabel: t('deploymentCenterPublishProfileCommandAriaLabel'),
       disabled: !isSiteLoaded(),
       onClick: onManagePublishProfileButtonClick,
-    };
-  };
-
-  const getRefreshButton = (): ICommandBarItemProps => {
-    return {
-      key: 'refresh',
-      name: t('refresh'),
-      iconProps: {
-        iconName: 'Refresh',
-      },
-      ariaLabel: t('deploymentCenterRefreshCommandAriaLabel'),
-      disabled: isDisabledOnReload(),
-      onClick: onRefreshButtonClick,
     };
   };
 

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
@@ -41,7 +41,6 @@ import GitHubService from '../../../../ApiHelpers/GitHubService';
 
 const DeploymentCenterCodeForm: React.FC<DeploymentCenterCodeFormProps> = props => {
   const { t } = useTranslation();
-  const [isRefreshConfirmDialogVisible, setIsRefreshConfirmDialogVisible] = useState(false);
   const [isRedeployConfirmDialogVisible, setIsRedeployConfirmDialogVisible] = useState(false);
   const [isDiscardConfirmDialogVisible, setIsDiscardConfirmDialogVisible] = useState(false);
 
@@ -379,15 +378,6 @@ const DeploymentCenterCodeForm: React.FC<DeploymentCenterCodeFormProps> = props 
     }
   };
 
-  const refreshFunction = () => {
-    hideRefreshConfirmDialog();
-    props.refresh();
-  };
-
-  const hideRefreshConfirmDialog = () => {
-    setIsRefreshConfirmDialogVisible(false);
-  };
-
   const redeployFunction = async () => {
     hideRedeployConfirmDialog();
 
@@ -534,25 +524,10 @@ const DeploymentCenterCodeForm: React.FC<DeploymentCenterCodeFormProps> = props 
               saveFunction={formProps.submitForm}
               showPublishProfilePanel={deploymentCenterPublishingContext.showPublishProfilePanel}
               discardFunction={() => setIsDiscardConfirmDialogVisible(true)}
-              refresh={() => setIsRefreshConfirmDialogVisible(true)}
               redeploy={() => setIsRedeployConfirmDialogVisible(true)}
             />
           </div>
           <>
-            <ConfirmDialog
-              primaryActionButton={{
-                title: t('ok'),
-                onClick: refreshFunction,
-              }}
-              defaultActionButton={{
-                title: t('cancel'),
-                onClick: hideRefreshConfirmDialog,
-              }}
-              title={t('deploymentCenterRefreshConfirmTitle')}
-              content={t('deploymentCenterDataLossMessage')}
-              hidden={!isRefreshConfirmDialogVisible}
-              onDismiss={hideRefreshConfirmDialog}
-            />
             <ConfirmDialog
               primaryActionButton={{
                 title: t('ok'),

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeLogsTimer.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeLogsTimer.tsx
@@ -6,6 +6,7 @@ import { CommandBarStyles } from '../../../../theme/CustomOfficeFabric/AzurePort
 import { CustomCommandBarButton } from '../../../../components/CustomCommandBarButton';
 import { getTelemetryInfo } from '../utility/DeploymentCenterUtility';
 import { PortalContext } from '../../../../PortalContext';
+import { logsTimerStyle } from '../DeploymentCenter.styles';
 
 const DeploymentCenterCodeLogsTimer: React.FC<DeploymentCenterCodeLogsTimerProps> = props => {
   const refreshMilliseconds = 30000;
@@ -45,15 +46,16 @@ const DeploymentCenterCodeLogsTimer: React.FC<DeploymentCenterCodeLogsTimerProps
     },
   ];
 
-  //return <div className={logsTimerStyle}>{t('logsRefreshTimerMessage').format(timeLeft)}</div>;
   return (
-    <CommandBar
-      items={commandBarItems}
-      role="nav"
-      styles={CommandBarStyles}
-      ariaLabel={t('managePublishProfileCommandBarAriaLabel')}
-      buttonAs={CustomCommandBarButton}
-    />
+    <div className={logsTimerStyle}>
+      <CommandBar
+        items={commandBarItems}
+        role="nav"
+        styles={CommandBarStyles}
+        ariaLabel={t('managePublishProfileCommandBarAriaLabel')}
+        buttonAs={CustomCommandBarButton}
+      />
+    </div>
   );
 };
 

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeLogsTimer.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeLogsTimer.tsx
@@ -1,12 +1,18 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { DeploymentCenterCodeLogsTimerProps } from '../DeploymentCenter.types';
-import { logsTimerStyle } from '../DeploymentCenter.styles';
 import { useTranslation } from 'react-i18next';
+import { CommandBar, ICommandBarItemProps } from 'office-ui-fabric-react';
+import { CommandBarStyles } from '../../../../theme/CustomOfficeFabric/AzurePortal/CommandBar.styles';
+import { CustomCommandBarButton } from '../../../../components/CustomCommandBarButton';
+import { getTelemetryInfo } from '../utility/DeploymentCenterUtility';
+import { PortalContext } from '../../../../PortalContext';
 
 const DeploymentCenterCodeLogsTimer: React.FC<DeploymentCenterCodeLogsTimerProps> = props => {
   const refreshMilliseconds = 30000;
   const [timeLeft, setTimeLeft] = useState(refreshMilliseconds / 1000);
   const { t } = useTranslation();
+
+  const portalContext = useContext(PortalContext);
 
   useEffect(() => {
     setInterval(() => {
@@ -24,7 +30,31 @@ const DeploymentCenterCodeLogsTimer: React.FC<DeploymentCenterCodeLogsTimerProps
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return <div className={logsTimerStyle}>{t('logsRefreshTimerMessage').format(timeLeft)}</div>;
+  const commandBarItems: ICommandBarItemProps[] = [
+    {
+      key: 'refresh',
+      name: t('refresh'),
+      iconProps: {
+        iconName: 'Refresh',
+      },
+      ariaLabel: t('deploymentCenterRefreshCommandAriaLabel'),
+      onClick: () => {
+        portalContext.log(getTelemetryInfo('verbose', 'refreshButton', 'clicked'));
+        props.refreshLogs();
+      },
+    },
+  ];
+
+  //return <div className={logsTimerStyle}>{t('logsRefreshTimerMessage').format(timeLeft)}</div>;
+  return (
+    <CommandBar
+      items={commandBarItems}
+      role="nav"
+      styles={CommandBarStyles}
+      ariaLabel={t('managePublishProfileCommandBarAriaLabel')}
+      buttonAs={CustomCommandBarButton}
+    />
+  );
 };
 
 export default DeploymentCenterCodeLogsTimer;

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -48,7 +48,6 @@ interface ResponseResult {
 const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps> = props => {
   const { t } = useTranslation();
 
-  const [isRefreshConfirmDialogVisible, setIsRefreshConfirmDialogVisible] = useState(false);
   const [isDiscardConfirmDialogVisible, setIsDiscardConfirmDialogVisible] = useState(false);
 
   const deploymentCenterContext = useContext(DeploymentCenterContext);
@@ -554,11 +553,6 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
     }
   };
 
-  const refreshFunction = () => {
-    hideRefreshConfirmDialog();
-    props.refresh();
-  };
-
   const onSubmit = async (values: DeploymentCenterFormData<DeploymentCenterContainerFormData>) => {
     portalContext.log(getTelemetryInfo('info', 'onSubmitContainer', 'submit'));
 
@@ -630,10 +624,6 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
     }
   };
 
-  const hideRefreshConfirmDialog = () => {
-    setIsRefreshConfirmDialogVisible(false);
-  };
-
   const hideDiscardConfirmDialog = () => {
     setIsDiscardConfirmDialogVisible(false);
   };
@@ -653,28 +643,12 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
               saveFunction={formProps.submitForm}
               discardFunction={() => setIsDiscardConfirmDialogVisible(true)}
               showPublishProfilePanel={deploymentCenterPublishingContext.showPublishProfilePanel}
-              refresh={() => setIsRefreshConfirmDialogVisible(true)}
               isLoading={props.isLoading}
               isDirty={formProps.dirty}
               isVstsBuildProvider={formProps.values.scmType === ScmType.Vsts}
             />
           </div>
           <>
-            <ConfirmDialog
-              primaryActionButton={{
-                title: t('ok'),
-                onClick: refreshFunction,
-              }}
-              defaultActionButton={{
-                title: t('cancel'),
-                onClick: hideRefreshConfirmDialog,
-              }}
-              title={t('deploymentCenterRefreshConfirmTitle')}
-              content={t('deploymentCenterDataLossMessage')}
-              hidden={!isRefreshConfirmDialogVisible}
-              onDismiss={hideRefreshConfirmDialog}
-            />
-
             <ConfirmDialog
               primaryActionButton={{
                 title: t('ok'),

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerLogs.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerLogs.tsx
@@ -1,12 +1,18 @@
-import React from 'react';
-import { ProgressIndicator } from 'office-ui-fabric-react';
+import React, { useContext } from 'react';
+import { CommandBar, ICommandBarItemProps, ProgressIndicator } from 'office-ui-fabric-react';
 import { useTranslation } from 'react-i18next';
-import { deploymentCenterContent, deploymentCenterContainerLogs } from '../DeploymentCenter.styles';
+import { deploymentCenterContent, deploymentCenterContainerLogs, logsTimerStyle } from '../DeploymentCenter.styles';
 import { DeploymentCenterContainerLogsProps } from '../DeploymentCenter.types';
+import { getTelemetryInfo } from '../utility/DeploymentCenterUtility';
+import { PortalContext } from '../../../../PortalContext';
+import { CommandBarStyles } from '../../../../theme/CustomOfficeFabric/AzurePortal/CommandBar.styles';
+import { CustomCommandBarButton } from '../../../../components/CustomCommandBarButton';
 
 const DeploymentCenterContainerLogs: React.FC<DeploymentCenterContainerLogsProps> = props => {
-  const { logs, isLoading } = props;
+  const { logs, isLoading, refresh } = props;
   const { t } = useTranslation();
+
+  const portalContext = useContext(PortalContext);
 
   const getProgressIndicator = () => {
     return (
@@ -17,21 +23,47 @@ const DeploymentCenterContainerLogs: React.FC<DeploymentCenterContainerLogsProps
     );
   };
 
+  const commandBarItems: ICommandBarItemProps[] = [
+    {
+      key: 'refresh',
+      name: t('refresh'),
+      iconProps: {
+        iconName: 'Refresh',
+      },
+      ariaLabel: t('deploymentCenterRefreshCommandAriaLabel'),
+      onClick: () => {
+        portalContext.log(getTelemetryInfo('verbose', 'refreshButton', 'clicked'));
+        refresh();
+      },
+    },
+  ];
+
   return (
     <>
       {isLoading ? (
         getProgressIndicator()
       ) : (
-        <div className={deploymentCenterContent}>
+        <>
           {logs ? (
             <>
-              {t('deploymentCenterContainerLogsDesc')}
-              <pre className={deploymentCenterContainerLogs}>{logs}</pre>
+              <div className={logsTimerStyle}>
+                <CommandBar
+                  items={commandBarItems}
+                  role="nav"
+                  styles={CommandBarStyles}
+                  ariaLabel={t('managePublishProfileCommandBarAriaLabel')}
+                  buttonAs={CustomCommandBarButton}
+                />
+              </div>
+              <div className={deploymentCenterContent}>
+                {t('deploymentCenterContainerLogsDesc')}
+                <pre className={deploymentCenterContainerLogs}>{logs}</pre>
+              </div>
             </>
           ) : (
             getProgressIndicator()
           )}
-        </div>
+        </>
       )}
     </>
   );

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPivot.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPivot.tsx
@@ -12,7 +12,7 @@ import { ThemeContext } from '../../../../ThemeContext';
 import CustomTabRenderer from '../../app-settings/Sections/CustomTabRenderer';
 
 const DeploymentCenterContainerPivot: React.FC<DeploymentCenterContainerPivotProps> = props => {
-  const { logs, formProps, isLoading } = props;
+  const { logs, formProps, isLoading, refresh } = props;
   const { t } = useTranslation();
 
   const deploymentCenterContext = useContext(DeploymentCenterContext);
@@ -25,7 +25,8 @@ const DeploymentCenterContainerPivot: React.FC<DeploymentCenterContainerPivotPro
         (formProps.values.registrySource === ContainerRegistrySources.privateRegistry && isPrivateRegistrySettingsDirty()) ||
         (formProps.values.registrySource === ContainerRegistrySources.docker && isDockerSettingsDirty()) ||
         (formProps.values.registrySource === ContainerRegistrySources.acr && isAcrSettingsDirty())) &&
-      !!deploymentCenterContext.siteConfig && deploymentCenterContext.siteConfig.properties.scmType === ScmType.None
+      !!deploymentCenterContext.siteConfig &&
+      deploymentCenterContext.siteConfig.properties.scmType === ScmType.None
     );
   };
 
@@ -79,7 +80,7 @@ const DeploymentCenterContainerPivot: React.FC<DeploymentCenterContainerPivotPro
   return (
     <Pivot>
       <PivotItem headerText={t('deploymentCenterPivotItemLogsHeaderText')} ariaLabel={t('deploymentCenterPivotItemLogsAriaLabel')}>
-        <DeploymentCenterContainerLogs logs={logs} isLoading={isLoading} />
+        <DeploymentCenterContainerLogs logs={logs} isLoading={isLoading} refresh={refresh} />
       </PivotItem>
 
       <PivotItem

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -6924,9 +6924,6 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="endOfLifeStackMessage" xml:space="preserve">
         <value>The selected version '{0}' will deprecate on {1}. Please consider updating it soon.</value>
     </data>
-    <data name="logsRefreshTimerMessage" xml:space="preserve">
-        <value>Logs will refresh in {0} seconds</value>
-    </data>
     <data name="classicContainerSettingDeprecationMessage" xml:space="preserve">
         <value>This Container Settings (Classic) experience is deprecated and will be removed in March of 2021. To continue managing your container settings, try out the new Deployment Center experience.</value>
     </data>


### PR DESCRIPTION
Fixes AB#

Code Logs (GitHub Actions):
![image](https://user-images.githubusercontent.com/35281019/108289869-12ad6380-7144-11eb-94ce-54dec9718f4b.png)

Code Logs (non-GitHub Actions):
![image](https://user-images.githubusercontent.com/35281019/108289947-3a043080-7144-11eb-961f-eecb81780091.png)

Container Logs:
![image](https://user-images.githubusercontent.com/35281019/108289982-4b4d3d00-7144-11eb-9ba6-9055ebb0062d.png)

