### PR TITLE
Fix dockerHub bugs in deployment center related to image/tag/credentials.

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -72,7 +72,7 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
     } else if (values.registrySource === ContainerRegistrySources.privateRegistry) {
       return values.privateRegistryUsername;
     } else {
-      return values.dockerHubUsername;
+      return values.dockerHubAccessType === ContainerDockerAccessTypes.private ? values.dockerHubUsername : '';
     }
   };
 
@@ -82,7 +82,7 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
     } else if (values.registrySource === ContainerRegistrySources.privateRegistry) {
       return values.privateRegistryPassword;
     } else {
-      return values.dockerHubPassword;
+      return values.dockerHubAccessType === ContainerDockerAccessTypes.private ? values.dockerHubPassword : '';
     }
   };
 
@@ -115,9 +115,7 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
       const server = values.privateRegistryServerUrl.toLocaleLowerCase().replace('https://', '');
       return `${prefix}|${server}/${values.privateRegistryImageAndTag}`;
     } else {
-      return values.dockerHubAccessType === ContainerDockerAccessTypes.public
-        ? `${prefix}|${values.dockerHubImageAndTag}`
-        : `${prefix}|${values.dockerHubUsername}/${values.dockerHubImageAndTag}`;
+      return `${prefix}|${values.dockerHubImageAndTag}`;
     }
   };
 
@@ -210,8 +208,16 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
       appSettings[DeploymentCenterConstants.enableCISetting] = 'true';
     }
 
-    appSettings[DeploymentCenterConstants.usernameSetting] = getUsername(values);
-    appSettings[DeploymentCenterConstants.passwordSetting] = getPassword(values);
+    const userName = getUsername(values);
+    if (userName) {
+      appSettings[DeploymentCenterConstants.usernameSetting] = userName;
+    }
+
+    const password = getPassword(values);
+    if (password) {
+      appSettings[DeploymentCenterConstants.passwordSetting] = password;
+    }
+
     appSettings[DeploymentCenterConstants.serverUrlSetting] = getServerUrl(values);
 
     return appSettings;

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -262,7 +262,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
     if (this._isServerUrlAcr(appSettingServerUrl)) {
       return this._getAcrFxVersionParts(appSettingServerUrl, fxVersionParts[1], isDockerCompose);
     } else if (this._isServerUrlDockerHub(appSettingServerUrl)) {
-      return this._getDockerHubFxVersionParts(appSettingUsername, fxVersionParts[1], isDockerCompose);
+      return this._getDockerHubFxVersionParts(fxVersionParts[1], isDockerCompose);
     } else {
       return this._getPrivateRegistryFxVersionParts(appSettingServerUrl, fxVersionParts[1], isDockerCompose);
     }
@@ -296,7 +296,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
     }
   }
 
-  private _getDockerHubFxVersionParts(appSettingUsername: string, registryInfo: string, isDockerCompose: boolean): FxVersionParts {
+  private _getDockerHubFxVersionParts(registryInfo: string, isDockerCompose: boolean): FxVersionParts {
     if (isDockerCompose) {
       return {
         server: DeploymentCenterConstants.dockerHubServerUrlHost,
@@ -306,21 +306,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
         composeYml: atob(registryInfo),
       };
     } else {
-      // NOTE(michinoy): For DockerHub the username could be in FxVersion. This would needed in case of pulling from a private repo.
-      // The image and/or tags could definitely have /'s. The username is a separate field on the form, so image and tag should not have that.
-      // In this case, remove the serverInfo and/or username from the FxVersion and compute the image and tag by splitting on :.
-
-      const serverAndUsernamePrefix = appSettingUsername
-        ? `${DeploymentCenterConstants.dockerHubServerUrlHost}/${appSettingUsername}/`
-        : `${DeploymentCenterConstants.dockerHubServerUrlHost}/`;
-
-      const usernamePrefix = appSettingUsername ? `${appSettingUsername}/` : '';
-
-      let imageAndTagInfo = registryInfo
-        .toLocaleLowerCase()
-        .replace(serverAndUsernamePrefix, '')
-        .replace(usernamePrefix, '');
-
+      const imageAndTagInfo = registryInfo.toLocaleLowerCase().replace(`${DeploymentCenterConstants.dockerHubServerUrlHost}/`, '');
       const imageAndTagParts = imageAndTagInfo.split(':');
 
       return {


### PR DESCRIPTION
fixes AB#9322899

Fixes the image/tag sync issue between classic and new experience.
When switching from private to public in the new experience, the correct settings are retained.