### PR TITLE
AB#8027994 Update Elastic Premium prices to use the multiplier from billingMeters API and remove hardcoding

### DIFF
--- a/client/src/app/shared/models/arm/billingMeter.ts
+++ b/client/src/app/shared/models/arm/billingMeter.ts
@@ -4,4 +4,5 @@ export interface BillingMeter {
   shortName: string;
   friendlyName: string;
   resourceType: string;
+  multiplier: number;
 }

--- a/client/src/app/site/spec-picker/price-spec-manager/elastic-premium-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/elastic-premium-plan-price-spec.ts
@@ -80,8 +80,6 @@ export abstract class ElasticPremiumPlanPriceSpec extends DV2SeriesPriceSpec {
 }
 
 export class ElasticPremiumSmallPlanPriceSpec extends ElasticPremiumPlanPriceSpec {
-  private readonly _ep1CpuCore = 1;
-  private readonly _ep1Memory = 3.5;
   skuCode = SkuCode.ElasticPremium.EP1;
   legacySkuName = 'small_elastic_premium';
   topLevelFeatures = [
@@ -97,12 +95,12 @@ export class ElasticPremiumSmallPlanPriceSpec extends ElasticPremiumPlanPriceSpe
     firstParty: [
       {
         id: SkuCode.ElasticPremium.EP1CPU,
-        quantity: Pricing.hoursInAzureMonth * this._ep1CpuCore,
+        quantity: Pricing.hoursInAzureMonth,
         resourceId: null,
       },
       {
         id: SkuCode.ElasticPremium.EP1Memory,
-        quantity: Pricing.hoursInAzureMonth * this._ep1Memory,
+        quantity: Pricing.hoursInAzureMonth,
         resourceId: null,
       },
     ],
@@ -110,8 +108,6 @@ export class ElasticPremiumSmallPlanPriceSpec extends ElasticPremiumPlanPriceSpe
 }
 
 export class ElasticPremiumMediumPlanPriceSpec extends ElasticPremiumPlanPriceSpec {
-  private readonly _ep2CpuCore = 2;
-  private readonly _ep2Memory = 7;
   skuCode = SkuCode.ElasticPremium.EP2;
   legacySkuName = 'medium_elastic_premium';
   topLevelFeatures = [
@@ -127,12 +123,12 @@ export class ElasticPremiumMediumPlanPriceSpec extends ElasticPremiumPlanPriceSp
     firstParty: [
       {
         id: SkuCode.ElasticPremium.EP2CPU,
-        quantity: Pricing.hoursInAzureMonth * this._ep2CpuCore,
+        quantity: Pricing.hoursInAzureMonth,
         resourceId: null,
       },
       {
         id: SkuCode.ElasticPremium.EP2Memory,
-        quantity: Pricing.hoursInAzureMonth * this._ep2Memory,
+        quantity: Pricing.hoursInAzureMonth,
         resourceId: null,
       },
     ],
@@ -140,8 +136,6 @@ export class ElasticPremiumMediumPlanPriceSpec extends ElasticPremiumPlanPriceSp
 }
 
 export class ElasticPremiumLargePlanPriceSpec extends ElasticPremiumPlanPriceSpec {
-  private readonly _ep3CpuCore = 4;
-  private readonly _ep3Memory = 14;
   skuCode = SkuCode.ElasticPremium.EP3;
   legacySkuName = 'large_elastic_premium';
   topLevelFeatures = [
@@ -157,12 +151,12 @@ export class ElasticPremiumLargePlanPriceSpec extends ElasticPremiumPlanPriceSpe
     firstParty: [
       {
         id: SkuCode.ElasticPremium.EP3CPU,
-        quantity: Pricing.hoursInAzureMonth * this._ep3CpuCore,
+        quantity: Pricing.hoursInAzureMonth,
         resourceId: null,
       },
       {
         id: SkuCode.ElasticPremium.EP3Memory,
-        quantity: Pricing.hoursInAzureMonth * this._ep3Memory,
+        quantity: Pricing.hoursInAzureMonth,
         resourceId: null,
       },
     ],

--- a/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
@@ -181,8 +181,8 @@ export class PlanPriceSpecManager {
         let specsToAllowZeroCost: string[] = [];
 
         this.specGroups.forEach(g => {
-          g.recommendedSpecs.forEach(s => this._setBillingResourceId(s, meters));
-          g.additionalSpecs.forEach(s => this._setBillingResourceId(s, meters));
+          g.recommendedSpecs.forEach(s => this._setBillingResourceIdAndQuantity(s, meters));
+          g.additionalSpecs.forEach(s => this._setBillingResourceIdAndQuantity(s, meters));
 
           specResourceSets = this._concatAllResourceSetsForSpecs(specResourceSets, g.recommendedSpecs);
           specResourceSets = this._concatAllResourceSetsForSpecs(specResourceSets, g.additionalSpecs);
@@ -687,7 +687,7 @@ export class PlanPriceSpecManager {
     return inputs.data.isLinux ? OsType.Linux : OsType.Windows;
   }
 
-  private _setBillingResourceId(spec: PriceSpec, billingMeters: ArmObj<BillingMeter>[]) {
+  private _setBillingResourceIdAndQuantity(spec: PriceSpec, billingMeters: ArmObj<BillingMeter>[]) {
     if (!spec.meterFriendlyName) {
       throw Error('meterFriendlyName must be set');
     }
@@ -716,6 +716,7 @@ export class PlanPriceSpecManager {
         }
       } else {
         firstPartyResource.resourceId = billingMeter.properties.meterId;
+        firstPartyResource.quantity = firstPartyResource.quantity * billingMeter.properties.multiplier;
       }
     });
   }


### PR DESCRIPTION
Fixes AB#8027994

**Before**:
![image](https://user-images.githubusercontent.com/14221995/109055216-babab380-7693-11eb-8cf6-374fb4da344a.png)

![image](https://user-images.githubusercontent.com/14221995/109055414-02413f80-7694-11eb-981d-072aeec2ee02.png)



**After**:
![image](https://user-images.githubusercontent.com/14221995/109055166-a971a700-7693-11eb-8150-88f41c47db55.png)

![image](https://user-images.githubusercontent.com/14221995/109055339-e6d63480-7693-11eb-9b7b-78b65c194f6d.png)
