### PR TITLE
Unhide Java 7

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Java.ts
@@ -633,7 +633,7 @@ export const javaStack: WebAppStack = {
             windowsRuntimeSettings: {
               runtimeVersion: '1.7',
               isAutoUpdate: true,
-              isDeprecated: true,
+              isDeprecated: false,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
@@ -651,7 +651,7 @@ export const javaStack: WebAppStack = {
           stackSettings: {
             windowsRuntimeSettings: {
               runtimeVersion: '1.7.0_272_ZULU',
-              isDeprecated: true,
+              isDeprecated: false,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
@@ -669,7 +669,7 @@ export const javaStack: WebAppStack = {
           stackSettings: {
             windowsRuntimeSettings: {
               runtimeVersion: '1.7.0_262_ZULU',
-              isDeprecated: true,
+              isDeprecated: false,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
@@ -633,7 +633,7 @@ export const javaStack: WebAppStack = {
             windowsRuntimeSettings: {
               runtimeVersion: '1.7',
               isAutoUpdate: true,
-              isDeprecated: true,
+              isDeprecated: false,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
@@ -651,7 +651,7 @@ export const javaStack: WebAppStack = {
           stackSettings: {
             windowsRuntimeSettings: {
               runtimeVersion: '1.7.0_272_ZULU',
-              isDeprecated: true,
+              isDeprecated: false,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
@@ -669,7 +669,7 @@ export const javaStack: WebAppStack = {
           stackSettings: {
             windowsRuntimeSettings: {
               runtimeVersion: '1.7.0_262_ZULU',
-              isDeprecated: true,
+              isDeprecated: false,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,


### PR DESCRIPTION
The EOL date for Java 7 is much farther out than I assumed (egg on my face).  The intent of this PR is to show Java 7 on creates and configures. On configures only Java 7 auto-update, 1.7.0_272, 1.7.0_262 should be shown. Hope I got this right! :P 

Java 7 is only available on Windows.