### PR TITLE
[FunctionEditor] Show read-only banner first instead of generic Runtime unreachable

### DIFF
--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
@@ -31,7 +31,7 @@ import EditModeBanner from '../../../../../components/EditModeBanner/EditModeBan
 import { SiteStateContext } from '../../../../../SiteState';
 import SiteHelper from '../../../../../utils/SiteHelper';
 import { StartupInfoContext } from '../../../../../StartupInfoContext';
-import { FunctionAppEditMode, PortalTheme } from '../../../../../models/portal-models';
+import { PortalTheme } from '../../../../../models/portal-models';
 import CustomBanner from '../../../../../components/CustomBanner/CustomBanner';
 import LogService from '../../../../../utils/LogService';
 import { LogCategories } from '../../../../../utils/LogCategories';
@@ -512,15 +512,16 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
           hidden={!selectedDropdownOption}
           onDismiss={onCancelButtonClick}
         />
-        {/* NOTE (krmitta): For .NET5 FunctionApps, we need to show the read-only banner irrespective of getFiles call not returning the list. */}
-        {(!isRuntimeReachable() || (!isSelectedFileBlacklisted() && isFileContentAvailable !== undefined && !isFileContentAvailable)) &&
-        siteStateContext.siteAppEditState !== FunctionAppEditMode.ReadOnlyDotnet5 ? (
-          <CustomBanner
-            message={!isRuntimeReachable() ? t('scmPingFailedErrorMessage') : t('fetchFileContentFailureMessage')}
-            type={MessageBarType.error}
-          />
-        ) : (
+        {/* NOTE (krmitta): Show the read-only banner first, instead of showing the Generic Runtime failure method */}
+        {SiteHelper.isFunctionAppReadOnly(siteStateContext.siteAppEditState) ? (
           <EditModeBanner setBanner={setReadOnlyBanner} />
+        ) : (
+          (!isRuntimeReachable() || (!isSelectedFileBlacklisted() && isFileContentAvailable !== undefined && !isFileContentAvailable)) && (
+            <CustomBanner
+              message={!isRuntimeReachable() ? t('scmPingFailedErrorMessage') : t('fetchFileContentFailureMessage')}
+              type={MessageBarType.error}
+            />
+          )
         )}
         <FunctionEditorFileSelectorBar
           disabled={isDisabled()}


### PR DESCRIPTION
Fixes AB#9459250

Now
![image](https://user-images.githubusercontent.com/11722204/110024532-18c64700-7ce3-11eb-9334-f147e68f4404.png)

![image](https://user-images.githubusercontent.com/11722204/110024584-28459000-7ce3-11eb-9e71-aa9146c5fa59.png)

Old
![image](https://user-images.githubusercontent.com/11722204/110024772-5b881f00-7ce3-11eb-8404-462da2c5e127.png)
