### PR TITLE
Add JBoss EAP 7.3 as a pinned version

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
@@ -106,12 +106,23 @@ export const javaContainersStack: WebAppStack = {
           value: '7',
           stackSettings: {
             linuxContainerSettings: {
-              java8Runtime: 'JBOSSEAP|7.2-java8',
+              java8Runtime: 'JBOSSEAP|7-java8',
               java11Runtime: "JBOSSEAP|7-java11",
               isPreview: true,
               isAutoUpdate: true
             },
           },
+        },
+        {
+          displayText: 'JBoss EAP 7.3',
+          value: '7.3',
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: 'JBOSSEAP|7.3-java8',
+              java11Runtime: 'JBOSSEAP|7.3-java11',
+              isPreview: true,
+            },
+          }
         },
         {
           displayText: 'JBoss EAP 7.2',

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -114,6 +114,17 @@ export const javaContainersStack: WebAppStack = {
           }
         },
         {
+          displayText: 'JBoss EAP 7.3',
+          value: '7.3',
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: 'JBOSSEAP|7.3-java8',
+              java11Runtime: 'JBOSSEAP|7.3-java11',
+              isPreview: true,
+            },
+          },
+        },
+        {
           displayText: 'JBoss EAP 7.2',
           value: '7.2',
           stackSettings: {


### PR DESCRIPTION
- This PR adds JBoss 7.3, which is a pinned version that works for Java 8 and 11
- Also, the 2020-06-01 version had a pinned version (7.2) under the "java8Runtime"  property for an **auto-update** option (line 109)