### PR TITLE
Remove "Early Access" for Node 14

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
@@ -55,7 +55,7 @@ export const nodeStack: WebAppStack = {
                 isSupported: true,
                 supportedVersion: '14.x',
               },
-              isEarlyAccess: true,
+              isEarlyAccess: false,
               endOfLifeDate: node14EOL,
             },
             windowsRuntimeSettings: {

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
@@ -55,7 +55,6 @@ export const nodeStack: WebAppStack = {
                 isSupported: true,
                 supportedVersion: '14.x',
               },
-              isEarlyAccess: false,
               endOfLifeDate: node14EOL,
             },
             windowsRuntimeSettings: {
@@ -68,7 +67,6 @@ export const nodeStack: WebAppStack = {
                 isSupported: true,
                 supportedVersion: '14.x',
               },
-              isEarlyAccess: false,
               endOfLifeDate: node14EOL,
             },
           },

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
@@ -68,7 +68,7 @@ export const nodeStack: WebAppStack = {
                 isSupported: true,
                 supportedVersion: '14.x',
               },
-              isEarlyAccess: true,
+              isEarlyAccess: false,
               endOfLifeDate: node14EOL,
             },
           },

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
@@ -55,7 +55,7 @@ export const nodeStack: WebAppStack = {
                 isSupported: true,
                 supportedVersion: '14.x',
               },
-              isEarlyAccess: true,
+              isEarlyAccess: false,
               endOfLifeDate: node14EOL,
             },
             windowsRuntimeSettings: {

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
@@ -55,7 +55,6 @@ export const nodeStack: WebAppStack = {
                 isSupported: true,
                 supportedVersion: '14.x',
               },
-              isEarlyAccess: false,
               endOfLifeDate: node14EOL,
             },
             windowsRuntimeSettings: {
@@ -68,7 +67,6 @@ export const nodeStack: WebAppStack = {
                 isSupported: true,
                 supportedVersion: '14.x',
               },
-              isEarlyAccess: false,
               endOfLifeDate: node14EOL,
             },
           },

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
@@ -68,7 +68,7 @@ export const nodeStack: WebAppStack = {
                 isSupported: true,
                 supportedVersion: '14.x',
               },
-              isEarlyAccess: true,
+              isEarlyAccess: false,
               endOfLifeDate: node14EOL,
             },
           },


### PR DESCRIPTION
Sanchit, jenny confirmed that Node 14 has been promoted out of "Early Access" on Linux

Marie confirmed that the same goes for Windows