### PR TITLE
AB#9515077 [Spec picker] Enable Free and Basic sku for Dreamspark subs in create scenario (for linux and webapp) and enable all skus for scale up (for Linux)

### DIFF
--- a/client/src/app/shared/models/server-farm.ts
+++ b/client/src/app/shared/models/server-farm.ts
@@ -4,4 +4,5 @@ export interface ServerFarm {
   provisioningState?: 'InProgress' | 'Succeeded' | 'Failed';
   hyperV?: boolean;
   numberOfWorkers?: number;
+  reserved?: boolean;
 }

--- a/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
@@ -64,7 +64,10 @@ export abstract class BasicPlanPriceSpec extends PriceSpec {
         this.state = 'hidden';
       }
 
-      if (input.specPickerInput.data.isLinux && input.specPickerInput.data.isNewFunctionAppCreate) {
+      if (
+        !input.specPickerInput.data.isLinux ||
+        (input.specPickerInput.data.isLinux && input.specPickerInput.data.isNewFunctionAppCreate)
+      ) {
         return this.checkIfDreamspark(input.subscriptionId);
       }
     }

--- a/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
@@ -51,9 +51,7 @@ export abstract class BasicPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
-      if (input.plan.properties.reserved) {
-        return Observable.of(null);
-      } else {
+      if (!input.plan.properties.reserved) {
         return this.checkIfDreamspark(input.subscriptionId);
       }
     } else if (input.specPickerInput.data) {
@@ -66,9 +64,7 @@ export abstract class BasicPlanPriceSpec extends PriceSpec {
         this.state = 'hidden';
       }
 
-      if (input.specPickerInput.data.isLinux && !input.specPickerInput.data.isNewFunctionAppCreate) {
-        return Observable.of(null);
-      } else {
+      if (input.specPickerInput.data.isLinux && input.specPickerInput.data.isNewFunctionAppCreate) {
         return this.checkIfDreamspark(input.subscriptionId);
       }
     }

--- a/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
@@ -3,6 +3,7 @@ import { Tier, SkuCode } from './../../../shared/models/serverFarmSku';
 import { PortalResources } from './../../../shared/models/portal-resources';
 import { AppKind } from './../../../shared/Utilities/app-kind';
 import { PriceSpec, PriceSpecInput } from './price-spec';
+import { Observable } from 'rxjs/Observable';
 
 export abstract class BasicPlanPriceSpec extends PriceSpec {
   tier = Tier.basic;
@@ -50,6 +51,11 @@ export abstract class BasicPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
+      if (input.plan.properties.reserved) {
+        return Observable.of(null);
+      } else {
+        return this.checkIfDreamspark(input.subscriptionId);
+      }
     } else if (input.specPickerInput.data) {
       if (
         input.specPickerInput.data.hostingEnvironmentName ||
@@ -59,9 +65,14 @@ export abstract class BasicPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
-    }
 
-    return this.checkIfDreamspark(input.subscriptionId);
+      if (input.specPickerInput.data.isLinux && !input.specPickerInput.data.isNewFunctionAppCreate) {
+        return Observable.of(null);
+      } else {
+        return this.checkIfDreamspark(input.subscriptionId);
+      }
+    }
+    return Observable.of(null);
   }
 }
 

--- a/client/src/app/site/spec-picker/price-spec-manager/dV2series-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/dV2series-price-spec.ts
@@ -58,7 +58,11 @@ export abstract class DV2SeriesPriceSpec extends PriceSpec {
       this.state = this._shouldHideForExistingPlan(input.plan) ? 'hidden' : this.state;
 
       return this._checkIfSkuEnabledOnStamp(input.plan.id).switchMap(_ => {
-        return this.checkIfDreamspark(input.subscriptionId);
+        if (input.plan.properties.reserved) {
+          return Observable.of(null);
+        } else {
+          return this.checkIfDreamspark(input.subscriptionId);
+        }
       });
     } else if (input.specPickerInput.data) {
       this.state = this._shouldHideForNewPlan(input.specPickerInput.data) ? 'hidden' : this.state;

--- a/client/src/app/site/spec-picker/price-spec-manager/dV2series-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/dV2series-price-spec.ts
@@ -58,9 +58,7 @@ export abstract class DV2SeriesPriceSpec extends PriceSpec {
       this.state = this._shouldHideForExistingPlan(input.plan) ? 'hidden' : this.state;
 
       return this._checkIfSkuEnabledOnStamp(input.plan.id).switchMap(_ => {
-        if (input.plan.properties.reserved) {
-          return Observable.of(null);
-        } else {
+        if (!input.plan.properties.reserved) {
           return this.checkIfDreamspark(input.subscriptionId);
         }
       });

--- a/client/src/app/site/spec-picker/price-spec-manager/dV2series-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/dV2series-price-spec.ts
@@ -60,6 +60,8 @@ export abstract class DV2SeriesPriceSpec extends PriceSpec {
       return this._checkIfSkuEnabledOnStamp(input.plan.id).switchMap(_ => {
         if (!input.plan.properties.reserved) {
           return this.checkIfDreamspark(input.subscriptionId);
+        } else {
+          return Observable.of(null);
         }
       });
     } else if (input.specPickerInput.data) {

--- a/client/src/app/site/spec-picker/price-spec-manager/dV3series-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/dV3series-price-spec.ts
@@ -70,9 +70,7 @@ export abstract class DV3SeriesPriceSpec extends PriceSpec {
       this.state = this._shouldHideForExistingPlan(input.plan) ? 'hidden' : this.state;
 
       return this._checkIfSkuEnabledOnStamp(input.plan.id).switchMap(_ => {
-        if (input.plan.properties.reserved) {
-          return Observable.of(null);
-        } else {
+        if (!input.plan.properties.reserved) {
           return this.checkIfDreamspark(input.subscriptionId);
         }
       });

--- a/client/src/app/site/spec-picker/price-spec-manager/dV3series-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/dV3series-price-spec.ts
@@ -70,7 +70,11 @@ export abstract class DV3SeriesPriceSpec extends PriceSpec {
       this.state = this._shouldHideForExistingPlan(input.plan) ? 'hidden' : this.state;
 
       return this._checkIfSkuEnabledOnStamp(input.plan.id).switchMap(_ => {
-        return this.checkIfDreamspark(input.subscriptionId);
+        if (input.plan.properties.reserved) {
+          return Observable.of(null);
+        } else {
+          return this.checkIfDreamspark(input.subscriptionId);
+        }
       });
     } else if (input.specPickerInput.data) {
       const isXenon = input.specPickerInput.data.hyperV || input.specPickerInput.data.isXenon;

--- a/client/src/app/site/spec-picker/price-spec-manager/dV3series-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/dV3series-price-spec.ts
@@ -72,6 +72,8 @@ export abstract class DV3SeriesPriceSpec extends PriceSpec {
       return this._checkIfSkuEnabledOnStamp(input.plan.id).switchMap(_ => {
         if (!input.plan.properties.reserved) {
           return this.checkIfDreamspark(input.subscriptionId);
+        } else {
+          return Observable.of(null);
         }
       });
     } else if (input.specPickerInput.data) {

--- a/client/src/app/site/spec-picker/price-spec-manager/free-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/free-plan-price-spec.ts
@@ -73,9 +73,7 @@ export class FreePlanPriceSpec extends PriceSpec {
         this.state = 'hidden';
       }
 
-      return this._checkIfSkuEnabledOnStamp(input.plan.id).switchMap(_ => {
-        return this.checkIfDreamspark(input.subscriptionId);
-      });
+      return this._checkIfSkuEnabledOnStamp(input.plan.id);
     } else if (input.specPickerInput.data) {
       isLinux = input.specPickerInput.data.isLinux;
       if (isLinux) {

--- a/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
@@ -4,6 +4,7 @@ import { Tier, SkuCode } from './../../../shared/models/serverFarmSku';
 import { PortalResources } from '../../../shared/models/portal-resources';
 import { AppKind } from './../../../shared/Utilities/app-kind';
 import { PriceSpec, PriceSpecInput } from './price-spec';
+import { Observable } from 'rxjs/Observable';
 
 export abstract class PremiumPlanPriceSpec extends PriceSpec {
   tier = Tier.premium;
@@ -71,6 +72,12 @@ export abstract class PremiumPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
+
+      if (input.plan.properties.reserved) {
+        return Observable.of(null);
+      } else {
+        return this.checkIfDreamspark(input.subscriptionId);
+      }
     } else if (input.specPickerInput.data) {
       if (
         input.specPickerInput.data.hostingEnvironmentName ||
@@ -81,9 +88,10 @@ export abstract class PremiumPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
+      return this.checkIfDreamspark(input.subscriptionId);
     }
 
-    return this.checkIfDreamspark(input.subscriptionId);
+    return Observable.of(null);
   }
 }
 

--- a/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
@@ -73,9 +73,7 @@ export abstract class PremiumPlanPriceSpec extends PriceSpec {
         this.state = 'hidden';
       }
 
-      if (input.plan.properties.reserved) {
-        return Observable.of(null);
-      } else {
+      if (!input.plan.properties.reserved) {
         return this.checkIfDreamspark(input.subscriptionId);
       }
     } else if (input.specPickerInput.data) {

--- a/client/src/app/site/spec-picker/price-spec-manager/shared-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/shared-plan-price-spec.ts
@@ -3,6 +3,7 @@ import { Tier, SkuCode } from './../../../shared/models/serverFarmSku';
 import { PortalResources } from './../../../shared/models/portal-resources';
 import { AppKind } from './../../../shared/Utilities/app-kind';
 import { PriceSpec, PriceSpecInput } from './price-spec';
+import { Observable } from 'rxjs/Observable';
 
 export class SharedPlanPriceSpec extends PriceSpec {
   tier = Tier.shared;
@@ -59,6 +60,12 @@ export class SharedPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
+
+      if (input.plan.properties.reserved) {
+        return Observable.of(null);
+      } else {
+        return this.checkIfDreamspark(input.subscriptionId);
+      }
     } else if (input.specPickerInput.data) {
       if (
         input.specPickerInput.data.hostingEnvironmentName ||
@@ -69,8 +76,9 @@ export class SharedPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
+      return this.checkIfDreamspark(input.subscriptionId);
     }
 
-    return this.checkIfDreamspark(input.subscriptionId);
+    return Observable.of(null);
   }
 }

--- a/client/src/app/site/spec-picker/price-spec-manager/shared-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/shared-plan-price-spec.ts
@@ -61,9 +61,7 @@ export class SharedPlanPriceSpec extends PriceSpec {
         this.state = 'hidden';
       }
 
-      if (input.plan.properties.reserved) {
-        return Observable.of(null);
-      } else {
+      if (!input.plan.properties.reserved) {
         return this.checkIfDreamspark(input.subscriptionId);
       }
     } else if (input.specPickerInput.data) {

--- a/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
@@ -4,6 +4,7 @@ import { Tier, SkuCode } from './../../../shared/models/serverFarmSku';
 import { PortalResources } from './../../../shared/models/portal-resources';
 import { AppKind } from './../../../shared/Utilities/app-kind';
 import { PriceSpec, PriceSpecInput } from './price-spec';
+import { Observable } from 'rxjs/Observable';
 
 export abstract class StandardPlanPriceSpec extends PriceSpec {
   tier = Tier.standard;
@@ -71,6 +72,12 @@ export abstract class StandardPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
+
+      if (input.plan.properties.reserved) {
+        return Observable.of(null);
+      } else {
+        return this.checkIfDreamspark(input.subscriptionId);
+      }
     } else if (input.specPickerInput.data) {
       if (
         input.specPickerInput.data.hostingEnvironmentName ||
@@ -80,9 +87,10 @@ export abstract class StandardPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
+      return this.checkIfDreamspark(input.subscriptionId);
     }
 
-    return this.checkIfDreamspark(input.subscriptionId);
+    return Observable.of(null);
   }
 }
 

--- a/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
@@ -73,9 +73,7 @@ export abstract class StandardPlanPriceSpec extends PriceSpec {
         this.state = 'hidden';
       }
 
-      if (input.plan.properties.reserved) {
-        return Observable.of(null);
-      } else {
+      if (!input.plan.properties.reserved) {
         return this.checkIfDreamspark(input.subscriptionId);
       }
     } else if (input.specPickerInput.data) {


### PR DESCRIPTION
Fixes AB#9515077

Can't give screenshots for create scenario till my Ibiza change goes to canary and I need to work on Fusion repo on my Mac as Windows does not work so can't load both locals together. Sorry about that.

Screenshots for scaleup:

**Linux WebApp**
![image](https://user-images.githubusercontent.com/14221995/110991114-0d010300-8329-11eb-8fb8-5290f21fe32b.png)

![image](https://user-images.githubusercontent.com/14221995/110991159-1e4a0f80-8329-11eb-9878-6f1efef96252.png)

**Windows WebApp**
![image](https://user-images.githubusercontent.com/14221995/110991272-476aa000-8329-11eb-80b0-72d63c85c62e.png)

![image](https://user-images.githubusercontent.com/14221995/110991315-57827f80-8329-11eb-9737-622761a75b74.png)

