### PR TITLE
Introduce isKubeApp property on the siteStateContext along with the ScenarioChecker.

### DIFF
--- a/client-react/src/SiteState.ts
+++ b/client-react/src/SiteState.ts
@@ -9,6 +9,7 @@ export interface ISiteState {
   isLinuxApp: boolean;
   isContainerApp: boolean;
   isFunctionApp: boolean;
+  isKubeApp: boolean;
   resourceId?: string;
   site?: ArmObj<Site>;
 }

--- a/client-react/src/pages/app/SiteRouter.tsx
+++ b/client-react/src/pages/app/SiteRouter.tsx
@@ -10,7 +10,7 @@ import { SiteStateContext } from '../../SiteState';
 import { StartupInfoContext } from '../../StartupInfoContext';
 import { iconStyles } from '../../theme/iconStyles';
 import { ThemeContext } from '../../ThemeContext';
-import { isContainerApp, isElastic, isFunctionApp, isLinuxApp, isLinuxDynamic } from '../../utils/arm-utils';
+import { isContainerApp, isElastic, isFunctionApp, isKubeApp, isLinuxApp, isLinuxDynamic } from '../../utils/arm-utils';
 import { CommonConstants } from '../../utils/CommonConstants';
 import FunctionAppService from '../../utils/FunctionAppService';
 import { LogCategories } from '../../utils/LogCategories';
@@ -79,6 +79,7 @@ const SiteRouter: React.FC<RouteComponentProps<SiteRouterProps>> = props => {
   const [isLinuxApplication, setIsLinuxApplication] = useState<boolean>(false);
   const [isContainerApplication, setIsContainerApplication] = useState<boolean>(false);
   const [isFunctionApplication, setIsFunctionApplication] = useState<boolean>(false);
+  const [isKubeApplication, setIsKubeApplication] = useState<boolean>(false);
 
   const getSiteStateFromSiteData = (site: ArmObj<Site>): FunctionAppEditMode | undefined => {
     if (isLinuxDynamic(site)) {
@@ -223,6 +224,7 @@ const SiteRouter: React.FC<RouteComponentProps<SiteRouterProps>> = props => {
         setIsLinuxApplication(isLinuxApp(siteResponse.data));
         setIsContainerApplication(isContainerApp(siteResponse.data));
         setIsFunctionApplication(isFunctionApp(siteResponse.data));
+        setIsKubeApplication(isKubeApp(siteResponse.data));
       }
       setSiteAppEditState(functionAppEditMode);
     }
@@ -251,6 +253,7 @@ const SiteRouter: React.FC<RouteComponentProps<SiteRouterProps>> = props => {
                     isLinuxApp: isLinuxApplication,
                     isContainerApp: isContainerApplication,
                     isFunctionApp: isFunctionApplication,
+                    isKubeApp: isKubeApplication,
                   }}>
                   <Router>
                     {/* NOTE(michinoy): The paths should be always all lowercase. */}

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -43,6 +43,7 @@ export class CommonConstants {
     showServiceLinkerConnector: 'showServiceLinkerConnector',
     enableGitHubOnNationalCloud: 'enableGitHubOnNationalCloud',
     enableEditingForLinuxConsumption: 'enableEditingForLinuxConsumption',
+    treatAsKubeApp: 'treatAsKubeApp', // websitesextension_ext=appsvc.treatAsKubeApp%3Dtrue
   };
 
   public static readonly AppDensityLimit = 8;

--- a/client-react/src/utils/arm-utils.ts
+++ b/client-react/src/utils/arm-utils.ts
@@ -41,6 +41,7 @@ export function isWorkflowApp(obj: ArmObj<any>): boolean {
 export function isKubeApp(obj: ArmObj<unknown>): boolean {
   // NOTE(michinoy): While there is a bug in place, we can pass in a flag in the
   // url to treat the app as Kube app.
+  // BUG - https://msazure.visualstudio.com/Antares/_workitems/edit/9449377
   return AppKind.hasKinds(obj, ['kubeapp']) || Url.getFeatureValue(CommonConstants.FeatureFlags.treatAsKubeApp) === 'true';
 }
 

--- a/client-react/src/utils/arm-utils.ts
+++ b/client-react/src/utils/arm-utils.ts
@@ -2,6 +2,7 @@ import { AppKind } from './AppKind';
 import { ArmObj, ResourceGraphColumn, Identity, ArmSku } from '../models/arm-obj';
 import { Site } from '../models/site/site';
 import { CommonConstants } from './CommonConstants';
+import Url from './url';
 
 export function isFunctionApp(obj: ArmObj<any>): boolean {
   return AppKind.hasKinds(obj, ['functionapp']) && !AppKind.hasKinds(obj, ['botapp']);
@@ -35,6 +36,12 @@ export function isXenonApp(obj: ArmObj<Site>): boolean {
 
 export function isWorkflowApp(obj: ArmObj<any>): boolean {
   return AppKind.hasKinds(obj, ['functionapp', 'workflowapp']);
+}
+
+export function isKubeApp(obj: ArmObj<unknown>): boolean {
+  // NOTE(michinoy): While there is a bug in place, we can pass in a flag in the
+  // url to treat the app as Kube app.
+  return AppKind.hasKinds(obj, ['kubeapp']) || Url.getFeatureValue(CommonConstants.FeatureFlags.treatAsKubeApp) === 'true';
 }
 
 export function mapResourcesTopologyToArmObjects<T>(columns: ResourceGraphColumn[], rows: any[][]): ArmObj<T>[] {

--- a/client-react/src/utils/scenario-checker/kube-app.environment.ts
+++ b/client-react/src/utils/scenario-checker/kube-app.environment.ts
@@ -39,12 +39,12 @@ export class KubeApp extends Environment {
     };
 
     this.scenarioChecks[ScenarioIds.kuduBuildProvider] = {
-      id: ScenarioIds.ftpSource,
+      id: ScenarioIds.kuduBuildProvider,
       runCheck: () => ({ status: 'disabled' }),
     };
 
     this.scenarioChecks[ScenarioIds.azurePipelinesBuildProvider] = {
-      id: ScenarioIds.ftpSource,
+      id: ScenarioIds.azurePipelinesBuildProvider,
       runCheck: () => ({ status: 'disabled' }),
     };
   }

--- a/client-react/src/utils/scenario-checker/kube-app.environment.ts
+++ b/client-react/src/utils/scenario-checker/kube-app.environment.ts
@@ -1,0 +1,59 @@
+import { ScenarioIds } from './scenario-ids';
+import { ScenarioCheckInput, Environment } from './scenario.models';
+import { isKubeApp } from '../arm-utils';
+
+export class KubeApp extends Environment {
+  public name = 'KubeApp';
+
+  constructor(t: (string) => string) {
+    super();
+
+    this.scenarioChecks[ScenarioIds.onedriveSource] = {
+      id: ScenarioIds.onedriveSource,
+      runCheck: () => ({ status: 'disabled' }),
+    };
+
+    this.scenarioChecks[ScenarioIds.dropboxSource] = {
+      id: ScenarioIds.dropboxSource,
+      runCheck: () => ({ status: 'disabled' }),
+    };
+
+    this.scenarioChecks[ScenarioIds.externalSource] = {
+      id: ScenarioIds.externalSource,
+      runCheck: () => ({ status: 'disabled' }),
+    };
+
+    this.scenarioChecks[ScenarioIds.bitbucketSource] = {
+      id: ScenarioIds.bitbucketSource,
+      runCheck: () => ({ status: 'disabled' }),
+    };
+
+    this.scenarioChecks[ScenarioIds.vstsSource] = {
+      id: ScenarioIds.vstsSource,
+      runCheck: () => ({ status: 'disabled' }),
+    };
+
+    this.scenarioChecks[ScenarioIds.ftpSource] = {
+      id: ScenarioIds.ftpSource,
+      runCheck: () => ({ status: 'disabled' }),
+    };
+
+    this.scenarioChecks[ScenarioIds.kuduBuildProvider] = {
+      id: ScenarioIds.ftpSource,
+      runCheck: () => ({ status: 'disabled' }),
+    };
+
+    this.scenarioChecks[ScenarioIds.azurePipelinesBuildProvider] = {
+      id: ScenarioIds.ftpSource,
+      runCheck: () => ({ status: 'disabled' }),
+    };
+  }
+
+  public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {
+    if (input && input.site) {
+      return isKubeApp(input.site);
+    }
+
+    return false;
+  }
+}

--- a/client-react/src/utils/scenario-checker/scenario-ids.ts
+++ b/client-react/src/utils/scenario-checker/scenario-ids.ts
@@ -110,4 +110,5 @@ export class ScenarioIds {
   public static readonly deploymentCenterLogs = 'deploymentCenterLogs';
   public static readonly kuduBuildProvider = 'kuduBuildProvider';
   public static readonly dockerCompose = 'dockerCompose';
+  public static readonly azurePipelinesBuildProvider = 'azurePipelinesBuildProvider';
 }

--- a/client-react/src/utils/scenario-checker/scenario.service.ts
+++ b/client-react/src/utils/scenario-checker/scenario.service.ts
@@ -9,6 +9,7 @@ import { DynamicLinuxEnvironment } from './dynamic-linux.environment';
 import { FunctionAppEnvironment } from './function-app.environment';
 import { WindowsCode } from './windows-code.environment';
 import { ContainerApp } from './container.environment';
+import { KubeApp } from './kube-app.environment';
 import { ElasticPremiumAppEnvironment } from './elastic-premium.environment';
 import { WorkflowAppEnvironment } from './workflow-app.environment';
 
@@ -31,6 +32,7 @@ export class ScenarioService {
       new FunctionAppEnvironment(t),
       new WindowsCode(t),
       new ContainerApp(t),
+      new KubeApp(t),
       new ElasticPremiumAppEnvironment(t),
       new WorkflowAppEnvironment(t),
     ];


### PR DESCRIPTION
fixes AB#9522246
fixes AB#9522282 

**Introduce isKubeApp on siteStateContext**
This is a temporary feature flag till kind property is available via the API. Adding this in because eventually when the kind property is available, isKubeApp will still be needed on the siteStateContext. 

Sample url - https://portal.azure.com/?feature.customportal=false&websitesextension_functionslocal=true&websitesextension_ext=appsvc.treatAsKubeApp%3Dtrue#home

**Introduce KubeApp ScenarioChecker**
This is needed to enable/disable and/or hide/show options in the Deployment Center. 

