### PR TITLE
Setup up screen for deployment center updated for K8se apps.

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenterConstants.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterConstants.ts
@@ -68,4 +68,11 @@ export class DeploymentCenterConstants {
   public static readonly singleContainerQSLink = 'https://go.microsoft.com/fwlink/?linkid=873144';
   public static readonly dockerComposeQSLink = 'https://go.microsoft.com/fwlink/?linkid=873149';
   public static readonly kubeQSLink = 'https://go.microsoft.com/fwlink/?linkid=873150';
+
+  public static readonly metadataIsGitHubAction = 'isGitHubAction';
+  public static readonly metadataRepoUrl = 'RepoUrl';
+  public static readonly metadataBranch = 'branch';
+  public static readonly metadataOAuthToken = 'OAuthToken';
+  public static readonly metadataScmUri = 'ScmUri';
+  public static readonly metadataCloneUri = 'CloneUri';
 }

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildCallout.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildCallout.tsx
@@ -25,6 +25,10 @@ const DeploymentCenterCodeBuildCallout: React.FC<DeploymentCenterCodeBuildCallou
     return scenarioService.checkScenario(ScenarioIds.kuduBuildProvider, { site: siteStateContext.site }).status === 'disabled';
   };
 
+  const isAzurePipelinesDisabled = () => {
+    return scenarioService.checkScenario(ScenarioIds.azurePipelinesBuildProvider, { site: siteStateContext.site }).status === 'disabled';
+  };
+
   const permanentBuildOptions: BuildChoiceGroupOption[] = [
     {
       key: BuildProvider.AppServiceBuildService,
@@ -36,6 +40,7 @@ const DeploymentCenterCodeBuildCallout: React.FC<DeploymentCenterCodeBuildCallou
       key: BuildProvider.Vsts,
       text: t('deploymentCenterCodeSettingsBuildVsts'),
       buildType: BuildProvider.Vsts,
+      disabled: isAzurePipelinesDisabled(),
     },
   ];
 

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
@@ -85,7 +85,12 @@ const DeploymentCenterCodeForm: React.FC<DeploymentCenterCodeFormProps> = props 
         // workaround.
         portalContext.log(getTelemetryInfo('warning', 'updateSourceControlsWorkaround', 'submit'));
 
-        return updateGitHubActionSourceControlPropertiesManually(deploymentCenterData, deploymentCenterContext.resourceId, payload);
+        return updateGitHubActionSourceControlPropertiesManually(
+          deploymentCenterData,
+          deploymentCenterContext.resourceId,
+          payload,
+          deploymentCenterContext.gitHubToken
+        );
       } else {
         if (!updateSourceControlResponse.metadata.success) {
           portalContext.log(

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodePivot.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodePivot.tsx
@@ -22,6 +22,7 @@ const DeploymentCenterCodePivot: React.FC<DeploymentCenterCodePivotProps> = prop
   const { t } = useTranslation();
   const [selectedKey, setSelectedKey] = useState<string>('settings');
   const [showLogsTab, setShowLogsTab] = useState(true);
+  const [showFtpsTab, setShowFtpsTab] = useState(false);
 
   const deploymentCenterContext = useContext(DeploymentCenterContext);
   const deploymentCenterPublishingContext = useContext(DeploymentCenterPublishingContext);
@@ -112,6 +113,11 @@ const DeploymentCenterCodePivot: React.FC<DeploymentCenterCodePivotProps> = prop
       setShowLogsTab(scenarioStatus !== 'disabled');
     }
 
+    if (siteStateContext && siteStateContext.site) {
+      const scenarioStatus = scenarioService.checkScenario(ScenarioIds.ftpSource, { site: siteStateContext.site }).status;
+      setShowFtpsTab(scenarioStatus !== 'disabled');
+    }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [siteStateContext.site]);
 
@@ -136,15 +142,17 @@ const DeploymentCenterCodePivot: React.FC<DeploymentCenterCodePivotProps> = prop
         </PivotItem>
       )}
 
-      <PivotItem
-        itemKey="ftps"
-        headerText={isScmLocalGit ? t('deploymentCenterPivotItemGitFtpsHeaderText') : t('deploymentCenterPivotItemFtpsHeaderText')}
-        ariaLabel={isScmLocalGit ? t('deploymentCenterPivotItemGitFtpsAriaLabel') : t('deploymentCenterPivotItemFtpsAriaLabel')}
-        onRenderItemLink={(link: IPivotItemProps, defaultRenderer: (link: IPivotItemProps) => JSX.Element) =>
-          CustomTabRenderer(link, defaultRenderer, theme, isFtpsDirty, t('modifiedTag'))
-        }>
-        <DeploymentCenterFtps formProps={formProps} isDataRefreshing={isDataRefreshing} />
-      </PivotItem>
+      {showFtpsTab && (
+        <PivotItem
+          itemKey="ftps"
+          headerText={isScmLocalGit ? t('deploymentCenterPivotItemGitFtpsHeaderText') : t('deploymentCenterPivotItemFtpsHeaderText')}
+          ariaLabel={isScmLocalGit ? t('deploymentCenterPivotItemGitFtpsAriaLabel') : t('deploymentCenterPivotItemFtpsAriaLabel')}
+          onRenderItemLink={(link: IPivotItemProps, defaultRenderer: (link: IPivotItemProps) => JSX.Element) =>
+            CustomTabRenderer(link, defaultRenderer, theme, isFtpsDirty, t('modifiedTag'))
+          }>
+          <DeploymentCenterFtps formProps={formProps} isDataRefreshing={isDataRefreshing} />
+        </PivotItem>
+      )}
     </Pivot>
   );
 };

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
@@ -16,7 +16,7 @@ import {
   getCodeFunctionAppCodeWorkflowInformation,
   isWorkflowOptionExistingOrAvailable,
 } from '../utility/GitHubActionUtility';
-import { getWorkflowFileName } from '../utility/DeploymentCenterUtility';
+import { getWorkflowFileName, isGitHubActionSetupViaMetadata } from '../utility/DeploymentCenterUtility';
 import DeploymentCenterCodeSourceKuduConfiguredView from './DeploymentCenterCodeSourceKuduConfiguredView';
 import { DeploymentCenterLinks } from '../../../../utils/FwLinks';
 import { learnMoreLinkStyle } from '../../../../components/form-controls/formControl.override.styles';
@@ -48,19 +48,23 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
   const [isPreviewFileButtonDisabled, setIsPreviewFileButtonDisabled] = useState(false);
   const [panelMessage, setPanelMessage] = useState('');
 
-  const isDeploymentSetup = deploymentCenterContext.siteConfig && deploymentCenterContext.siteConfig.properties.scmType !== ScmType.None;
+  const isDeploymentSetup = siteStateContext.isKubeApp
+    ? isGitHubActionSetupViaMetadata(deploymentCenterContext.configMetadata)
+    : deploymentCenterContext.siteConfig && deploymentCenterContext.siteConfig.properties.scmType !== ScmType.None;
 
   const isKuduBuild = formProps.values.buildProvider === BuildProvider.AppServiceBuildService;
   const isVstsBuild = formProps.values.buildProvider === BuildProvider.Vsts;
 
   const isGitHubSource = formProps.values.sourceProvider === ScmType.GitHub;
   const isGitHubActionsBuild = formProps.values.buildProvider === BuildProvider.GitHubAction;
-  const isGitHubActionsSetup =
-    deploymentCenterContext.siteConfig && deploymentCenterContext.siteConfig.properties.scmType === ScmType.GitHubAction;
-  const isGitHubSourceSetup =
-    deploymentCenterContext.siteConfig &&
-    (deploymentCenterContext.siteConfig.properties.scmType === ScmType.GitHubAction ||
-      deploymentCenterContext.siteConfig.properties.scmType === ScmType.GitHub);
+  const isGitHubActionsSetup = siteStateContext.isKubeApp
+    ? isGitHubActionSetupViaMetadata(deploymentCenterContext.configMetadata)
+    : deploymentCenterContext.siteConfig && deploymentCenterContext.siteConfig.properties.scmType === ScmType.GitHubAction;
+  const isGitHubSourceSetup = siteStateContext.isKubeApp
+    ? isGitHubActionSetupViaMetadata(deploymentCenterContext.configMetadata)
+    : deploymentCenterContext.siteConfig &&
+      (deploymentCenterContext.siteConfig.properties.scmType === ScmType.GitHubAction ||
+        deploymentCenterContext.siteConfig.properties.scmType === ScmType.GitHub);
   const isUsingExistingOrAvailableWorkflowConfig = isWorkflowOptionExistingOrAvailable(formProps.values.workflowOption);
 
   const isBitbucketSource = formProps.values.sourceProvider === ScmType.BitbucketGit;
@@ -204,7 +208,7 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
           {!isTfsOrVsoSetup && <DeploymentCenterCodeBuildConfiguredView />}
         </>
       ) : (
-        <div tabIndex={-1}>
+        <div>
           <DeploymentCenterCodeSourceAndBuild formProps={formProps} />
 
           {isGitHubActionsBuild && (

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -483,7 +483,12 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
 
       portalContext.log(getTelemetryInfo('warning', 'updateSourceControlDetailsWorkaround', 'submit'));
 
-      return updateGitHubActionSourceControlPropertiesManually(deploymentCenterData, deploymentCenterContext.resourceId, payload);
+      return updateGitHubActionSourceControlPropertiesManually(
+        deploymentCenterData,
+        deploymentCenterContext.resourceId,
+        payload,
+        deploymentCenterContext.gitHubToken
+      );
     } else {
       return updateSourceControlResponse;
     }

--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
@@ -8,6 +8,7 @@ import { ArmSiteDescriptor } from '../../../../utils/resourceDescriptors';
 import { PublishingCredentials } from '../../../../models/site/publish';
 import { LogLevel, TelemetryInfo } from '../../../../models/telemetry';
 import { LogCategories } from '../../../../utils/LogCategories';
+import { DeploymentCenterConstants } from '../DeploymentCenterConstants';
 
 export const getLogId = (component: string, event: string): string => {
   return `${component}/${event}`;
@@ -277,4 +278,12 @@ export const extractConfigFromFile = (input): Promise<string> => {
     };
     reader.readAsText(input.files[0]);
   });
+};
+
+export const isGitHubActionSetupViaMetadata = (metadata?: ArmObj<KeyValue<string>>) => {
+  return (
+    metadata &&
+    metadata[DeploymentCenterConstants.metadataIsGitHubAction] &&
+    metadata[DeploymentCenterConstants.metadataIsGitHubAction] === 'true'
+  );
 };

--- a/client-react/src/pages/app/deployment-center/utility/GitHubActionUtility.ts
+++ b/client-react/src/pages/app/deployment-center/utility/GitHubActionUtility.ts
@@ -14,7 +14,8 @@ import { DeploymentCenterConstants } from '../DeploymentCenterConstants';
 export const updateGitHubActionSourceControlPropertiesManually = async (
   deploymentCenterData: DeploymentCenterData,
   resourceId: string,
-  payload: SiteSourceControlRequestBody
+  payload: SiteSourceControlRequestBody,
+  gitHubToken: string
 ) => {
   // NOTE(michinoy): To be on the safe side, the update operations should be sequential rather than
   // parallel. The reason behind this is because incase the metadata update fails, but the scmtype is updated
@@ -31,13 +32,15 @@ export const updateGitHubActionSourceControlPropertiesManually = async (
   }
 
   const properties = fetchExistingMetadataResponse.data.properties;
-  delete properties['RepoUrl'];
-  delete properties['ScmUri'];
-  delete properties['CloneUri'];
-  delete properties['branch'];
+  delete properties[DeploymentCenterConstants.metadataRepoUrl];
+  delete properties[DeploymentCenterConstants.metadataScmUri];
+  delete properties[DeploymentCenterConstants.metadataCloneUri];
+  delete properties[DeploymentCenterConstants.metadataBranch];
+  delete properties[DeploymentCenterConstants.metadataOAuthToken];
 
-  properties['RepoUrl'] = payload.repoUrl;
-  properties['branch'] = payload.branch;
+  properties[DeploymentCenterConstants.metadataRepoUrl] = payload.repoUrl;
+  properties[DeploymentCenterConstants.metadataBranch] = payload.branch;
+  properties[DeploymentCenterConstants.metadataOAuthToken] = gitHubToken;
 
   const updateMetadataResponse = await deploymentCenterData.updateConfigMetadata(resourceId, properties);
 
@@ -667,7 +670,7 @@ jobs:
     - name: Download artifact from build job
         uses: actions/download-artifact@v2
         with:
-          name: ASP-app 
+          name: ASP-app
 
     - name: Deploy to Azure Web App
       id: deploy-to-webapp
@@ -735,7 +738,7 @@ jobs:
         push: true
         tags: __image__:\${{ github.sha }}
         file: ./Dockerfile
-  
+
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/client-react/src/utils/scenario-checker/kube-app.environment.ts
+++ b/client-react/src/utils/scenario-checker/kube-app.environment.ts
@@ -38,6 +38,11 @@ export class KubeApp extends Environment {
       runCheck: () => ({ status: 'disabled' }),
     };
 
+    this.scenarioChecks[ScenarioIds.localGitSource] = {
+      id: ScenarioIds.localGitSource,
+      runCheck: () => ({ status: 'disabled' }),
+    };
+
     this.scenarioChecks[ScenarioIds.kuduBuildProvider] = {
       id: ScenarioIds.kuduBuildProvider,
       runCheck: () => ({ status: 'disabled' }),


### PR DESCRIPTION
fixes AB#9522377

** NOTE ** Saves do not work yet.
** NOTE ** use websitesextension_ext=appsvc.treatAsKubeApp%3Dtrue in the URL.

In this PR the deployment center page will load with Settings and Logs tabs. FTPs tab is omitted. The Settings tab load is driven by reading Metadata values rather than siteConfig.scmType value. (we might be able to get away with just using the scmType, but I need to experiment with that a little more).

The main part of this PR is to remove the FTPs tab and also any non supported options for deployment, so anything other than GitHub Action.

![image](https://user-images.githubusercontent.com/493476/111041374-ba891a80-83ec-11eb-89ca-640b78d9644f.png)

![image](https://user-images.githubusercontent.com/493476/111041382-c248bf00-83ec-11eb-98ad-f00cb3d805c4.png)

![image](https://user-images.githubusercontent.com/493476/111041387-cb399080-83ec-11eb-90bc-d29be687f4c8.png)

![image](https://user-images.githubusercontent.com/493476/111041398-d5f42580-83ec-11eb-8e3d-460ee6f1194b.png)
