### PR TITLE
Load the configured view and update using metadata

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,8 @@
 "typescript.preferences.importModuleSpecifier": "relative",
 "cSpell.ignoreWords": [
     "applicationinsightapi"
+],
+"cSpell.words": [
+  "Kube"
 ]
 }

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
@@ -362,13 +362,13 @@ const DeploymentCenterCodeForm: React.FC<DeploymentCenterCodeFormProps> = props 
   ) => {
     // Only do the save if build provider is set by the user and the scmtype in the config is set to none.
     // If the scmtype in the config is not none, the user should be doing a disconnect operation first.
-    // This check is in place, because the use could set the form props ina dirty state by just modifying the
+    // This check is in place, because the use could set the form props in a dirty state by just modifying the
     // publishing user information.
-    if (
-      values.buildProvider !== BuildProvider.None &&
+    const isMissingOriginalConfigScmType =
       deploymentCenterContext.siteConfig &&
-      deploymentCenterContext.siteConfig.properties.scmType === ScmType.None
-    ) {
+      (!deploymentCenterContext.siteConfig.properties.scmType || deploymentCenterContext.siteConfig.properties.scmType === ScmType.None);
+
+    if (values.buildProvider !== BuildProvider.None && isMissingOriginalConfigScmType) {
       // NOTE(stpelleg):Reset the form values only if deployment settings need to be updated.
       formikActions.resetForm(values);
       if (values.buildProvider === BuildProvider.GitHubAction) {

--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
@@ -288,7 +288,8 @@ export const extractConfigFromFile = (input): Promise<string> => {
 export const isGitHubActionSetupViaMetadata = (metadata?: ArmObj<KeyValue<string>>) => {
   return (
     metadata &&
-    metadata[DeploymentCenterConstants.metadataIsGitHubAction] &&
-    metadata[DeploymentCenterConstants.metadataIsGitHubAction] === 'true'
+    metadata.properties &&
+    metadata.properties[DeploymentCenterConstants.metadataIsGitHubAction] &&
+    metadata.properties[DeploymentCenterConstants.metadataIsGitHubAction] === 'true'
   );
 };

--- a/client-react/src/pages/app/deployment-center/utility/GitHubActionUtility.ts
+++ b/client-react/src/pages/app/deployment-center/utility/GitHubActionUtility.ts
@@ -37,10 +37,12 @@ export const updateGitHubActionSourceControlPropertiesManually = async (
   delete properties[DeploymentCenterConstants.metadataCloneUri];
   delete properties[DeploymentCenterConstants.metadataBranch];
   delete properties[DeploymentCenterConstants.metadataOAuthToken];
+  delete properties[DeploymentCenterConstants.metadataIsGitHubAction];
 
   properties[DeploymentCenterConstants.metadataRepoUrl] = payload.repoUrl;
   properties[DeploymentCenterConstants.metadataBranch] = payload.branch;
   properties[DeploymentCenterConstants.metadataOAuthToken] = gitHubToken;
+  properties[DeploymentCenterConstants.metadataIsGitHubAction] = 'true';
 
   const updateMetadataResponse = await deploymentCenterData.updateConfigMetadata(resourceId, properties);
 


### PR DESCRIPTION
fixes AB#9531489
fixes AB#9532080

With this change, for Kube apps, the save operation will update the metadata directly and pull data from the metadata. For non-kube apps the current process will work as is.