### PR TITLE
Expand pinned version string

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
@@ -115,7 +115,7 @@ export const javaContainersStack: WebAppStack = {
         },
         {
           displayText: 'JBoss EAP 7.3',
-          value: '7.3',
+          value: '7.3.x',
           stackSettings: {
             linuxContainerSettings: {
               java8Runtime: 'JBOSSEAP|7.3-java8',
@@ -126,11 +126,12 @@ export const javaContainersStack: WebAppStack = {
         },
         {
           displayText: 'JBoss EAP 7.2',
-          value: '7.2',
+          value: '7.2.x',
           stackSettings: {
             linuxContainerSettings: {
               java8Runtime: 'JBOSSEAP|7.2-java8',
               isPreview: true,
+              isDeprecated: true
             },
           },
         },

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
@@ -115,7 +115,7 @@ export const javaContainersStack: WebAppStack = {
         },
         {
           displayText: 'JBoss EAP 7.3',
-          value: '7.3.x',
+          value: '7.3.0',
           stackSettings: {
             linuxContainerSettings: {
               java8Runtime: 'JBOSSEAP|7.3-java8',
@@ -126,7 +126,7 @@ export const javaContainersStack: WebAppStack = {
         },
         {
           displayText: 'JBoss EAP 7.2',
-          value: '7.2.x',
+          value: '7.2.0',
           stackSettings: {
             linuxContainerSettings: {
               java8Runtime: 'JBOSSEAP|7.2-java8',

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -115,7 +115,7 @@ export const javaContainersStack: WebAppStack = {
         },
         {
           displayText: 'JBoss EAP 7.3',
-          value: '7.3',
+          value: '7.3.x',
           stackSettings: {
             linuxContainerSettings: {
               java8Runtime: 'JBOSSEAP|7.3-java8',
@@ -126,11 +126,12 @@ export const javaContainersStack: WebAppStack = {
         },
         {
           displayText: 'JBoss EAP 7.2',
-          value: '7.2',
+          value: '7.2.x',
           stackSettings: {
             linuxContainerSettings: {
               java8Runtime: 'JBOSSEAP|7.2-java8',
               isPreview: true,
+              isDeprecated: true
             },
           },
         },

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -115,7 +115,7 @@ export const javaContainersStack: WebAppStack = {
         },
         {
           displayText: 'JBoss EAP 7.3',
-          value: '7.3.x',
+          value: '7.3.0',
           stackSettings: {
             linuxContainerSettings: {
               java8Runtime: 'JBOSSEAP|7.3-java8',
@@ -126,7 +126,7 @@ export const javaContainersStack: WebAppStack = {
         },
         {
           displayText: 'JBoss EAP 7.2',
-          value: '7.2.x',
+          value: '7.2.0',
           stackSettings: {
             linuxContainerSettings: {
               java8Runtime: 'JBOSSEAP|7.2-java8',


### PR DESCRIPTION
The pinned JBoss versions had short strings in the "value" property (ex: `value: "7.2"` while other stacks have strings like  "10.4.5") so the create blade determined these were auto-update stacks. I've added ".x" to the pinned versions so it adheres to what the create blade is already doing.

This is what I hope to get: 
![image](https://user-images.githubusercontent.com/18747768/112399694-ee552180-8cc3-11eb-8303-743151f739c7.png)

Finally, JBoss 7.2 uses an old base OS that RedHat asked us to change going forward so I'm marking that as deprecated to keep people off of it.