### PR TITLE
Set the docker access type to private if GitHub Action is selected.

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDockerHubSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDockerHubSettings.tsx
@@ -31,7 +31,13 @@ const DeploymentCenterContainerDockerHubSettings: React.FC<DeploymentCenterField
   }, [formProps.values.dockerHubAccessType]);
 
   useEffect(() => {
-    setIsGitHubActionSelected(formProps.values.scmType === ScmType.GitHubAction);
+    const isGitHubAction = formProps.values.scmType === ScmType.GitHubAction;
+
+    setIsGitHubActionSelected(isGitHubAction);
+
+    if (isGitHubAction) {
+      formProps.setFieldValue('dockerHubAccessType', ContainerDockerAccessTypes.private);
+    }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formProps.values.scmType]);


### PR DESCRIPTION
fixes AB#9683995

This will make sure the username/password are sent over in the request payload when setting the action workflow.