### PR TITLE
Revert "AB#9515077 [Spec picker] Enable Free and Basic sku for Dreamspark subs in create scenario (for linux and webapp) and enable all skus for scale up (for Linux) (#5796)"

### DIFF
--- a/client/src/app/shared/models/server-farm.ts
+++ b/client/src/app/shared/models/server-farm.ts
@@ -4,5 +4,4 @@ export interface ServerFarm {
   provisioningState?: 'InProgress' | 'Succeeded' | 'Failed';
   hyperV?: boolean;
   numberOfWorkers?: number;
-  reserved?: boolean;
 }

--- a/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
@@ -3,7 +3,6 @@ import { Tier, SkuCode } from './../../../shared/models/serverFarmSku';
 import { PortalResources } from './../../../shared/models/portal-resources';
 import { AppKind } from './../../../shared/Utilities/app-kind';
 import { PriceSpec, PriceSpecInput } from './price-spec';
-import { Observable } from 'rxjs/Observable';
 
 export abstract class BasicPlanPriceSpec extends PriceSpec {
   tier = Tier.basic;
@@ -51,9 +50,6 @@ export abstract class BasicPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
-      if (!input.plan.properties.reserved) {
-        return this.checkIfDreamspark(input.subscriptionId);
-      }
     } else if (input.specPickerInput.data) {
       if (
         input.specPickerInput.data.hostingEnvironmentName ||
@@ -63,15 +59,9 @@ export abstract class BasicPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
-
-      if (
-        !input.specPickerInput.data.isLinux ||
-        (input.specPickerInput.data.isLinux && input.specPickerInput.data.isNewFunctionAppCreate)
-      ) {
-        return this.checkIfDreamspark(input.subscriptionId);
-      }
     }
-    return Observable.of(null);
+
+    return this.checkIfDreamspark(input.subscriptionId);
   }
 }
 

--- a/client/src/app/site/spec-picker/price-spec-manager/dV2series-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/dV2series-price-spec.ts
@@ -58,11 +58,7 @@ export abstract class DV2SeriesPriceSpec extends PriceSpec {
       this.state = this._shouldHideForExistingPlan(input.plan) ? 'hidden' : this.state;
 
       return this._checkIfSkuEnabledOnStamp(input.plan.id).switchMap(_ => {
-        if (!input.plan.properties.reserved) {
-          return this.checkIfDreamspark(input.subscriptionId);
-        } else {
-          return Observable.of(null);
-        }
+        return this.checkIfDreamspark(input.subscriptionId);
       });
     } else if (input.specPickerInput.data) {
       this.state = this._shouldHideForNewPlan(input.specPickerInput.data) ? 'hidden' : this.state;

--- a/client/src/app/site/spec-picker/price-spec-manager/dV3series-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/dV3series-price-spec.ts
@@ -70,11 +70,7 @@ export abstract class DV3SeriesPriceSpec extends PriceSpec {
       this.state = this._shouldHideForExistingPlan(input.plan) ? 'hidden' : this.state;
 
       return this._checkIfSkuEnabledOnStamp(input.plan.id).switchMap(_ => {
-        if (!input.plan.properties.reserved) {
-          return this.checkIfDreamspark(input.subscriptionId);
-        } else {
-          return Observable.of(null);
-        }
+        return this.checkIfDreamspark(input.subscriptionId);
       });
     } else if (input.specPickerInput.data) {
       const isXenon = input.specPickerInput.data.hyperV || input.specPickerInput.data.isXenon;

--- a/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
@@ -4,7 +4,6 @@ import { Tier, SkuCode } from './../../../shared/models/serverFarmSku';
 import { PortalResources } from '../../../shared/models/portal-resources';
 import { AppKind } from './../../../shared/Utilities/app-kind';
 import { PriceSpec, PriceSpecInput } from './price-spec';
-import { Observable } from 'rxjs/Observable';
 
 export abstract class PremiumPlanPriceSpec extends PriceSpec {
   tier = Tier.premium;
@@ -72,10 +71,6 @@ export abstract class PremiumPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
-
-      if (!input.plan.properties.reserved) {
-        return this.checkIfDreamspark(input.subscriptionId);
-      }
     } else if (input.specPickerInput.data) {
       if (
         input.specPickerInput.data.hostingEnvironmentName ||
@@ -86,10 +81,9 @@ export abstract class PremiumPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
-      return this.checkIfDreamspark(input.subscriptionId);
     }
 
-    return Observable.of(null);
+    return this.checkIfDreamspark(input.subscriptionId);
   }
 }
 

--- a/client/src/app/site/spec-picker/price-spec-manager/shared-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/shared-plan-price-spec.ts
@@ -3,7 +3,6 @@ import { Tier, SkuCode } from './../../../shared/models/serverFarmSku';
 import { PortalResources } from './../../../shared/models/portal-resources';
 import { AppKind } from './../../../shared/Utilities/app-kind';
 import { PriceSpec, PriceSpecInput } from './price-spec';
-import { Observable } from 'rxjs/Observable';
 
 export class SharedPlanPriceSpec extends PriceSpec {
   tier = Tier.shared;
@@ -60,10 +59,6 @@ export class SharedPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
-
-      if (!input.plan.properties.reserved) {
-        return this.checkIfDreamspark(input.subscriptionId);
-      }
     } else if (input.specPickerInput.data) {
       if (
         input.specPickerInput.data.hostingEnvironmentName ||
@@ -74,9 +69,8 @@ export class SharedPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
-      return this.checkIfDreamspark(input.subscriptionId);
     }
 
-    return Observable.of(null);
+    return this.checkIfDreamspark(input.subscriptionId);
   }
 }

--- a/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
@@ -4,7 +4,6 @@ import { Tier, SkuCode } from './../../../shared/models/serverFarmSku';
 import { PortalResources } from './../../../shared/models/portal-resources';
 import { AppKind } from './../../../shared/Utilities/app-kind';
 import { PriceSpec, PriceSpecInput } from './price-spec';
-import { Observable } from 'rxjs/Observable';
 
 export abstract class StandardPlanPriceSpec extends PriceSpec {
   tier = Tier.standard;
@@ -72,10 +71,6 @@ export abstract class StandardPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
-
-      if (!input.plan.properties.reserved) {
-        return this.checkIfDreamspark(input.subscriptionId);
-      }
     } else if (input.specPickerInput.data) {
       if (
         input.specPickerInput.data.hostingEnvironmentName ||
@@ -85,10 +80,9 @@ export abstract class StandardPlanPriceSpec extends PriceSpec {
       ) {
         this.state = 'hidden';
       }
-      return this.checkIfDreamspark(input.subscriptionId);
     }
 
-    return Observable.of(null);
+    return this.checkIfDreamspark(input.subscriptionId);
   }
 }
 


### PR DESCRIPTION
This reverts commit bacebab01f3e9eac6900a08e0591b0bf76e73643.

Fixes AB#9700835

9700835 - [WebApp] [Speck Picker] Revert the change of enabling Basic sku for Linux OS ONLY for Dreamspark subscription. Dreamspark should only support Free sku