### PR TITLE
AB#9300051 [Behind feature flag] Update spec picker to support new WorkflowStandard skus for LAv2 ONLY

### DIFF
--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2290,4 +2290,5 @@ export class PortalResources {
   public static resourceConnector = 'resourceConnector';
   public static keyVaultReferenceInitializedStatus = 'keyVaultReferenceInitializedStatus';
   public static clickHereToAccessSite = 'clickHereToAccessSite';
+  public static pricing_workflowStandardNotAvailable = 'pricing_workflowStandardNotAvailable';
 }

--- a/client/src/app/shared/models/serverFarmSku.ts
+++ b/client/src/app/shared/models/serverFarmSku.ts
@@ -12,6 +12,7 @@ export class Tier {
   public static readonly elasticIsolated = 'ElasticIsolated';
   public static readonly premiumV3 = 'PremiumV3';
   public static readonly isolatedV2 = 'IsolatedV2';
+  public static readonly workflowStandard = 'WorkflowStandard';
 }
 
 export class SkuCode {
@@ -81,5 +82,17 @@ export class SkuCode {
     I1V2: 'I1V2',
     I2V2: 'I2V2',
     I3V2: 'I3V2',
+  };
+
+  public static readonly WorkflowStandard = {
+    WS1: 'WS1',
+    WS2: 'WS2',
+    WS3: 'WS3',
+    WS1CPU: 'WS1-C',
+    WS1Memory: 'WS1-M',
+    WS2CPU: 'WS2-C',
+    WS2Memory: 'WS2-M',
+    WS3CPU: 'WS3-C',
+    WS3Memory: 'WS3-M',
   };
 }

--- a/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
@@ -55,7 +55,8 @@ export abstract class BasicPlanPriceSpec extends PriceSpec {
         input.specPickerInput.data.hostingEnvironmentName ||
         input.specPickerInput.data.isXenon ||
         input.specPickerInput.data.hyperV ||
-        (input.specPickerInput.data.isNewFunctionAppCreate && input.specPickerInput.data.isElastic)
+        (input.specPickerInput.data.isNewFunctionAppCreate &&
+          (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard))
       ) {
         this.state = 'hidden';
       }

--- a/client/src/app/site/spec-picker/price-spec-manager/free-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/free-plan-price-spec.ts
@@ -86,7 +86,8 @@ export class FreePlanPriceSpec extends PriceSpec {
         input.specPickerInput.data.hostingEnvironmentName ||
         input.specPickerInput.data.isXenon ||
         input.specPickerInput.data.hyperV ||
-        (input.specPickerInput.data.isNewFunctionAppCreate && input.specPickerInput.data.isElastic)
+        (input.specPickerInput.data.isNewFunctionAppCreate &&
+          (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard))
       ) {
         this.state = 'hidden';
       }

--- a/client/src/app/site/spec-picker/price-spec-manager/isolated-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/isolated-plan-price-spec.ts
@@ -94,7 +94,8 @@ export abstract class IsolatedPlanPriceSpec extends PriceSpec {
       (!input.specPickerInput.data.allowAseV2Creation ||
         input.specPickerInput.data.isXenon ||
         input.specPickerInput.data.hyperV ||
-        (input.specPickerInput.data.isNewFunctionAppCreate && input.specPickerInput.data.isElastic))
+        (input.specPickerInput.data.isNewFunctionAppCreate &&
+          (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard)))
     ) {
       this.state = 'hidden';
     }

--- a/client/src/app/site/spec-picker/price-spec-manager/isolatedv2-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/isolatedv2-plan-price-spec.ts
@@ -121,7 +121,8 @@ export abstract class IsolatedV2PlanPriceSpec extends PriceSpec {
       (!input.specPickerInput.data.allowAseV3Creation ||
         input.specPickerInput.data.isXenon ||
         input.specPickerInput.data.hyperV ||
-        (input.specPickerInput.data.isNewFunctionAppCreate && input.specPickerInput.data.isElastic))
+        (input.specPickerInput.data.isNewFunctionAppCreate &&
+          (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard)))
     ) {
       this.state = 'hidden';
       return this.checkIfDreamspark(input.subscriptionId);

--- a/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/plan-price-spec-manager.ts
@@ -71,6 +71,7 @@ export interface PlanSpecPickerData {
   // Since old creates always shows elastic premium sku's along with other sku's.
   // However, in new full screen creates it would be based on the plan type selected which will determing isElastic boolean value.
   allowAseV3Creation?: boolean; // NOTE(shimedh): This will be set for new ASP creating in existing ASEv3. It will later also be used for new app in new ASEv3 scenario from webapp create (will be enabled for GA).
+  isWorkflowStandard?: boolean;
 }
 
 export type ApplyButtonState = 'enabled' | 'disabled';

--- a/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
@@ -77,7 +77,8 @@ export abstract class PremiumPlanPriceSpec extends PriceSpec {
         input.specPickerInput.data.isLinux ||
         input.specPickerInput.data.isXenon ||
         input.specPickerInput.data.hyperV ||
-        (input.specPickerInput.data.isNewFunctionAppCreate && input.specPickerInput.data.isElastic)
+        (input.specPickerInput.data.isNewFunctionAppCreate &&
+          (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard))
       ) {
         this.state = 'hidden';
       }

--- a/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
@@ -19,6 +19,11 @@ import {
   ElasticPremiumMediumPlanPriceSpec,
   ElasticPremiumLargePlanPriceSpec,
 } from './elastic-premium-plan-price-spec';
+import {
+  WorkflowStandardSmallPlanPriceSpec,
+  WorkflowStandardMediumPlanPriceSpec,
+  WorkflowStandardLargePlanPriceSpec,
+} from './workflow-standard-plan-price-spec';
 import { Injector } from '@angular/core';
 import { PortalResources } from '../../../shared/models/portal-resources';
 import { TranslateService } from '@ngx-translate/core';
@@ -221,6 +226,9 @@ export class ProdSpecGroup extends PriceSpecGroup {
     new ElasticPremiumSmallPlanPriceSpec(this.injector),
     new ElasticPremiumMediumPlanPriceSpec(this.injector),
     new ElasticPremiumLargePlanPriceSpec(this.injector),
+    new WorkflowStandardSmallPlanPriceSpec(this.injector),
+    new WorkflowStandardMediumPlanPriceSpec(this.injector),
+    new WorkflowStandardLargePlanPriceSpec(this.injector),
   ];
 
   additionalSpecs = [

--- a/client/src/app/site/spec-picker/price-spec-manager/shared-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/shared-plan-price-spec.ts
@@ -65,7 +65,8 @@ export class SharedPlanPriceSpec extends PriceSpec {
         input.specPickerInput.data.isLinux ||
         input.specPickerInput.data.isXenon ||
         input.specPickerInput.data.hyperV ||
-        (input.specPickerInput.data.isNewFunctionAppCreate && input.specPickerInput.data.isElastic)
+        (input.specPickerInput.data.isNewFunctionAppCreate &&
+          (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard))
       ) {
         this.state = 'hidden';
       }

--- a/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
@@ -76,7 +76,8 @@ export abstract class StandardPlanPriceSpec extends PriceSpec {
         input.specPickerInput.data.hostingEnvironmentName ||
         input.specPickerInput.data.isXenon ||
         input.specPickerInput.data.hyperV ||
-        (input.specPickerInput.data.isNewFunctionAppCreate && input.specPickerInput.data.isElastic)
+        (input.specPickerInput.data.isNewFunctionAppCreate &&
+          (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard))
       ) {
         this.state = 'hidden';
       }

--- a/client/src/app/site/spec-picker/price-spec-manager/workflow-standard-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/workflow-standard-plan-price-spec.ts
@@ -1,15 +1,15 @@
 import { Injector } from '@angular/core';
-import { Kinds, Links, Pricing } from './../../../shared/models/constants';
-import { Tier, SkuCode } from './../../../shared/models/serverFarmSku';
-import { PortalResources } from './../../../shared/models/portal-resources';
-import { ServerFarm } from './../../../shared/models/server-farm';
+import { Kinds, Links, Pricing } from '../../../shared/models/constants';
+import { Tier, SkuCode } from '../../../shared/models/serverFarmSku';
+import { PortalResources } from '../../../shared/models/portal-resources';
+import { ServerFarm } from '../../../shared/models/server-farm';
 import { Sku, ArmObj } from '../../../shared/models/arm/arm-obj';
-import { AppKind } from './../../../shared/Utilities/app-kind';
+import { AppKind } from '../../../shared/Utilities/app-kind';
 import { DV2SeriesPriceSpec } from './dV2series-price-spec';
 import { PlanSpecPickerData } from './plan-price-spec-manager';
 
-export abstract class ElasticPremiumPlanPriceSpec extends DV2SeriesPriceSpec {
-  tier = Tier.elasticPremium;
+export abstract class WorkflowStandardPlanPriceSpec extends DV2SeriesPriceSpec {
+  tier = Tier.workflowStandard;
 
   featureItems = [
     {
@@ -56,12 +56,13 @@ export abstract class ElasticPremiumPlanPriceSpec extends DV2SeriesPriceSpec {
   cssClass = 'spec premium-spec';
   priceIsBaseline = true;
 
+  // TODO(shimedh): Will update the learn more link once we get a new one from LA team. Till then using elastic premium one as they are the same under the hood.
   constructor(injector: Injector) {
-    super(injector, Tier.elasticPremium, PortalResources.pricing_epNotAvailable, Links.elasticPremiumNotAvailableLearnMore);
+    super(injector, Tier.workflowStandard, PortalResources.pricing_workflowStandardNotAvailable, Links.elasticPremiumNotAvailableLearnMore);
   }
 
   protected _matchSku(sku: Sku): boolean {
-    return sku.name.toLowerCase().startsWith('ep');
+    return sku.name.toLowerCase().startsWith('ws');
   }
 
   protected _shouldHideForNewPlan(data: PlanSpecPickerData): boolean {
@@ -70,7 +71,7 @@ export abstract class ElasticPremiumPlanPriceSpec extends DV2SeriesPriceSpec {
       data.isXenon ||
       data.hyperV ||
       !data.isFunctionApp ||
-      (data.isNewFunctionAppCreate && !data.isElastic)
+      (data.isNewFunctionAppCreate && !data.isWorkflowStandard)
     );
   }
 
@@ -80,32 +81,32 @@ export abstract class ElasticPremiumPlanPriceSpec extends DV2SeriesPriceSpec {
       !!plan.properties.hostingEnvironmentProfile ||
       plan.properties.hyperV ||
       !AppKind.hasAnyKind(plan, [Kinds.elastic]) ||
-      plan.sku.tier === Tier.workflowStandard
+      plan.sku.tier !== Tier.workflowStandard
     );
   }
 }
 
-export class ElasticPremiumSmallPlanPriceSpec extends ElasticPremiumPlanPriceSpec {
-  skuCode = SkuCode.ElasticPremium.EP1;
-  legacySkuName = 'small_elastic_premium';
+export class WorkflowStandardSmallPlanPriceSpec extends WorkflowStandardPlanPriceSpec {
+  skuCode = SkuCode.WorkflowStandard.WS1;
+  legacySkuName = SkuCode.WorkflowStandard.WS1;
   topLevelFeatures = [
     this._ts.instant(PortalResources.pricing_ACU).format('210'),
     this._ts.instant(PortalResources.pricing_memory).format('3.5'),
     this._ts.instant(PortalResources.pricing_dSeriesComputeEquivalent),
   ];
 
-  meterFriendlyName = 'Premium V2 Small App Service Hours';
+  meterFriendlyName = 'Workflow Standard Small App Service Hours';
 
   specResourceSet = {
     id: this.skuCode,
     firstParty: [
       {
-        id: SkuCode.ElasticPremium.EP1CPU,
+        id: SkuCode.WorkflowStandard.WS1CPU,
         quantity: Pricing.hoursInAzureMonth,
         resourceId: null,
       },
       {
-        id: SkuCode.ElasticPremium.EP1Memory,
+        id: SkuCode.WorkflowStandard.WS1Memory,
         quantity: Pricing.hoursInAzureMonth,
         resourceId: null,
       },
@@ -113,27 +114,27 @@ export class ElasticPremiumSmallPlanPriceSpec extends ElasticPremiumPlanPriceSpe
   };
 }
 
-export class ElasticPremiumMediumPlanPriceSpec extends ElasticPremiumPlanPriceSpec {
-  skuCode = SkuCode.ElasticPremium.EP2;
-  legacySkuName = 'medium_elastic_premium';
+export class WorkflowStandardMediumPlanPriceSpec extends WorkflowStandardPlanPriceSpec {
+  skuCode = SkuCode.WorkflowStandard.WS2;
+  legacySkuName = SkuCode.WorkflowStandard.WS2;
   topLevelFeatures = [
     this._ts.instant(PortalResources.pricing_ACU).format('420'),
     this._ts.instant(PortalResources.pricing_memory).format('7'),
     this._ts.instant(PortalResources.pricing_dSeriesComputeEquivalent),
   ];
 
-  meterFriendlyName = 'Premium V2 Medium App Service Hours';
+  meterFriendlyName = 'Workflow Standard Medium App Service Hours';
 
   specResourceSet = {
     id: this.skuCode,
     firstParty: [
       {
-        id: SkuCode.ElasticPremium.EP2CPU,
+        id: SkuCode.WorkflowStandard.WS2CPU,
         quantity: Pricing.hoursInAzureMonth,
         resourceId: null,
       },
       {
-        id: SkuCode.ElasticPremium.EP2Memory,
+        id: SkuCode.WorkflowStandard.WS2Memory,
         quantity: Pricing.hoursInAzureMonth,
         resourceId: null,
       },
@@ -141,27 +142,27 @@ export class ElasticPremiumMediumPlanPriceSpec extends ElasticPremiumPlanPriceSp
   };
 }
 
-export class ElasticPremiumLargePlanPriceSpec extends ElasticPremiumPlanPriceSpec {
-  skuCode = SkuCode.ElasticPremium.EP3;
-  legacySkuName = 'large_elastic_premium';
+export class WorkflowStandardLargePlanPriceSpec extends WorkflowStandardPlanPriceSpec {
+  skuCode = SkuCode.WorkflowStandard.WS3;
+  legacySkuName = SkuCode.WorkflowStandard.WS3;
   topLevelFeatures = [
     this._ts.instant(PortalResources.pricing_ACU).format('840'),
     this._ts.instant(PortalResources.pricing_memory).format('14'),
     this._ts.instant(PortalResources.pricing_dSeriesComputeEquivalent),
   ];
 
-  meterFriendlyName = 'Premium V2 Large App Service Hours';
+  meterFriendlyName = 'Workflow Standard Large App Service Hours';
 
   specResourceSet = {
     id: this.skuCode,
     firstParty: [
       {
-        id: SkuCode.ElasticPremium.EP3CPU,
+        id: SkuCode.WorkflowStandard.WS3CPU,
         quantity: Pricing.hoursInAzureMonth,
         resourceId: null,
       },
       {
-        id: SkuCode.ElasticPremium.EP3Memory,
+        id: SkuCode.WorkflowStandard.WS3Memory,
         quantity: Pricing.hoursInAzureMonth,
         resourceId: null,
       },

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7014,4 +7014,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="clickHereToAccessSite" xml:space="preserve">
         <value> Click here to access the app.</value>
     </data>
+    <data name="pricing_workflowStandardNotAvailable" xml:space="preserve">
+        <value>Workflow Standard is not supported for this scale unit. Please consider redeploying or cloning your app.</value>
+    </data>
 </root>


### PR DESCRIPTION
Fixes AB#9300051

WorkflowStandard is a new sku ONLY for LAv2 apps. The plan kind will still be "elastic" for both Elastic Premium and Workflow Standard sku since they are under the hood the same except pricing.

I did not add an explicit feature flag on this change on the Fusion side as we will have a feature flag on the Ibiza side change (working on that next) which will pass in the new "isWorkflowStandard" as true only when flag is ON and only for LAv2 creates.
For scaleup, since this new sku is not released yet, there will be no plans with this sku anyways.

**Create scenario:**
WorkflowStandard sku's should be visible only for LAv2 create

**Scale up scenario:**
WorkflowStandard sku's should be visible only for LAv2 apps that have existing sku as Workflow standard sku. No other sku's are shown.
Old/current LAv2 apps with elastic premium sku will continue to show Elastic sku's during scaleup and will not see this new sku.