### PR TITLE
Hide PV2 and PV3 sku's for new plan scenario for WorkflowStandard sku type

### DIFF
--- a/client/src/app/site/spec-picker/price-spec-manager/premiumv2-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premiumv2-plan-price-spec.ts
@@ -69,7 +69,12 @@ export abstract class PremiumV2PlanPriceSpec extends DV2SeriesPriceSpec {
   }
 
   protected _shouldHideForNewPlan(data: PlanSpecPickerData): boolean {
-    return !!data.hostingEnvironmentName || data.isXenon || data.hyperV || (data.isNewFunctionAppCreate && data.isElastic);
+    return (
+      !!data.hostingEnvironmentName ||
+      data.isXenon ||
+      data.hyperV ||
+      (data.isNewFunctionAppCreate && (data.isElastic || data.isWorkflowStandard))
+    );
   }
 
   protected _shouldHideForExistingPlan(plan: ArmObj<ServerFarm>): boolean {

--- a/client/src/app/site/spec-picker/price-spec-manager/premiumv3-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premiumv3-plan-price-spec.ts
@@ -70,7 +70,7 @@ export abstract class PremiumV3PlanPriceSpec extends DV3SeriesPriceSpec {
   }
 
   protected _shouldHideForNewPlan(data: PlanSpecPickerData): boolean {
-    return !!data.hostingEnvironmentName || (data.isNewFunctionAppCreate && data.isElastic);
+    return !!data.hostingEnvironmentName || (data.isNewFunctionAppCreate && (data.isElastic || data.isWorkflowStandard));
   }
 
   protected _shouldHideForExistingPlan(plan: ArmObj<ServerFarm>): boolean {


### PR DESCRIPTION
Missed these two in my previous change - PR for reference https://github.com/Azure/azure-functions-ux/pull/5902