### PR TITLE
Update close (X button) styling to match the rest of the portal

### DIFF
--- a/client-react/src/components/CustomPanel/CustomPanel.styles.ts
+++ b/client-react/src/components/CustomPanel/CustomPanel.styles.ts
@@ -2,26 +2,14 @@ import { style } from 'typestyle';
 import { ThemeExtended } from '../../theme/SemanticColorsExtended';
 
 export const panelHeaderStyle = style({
+  padding: '8px 20px',
   width: '100%',
 
   $nest: {
     h3: {
       display: 'inline-block',
-      marginLeft: '15px',
-      marginTop: '12px',
       fontSize: '20px',
-    },
-
-    span: {
-      float: 'right',
-    },
-
-    svg: {
-      marginTop: '18px',
-      marginRight: '3px',
-      height: '12px',
-      width: '12px',
-      cursor: 'pointer',
+      margin: '0px',
     },
   },
 });
@@ -49,5 +37,25 @@ export const panelBodyStyle = {
 
 export const closeButtonStyle = (theme: ThemeExtended) =>
   style({
+    $nest: {
+      '&:hover': { background: 'red' },
+    },
+    backgroundColor: 'transparent',
+    transitionProperty: 'background-color',
+    transitionDelay: '0s',
+    transitionDuration: '0.2s',
+    transitionTimingFunction: 'ease-out',
     fill: theme.semanticColors.bodyText,
+    height: '32px',
+    width: '32px',
+    cursor: 'pointer',
+    border: '0px',
+    padding: '0px',
+    float: 'right',
+  });
+
+export const closeButtonSvgStyle = (theme: ThemeExtended) =>
+  style({
+    height: '12px',
+    width: '12px',
   });

--- a/client-react/src/components/CustomPanel/CustomPanel.tsx
+++ b/client-react/src/components/CustomPanel/CustomPanel.tsx
@@ -1,9 +1,9 @@
-import React, { KeyboardEvent, useContext } from 'react';
-import { Panel as OfficePanel, IPanelProps, PanelType, Overlay, KeyCodes } from 'office-ui-fabric-react';
-import { ReactComponent as CloseSvg } from '../../images/Common/close.svg';
+import { IPanelProps, Overlay, Panel as OfficePanel, PanelType } from 'office-ui-fabric-react';
+import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { panelStyle, panelHeaderStyle, panelBodyStyle, closeButtonStyle } from './CustomPanel.styles';
+import { ReactComponent as CloseSvg } from '../../images/Common/close.svg';
 import { ThemeContext } from '../../ThemeContext';
+import { closeButtonStyle, closeButtonSvgStyle, panelBodyStyle, panelHeaderStyle, panelStyle } from './CustomPanel.styles';
 
 type IPanelPropsReduced = Pick<IPanelProps, Exclude<keyof IPanelProps, 'styles' | 'closeButtonAriaLabel' | 'onRenderNavigationContent'>>;
 
@@ -27,21 +27,12 @@ const CustomPanel: React.SFC<CustomPanelProps & IPanelPropsReduced> = props => {
   const onRenderNavigationContent = panelProps => {
     const onClick = panelProps.onDismiss && (() => panelProps.onDismiss());
 
-    const onKeyUp = (event: KeyboardEvent<unknown>) => {
-      if (event.keyCode === KeyCodes.enter || event.keyCode === KeyCodes.space) {
-        event.preventDefault();
-        if (panelProps.onDismiss) {
-          panelProps.onDismiss();
-        }
-      }
-    };
-
     return (
       <div className={panelHeaderStyle}>
         {headerText && <h3>{headerText}</h3>}
-        <span onKeyUp={onKeyUp} tabIndex={0}>
-          <CloseSvg onClick={onClick} role="button" aria-label={t('close')} className={closeButtonStyle(theme)} focusable="true" />
-        </span>
+        <button onClick={onClick} className={closeButtonStyle(theme)}>
+          <CloseSvg role="button" aria-label={t('close')} className={closeButtonSvgStyle(theme)} focusable="true" />
+        </button>
         {!!headerContent && headerContent}
       </div>
     );


### PR DESCRIPTION
Fixes AB#9528733

* Tab stops work correctly
* Closes on click, space bar, or enter

Current
![image](https://user-images.githubusercontent.com/37600290/117508881-221b9c00-af3e-11eb-96bb-3d41632d131b.png)

![image](https://user-images.githubusercontent.com/37600290/117508909-2b0c6d80-af3e-11eb-9b01-c4848af265e9.png)

Fixed
------

Unhovered
![image](https://user-images.githubusercontent.com/37600290/117508294-30b58380-af3d-11eb-9129-188289bcc90d.png)

Hovered
![image](https://user-images.githubusercontent.com/37600290/117508313-3a3eeb80-af3d-11eb-9e1e-ea4554a0d32b.png)

Focused
![image](https://user-images.githubusercontent.com/37600290/117508851-15974380-af3e-11eb-86c9-08cb520910fe.png)
