### PR TITLE
[DC] Make ACR Tag case sensitive

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
@@ -264,9 +264,7 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
       const tagOptions: IDropdownOption[] = [];
       tagsResponse.forEach(response => {
         const dropdownOptions =
-          response && response.tags && response.tags.length > 0
-            ? response.tags.map(tag => ({ key: tag.toLocaleLowerCase(), text: tag }))
-            : [];
+          response && response.tags && response.tags.length > 0 ? response.tags.map(tag => ({ key: tag, text: tag })) : [];
         tagOptions.push(...dropdownOptions);
       });
 

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -285,7 +285,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
         composeYml: atob(registryInfo),
       };
     } else {
-      const imageAndTagInfo = registryInfo.toLocaleLowerCase().replace(`${acrHost}/`, '');
+      const imageAndTagInfo = registryInfo.replace(`${acrHost}/`, '');
       const imageAndTagParts = imageAndTagInfo.split(':');
 
       return {


### PR DESCRIPTION
When we save the image and/or tag in the new DC, we're changing it all to lowercase instead of leaving it as-is.  It looks like ACR is case-sensitive so it's causing the Docker pull at runtime to fail.

Fixes AB #9817722

![image](https://user-images.githubusercontent.com/35281019/118739319-0b0e6100-b7fe-11eb-9e4c-42013f34ca8d.png)
![image](https://user-images.githubusercontent.com/35281019/118739369-28dbc600-b7fe-11eb-8429-ecb3b78e024f.png)
