### PR TITLE
[App Setting][BYOS] Handle Add/Edit Azure Storage Mount Blade Crash

### DIFF
--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
@@ -56,7 +56,6 @@ const AzureStorageMountsAddEdit: React.SFC<AzureStorageMountsAddEditPropsCombine
       }),
     accountName: Yup.string().required(t('validation_requiredError')),
     shareName: Yup.string()
-      .required(t('validation_requiredError'))
       .max(shareNameMaxLength, t('validation_fieldMaxCharacters').format(shareNameMaxLength))
       .matches(shareNameRegex, t('validation_shareNameAllowedCharacters')),
     accessKey: Yup.string().required(t('validation_requiredError')),

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditAdvanced.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditAdvanced.tsx
@@ -20,10 +20,7 @@ const AzureStorageMountsAddEditAdvanced: React.FC<FormikProps<FormAzureStorageMo
   const scenarioService = new ScenarioService(t);
 
   const validateShareName = (value: any): string | undefined => {
-    if (value) {
-      return value.length === 0 ? t('validation_requiredError') : undefined;
-    }
-    return t('validation_requiredError');
+    return !!value ? undefined : t('validation_requiredError');
   };
 
   const supportsBlobStorage = scenarioService.checkScenario(ScenarioIds.azureBlobMount, { site }).status !== 'disabled';

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditAdvanced.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditAdvanced.tsx
@@ -14,10 +14,17 @@ import { ScenarioService } from '../../../../utils/scenario-checker/scenario.ser
 import { ScenarioIds } from '../../../../utils/scenario-checker/scenario-ids';
 
 const AzureStorageMountsAddEditAdvanced: React.FC<FormikProps<FormAzureStorageMounts> & AzureStorageMountsAddEditPropsCombined> = props => {
-  const { errors, values, setFieldValue } = props;
+  const { errors, values, setFieldValue, validateField } = props;
   const { t } = useTranslation();
   const site = useContext(SiteContext);
   const scenarioService = new ScenarioService(t);
+
+  const validateShareName = (value: any): string | undefined => {
+    if (value) {
+      return value.length === 0 ? t('validation_requiredError') : undefined;
+    }
+    return t('validation_requiredError');
+  };
 
   const supportsBlobStorage = scenarioService.checkScenario(ScenarioIds.azureBlobMount, { site }).status !== 'disabled';
 
@@ -25,6 +32,7 @@ const AzureStorageMountsAddEditAdvanced: React.FC<FormikProps<FormAzureStorageMo
     if (!supportsBlobStorage) {
       setFieldValue('type', StorageType.azureFiles);
     }
+    validateField('shareName');
   }, []);
 
   return (
@@ -71,6 +79,7 @@ const AzureStorageMountsAddEditAdvanced: React.FC<FormikProps<FormAzureStorageMo
         id="azure-storage-mounts-share-name"
         errorMessage={errors.shareName}
         required={true}
+        validate={validateShareName}
       />
       <Field
         component={TextField}

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
@@ -53,16 +53,16 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
     .map(val => ({ key: val.name, text: val.name }));
 
   const validateStorageContainer = (value: string): string | undefined => {
-    const vnetRestrictionError = validateGetStorageContainerFailure();
-    const emptyError = validateStorageContainerEmpty(value);
-    const error = vnetRestrictionError ? vnetRestrictionError : emptyError;
+    const emptyListError = validateNoStorageContainerAvailable();
+    const notSelectedError = validateNoStorageContainerSelected(value);
+    const error = emptyListError ? emptyListError : notSelectedError;
     return error;
   };
 
-  const validateStorageContainerEmpty = (value: string): string | undefined => {
+  const validateNoStorageContainerSelected = (value: string): string | undefined => {
     if (
       sharesLoading ||
-      (value && values.type === 'AzureBlob'
+      (value && values.type === StorageType.azureBlob
         ? blobContainerOptions.find(x => x.key === value)
         : filesContainerOptions.find(x => x.key === value))
     ) {
@@ -72,7 +72,7 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
     return t('validation_requiredError');
   };
 
-  const validateGetStorageContainerFailure = (): string | undefined => {
+  const validateNoStorageContainerAvailable = (): string | undefined => {
     if (accountError) {
       return accountError;
     }
@@ -154,9 +154,9 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
               errorSchema.filesContainerIsEmpty = filesData.length === 0;
             }
 
+            setSharesLoading(false);
             setAccountSharesFiles(filesData);
             setAccountSharesBlob(blobData);
-            setSharesLoading(false);
             setStorageContainerErrorSchema(errorSchema);
             if (!supportsBlobStorage) {
               setFieldValue('type', StorageType.azureFiles);

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
@@ -25,13 +25,23 @@ const storageKinds = {
   Storage: 'Storage',
 };
 
-class StorageContainerErrorSchema {
-  public blobsContainerIsEmpty: boolean;
-  public filesContainerIsEmpty: boolean;
-  public getBlobsFailure: boolean;
-  public getFilesFailure: boolean;
-  public isVnetRestrictionError: boolean;
+interface StorageContainerErrorSchema {
+  blobsContainerIsEmpty: boolean;
+  filesContainerIsEmpty: boolean;
+  getBlobsFailure: boolean;
+  getFilesFailure: boolean;
+  isVnetRestrictionError: boolean;
 }
+
+const initializeStorageContainerErrorSchemaValue = (): StorageContainerErrorSchema => {
+  return {
+    blobsContainerIsEmpty: false,
+    filesContainerIsEmpty: false,
+    getBlobsFailure: false,
+    getFilesFailure: false,
+    isVnetRestrictionError: false,
+  };
+};
 
 const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMounts> & AzureStorageMountsAddEditPropsCombined> = props => {
   const { errors, values, setValues, setFieldValue, validateForm } = props;
@@ -40,7 +50,7 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
   const [sharesLoading, setSharesLoading] = useState(false);
   const [accountError, setAccountError] = useState('');
   const [storageContainerErrorSchema, setStorageContainerErrorSchema] = useState<StorageContainerErrorSchema>(
-    new StorageContainerErrorSchema()
+    initializeStorageContainerErrorSchemaValue()
   );
   const storageAccounts = useContext(StorageAccountsContext);
   const site = useContext(SiteContext);
@@ -55,8 +65,7 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
   const validateStorageContainer = (value: string): string | undefined => {
     const emptyListError = validateNoStorageContainerAvailable();
     const notSelectedError = validateNoStorageContainerSelected(value);
-    const error = emptyListError ? emptyListError : notSelectedError;
-    return error;
+    return emptyListError ? emptyListError : notSelectedError;
   };
 
   const validateNoStorageContainerSelected = (value: string): string | undefined => {
@@ -104,7 +113,7 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
 
   useEffect(() => {
     setAccountError('');
-    setStorageContainerErrorSchema(new StorageContainerErrorSchema());
+    setStorageContainerErrorSchema(initializeStorageContainerErrorSchemaValue());
     if (storageAccount) {
       setAccountSharesBlob([]);
       setAccountSharesFiles([]);
@@ -147,7 +156,7 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
 
             let blobData = [];
             let filesData = [];
-            const errorSchema: StorageContainerErrorSchema = new StorageContainerErrorSchema();
+            const errorSchema: StorageContainerErrorSchema = initializeStorageContainerErrorSchemaValue();
 
             if (blobsFailure && supportsBlobStorage) {
               const errorMessage = getErrorMessageOrStringify(!!blobsMetaData && !!blobsMetaData.error ? blobsMetaData.error : '');

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
@@ -11,12 +11,13 @@ import { StorageAccountsContext, SiteContext } from '../Contexts';
 import { ScenarioService } from '../../../../utils/scenario-checker/scenario.service';
 import { ScenarioIds } from '../../../../utils/scenario-checker/scenario-ids';
 import { MessageBarType } from 'office-ui-fabric-react';
-import { StorageType } from '../../../../models/site/config';
 import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
 import { Links } from '../../../../utils/FwLinks';
 import FunctionsService from '../../../../ApiHelpers/FunctionsService';
 import LogService from '../../../../utils/LogService';
 import { LogCategories } from '../../../../utils/LogCategories';
+import { HttpConstants } from '../../../../utils/constants/HttpConstants';
+import { StorageType } from '../../../../models/site/config';
 
 const storageKinds = {
   StorageV2: 'StorageV2',
@@ -24,12 +25,23 @@ const storageKinds = {
   Storage: 'Storage',
 };
 
+class StorageContainerErrorSchema {
+  public blobsContainerIsEmpty: boolean;
+  public filesContainerIsEmpty: boolean;
+  public getBlobsFailure: boolean;
+  public getFilesFailure: boolean;
+  public isVnetRestrictionError: boolean;
+}
+
 const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMounts> & AzureStorageMountsAddEditPropsCombined> = props => {
-  const { errors, values, setValues, setFieldValue } = props;
+  const { errors, values, setValues, setFieldValue, validateForm } = props;
   const [accountSharesFiles, setAccountSharesFiles] = useState([]);
   const [accountSharesBlob, setAccountSharesBlob] = useState([]);
   const [sharesLoading, setSharesLoading] = useState(false);
   const [accountError, setAccountError] = useState('');
+  const [storageContainerErrorSchema, setStorageContainerErrorSchema] = useState<StorageContainerErrorSchema>(
+    new StorageContainerErrorSchema()
+  );
   const storageAccounts = useContext(StorageAccountsContext);
   const site = useContext(SiteContext);
   const { t } = useTranslation();
@@ -41,6 +53,13 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
     .map(val => ({ key: val.name, text: val.name }));
 
   const validateStorageContainer = (value: string): string | undefined => {
+    const vnetRestrictionError = validateGetStorageContainerFailure();
+    const emptyError = validateStorageContainerEmpty(value);
+    const error = vnetRestrictionError ? vnetRestrictionError : emptyError;
+    return error;
+  };
+
+  const validateStorageContainerEmpty = (value: string): string | undefined => {
     if (
       sharesLoading ||
       (value && values.type === 'AzureBlob'
@@ -53,10 +72,18 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
     return t('validation_requiredError');
   };
 
+  const validateGetStorageContainerFailure = (): string | undefined => {
+    if (accountError) {
+      return accountError;
+    }
+    return undefined;
+  };
+
   const storageAccount = storageAccounts.value.find(x => x.name === values.accountName);
 
   useEffect(() => {
     setAccountError('');
+    setStorageContainerErrorSchema(new StorageContainerErrorSchema());
     if (storageAccount) {
       setAccountSharesBlob([]);
       setAccountSharesFiles([]);
@@ -99,63 +126,40 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
 
             let blobData = [];
             let filesData = [];
+            const errorSchema: StorageContainerErrorSchema = new StorageContainerErrorSchema();
 
             if (blobsFailure && supportsBlobStorage) {
-              LogService.error(
-                LogCategories.appSettings,
-                'getStorageContainers',
-                `Failed to get storage containers: ${getErrorMessageOrStringify(
-                  !!blobsMetaData && !!blobsMetaData.error ? blobsMetaData.error : ''
-                )}`
-              );
+              const errorMessage = getErrorMessageOrStringify(!!blobsMetaData && !!blobsMetaData.error ? blobsMetaData.error : '');
+              LogService.error(LogCategories.appSettings, 'getStorageContainers', `Failed to get storage containers: ${errorMessage}`);
+              errorSchema.blobsContainerIsEmpty = true;
+              errorSchema.getBlobsFailure = true;
+              if (errorMessage.toLocaleLowerCase() === HttpConstants.statusCodeMap['500'].toLocaleLowerCase()) {
+                errorSchema.isVnetRestrictionError = true;
+              }
             } else {
               blobData = blobs.data || [];
+              errorSchema.blobsContainerIsEmpty = blobData.length === 0;
             }
 
             if (filesFailure) {
-              LogService.error(
-                LogCategories.appSettings,
-                'getStorageFileShares',
-                `Failed to get storage file shares: ${getErrorMessageOrStringify(
-                  !!filesMetaData && !!filesMetaData.error ? filesMetaData.error : ''
-                )}`
-              );
+              const errorMessage = getErrorMessageOrStringify(!!filesMetaData && !!filesMetaData.error ? filesMetaData.error : '');
+              LogService.error(LogCategories.appSettings, 'getStorageFileShares', `Failed to get storage file shares: ${errorMessage}`);
+              errorSchema.filesContainerIsEmpty = true;
+              errorSchema.getFilesFailure = true;
+              if (errorMessage.toLocaleLowerCase() === HttpConstants.statusCodeMap['500'].toLocaleLowerCase()) {
+                errorSchema.isVnetRestrictionError = true;
+              }
             } else {
               filesData = files.data || [];
+              errorSchema.filesContainerIsEmpty = filesData.length === 0;
             }
 
-            setSharesLoading(false);
             setAccountSharesFiles(filesData);
             setAccountSharesBlob(blobData);
-            if (blobData.length === 0 || !supportsBlobStorage) {
-              setFieldValue('type', 'AzureFiles');
-            } else if (filesData.length === 0) {
-              setFieldValue('type', 'AzureBlob');
-            }
-            if (filesData.length === 0 && blobData.length === 0) {
-              let error = '';
-
-              if (!supportsBlobStorage) {
-                if (filesFailure) {
-                  error = files.metadata.error
-                    ? t('fileSharesFailureWithError').format(getErrorMessageOrStringify(files.metadata.error))
-                    : t('fileSharesFailure');
-                } else {
-                  error = t('noFileShares');
-                }
-              } else if (storageAccount.kind === storageKinds.BlobStorage) {
-                if (blobsFailure) {
-                  error = blobs.metadata.error
-                    ? t('blobsFailureWithError').format(getErrorMessageOrStringify(files.metadata.error))
-                    : t('blobsFailure');
-                } else {
-                  error = t('noBlobs');
-                }
-              } else {
-                error = t('noBlobsOrFilesShares');
-              }
-
-              setAccountError(error);
+            setSharesLoading(false);
+            setStorageContainerErrorSchema(errorSchema);
+            if (!supportsBlobStorage) {
+              setFieldValue('type', StorageType.azureFiles);
             }
           } catch (err) {
             setAccountError(t('noWriteAccessStorageAccount'));
@@ -168,6 +172,34 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [values.accountName]);
+
+  useEffect(() => {
+    validateForm();
+  }, [accountError]);
+
+  useEffect(() => {
+    const storageType = values.type;
+    const blobsContainerIsEmpty = storageContainerErrorSchema.blobsContainerIsEmpty;
+    const filesContainerIsEmpty = storageContainerErrorSchema.filesContainerIsEmpty;
+    const isVnetRestrictionError = storageContainerErrorSchema.isVnetRestrictionError;
+    const getBlobsFailure = storageContainerErrorSchema.getBlobsFailure;
+    const getFilesFailure = storageContainerErrorSchema.getFilesFailure;
+    if (storageType === StorageType.azureBlob && blobsContainerIsEmpty) {
+      setAccountError(
+        getBlobsFailure ? (isVnetRestrictionError ? `${t('blobsFailure')} ${t('switchToAdvancedMode')}` : t('blobsFailure')) : t('noBlobs')
+      );
+    } else if (storageType === StorageType.azureFiles && filesContainerIsEmpty) {
+      setAccountError(
+        getFilesFailure
+          ? isVnetRestrictionError
+            ? `${t('fileSharesFailure')} ${t('switchToAdvancedMode')}`
+            : t('fileSharesFailure')
+          : t('noFileShares')
+      );
+    } else {
+      setAccountError('');
+    }
+  }, [values.type, storageContainerErrorSchema]);
 
   const blobContainerOptions = accountSharesBlob.map((x: any) => ({ key: x.name, text: x.name }));
   const filesContainerOptions = accountSharesFiles.map((x: any) => ({ key: x.name, text: x.name }));
@@ -189,11 +221,6 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
         }}
         errorMessage={errors.accountName}
         required={true}
-        validate={() => {
-          if (accountError) {
-            return accountError;
-          }
-        }}
       />
       {showStorageTypeOption && (
         <Field
@@ -205,12 +232,10 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
             {
               key: StorageType.azureBlob,
               text: t('azureBlob'),
-              disabled: blobContainerOptions.length === 0,
             },
             {
               key: StorageType.azureFiles,
               text: t('azureFiles'),
-              disabled: filesContainerOptions.length === 0,
             },
           ]}
         />

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2222,6 +2222,7 @@ export class PortalResources {
   public static blobsFailure = 'blobsFailure';
   public static blobsFailureWithError = 'blobsFailureWithError';
   public static blobsAndFileSharesFailure = 'blobsAndFileSharesFailure';
+  public static switchToAdvancedMode = 'switchToAdvancedMode';
   public static containerImage = 'containerImage';
   public static containerImagePlaceholder = 'containerImagePlaceholder';
   public static savingContainerConfiguration = 'savingContainerConfiguration';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -47,10 +47,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-    <xsd:schema id="root"
-        xmlns=""
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
         <xsd:element name="root" msdata:IsDataSet="true">
             <xsd:complexType>
@@ -4878,7 +4875,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>Storage account name must be lower case</value>
     </data>
     <data name="noBlobsOrFilesShares" xml:space="preserve">
-        <value>This storage account has no blob containers or file shares</value>
+        <value>This storage account has no blob containers or file shares.</value>
     </data>
     <data name="noFileShares" xml:space="preserve">
         <value>This storage account has no file shares</value>
@@ -6799,19 +6796,22 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>Develop in portal</value>
     </data>
     <data name="fileSharesFailure" xml:space="preserve">
-        <value>Failed to fetch file shares in the storage account</value>
+        <value>Failed to fetch file shares in the storage account.</value>
     </data>
     <data name="fileSharesFailureWithError" xml:space="preserve">
-        <value>Failed to fetch file shares in the storage account with error: {0}</value>
+        <value>Failed to fetch file shares in the storage account with error: {0}.</value>
     </data>
     <data name="blobsFailure" xml:space="preserve">
-        <value>Failed to fetch blobs in the storage account</value>
+        <value>Failed to fetch blobs in the storage account.</value>
     </data>
     <data name="blobsFailureWithError" xml:space="preserve">
-        <value>Failed to fetch blobs in the storage account with error: {0}</value>
+        <value>Failed to fetch blobs in the storage account with error: {0}.</value>
     </data>
     <data name="blobsAndFileSharesFailure" xml:space="preserve">
-        <value>Failed to fetch blobs and file shares in the storage account</value>
+        <value>Failed to fetch blobs and file shares in the storage account.</value>
+    </data>
+    <data name="switchToAdvancedMode" xml:space="preserve">
+        <value>Please configure your storage mount with advanced mode.</value>
     </data>
     <data name="containerImage" xml:space="preserve">
         <value>Image name</value>


### PR DESCRIPTION
Handled the blade crash problem by updating the functionality of thet get request on blob containers and file shares of the storage account that has vnet restriction. The error messages were updated to inform cx to use advanced mode to add/edit storage mount.

Here are all the changes:
1. Removed the duplicated validation on share name field.
2. It makes more sense to display the error messge at storage container control than the storage account control. So the error messages are moved to storage container.
3. Removed the reason from the error messages because it could contain some raw error message from the api response.
![Inkederror_LI](https://user-images.githubusercontent.com/33185278/119571973-e159ba80-bd66-11eb-8ed1-2bc2fee4f146.jpg)
4. Added message to the error message to inform cx to use the advanced mode if the storage account has vnet restriction.
5. Update the error message based on the storage type

Here are some error message displaying cases:

1. Linux code/container:
![linuxnoblob](https://user-images.githubusercontent.com/33185278/119572142-2bdb3700-bd67-11eb-9824-042bdcc90203.PNG)
![linuxvnetblob](https://user-images.githubusercontent.com/33185278/119572192-3b5a8000-bd67-11eb-9ca5-e00559dc6844.PNG)
![linuxvnetfiles](https://user-images.githubusercontent.com/33185278/119572200-3e557080-bd67-11eb-80fc-65f58794ad6a.PNG)

2. Windows code/container:
![windowsfiles](https://user-images.githubusercontent.com/33185278/119572263-50cfaa00-bd67-11eb-87b3-29a8b5fc296f.PNG)
![windowsnofiles](https://user-images.githubusercontent.com/33185278/119572267-54633100-bd67-11eb-80eb-d9951be3e813.PNG)

