### PR TITLE
Adding Python 3.9 as early access and marking Node 10 and Ruby 2.5 as deprecated

### DIFF
--- a/server/src/stacks/2020-05-01/stacks/web-app-stacks/config/linux/Python.ts
+++ b/server/src/stacks/2020-05-01/stacks/web-app-stacks/config/linux/Python.ts
@@ -10,6 +10,23 @@ export const pythonLinuxConfigStack: WebAppConfigStack = {
     dependency: null,
     majorVersions: [
       {
+        displayVersion: '3.9',
+        runtimeVersion: 'PYTHON|3.9',
+        isDefault: false,
+        minorVersions: [
+          {
+            displayVersion: '3.9',
+            runtimeVersion: 'PYTHON|3.9',
+            isDefault: true,
+            isRemoteDebuggingEnabled: false,
+          },
+        ],
+        applicationInsights: false,
+        isPreview: false,
+        isDeprecated: false,
+        isHidden: false,
+      },
+      {
         displayVersion: '3.8',
         runtimeVersion: 'PYTHON|3.8',
         isDefault: true,

--- a/server/src/stacks/2020-05-01/stacks/web-app-stacks/create/Python.ts
+++ b/server/src/stacks/2020-05-01/stacks/web-app-stacks/create/Python.ts
@@ -6,9 +6,29 @@ export const pythonCreateStack: WebAppCreateStack = {
   sortOrder: 2,
   versions: [
     {
+      displayText: 'Python 3.9',
+      value: '3.9',
+      sortOrder: 0,
+      supportedPlatforms: [
+        {
+          os: 'linux',
+          isPreview: false,
+          isDeprecated: false,
+          isHidden: false,
+          applicationInsightsEnabled: false,
+          remoteDebuggingEnabled: false,
+          runtimeVersion: 'PYTHON|3.9',
+          sortOrder: 0,
+          githubActionSettings: {
+            supported: true,
+          },
+        },
+      ],
+    },
+    {
       displayText: 'Python 3.8',
       value: '3.8',
-      sortOrder: 0,
+      sortOrder: 1,
       supportedPlatforms: [
         {
           os: 'linux',
@@ -28,7 +48,7 @@ export const pythonCreateStack: WebAppCreateStack = {
     {
       displayText: 'Python 3.7',
       value: '3.7',
-      sortOrder: 1,
+      sortOrder: 2,
       supportedPlatforms: [
         {
           os: 'linux',
@@ -48,7 +68,7 @@ export const pythonCreateStack: WebAppCreateStack = {
     {
       displayText: 'Python 3.6',
       value: '3.6',
-      sortOrder: 2,
+      sortOrder: 3,
       supportedPlatforms: [
         {
           os: 'linux',

--- a/server/src/stacks/2020-06-01/stacks/function-app-stacks/Node.ts
+++ b/server/src/stacks/2020-06-01/stacks/function-app-stacks/Node.ts
@@ -115,6 +115,7 @@ export const nodeStack: FunctionAppStack = {
           stackSettings: {
             windowsRuntimeSettings: {
               runtimeVersion: '~10',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -134,6 +135,7 @@ export const nodeStack: FunctionAppStack = {
             },
             linuxRuntimeSettings: {
               runtimeVersion: 'Node|10',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
@@ -137,6 +137,7 @@ export const nodeStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'NODE|10-lts',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -174,6 +175,7 @@ export const nodeStack: WebAppStack = {
           stackSettings: {
             windowsRuntimeSettings: {
               runtimeVersion: '10.15.2',
+              isDeprecated: true,
               isPreview: true,
               isHidden: true,
               remoteDebuggingSupported: false,
@@ -194,6 +196,7 @@ export const nodeStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'NODE|10.14',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -206,6 +209,7 @@ export const nodeStack: WebAppStack = {
             },
             windowsRuntimeSettings: {
               runtimeVersion: '10.14.1',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -256,6 +260,7 @@ export const nodeStack: WebAppStack = {
             },
             windowsRuntimeSettings: {
               runtimeVersion: '10.0.0',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -274,6 +279,7 @@ export const nodeStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'NODE|10.6',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -286,6 +292,7 @@ export const nodeStack: WebAppStack = {
             },
             windowsRuntimeSettings: {
               runtimeVersion: '10.6.0',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -303,6 +310,7 @@ export const nodeStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'NODE|10.1',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Python.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Python.ts
@@ -12,6 +12,25 @@ export const pythonStack: WebAppStack = {
       value: '3',
       minorVersions: [
         {
+          displayText: 'Python 3.9',
+          value: '3.9',
+          stackSettings: {
+            linuxRuntimeSettings: {
+              runtimeVersion: 'PYTHON|3.9',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: false,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '3.9',
+              },
+              isHidden: false,
+              isEarlyAccess: true,
+            },
+          },
+        },
+        {
           displayText: 'Python 3.8',
           value: '3.8',
           stackSettings: {

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Ruby.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Ruby.ts
@@ -1,5 +1,7 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
 
+const ruby2Point6EOL = new Date(2022, 3, 31).toString();
+const ruby2Point5EOL = new Date(2021, 3, 31).toString();
 const ruby2Point4EOL = new Date(2020, 4, 1).toString();
 const ruby2Point3EOL = new Date(2019, 3, 31).toString();
 
@@ -25,6 +27,7 @@ export const rubyStack: WebAppStack = {
               gitHubActionSettings: {
                 isSupported: false,
               },
+              endOfLifeDate: ruby2Point6EOL,
             },
           },
         },
@@ -41,6 +44,7 @@ export const rubyStack: WebAppStack = {
               gitHubActionSettings: {
                 isSupported: false,
               },
+              endOfLifeDate: ruby2Point6EOL,
             },
           },
         },
@@ -50,6 +54,7 @@ export const rubyStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'RUBY|2.5',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
@@ -57,6 +62,7 @@ export const rubyStack: WebAppStack = {
               gitHubActionSettings: {
                 isSupported: false,
               },
+              endOfLifeDate: ruby2Point5EOL,
             },
           },
         },
@@ -66,6 +72,7 @@ export const rubyStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'RUBY|2.5.5',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
@@ -73,6 +80,7 @@ export const rubyStack: WebAppStack = {
               gitHubActionSettings: {
                 isSupported: false,
               },
+              endOfLifeDate: ruby2Point5EOL,
             },
           },
         },

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Node.ts
@@ -115,6 +115,7 @@ export const nodeStack: FunctionAppStack = {
           stackSettings: {
             windowsRuntimeSettings: {
               runtimeVersion: '~10',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -134,6 +135,7 @@ export const nodeStack: FunctionAppStack = {
             },
             linuxRuntimeSettings: {
               runtimeVersion: 'Node|10',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
@@ -137,6 +137,7 @@ export const nodeStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'NODE|10-lts',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -174,6 +175,7 @@ export const nodeStack: WebAppStack = {
           stackSettings: {
             windowsRuntimeSettings: {
               runtimeVersion: '10.15.2',
+              isDeprecated: true,
               isPreview: true,
               isHidden: true,
               remoteDebuggingSupported: false,
@@ -194,6 +196,7 @@ export const nodeStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'NODE|10.14',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -206,6 +209,7 @@ export const nodeStack: WebAppStack = {
             },
             windowsRuntimeSettings: {
               runtimeVersion: '10.14.1',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -256,6 +260,7 @@ export const nodeStack: WebAppStack = {
             },
             windowsRuntimeSettings: {
               runtimeVersion: '10.0.0',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -274,6 +279,7 @@ export const nodeStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'NODE|10.6',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -286,6 +292,7 @@ export const nodeStack: WebAppStack = {
             },
             windowsRuntimeSettings: {
               runtimeVersion: '10.6.0',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -303,6 +310,7 @@ export const nodeStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'NODE|10.1',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Python.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Python.ts
@@ -12,6 +12,25 @@ export const pythonStack: WebAppStack = {
       value: '3',
       minorVersions: [
         {
+          displayText: 'Python 3.9',
+          value: '3.9',
+          stackSettings: {
+            linuxRuntimeSettings: {
+              runtimeVersion: 'PYTHON|3.9',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: false,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '3.9',
+              },
+              isHidden: false,
+              isEarlyAccess: true,
+            },
+          },
+        },
+        {
           displayText: 'Python 3.8',
           value: '3.8',
           stackSettings: {

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Ruby.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Ruby.ts
@@ -1,5 +1,7 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
 
+const ruby2Point6EOL = new Date(2022, 3, 31).toString();
+const ruby2Point5EOL = new Date(2021, 3, 31).toString();
 const ruby2Point4EOL = new Date(2020, 4, 1).toString();
 const ruby2Point3EOL = new Date(2019, 3, 31).toString();
 
@@ -25,6 +27,7 @@ export const rubyStack: WebAppStack = {
               gitHubActionSettings: {
                 isSupported: false,
               },
+              endOfLifeDate: ruby2Point6EOL,
             },
           },
         },
@@ -41,6 +44,7 @@ export const rubyStack: WebAppStack = {
               gitHubActionSettings: {
                 isSupported: false,
               },
+              endOfLifeDate: ruby2Point6EOL,
             },
           },
         },
@@ -50,6 +54,7 @@ export const rubyStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'RUBY|2.5',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
@@ -57,6 +62,7 @@ export const rubyStack: WebAppStack = {
               gitHubActionSettings: {
                 isSupported: false,
               },
+              endOfLifeDate: ruby2Point5EOL,
             },
           },
         },
@@ -66,6 +72,7 @@ export const rubyStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'RUBY|2.5.5',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
@@ -73,6 +80,7 @@ export const rubyStack: WebAppStack = {
               gitHubActionSettings: {
                 isSupported: false,
               },
+              endOfLifeDate: ruby2Point5EOL,
             },
           },
         },

--- a/server/src/tests/Stacks/2020-05-01/web-app/validations.ts
+++ b/server/src/tests/Stacks/2020-05-01/web-app/validations.ts
@@ -85,7 +85,7 @@ export function validatePythonCreateStack(stacks) {
   expect(pythonStack.displayText).to.equal('Python');
   expect(pythonStack.value).to.equal('Python');
   expect(pythonStack.sortOrder).to.equal(2);
-  expect(pythonStack.versions.length).to.equal(3);
+  expect(pythonStack.versions.length).to.equal(4);
   expect(pythonStack).to.deep.equal(pythonCreateStack);
 }
 
@@ -236,7 +236,7 @@ export function validatePythonLinuxConfigStack(stacks) {
   expect(pythonStack.type).to.equal('Microsoft.Web/availableStacks?osTypeSelected=Linux');
   expect(pythonStack.properties.name).to.equal('python');
   expect(pythonStack.properties.display).to.equal('Python');
-  expect(pythonStack.properties.majorVersions.length).to.equal(4);
+  expect(pythonStack.properties.majorVersions.length).to.equal(5);
   expect(pythonStack).to.deep.equal(pythonLinuxConfigStack);
 }
 


### PR DESCRIPTION
Fixes [AB#8723232](https://msazure.visualstudio.com/Antares/_workitems/edit/8723232)
Fixes [AB#9878062](https://msazure.visualstudio.com/Antares/_workitems/edit/9878062)
Fixes [AB#10015742](https://msazure.visualstudio.com/Antares/_workitems/edit/10015742)