### PR TITLE
AB#9578003 [Visual Requirement - App Services - Dev/Test]: Luminosity ratio is less than required non -text contrast (3:1) for focus indicator.

### DIFF
--- a/client/src/app/controls/group-tabs/group-tabs.component.scss
+++ b/client/src/app/controls/group-tabs/group-tabs.component.scss
@@ -19,6 +19,7 @@ nav {
   padding-top: 7px;
   box-shadow: $card-box-shadow;
   outline-offset: -2px;
+  outline-color: #0B9ECB;
 
   h3 {
     margin-top: 2px;
@@ -43,6 +44,7 @@ nav {
   .group-tab {
     background-color: lighten($chrome-color-dark, 10%);
     box-shadow: $card-box-shadow-hover-dark;
+    outline-color: #077A9A;
 
     &.selected-container {
       background-color: $chrome-color-dark;


### PR DESCRIPTION
Fixes AB#9578003

Before without setting the values with just defaults:
![image](https://user-images.githubusercontent.com/14221995/120392753-c7c7ee00-c2e5-11eb-83e6-6381e4b54053.png)


After:
Light mode
![image](https://user-images.githubusercontent.com/14221995/120392793-da422780-c2e5-11eb-95c7-10f436fb9619.png)


Dark mode
![image](https://user-images.githubusercontent.com/14221995/120392828-e5955300-c2e5-11eb-81c4-b4e3dfac2d04.png)
