### PR TITLE
AB#8725350 [SKU Picker] [Create + ScaleUp] Limit the SKUs shown when JBoss is on the App Service Plan

### DIFF
--- a/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/basic-plan-price-spec.ts
@@ -42,11 +42,12 @@ export abstract class BasicPlanPriceSpec extends PriceSpec {
   cssClass = 'spec basic-spec';
 
   runInitialization(input: PriceSpecInput) {
-    if (input.plan) {
+    if (input.planDetails) {
       if (
-        input.plan.properties.hostingEnvironmentProfile ||
-        input.plan.properties.hyperV ||
-        AppKind.hasAnyKind(input.plan, [Kinds.elastic])
+        input.planDetails.plan.properties.hostingEnvironmentProfile ||
+        input.planDetails.plan.properties.hyperV ||
+        AppKind.hasAnyKind(input.planDetails.plan, [Kinds.elastic]) ||
+        input.planDetails.containsJbossSite
       ) {
         this.state = 'hidden';
       }
@@ -56,7 +57,8 @@ export abstract class BasicPlanPriceSpec extends PriceSpec {
         input.specPickerInput.data.isXenon ||
         input.specPickerInput.data.hyperV ||
         (input.specPickerInput.data.isNewFunctionAppCreate &&
-          (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard))
+          (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard)) ||
+        input.specPickerInput.data.isJBoss
       ) {
         this.state = 'hidden';
       }

--- a/client/src/app/site/spec-picker/price-spec-manager/dV2series-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/dV2series-price-spec.ts
@@ -22,7 +22,7 @@ export abstract class DV2SeriesPriceSpec extends PriceSpec {
 
   protected abstract _matchSku(sku: Sku): boolean;
   protected abstract _shouldHideForNewPlan(data: PlanSpecPickerData): boolean;
-  protected abstract _shouldHideForExistingPlan(plan: ArmObj<ServerFarm>): boolean;
+  protected abstract _shouldHideForExistingPlan(plan: ArmObj<ServerFarm>, containsJbossSite: boolean): boolean;
 
   private _checkIfSkuEnabledOnStamp(resourceId: ResourceId) {
     if (this.state !== 'hidden') {
@@ -54,10 +54,10 @@ export abstract class DV2SeriesPriceSpec extends PriceSpec {
   }
 
   runInitialization(input: PriceSpecInput) {
-    if (input.plan) {
-      this.state = this._shouldHideForExistingPlan(input.plan) ? 'hidden' : this.state;
+    if (input.planDetails) {
+      this.state = this._shouldHideForExistingPlan(input.planDetails.plan, input.planDetails.containsJbossSite) ? 'hidden' : this.state;
 
-      return this._checkIfSkuEnabledOnStamp(input.plan.id).switchMap(_ => {
+      return this._checkIfSkuEnabledOnStamp(input.planDetails.plan.id).switchMap(_ => {
         return this.checkIfDreamspark(input.subscriptionId);
       });
     } else if (input.specPickerInput.data) {

--- a/client/src/app/site/spec-picker/price-spec-manager/dV3series-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/dV3series-price-spec.ts
@@ -23,7 +23,7 @@ export abstract class DV3SeriesPriceSpec extends PriceSpec {
 
   protected abstract _matchSku(sku: Sku): boolean;
   protected abstract _shouldHideForNewPlan(data: PlanSpecPickerData): boolean;
-  protected abstract _shouldHideForExistingPlan(plan: ArmObj<ServerFarm>): boolean;
+  protected abstract _shouldHideForExistingPlan(plan: ArmObj<ServerFarm>, containsJbossSite: boolean): boolean;
 
   private _checkIfSkuEnabledOnStamp(resourceId: ResourceId) {
     if (this.state !== 'hidden') {
@@ -65,11 +65,11 @@ export abstract class DV3SeriesPriceSpec extends PriceSpec {
   }
 
   runInitialization(input: PriceSpecInput) {
-    if (input.plan) {
-      this._updateHardwareItemsList(input.plan.properties.hyperV);
-      this.state = this._shouldHideForExistingPlan(input.plan) ? 'hidden' : this.state;
+    if (input.planDetails.plan) {
+      this._updateHardwareItemsList(input.planDetails.plan.properties.hyperV);
+      this.state = this._shouldHideForExistingPlan(input.planDetails.plan, input.planDetails.containsJbossSite) ? 'hidden' : this.state;
 
-      return this._checkIfSkuEnabledOnStamp(input.plan.id).switchMap(_ => {
+      return this._checkIfSkuEnabledOnStamp(input.planDetails.plan.id).switchMap(_ => {
         return this.checkIfDreamspark(input.subscriptionId);
       });
     } else if (input.specPickerInput.data) {

--- a/client/src/app/site/spec-picker/price-spec-manager/elastic-premium-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/elastic-premium-plan-price-spec.ts
@@ -70,17 +70,19 @@ export abstract class ElasticPremiumPlanPriceSpec extends DV2SeriesPriceSpec {
       data.isXenon ||
       data.hyperV ||
       !data.isFunctionApp ||
-      (data.isNewFunctionAppCreate && !data.isElastic)
+      (data.isNewFunctionAppCreate && !data.isElastic) ||
+      data.isJBoss
     );
   }
 
   // NOTE(shimedh): Plan kind is 'elastic' for both Elastic Premium and Workflow Standard. SO we need to check sku tier as well.
-  protected _shouldHideForExistingPlan(plan: ArmObj<ServerFarm>): boolean {
+  protected _shouldHideForExistingPlan(plan: ArmObj<ServerFarm>, containsJbossSite: boolean): boolean {
     return (
       !!plan.properties.hostingEnvironmentProfile ||
       plan.properties.hyperV ||
       !AppKind.hasAnyKind(plan, [Kinds.elastic]) ||
-      plan.sku.tier === Tier.workflowStandard
+      plan.sku.tier === Tier.workflowStandard ||
+      containsJbossSite
     );
   }
 }

--- a/client/src/app/site/spec-picker/price-spec-manager/free-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/free-plan-price-spec.ts
@@ -59,21 +59,22 @@ export class FreePlanPriceSpec extends PriceSpec {
 
   runInitialization(input: PriceSpecInput) {
     let isLinux = false;
-    if (input.plan) {
-      isLinux = AppKind.hasAnyKind(input.plan, [Kinds.linux]);
+    if (input.planDetails) {
+      isLinux = AppKind.hasAnyKind(input.planDetails.plan, [Kinds.linux]);
       if (isLinux) {
         this.topLevelFeatures.shift();
       }
 
       if (
-        input.plan.properties.hostingEnvironmentProfile ||
-        input.plan.properties.hyperV ||
-        AppKind.hasAnyKind(input.plan, [Kinds.elastic])
+        input.planDetails.plan.properties.hostingEnvironmentProfile ||
+        input.planDetails.plan.properties.hyperV ||
+        AppKind.hasAnyKind(input.planDetails.plan, [Kinds.elastic]) ||
+        input.planDetails.containsJbossSite
       ) {
         this.state = 'hidden';
       }
 
-      return this._checkIfSkuEnabledOnStamp(input.plan.id);
+      return this._checkIfSkuEnabledOnStamp(input.planDetails.plan.id);
     } else if (input.specPickerInput.data) {
       isLinux = input.specPickerInput.data.isLinux;
       if (isLinux) {
@@ -87,7 +88,8 @@ export class FreePlanPriceSpec extends PriceSpec {
         input.specPickerInput.data.isXenon ||
         input.specPickerInput.data.hyperV ||
         (input.specPickerInput.data.isNewFunctionAppCreate &&
-          (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard))
+          (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard)) ||
+        input.specPickerInput.data.isJBoss
       ) {
         this.state = 'hidden';
       }

--- a/client/src/app/site/spec-picker/price-spec-manager/isolated-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/isolated-plan-price-spec.ts
@@ -70,15 +70,16 @@ export abstract class IsolatedPlanPriceSpec extends PriceSpec {
   runInitialization(input: PriceSpecInput) {
     if (NationalCloudEnvironment.isBlackforest()) {
       this.state = 'hidden';
-    } else if (input.plan) {
+    } else if (input.planDetails) {
       if (
-        !input.plan.properties.hostingEnvironmentProfile ||
-        input.plan.properties.hyperV ||
-        AppKind.hasAnyKind(input.plan, [Kinds.elastic])
+        !input.planDetails.plan.properties.hostingEnvironmentProfile ||
+        input.planDetails.plan.properties.hyperV ||
+        AppKind.hasAnyKind(input.planDetails.plan, [Kinds.elastic]) ||
+        input.planDetails.containsJbossSite
       ) {
         this.state = 'hidden';
       } else {
-        return this._aseService.getAse(input.plan.properties.hostingEnvironmentProfile.id).do(r => {
+        return this._aseService.getAse(input.planDetails.plan.properties.hostingEnvironmentProfile.id).do(r => {
           // If the call to get the ASE fails (maybe due to RBAC), then we can't confirm ASE v1 or v2 or v3
           // but we'll let them see the isolated card anyway.  The plan update will probably fail in
           // the back-end if it's ASE v1, but at least we allow real ASE v2 customers who don't have
@@ -94,6 +95,7 @@ export abstract class IsolatedPlanPriceSpec extends PriceSpec {
       (!input.specPickerInput.data.allowAseV2Creation ||
         input.specPickerInput.data.isXenon ||
         input.specPickerInput.data.hyperV ||
+        input.specPickerInput.data.isJBoss ||
         (input.specPickerInput.data.isNewFunctionAppCreate &&
           (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard)))
     ) {

--- a/client/src/app/site/spec-picker/price-spec-manager/isolatedv2-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/isolatedv2-plan-price-spec.ts
@@ -94,15 +94,15 @@ export abstract class IsolatedV2PlanPriceSpec extends PriceSpec {
   runInitialization(input: PriceSpecInput) {
     if (NationalCloudEnvironment.isBlackforest()) {
       this.state = 'hidden';
-    } else if (input.plan) {
+    } else if (input.planDetails) {
       if (
-        !input.plan.properties.hostingEnvironmentProfile ||
-        input.plan.properties.hyperV ||
-        AppKind.hasAnyKind(input.plan, [Kinds.elastic])
+        !input.planDetails.plan.properties.hostingEnvironmentProfile ||
+        input.planDetails.plan.properties.hyperV ||
+        AppKind.hasAnyKind(input.planDetails.plan, [Kinds.elastic])
       ) {
         this.state = 'hidden';
       } else {
-        return this._aseService.getAse(input.plan.properties.hostingEnvironmentProfile.id).do(r => {
+        return this._aseService.getAse(input.planDetails.plan.properties.hostingEnvironmentProfile.id).do(r => {
           // If the call to get the ASE fails (maybe due to RBAC), then we can't confirm ASE v1 or v2 or v3
           // but we'll let them see the isolated card anyway.  The plan update will probably fail in
           // the back-end if it's ASE v1, but at least we allow real ASE v3 customers who don't have
@@ -113,7 +113,7 @@ export abstract class IsolatedV2PlanPriceSpec extends PriceSpec {
         });
       }
 
-      return this._checkIfSkuEnabledOnStamp(input.plan.id).switchMap(_ => {
+      return this._checkIfSkuEnabledOnStamp(input.planDetails && input.planDetails.plan.id).switchMap(_ => {
         return this.checkIfDreamspark(input.subscriptionId);
       });
     } else if (

--- a/client/src/app/site/spec-picker/price-spec-manager/premium-container-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premium-container-plan-price-spec.ts
@@ -57,7 +57,13 @@ export abstract class PremiumContainerPlanPriceSpec extends PriceSpec {
 
   runInitialization(input: PriceSpecInput) {
     // NOTE(shimedh): Only show premium container for existing xenon apps if sku is set to premiumContainer.
-    if (input.plan && input.plan.properties.hyperV && input.plan.sku.tier === Tier.premiumContainer) {
+    if (
+      input.planDetails &&
+      input.planDetails.plan &&
+      input.planDetails.plan.properties.hyperV &&
+      input.planDetails.plan.sku.tier === Tier.premiumContainer &&
+      !input.planDetails.containsJbossSite
+    ) {
       this.state = 'enabled';
     } else {
       this.state = 'hidden';

--- a/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premium-plan-price-spec.ts
@@ -63,11 +63,12 @@ export abstract class PremiumPlanPriceSpec extends PriceSpec {
   }
 
   runInitialization(input: PriceSpecInput) {
-    if (input.plan) {
+    if (input.planDetails) {
       if (
-        input.plan.properties.hostingEnvironmentProfile ||
-        input.plan.properties.hyperV ||
-        AppKind.hasAnyKind(input.plan, [Kinds.linux, Kinds.elastic])
+        input.planDetails.plan.properties.hostingEnvironmentProfile ||
+        input.planDetails.plan.properties.hyperV ||
+        AppKind.hasAnyKind(input.planDetails.plan, [Kinds.linux, Kinds.elastic]) ||
+        input.planDetails.containsJbossSite
       ) {
         this.state = 'hidden';
       }
@@ -77,6 +78,7 @@ export abstract class PremiumPlanPriceSpec extends PriceSpec {
         input.specPickerInput.data.isLinux ||
         input.specPickerInput.data.isXenon ||
         input.specPickerInput.data.hyperV ||
+        input.specPickerInput.data.isJBoss ||
         (input.specPickerInput.data.isNewFunctionAppCreate &&
           (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard))
       ) {

--- a/client/src/app/site/spec-picker/price-spec-manager/premiumv2-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premiumv2-plan-price-spec.ts
@@ -73,12 +73,18 @@ export abstract class PremiumV2PlanPriceSpec extends DV2SeriesPriceSpec {
       !!data.hostingEnvironmentName ||
       data.isXenon ||
       data.hyperV ||
-      (data.isNewFunctionAppCreate && (data.isElastic || data.isWorkflowStandard))
+      (data.isNewFunctionAppCreate && (data.isElastic || data.isWorkflowStandard)) ||
+      data.isJBoss
     );
   }
 
-  protected _shouldHideForExistingPlan(plan: ArmObj<ServerFarm>): boolean {
-    return !!plan.properties.hostingEnvironmentProfile || plan.properties.hyperV || AppKind.hasAnyKind(plan, [Kinds.elastic]);
+  protected _shouldHideForExistingPlan(plan: ArmObj<ServerFarm>, containsJbossSite: boolean): boolean {
+    return (
+      !!plan.properties.hostingEnvironmentProfile ||
+      plan.properties.hyperV ||
+      AppKind.hasAnyKind(plan, [Kinds.elastic]) ||
+      containsJbossSite
+    );
   }
 
   public updateUpsellBanner(): void {

--- a/client/src/app/site/spec-picker/price-spec-manager/premiumv3-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/premiumv3-plan-price-spec.ts
@@ -73,7 +73,7 @@ export abstract class PremiumV3PlanPriceSpec extends DV3SeriesPriceSpec {
     return !!data.hostingEnvironmentName || (data.isNewFunctionAppCreate && (data.isElastic || data.isWorkflowStandard));
   }
 
-  protected _shouldHideForExistingPlan(plan: ArmObj<ServerFarm>): boolean {
+  protected _shouldHideForExistingPlan(plan: ArmObj<ServerFarm>, containsJbossSite: boolean): boolean {
     return (
       !!plan.properties.hostingEnvironmentProfile ||
       (plan.properties.hyperV && plan.sku.tier === Tier.premiumContainer) ||

--- a/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/price-spec-group.ts
@@ -121,8 +121,8 @@ export class GenericSpecGroup extends PriceSpecGroup {
 
   initialize(input: PriceSpecInput) {
     this.pricingTiers.value.forEach(pricingTier => {
-      if (input.plan) {
-        if (input.plan.properties.hyperV !== pricingTier.properties.isXenon) {
+      if (input.planDetails && input.planDetails.plan) {
+        if (input.planDetails && input.planDetails.plan.properties.hyperV !== pricingTier.properties.isXenon) {
           return;
         }
       }
@@ -140,9 +140,13 @@ export class GenericSpecGroup extends PriceSpecGroup {
           return;
         }
       }
-      const numberOfWorkersRequired = (input.plan && input.plan.properties.numberOfWorkers) || 1;
+      const numberOfWorkersRequired =
+        (input.planDetails && input.planDetails.plan && input.planDetails && input.planDetails.plan.properties.numberOfWorkers) || 1;
       const spec = new GenericPlanPriceSpec(this.injector, pricingTier.properties);
-      if ((!input.plan || input.plan.sku.name !== spec.skuCode) && pricingTier.properties.availableInstances < numberOfWorkersRequired) {
+      if (
+        ((!input.planDetails && input.planDetails.plan) || (input.planDetails && input.planDetails.plan.sku.name !== spec.skuCode)) &&
+        pricingTier.properties.availableInstances < numberOfWorkersRequired
+      ) {
         spec.state = 'disabled';
         spec.disabledMessage = this.ts.instant(PortalResources.pricing_notEnoughInstances);
       } else {
@@ -262,7 +266,8 @@ export class ProdSpecGroup extends PriceSpecGroup {
     }
 
     const isPartOfPv2Experiment = FlightingUtil.checkSubscriptionInFlight(input.subscriptionId, FlightingUtil.Features.Pv2Experimentation);
-    const isLinux = (input.specPickerInput.data && input.specPickerInput.data.isLinux) || ArmUtil.isLinuxApp(input.plan);
+    const isLinux =
+      (input.specPickerInput.data && input.specPickerInput.data.isLinux) || ArmUtil.isLinuxApp(input.planDetails && input.planDetails.plan);
 
     // NOTE(michinoy): The OS type determines whether standard small plan is recommended or additional pricing tier.
     // NOTE(shimedh): If subscription is part of PV2 experiment flighting we always add standard small plan in additional pricing tier irrespective of OS.

--- a/client/src/app/site/spec-picker/price-spec-manager/price-spec-manager.spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/price-spec-manager.spec.ts
@@ -83,7 +83,7 @@ xdescribe('Price Spec Manager', () => {
     const expectedPriceSpecInput: PriceSpecInput = {
       specPickerInput: newPlanSpecPickerInput,
       subscriptionId: newPlanSpecPickerInput.data.subscriptionId,
-      plan: null,
+      planDetails: null,
     };
 
     specManager.specGroups.forEach(g => {
@@ -106,7 +106,10 @@ xdescribe('Price Spec Manager', () => {
     const expectedPriceSpecInput: PriceSpecInput = {
       specPickerInput: existingPlanSpecPickerInput,
       subscriptionId: new ArmSubcriptionDescriptor(existingPlanSpecPickerInput.id).subscriptionId,
-      plan: planService.planToReturn,
+      planDetails: {
+        plan: planService.planToReturn,
+        containsJbossSite: false,
+      },
     };
 
     specManager.specGroups.forEach(g => {
@@ -209,7 +212,9 @@ xdescribe('Price Spec Manager', () => {
   function _verifySpecPickerInput(spy: jasmine.Spy, expectedPriceSpecInput: PriceSpecInput) {
     const actualInput = <PriceSpecInput>spy.calls.argsFor(0)[0];
     expect(actualInput.specPickerInput).toEqual(expectedPriceSpecInput.specPickerInput);
-    expect(actualInput.plan).toEqual(expectedPriceSpecInput.plan);
+    expect(actualInput.planDetails && actualInput.planDetails.plan).toEqual(
+      expectedPriceSpecInput.planDetails && expectedPriceSpecInput.planDetails.plan
+    );
     expect(actualInput.subscriptionId).toEqual(expectedPriceSpecInput.subscriptionId);
   }
 });

--- a/client/src/app/site/spec-picker/price-spec-manager/price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/price-spec.ts
@@ -11,10 +11,15 @@ import { SpecResourceSet } from './billing-models';
 import { PriceSpecDetail } from './price-spec-detail';
 import { SpecPickerInput, PlanSpecPickerData } from './plan-price-spec-manager';
 
+export interface PlanDetailsForPriceSpecInput {
+  plan: ArmObj<ServerFarm>;
+  containsJbossSite: boolean;
+}
+
 export interface PriceSpecInput {
   specPickerInput: SpecPickerInput<PlanSpecPickerData>;
   subscriptionId: string;
-  plan?: ArmObj<ServerFarm>;
+  planDetails?: PlanDetailsForPriceSpecInput;
 }
 
 export abstract class PriceSpec {

--- a/client/src/app/site/spec-picker/price-spec-manager/shared-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/shared-plan-price-spec.ts
@@ -51,11 +51,12 @@ export class SharedPlanPriceSpec extends PriceSpec {
   cssClass = 'spec premium-spec';
 
   runInitialization(input: PriceSpecInput) {
-    if (input.plan) {
+    if (input.planDetails) {
       if (
-        input.plan.properties.hostingEnvironmentProfile ||
-        input.plan.properties.hyperV ||
-        AppKind.hasAnyKind(input.plan, [Kinds.linux, Kinds.elastic])
+        input.planDetails.plan.properties.hostingEnvironmentProfile ||
+        input.planDetails.plan.properties.hyperV ||
+        AppKind.hasAnyKind(input.planDetails.plan, [Kinds.linux, Kinds.elastic]) ||
+        input.planDetails.containsJbossSite
       ) {
         this.state = 'hidden';
       }
@@ -65,6 +66,7 @@ export class SharedPlanPriceSpec extends PriceSpec {
         input.specPickerInput.data.isLinux ||
         input.specPickerInput.data.isXenon ||
         input.specPickerInput.data.hyperV ||
+        input.specPickerInput.data.isJBoss ||
         (input.specPickerInput.data.isNewFunctionAppCreate &&
           (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard))
       ) {

--- a/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
+++ b/client/src/app/site/spec-picker/price-spec-manager/standard-plan-price-spec.ts
@@ -63,11 +63,12 @@ export abstract class StandardPlanPriceSpec extends PriceSpec {
   }
 
   runInitialization(input: PriceSpecInput) {
-    if (input.plan) {
+    if (input.planDetails) {
       if (
-        input.plan.properties.hostingEnvironmentProfile ||
-        input.plan.properties.hyperV ||
-        AppKind.hasAnyKind(input.plan, [Kinds.elastic])
+        input.planDetails.plan.properties.hostingEnvironmentProfile ||
+        input.planDetails.plan.properties.hyperV ||
+        AppKind.hasAnyKind(input.planDetails.plan, [Kinds.elastic]) ||
+        input.planDetails.containsJbossSite
       ) {
         this.state = 'hidden';
       }
@@ -77,7 +78,8 @@ export abstract class StandardPlanPriceSpec extends PriceSpec {
         input.specPickerInput.data.isXenon ||
         input.specPickerInput.data.hyperV ||
         (input.specPickerInput.data.isNewFunctionAppCreate &&
-          (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard))
+          (input.specPickerInput.data.isElastic || input.specPickerInput.data.isWorkflowStandard)) ||
+        input.specPickerInput.data.isJBoss
       ) {
         this.state = 'hidden';
       }


### PR DESCRIPTION
Fixes AB#8725350

**Only PremiumV3 and IsolatedV2 sku's are allowed for a plan which has atleast one JBoss site.** 

**The changes on the Portal side for create scenario are not done yet, so only adding screenshots for scaleup scenario:**


![image](https://user-images.githubusercontent.com/14221995/120560352-6708e600-c3b7-11eb-80ee-5544f67a5c97.png)

![image](https://user-images.githubusercontent.com/14221995/120560400-7ee06a00-c3b7-11eb-97ee-c48a50fe592b.png)
