### PR TITLE
[DC] Enable PHP for GitHub Actions

### DIFF
--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
@@ -85,6 +85,8 @@ const getRuntimeStackVersionForWindows = (
     // combined with the fact there is no storage of .NET CORE version, we now return an assumed value of the latest
     // .NET Core
     return '3.1';
+  } else if (stack === RuntimeStacks.php) {
+    return siteConfig.properties.phpVersion || '';
   } else {
     return '';
   }

--- a/client/src/app/controls/group-tabs/group-tabs.component.scss
+++ b/client/src/app/controls/group-tabs/group-tabs.component.scss
@@ -19,6 +19,7 @@ nav {
   padding-top: 7px;
   box-shadow: $card-box-shadow;
   outline-offset: -2px;
+  outline-color: #0B9ECB;
 
   h3 {
     margin-top: 2px;
@@ -43,6 +44,7 @@ nav {
   .group-tab {
     background-color: lighten($chrome-color-dark, 10%);
     box-shadow: $card-box-shadow-hover-dark;
+    outline-color: #077A9A;
 
     &.selected-container {
       background-color: $chrome-color-dark;

--- a/server/src/stacks/2020-05-01/models/WebAppStackModel.ts
+++ b/server/src/stacks/2020-05-01/models/WebAppStackModel.ts
@@ -86,4 +86,5 @@ export interface WebAppCreateStackVersionPlatform {
 export interface WebAppCreateStackVersionPlatformGithubAction {
   supported: boolean;
   recommendedVersion?: string; // The version representation between Antares backend and GitHub action might mismatch.
+  notSupportedInCreates?: boolean;
 }

--- a/server/src/stacks/2020-05-01/stacks/web-app-stacks/create/Php.ts
+++ b/server/src/stacks/2020-05-01/stacks/web-app-stacks/create/Php.ts
@@ -20,7 +20,9 @@ export const phpCreateStack: WebAppCreateStack = {
           runtimeVersion: 'PHP|7.4',
           sortOrder: 0,
           githubActionSettings: {
-            supported: false,
+            supported: true,
+            recommendedVersion: '7.4',
+            notSupportedInCreates: true,
           },
         },
         {
@@ -33,7 +35,9 @@ export const phpCreateStack: WebAppCreateStack = {
           runtimeVersion: '7.4',
           sortOrder: 1,
           githubActionSettings: {
-            supported: false,
+            supported: true,
+            recommendedVersion: '7.4',
+            notSupportedInCreates: true,
           },
         },
       ],
@@ -53,7 +57,9 @@ export const phpCreateStack: WebAppCreateStack = {
           runtimeVersion: 'PHP|7.3',
           sortOrder: 0,
           githubActionSettings: {
-            supported: false,
+            supported: true,
+            recommendedVersion: '7.3',
+            notSupportedInCreates: true,
           },
         },
         {
@@ -66,7 +72,9 @@ export const phpCreateStack: WebAppCreateStack = {
           runtimeVersion: '7.3',
           sortOrder: 1,
           githubActionSettings: {
-            supported: false,
+            supported: true,
+            recommendedVersion: '7.3',
+            notSupportedInCreates: true,
           },
         },
       ],

--- a/server/src/stacks/2020-06-01/models/AppStackModel.ts
+++ b/server/src/stacks/2020-06-01/models/AppStackModel.ts
@@ -27,6 +27,7 @@ export interface AppInsightsSettings {
 export interface GitHubActionSettings {
   isSupported: boolean;
   supportedVersion?: string;
+  notSupportedInCreates?: boolean;
 }
 
 export interface CommonSettings {

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Php.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Php.ts
@@ -27,7 +27,9 @@ export const phpStack: WebAppStack = {
                 isSupported: false,
               },
               gitHubActionSettings: {
-                isSupported: false,
+                isSupported: true,
+                supportedVersion: '7.4',
+                notSupportedInCreates: true,
               },
               endOfLifeDate: php7Point4EOL,
             },
@@ -38,7 +40,9 @@ export const phpStack: WebAppStack = {
                 isSupported: false,
               },
               gitHubActionSettings: {
-                isSupported: false,
+                isSupported: true,
+                supportedVersion: '7.4',
+                notSupportedInCreates: true,
               },
               endOfLifeDate: php7Point4EOL,
             },
@@ -55,7 +59,9 @@ export const phpStack: WebAppStack = {
                 isSupported: false,
               },
               gitHubActionSettings: {
-                isSupported: false,
+                isSupported: true,
+                supportedVersion: '7.3',
+                notSupportedInCreates: true,
               },
               endOfLifeDate: php7Point3EOL,
             },
@@ -66,7 +72,9 @@ export const phpStack: WebAppStack = {
                 isSupported: false,
               },
               gitHubActionSettings: {
-                isSupported: false,
+                isSupported: true,
+                supportedVersion: '7.3',
+                notSupportedInCreates: true,
               },
               endOfLifeDate: php7Point3EOL,
             },

--- a/server/src/stacks/2020-10-01/models/AppStackModel.ts
+++ b/server/src/stacks/2020-10-01/models/AppStackModel.ts
@@ -27,6 +27,7 @@ export interface AppInsightsSettings {
 export interface GitHubActionSettings {
   isSupported: boolean;
   supportedVersion?: string;
+  notSupportedInCreates?: boolean;
 }
 
 export interface CommonSettings {

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Php.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Php.ts
@@ -27,7 +27,9 @@ export const phpStack: WebAppStack = {
                 isSupported: false,
               },
               gitHubActionSettings: {
-                isSupported: false,
+                isSupported: true,
+                supportedVersion: '7.4',
+                notSupportedInCreates: true,
               },
               endOfLifeDate: php7Point4EOL,
             },
@@ -38,7 +40,9 @@ export const phpStack: WebAppStack = {
                 isSupported: false,
               },
               gitHubActionSettings: {
-                isSupported: false,
+                isSupported: true,
+                supportedVersion: '7.4',
+                notSupportedInCreates: true,
               },
               endOfLifeDate: php7Point4EOL,
             },
@@ -55,7 +59,9 @@ export const phpStack: WebAppStack = {
                 isSupported: false,
               },
               gitHubActionSettings: {
-                isSupported: false,
+                isSupported: true,
+                supportedVersion: '7.3',
+                notSupportedInCreates: true,
               },
               endOfLifeDate: php7Point3EOL,
             },
@@ -66,7 +72,9 @@ export const phpStack: WebAppStack = {
                 isSupported: false,
               },
               gitHubActionSettings: {
-                isSupported: false,
+                isSupported: true,
+                supportedVersion: '7.3',
+                notSupportedInCreates: true,
               },
               endOfLifeDate: php7Point3EOL,
             },
@@ -96,7 +104,7 @@ export const phpStack: WebAppStack = {
                 isSupported: false,
               },
               gitHubActionSettings: {
-                isSupported: false,
+                isSupported: true,
               },
               endOfLifeDate: php7Point2EOL,
             },

--- a/server/src/tests/Stacks/2020-05-01/web-app/validations.ts
+++ b/server/src/tests/Stacks/2020-05-01/web-app/validations.ts
@@ -46,17 +46,17 @@ export function validateConfigLinuxStackLength(stacks) {
 
 export function validateGithubActionStackLength(stacks) {
   expect(stacks).to.be.an('array');
-  expect(stacks.length).to.equal(6);
+  expect(stacks.length).to.equal(7);
 }
 
 export function validateGithubActionWindowsStackLength(stacks) {
   expect(stacks).to.be.an('array');
-  expect(stacks.length).to.equal(6);
+  expect(stacks.length).to.equal(7);
 }
 
 export function validateGithubActionLinuxStackLength(stacks) {
   expect(stacks).to.be.an('array');
-  expect(stacks.length).to.equal(6);
+  expect(stacks.length).to.equal(7);
 }
 
 export function validateASPCreateStack(stacks) {

--- a/server/src/tests/Stacks/2020-10-01/web-app/validations.ts
+++ b/server/src/tests/Stacks/2020-10-01/web-app/validations.ts
@@ -284,7 +284,7 @@ export function validateGitHubActionStacks(stacks) {
 
 function validateGitHubActionStacksLength(stacks) {
   expect(stacks).to.be.an('array');
-  expect(stacks.length).to.equal(4);
+  expect(stacks.length).to.equal(5);
 }
 
 function validateGitHubActionStacksProperties(stacks) {

--- a/server/src/workflows/2020-12-01/WorkflowService.ts
+++ b/server/src/workflows/2020-12-01/WorkflowService.ts
@@ -89,6 +89,8 @@ export class WorkflowService20201201 {
         return this.readWorkflowFile('web-app-configs/node-linux.config.yml');
       case RuntimeStacks.Python:
         return this.readWorkflowFile('web-app-configs/python-linux.config.yml');
+      case RuntimeStacks.Php:
+        return this.readWorkflowFile('web-app-configs/php-linux.config.yml');
       default:
         throw new HttpException(`The workflow file for the runtime stack '${runtimeStack}' and OS '${providedOs}' does not exist.`, 404);
     }
@@ -114,6 +116,8 @@ export class WorkflowService20201201 {
         return this.readWorkflowFile('web-app-configs/node-windows.config.yml');
       case RuntimeStacks.Python:
         return this.readWorkflowFile('web-app-configs/python-windows.config.yml');
+      case RuntimeStacks.Php:
+        return this.readWorkflowFile('web-app-configs/php-windows.config.yml');
       default:
         throw new HttpException(`The workflow file for the runtime stack '${runtimeStack}' and OS '${providedOs}' does not exist.`, 404);
     }

--- a/server/src/workflows/2020-12-01/web-app-configs/php-linux.config.yml
+++ b/server/src/workflows/2020-12-01/web-app-configs/php-linux.config.yml
@@ -1,0 +1,60 @@
+# Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
+# More GitHub Actions for Azure: https://github.com/Azure/actions
+
+name: Build and deploy PHP app to Azure Web App - __sitename__
+
+on:
+  push:
+    branches:
+      - __branch__
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '__runtimeversion__'
+
+      - name: Check if composer.json exists
+        id: check_files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: 'composer.json'
+
+      - name: Run composer install if composer.json exists
+        if: steps.check_files.outputs.files_exists == 'true'
+        run: composer validate --no-check-publish && composer install --prefer-dist --no-progress
+
+      - name: Upload artifact for deployment job
+        uses: actions/upload-artifact@v2
+        with:
+          name: php-app
+          path: .
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: '__slotname__'
+      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+
+    steps:
+      - name: Download artifact from build job
+        uses: actions/download-artifact@v2
+        with:
+          name: php-app
+
+      - name: 'Deploy to Azure Web App'
+        uses: azure/webapps-deploy@v2
+        id: deploy-to-webapp
+        with:
+          app-name: '__sitename__'
+          slot-name: '__slotname__'
+          publish-profile: \${{ secrets.__publishingprofilesecretname__ }}
+          package: .

--- a/server/src/workflows/2020-12-01/web-app-configs/php-windows.config.yml
+++ b/server/src/workflows/2020-12-01/web-app-configs/php-windows.config.yml
@@ -1,0 +1,60 @@
+# Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
+# More GitHub Actions for Azure: https://github.com/Azure/actions
+
+name: Build and deploy PHP app to Azure Web App - __sitename__
+
+on:
+  push:
+    branches:
+      - __branch__
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '__runtimeversion__'
+
+      - name: Check if composer.json exists
+        id: check_files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: 'composer.json'
+
+      - name: Run composer install if composer.json exists
+        if: steps.check_files.outputs.files_exists == 'true'
+        run: composer validate --no-check-publish && composer install --prefer-dist --no-progress
+
+      - name: Upload artifact for deployment job
+        uses: actions/upload-artifact@v2
+        with:
+          name: php-app
+          path: .
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: '__slotname__'
+      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+
+    steps:
+      - name: Download artifact from build job
+        uses: actions/download-artifact@v2
+        with:
+          name: php-app
+
+      - name: 'Deploy to Azure Web App'
+        uses: azure/webapps-deploy@v2
+        id: deploy-to-webapp
+        with:
+          app-name: '__sitename__'
+          slot-name: '__slotname__'
+          publish-profile: \${{ secrets.__publishingprofilesecretname__ }}
+          package: .

--- a/server/src/workflows/WorkflowModel.ts
+++ b/server/src/workflows/WorkflowModel.ts
@@ -19,6 +19,7 @@ export enum RuntimeStacks {
   Python = 'python',
   Powershell = 'powershell',
   Dotnet = 'dotnet',
+  Php = 'php',
 }
 
 export enum JavaContainers {

--- a/server/src/workflows/workflow.controller.ts
+++ b/server/src/workflows/workflow.controller.ts
@@ -119,7 +119,7 @@ export class WorkflowController {
       throw new HttpException(`Missing 'runtimeStack' in the request body.`, 400);
     }
 
-    const runtimeStacks = ['java', 'node', 'python', 'powershell', 'dotnet'];
+    const runtimeStacks = ['java', 'node', 'python', 'powershell', 'dotnet', 'php'];
     if (runtimeStack && !runtimeStacks.includes(runtimeStack.toLocaleLowerCase())) {
       throw new HttpException(`Incorrect runtimeStack '${runtimeStack}' provided. Accepted types are: ${runtimeStacks.join(', ')}.`, 400);
     }


### PR DESCRIPTION
Fixes AB#9798960

The server test is failing because the number of stacks that support GitHub Actions is changing as PHP is now added. I have updated the tests in this PR.

![image](https://user-images.githubusercontent.com/35281019/120715223-2a052800-c479-11eb-837b-509c306c579c.png)

![image](https://user-images.githubusercontent.com/35281019/120715326-5325b880-c479-11eb-809f-f17790ffd0b2.png)

![image](https://user-images.githubusercontent.com/35281019/120715380-60db3e00-c479-11eb-9ff6-f663ff4e50e2.png)

![image](https://user-images.githubusercontent.com/35281019/120715599-ac8de780-c479-11eb-9fb0-24cd768beb91.png)

Tested windows 7.3, windows 7.4, linux 7.3, linux 7.4, all had successful GHA workflow runs as seen above and I was able to browse to all the sites.