### PR TITLE
AB#9592796 [Programmatic Access - App Services - Dev/Test]: Ensures all elements with a role attribute use a valid value (#devtestB1)

### DIFF
--- a/client/src/app/site/spec-picker/spec-list/spec-list.component.html
+++ b/client/src/app/site/spec-picker/spec-list/spec-list.component.html
@@ -10,7 +10,7 @@
     [hidden]="spec.state === 'hidden'"
     [id]="specGroup.id + spec.skuCode"
     tabindex="0"
-    role="radio button"
+    role="radio"
     [attr.aria-disabled]="spec.state === 'disabled'"
     [attr.aria-checked]="spec === specGroup.selectedSpec"
     [attr.aria-labelledBy]="getAriaLabelledByForSpec(spec)">


### PR DESCRIPTION
Fixes AB#9592796

Changed role on each card to be "radio" in stead of "radio button". Following the recommendation here that was in the bug - https://accessibilityinsights.io/info-examples/web/aria-roles/

**Before**:
![image](https://user-images.githubusercontent.com/14221995/120872325-3bbafe00-c553-11eb-932e-a05975781d4b.png)


**After**:
![image](https://user-images.githubusercontent.com/14221995/120872231-ebdc3700-c552-11eb-8b28-8f8f8b8b32f5.png)
