### PR TITLE
Adding Java versions 1.7.0_292, 1.8.0_282 and 11.0.9 for Windows web apps

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Java.ts
@@ -67,6 +67,19 @@ export const javaStack: WebAppStack = {
               },
               endOfLifeDate: java11EOL,
             },
+            windowsRuntimeSettings: {
+              runtimeVersion: '11.0.9',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+                isDefaultOff: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '11',
+              },
+              endOfLifeDate: java11EOL,
+            },
           },
         },
         {
@@ -255,6 +268,25 @@ export const javaStack: WebAppStack = {
             windowsRuntimeSettings: {
               runtimeVersion: '1.8',
               isAutoUpdate: true,
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+                isDefaultOff: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '8',
+              },
+              endOfLifeDate: java8EOL,
+            },
+          },
+        },
+        {
+          displayText: 'Java 1.8.0_282',
+          value: '8.0.282',
+          stackSettings: {
+            windowsRuntimeSettings: {
+              runtimeVersion: '1.8.0_282',
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -682,11 +714,30 @@ export const javaStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java 1.7.0_292',
+          value: '7.0.292',
+          stackSettings: {
+            windowsRuntimeSettings: {
+              runtimeVersion: '1.7.0_292',
+              isDeprecated: false,
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+                isDefaultOff: true,
+              },
+              gitHubActionSettings: {
+                isSupported: false,
+              },
+              endOfLifeDate: java7EOL,
+            },
+          },
+        },
+        {
           displayText: 'Java 1.7.0_272',
           value: '7.0.272',
           stackSettings: {
             windowsRuntimeSettings: {
-              runtimeVersion: '1.7.0_272_ZULU',
+              runtimeVersion: '1.7.0_272',
               isDeprecated: false,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
@@ -705,7 +756,7 @@ export const javaStack: WebAppStack = {
           value: '7.0.262',
           stackSettings: {
             windowsRuntimeSettings: {
-              runtimeVersion: '1.7.0_262_ZULU',
+              runtimeVersion: '1.7.0_262',
               isDeprecated: false,
               remoteDebuggingSupported: false,
               appInsightsSettings: {

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
@@ -67,6 +67,19 @@ export const javaStack: WebAppStack = {
               },
               endOfLifeDate: java11EOL,
             },
+            windowsRuntimeSettings: {
+              runtimeVersion: '11.0.9',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+                isDefaultOff: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '11',
+              },
+              endOfLifeDate: java11EOL,
+            },
           },
         },
         {
@@ -255,6 +268,25 @@ export const javaStack: WebAppStack = {
             windowsRuntimeSettings: {
               runtimeVersion: '1.8',
               isAutoUpdate: true,
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+                isDefaultOff: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '8',
+              },
+              endOfLifeDate: java8EOL,
+            },
+          },
+        },
+        {
+          displayText: 'Java 1.8.0_282',
+          value: '8.0.282',
+          stackSettings: {
+            windowsRuntimeSettings: {
+              runtimeVersion: '1.8.0_282',
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -682,11 +714,30 @@ export const javaStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java 1.7.0_292',
+          value: '7.0.292',
+          stackSettings: {
+            windowsRuntimeSettings: {
+              runtimeVersion: '1.7.0_292',
+              isDeprecated: false,
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+                isDefaultOff: true,
+              },
+              gitHubActionSettings: {
+                isSupported: false,
+              },
+              endOfLifeDate: java7EOL,
+            },
+          },
+        },
+        {
           displayText: 'Java 1.7.0_272',
           value: '7.0.272',
           stackSettings: {
             windowsRuntimeSettings: {
-              runtimeVersion: '1.7.0_272_ZULU',
+              runtimeVersion: '1.7.0_272',
               isDeprecated: false,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
@@ -705,7 +756,7 @@ export const javaStack: WebAppStack = {
           value: '7.0.262',
           stackSettings: {
             windowsRuntimeSettings: {
-              runtimeVersion: '1.7.0_262_ZULU',
+              runtimeVersion: '1.7.0_262',
               isDeprecated: false,
               remoteDebuggingSupported: false,
               appInsightsSettings: {


### PR DESCRIPTION
Fixes [AB#9595967](https://msazure.visualstudio.com/Antares/_workitems/edit/9595967)