### PR TITLE
[DC] Remove build dropdowns

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -84,12 +84,13 @@ export enum RuntimeStackDisplayNames {
   Node = 'Node',
   PHP = 'PHP',
   AspDotNet = 'ASP.NET',
-  Dotnet = 'Dotnet',
+  Dotnet = '.NET',
 }
 
 export enum RuntimeVersionOptions {
   Java11 = 'java11',
   Java8 = 'java8',
+  Java8Linux = 'jre8',
 }
 
 export enum RuntimeVersionDisplayNames {
@@ -111,6 +112,12 @@ export enum GitHubActionRunConclusion {
   Skipped = 'skipped',
   TimedOut = 'timed_out',
   ActionRequired = 'action_required',
+}
+
+export enum JavaContainerDisplayNames {
+  JavaSE = 'Java SE',
+  Tomcat = 'Tomcat',
+  JBoss = 'JBoss EAP',
 }
 
 export interface AzureDevOpsUrl {
@@ -219,7 +226,7 @@ export interface LocationServiceData {
 }
 
 export interface Properties {
-  Account: Account;
+  Account: DevOpsAccount;
 }
 
 export interface DeploymentCenterDataLoaderProps {

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -226,7 +226,7 @@ export interface LocationServiceData {
 }
 
 export interface Properties {
-  Account: DevOpsAccount;
+  Account: Account;
 }
 
 export interface DeploymentCenterDataLoaderProps {

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -443,6 +443,7 @@ export interface DeploymentCenterCodeBuildCalloutProps {
   toggleIsCalloutVisible: () => void;
   updateSelectedBuild: () => void;
   formProps: FormikProps<DeploymentCenterFormData<any>>;
+  runtimeStack: string;
 }
 
 export interface AuthorizationResult {

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildCallout.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildCallout.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { DefaultButton, Callout, ChoiceGroup, PrimaryButton } from 'office-ui-fabric-react';
 import { BuildProvider, ScmType } from '../../../../models/site/config';
 import { calloutStyle, calloutContent, calloutContentButton, additionalTextFieldControl } from '../DeploymentCenter.styles';
-import { BuildChoiceGroupOption, DeploymentCenterCodeBuildCalloutProps } from '../DeploymentCenter.types';
+import { BuildChoiceGroupOption, DeploymentCenterCodeBuildCalloutProps, RuntimeStackOptions } from '../DeploymentCenter.types';
 import { ScenarioService } from '../../../../utils/scenario-checker/scenario.service';
 import { ScenarioIds } from '../../../../utils/scenario-checker/scenario-ids';
 import { SiteStateContext } from '../../../../SiteState';
@@ -16,10 +16,13 @@ const DeploymentCenterCodeBuildCallout: React.FC<DeploymentCenterCodeBuildCallou
     toggleIsCalloutVisible,
     updateSelectedBuild,
     formProps,
+    runtimeStack,
   } = props;
   const { t } = useTranslation();
   const scenarioService = new ScenarioService(t);
   const siteStateContext = useContext(SiteStateContext);
+
+  const isGitHubActionEnabled = runtimeStack !== RuntimeStackOptions.Ruby;
 
   const isKuduDisabled = () => {
     return scenarioService.checkScenario(ScenarioIds.kuduBuildProvider, { site: siteStateContext.site }).status === 'disabled';
@@ -45,7 +48,7 @@ const DeploymentCenterCodeBuildCallout: React.FC<DeploymentCenterCodeBuildCallou
   ];
 
   const getBuildOptions = () => {
-    return formProps.values.sourceProvider === ScmType.GitHub
+    return formProps.values.sourceProvider === ScmType.GitHub && isGitHubActionEnabled
       ? [
           {
             key: BuildProvider.GitHubAction,

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildCallout.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildCallout.tsx
@@ -22,7 +22,7 @@ const DeploymentCenterCodeBuildCallout: React.FC<DeploymentCenterCodeBuildCallou
   const scenarioService = new ScenarioService(t);
   const siteStateContext = useContext(SiteStateContext);
 
-  const isGitHubActionEnabled = runtimeStack !== RuntimeStackOptions.Ruby;
+  const isGitHubActionEnabled = runtimeStack.toLocaleLowerCase() !== RuntimeStackOptions.Ruby;
 
   const isKuduDisabled = () => {
     return scenarioService.checkScenario(ScenarioIds.kuduBuildProvider, { site: siteStateContext.site }).status === 'disabled';

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildConfiguredView.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildConfiguredView.tsx
@@ -1,13 +1,7 @@
 import React, { useEffect, useContext, useState } from 'react';
 import { DeploymentCenterContext } from '../DeploymentCenterContext';
-import {
-  RuntimeStackSetting,
-  RuntimeStackOptions,
-  RuntimeStackDisplayNames,
-  RuntimeVersionDisplayNames,
-  RuntimeVersionOptions,
-} from '../DeploymentCenter.types';
-import { getRuntimeStackSetting } from '../utility/DeploymentCenterUtility';
+import { RuntimeStackSetting } from '../DeploymentCenter.types';
+import { getDefaultVersionDisplayName, getRuntimeStackDisplayName, getRuntimeStackSetting } from '../utility/DeploymentCenterUtility';
 import { useTranslation } from 'react-i18next';
 import ReactiveFormControl from '../../../../components/form-controls/ReactiveFormControl';
 import { ScmType } from '../../../../models/site/config';
@@ -33,53 +27,7 @@ const DeploymentCenterCodeBuildConfiguredView: React.FC<{}> = () => {
     );
 
     setDefaultStack(getRuntimeStackDisplayName(defaultStackAndVersionKeys.runtimeStack));
-    setDefaultVersion(getDefaultVersionDisplayName(defaultStackAndVersionKeys.runtimeVersion));
-  };
-
-  const getDefaultVersionDisplayName = (version: string) => {
-    return siteStateContext.isLinuxApp ? getLinuxDefaultVersionDisplayName(version) : getWindowsDefaultVersionDisplayName(version);
-  };
-
-  const getLinuxDefaultVersionDisplayName = (version: string) => {
-    //NOTE(stpelleg): Java is different
-    if (version === RuntimeVersionOptions.Java11) {
-      return RuntimeVersionDisplayNames.Java11;
-    } else if (version === RuntimeVersionOptions.Java8) {
-      return RuntimeVersionDisplayNames.Java8;
-    }
-    const versionNameParts: string[] = version.toLocaleLowerCase().split('|');
-
-    return versionNameParts.length === 2
-      ? `${getRuntimeStackDisplayName(versionNameParts[0])} ${versionNameParts[1].replace('-', ' ').toUpperCase()}`
-      : version;
-  };
-
-  const getWindowsDefaultVersionDisplayName = (version: string) => {
-    return version.replace('-', ' ');
-  };
-
-  const getRuntimeStackDisplayName = (stack: string) => {
-    const stackName = stack.toLocaleLowerCase();
-    switch (stackName) {
-      case RuntimeStackOptions.Python:
-        return RuntimeStackDisplayNames.Python;
-      case RuntimeStackOptions.DotNetCore:
-        return RuntimeStackDisplayNames.DotNetCore;
-      case RuntimeStackOptions.Ruby:
-        return RuntimeStackDisplayNames.Ruby;
-      case RuntimeStackOptions.Java:
-        return RuntimeStackDisplayNames.Java;
-      case RuntimeStackOptions.Node:
-        return RuntimeStackDisplayNames.Node;
-      case RuntimeStackOptions.PHP:
-        return RuntimeStackDisplayNames.PHP;
-      case RuntimeStackOptions.AspDotNet:
-        return RuntimeStackDisplayNames.AspDotNet;
-      case RuntimeStackOptions.Dotnet:
-        return RuntimeStackDisplayNames.Dotnet;
-      default:
-        return '';
-    }
+    setDefaultVersion(getDefaultVersionDisplayName(defaultStackAndVersionKeys.runtimeVersion, siteStateContext.isLinuxApp));
   };
 
   useEffect(() => {

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildRuntimeAndVersion.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildRuntimeAndVersion.tsx
@@ -1,9 +1,7 @@
-import React, { useState, useEffect, useContext, useRef } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { IDropdownOption, MessageBarType } from 'office-ui-fabric-react';
+import { MessageBarType } from 'office-ui-fabric-react';
 import { BuildProvider } from '../../../../models/site/config';
-import { Field } from 'formik';
-import Dropdown from '../../../../components/form-controls/DropDown';
 import {
   DeploymentCenterFieldProps,
   DeploymentCenterCodeFormData,
@@ -13,7 +11,13 @@ import {
 import { DeploymentCenterContext } from '../DeploymentCenterContext';
 import DeploymentCenterData from '../DeploymentCenter.data';
 import { getErrorMessage } from '../../../../ApiHelpers/ArmHelper';
-import { getRuntimeStackSetting, getTelemetryInfo } from '../utility/DeploymentCenterUtility';
+import {
+  getDefaultVersionDisplayName,
+  getJavaContainerDisplayName,
+  getRuntimeStackDisplayName,
+  getRuntimeStackSetting,
+  getTelemetryInfo,
+} from '../utility/DeploymentCenterUtility';
 import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
 import { deploymentCenterInfoBannerDiv, titleWithPaddingStyle } from '../DeploymentCenter.styles';
 import { SiteStateContext } from '../../../../SiteState';
@@ -21,33 +25,24 @@ import { JavaContainers, WebAppRuntimes, WebAppStack } from '../../../../models/
 import { RuntimeStacks } from '../../../../utils/stacks-utils';
 import { FunctionAppRuntimes, FunctionAppStack } from '../../../../models/stacks/function-app-stacks';
 import { AppStackOs } from '../../../../models/stacks/app-stacks';
-import { KeyValue } from '../../../../models/portal-models';
 import { PortalContext } from '../../../../PortalContext';
 import { ArmArray } from '../../../../models/arm-obj';
+import ReactiveFormControl from '../../../../components/form-controls/ReactiveFormControl';
+import { KeyValue } from '../../../../models/portal-models';
 
 type StackSettings = WebAppRuntimes & JavaContainers | FunctionAppRuntimes;
 
 const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterFieldProps<DeploymentCenterCodeFormData>> = props => {
   const { formProps } = props;
   const { t } = useTranslation();
-  const [selectedRuntime, setSelectedRuntime] = useState<string | undefined>(undefined);
-  const [selectedVersion, setSelectedVersion] = useState<string | undefined>(undefined);
   // NOTE(michinoy): Disabling preferred array literal rule to allow '.find' operation on the runtimeStacksData.
   // tslint:disable-next-line: prefer-array-literal
   const [runtimeStacksData, setRuntimeStacksData] = useState<Array<WebAppStack | FunctionAppStack>>([]);
-  const [runtimeStackOptions, setRuntimeStackOptions] = useState<IDropdownOption[]>([]);
-  const [runtimeVersionOptions, setRuntimeVersionOptions] = useState<IDropdownOption[]>([]);
   const [defaultStack, setDefaultStack] = useState<string>('');
   const [defaultVersion, setDefaultVersion] = useState<string>('');
+  const [javaContainer, setJavaContainer] = useState<string>('');
   const [stackNotSupportedMessage, setStackNotSupportedMessage] = useState<string>('');
-  const [stackMismatchMessage, setStackMismatchMessage] = useState<string>('');
   const [showNotSupportedWarningBar, setShowNotSupportedWarningBar] = useState(true);
-  const [showMismatchWarningBar, setShowMismatchWarningBar] = useState(true);
-
-  // NOTE(michinoy): aggregate a cache of os, runtimestack, minor version, and github action
-  // recommended version mapping. This will make the look up post selection of dropdowns much
-  // simpler.
-  const gitHubActionRuntimeVersionMapping = useRef<KeyValue<string>>({});
 
   const deploymentCenterContext = useContext(DeploymentCenterContext);
   const siteStateContext = useContext(SiteStateContext);
@@ -56,10 +51,6 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
 
   const closeStackNotSupportedWarningBanner = () => {
     setShowNotSupportedWarningBar(false);
-  };
-
-  const closeStackMismatchWarningBanner = () => {
-    setShowMismatchWarningBar(false);
   };
 
   const fetchStacks = async () => {
@@ -81,11 +72,6 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
       // tslint:disable-next-line: prefer-array-literal
       const runtimeStacks = (runtimeStacksResponse.data as ArmArray<WebAppStack | FunctionAppStack>).value.map(stack => stack.properties);
       setRuntimeStacksData(runtimeStacks);
-      setRuntimeStackOptions(
-        runtimeStacks.map(stack => {
-          return { text: stack.displayText, key: stack.value.toLocaleLowerCase() };
-        })
-      );
     } else {
       portalContext.log(
         getTelemetryInfo('error', 'runtimeStacksResponse', 'failed', {
@@ -96,12 +82,57 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
     }
   };
 
-  const populateVersionDropdown = (selectedStack: string) => {
-    const runtimeStack = runtimeStacksData.find(stack => stack.value.toLocaleLowerCase() === selectedStack);
+  const setDefaultValues = () => {
+    const defaultStackAndVersion: RuntimeStackSetting = getRuntimeStackSetting(
+      siteStateContext.isLinuxApp,
+      siteStateContext.isFunctionApp,
+      siteStateContext.isKubeApp,
+      deploymentCenterContext.siteConfig,
+      deploymentCenterContext.configMetadata,
+      deploymentCenterContext.applicationSettings
+    );
+
+    //Note (stpelleg): Java is different
+    if (defaultStackAndVersion.runtimeVersion.toLocaleLowerCase() === RuntimeVersionOptions.Java11) {
+      defaultStackAndVersion.runtimeVersion = '11.0';
+    } else if (
+      defaultStackAndVersion.runtimeVersion.toLocaleLowerCase() === RuntimeVersionOptions.Java8 ||
+      defaultStackAndVersion.runtimeVersion.toLocaleLowerCase() === RuntimeVersionOptions.Java8Linux
+    ) {
+      defaultStackAndVersion.runtimeVersion = '8.0';
+    }
+
+    formProps.setFieldValue('runtimeStack', defaultStackAndVersion.runtimeStack);
+    formProps.setFieldValue('runtimeVersion', defaultStackAndVersion.runtimeVersion.toLocaleLowerCase());
+
+    setDefaultStack(getRuntimeStackDisplayName(defaultStackAndVersion.runtimeStack));
+    setDefaultVersion(getDefaultVersionDisplayName(defaultStackAndVersion.runtimeVersion, siteStateContext.isLinuxApp));
+  };
+
+  const updateJavaContainer = () => {
+    if (deploymentCenterContext.siteConfig && formProps.values.runtimeStack && formProps.values.runtimeStack === RuntimeStacks.java) {
+      const siteConfigJavaContainer = siteStateContext.isLinuxApp
+        ? deploymentCenterContext.siteConfig.properties.linuxFxVersion.toLowerCase().split('|')[0]
+        : deploymentCenterContext.siteConfig.properties.javaContainer &&
+          deploymentCenterContext.siteConfig.properties.javaContainer.toLowerCase();
+
+      formProps.setFieldValue('javaContainer', siteConfigJavaContainer);
+      setJavaContainer(getJavaContainerDisplayName(siteConfigJavaContainer));
+    } else {
+      formProps.setFieldValue('javaContainer', '');
+      setJavaContainer('');
+    }
+  };
+
+  const setGitHubActionsRecommendedVersion = () => {
+    // NOTE(michinoy): Try our best to get the GitHub Action recommended version from the stacks API. At worst case,
+    // select the minor version. Do not fail at this point, like this in case if a new stack is incorrectly added, we can
+    // always fall back on the minor version instead of blocking or messing customers workflow file.
+    const gitHubActionRuntimeVersionMapping: KeyValue<string> = {};
+    const curStack = formProps.values.runtimeStack || '';
+    const runtimeStack = runtimeStacksData.find(stack => stack.value.toLocaleLowerCase() === curStack);
 
     if (runtimeStack) {
-      const displayedVersions: IDropdownOption[] = [];
-
       runtimeStack.majorVersions.forEach(majorVersion => {
         majorVersion.minorVersions.forEach(minorVersion => {
           let value = minorVersion.value;
@@ -121,93 +152,27 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
               ? minorVersion.stackSettings.windowsRuntimeSettings.runtimeVersion
               : value;
 
-          addGitHubActionRuntimeVersionMapping(selectedStack, value.toLocaleLowerCase(), minorVersion.stackSettings);
-          displayedVersions.push({ text: minorVersion.displayText, key: value.toLocaleLowerCase() });
+          addGitHubActionRuntimeVersionMapping(
+            curStack,
+            value.toLocaleLowerCase(),
+            minorVersion.stackSettings,
+            gitHubActionRuntimeVersionMapping
+          );
         });
       });
-
-      setRuntimeVersionOptions(displayedVersions);
-    }
-  };
-
-  const updateStackMismatchMessage = () => {
-    if (deploymentCenterContext.siteDescriptor) {
-      const siteName = deploymentCenterContext.siteDescriptor.site;
-      const slotName = deploymentCenterContext.siteDescriptor.slot;
-      setShowMismatchWarningBar(true);
-      setStackMismatchMessage(
-        t('githubActionStackMismatchMessage', {
-          appName: slotName ? `${siteName} (${slotName})` : siteName,
-          stack: defaultStack,
-        })
-      );
-    } else {
-      setStackMismatchMessage('');
-    }
-  };
-
-  const updateSelectedRuntime = (e: any, option: IDropdownOption) => {
-    setSelectedRuntime(option.key.toString());
-    formProps.setFieldValue('runtimeStack', option.key.toString());
-
-    // NOTE(michinoy): Show a warning message if the user selects a stack which does not match what their app is configured with.
-    if (defaultStack && option.key.toString() !== defaultStack.toLocaleLowerCase() && !stackNotSupportedMessage) {
-      updateStackMismatchMessage();
-    } else {
-      setStackMismatchMessage('');
     }
 
-    populateVersionDropdown(option.key.toString());
-  };
-
-  const updateSelectedVersion = (e: any, option: IDropdownOption) => {
-    setSelectedVersion(option.key.toString());
-
-    formProps.setFieldValue('runtimeVersion', option.key.toString());
-    formProps.setFieldValue(
-      'runtimeRecommendedVersion',
-      getRuntimeStackRecommendedVersion(formProps.values.runtimeStack, option.key.toString())
-    );
-  };
-
-  const getRuntimeStackRecommendedVersion = (stackValue: string, runtimeVersionValue: string): string => {
-    const key = generateGitHubActionRuntimeVersionMappingKey(siteStateContext.isLinuxApp, stackValue, runtimeVersionValue);
-
-    return gitHubActionRuntimeVersionMapping.current[key] ? gitHubActionRuntimeVersionMapping.current[key] : runtimeVersionValue;
-  };
-
-  const setDefaultSelectedRuntimeVersion = () => {
-    // NOTE(michinoy): once the stack versions dropdown is populated, default selection can be done in either of following ways:
-    // 1. If the stack version is selected for the app and it exists in the list
-    // 2. Select the first item in the list if the stack version does not exist (e.g. .NET Core) Or does not exist in the list (e.g. Node LTS)
-    let defaultRuntimeVersion = defaultVersion;
-    if (defaultRuntimeVersion.toLocaleLowerCase() === RuntimeVersionOptions.Java11) {
-      defaultRuntimeVersion = '11.0';
-    } else if (defaultRuntimeVersion.toLocaleLowerCase() === RuntimeVersionOptions.Java8) {
-      defaultRuntimeVersion = '8.0';
+    //Note (stpelleg): Java is different
+    let curVersion = formProps.values.runtimeVersion || '';
+    if (curVersion === '11.0') {
+      curVersion = '11';
+    } else if (curVersion === '8.0') {
+      curVersion = '8';
     }
 
-    if (runtimeVersionOptions.length >= 1) {
-      const defaultRuntimeVersionOption = runtimeVersionOptions.filter(
-        item => item.key.toString().toLocaleLowerCase() === defaultRuntimeVersion.toLocaleLowerCase()
-      );
-
-      if (defaultRuntimeVersionOption && defaultRuntimeVersionOption.length === 1) {
-        setSelectedVersion(defaultRuntimeVersionOption[0].key.toString());
-        formProps.setFieldValue('runtimeVersion', defaultRuntimeVersionOption[0].key.toString());
-        formProps.setFieldValue(
-          'runtimeRecommendedVersion',
-          getRuntimeStackRecommendedVersion(formProps.values.runtimeStack, defaultRuntimeVersionOption[0].key.toString())
-        );
-      } else {
-        setSelectedVersion(runtimeVersionOptions[0].key.toString());
-        formProps.setFieldValue('runtimeVersion', runtimeVersionOptions[0].key.toString());
-        formProps.setFieldValue(
-          'runtimeRecommendedVersion',
-          getRuntimeStackRecommendedVersion(formProps.values.runtimeStack, runtimeVersionOptions[0].key.toString())
-        );
-      }
-    }
+    const key = generateGitHubActionRuntimeVersionMappingKey(siteStateContext.isLinuxApp, curStack, curVersion);
+    const version = gitHubActionRuntimeVersionMapping[key] ? gitHubActionRuntimeVersionMapping[key] : curVersion;
+    formProps.setFieldValue('runtimeRecommendedVersion', version);
   };
 
   const updateStackNotSupportedMessage = () => {
@@ -223,40 +188,44 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
     }
   };
 
-  const setDefaultSelectedRuntimeStack = () => {
-    // NOTE(michinoy): Once the dropdown is populated, preselect stack that the user had selected during create.
+  const setGitHubActionsNotSupportedMessage = () => {
     // If the users app was built using a stack that is not supported, show a warning message.
-    if (formProps.values.buildProvider === BuildProvider.GitHubAction && defaultStack && runtimeStackOptions.length >= 1) {
-      const appSelectedStack = runtimeStackOptions.filter(item => item.key.toString() === defaultStack.toLocaleLowerCase());
+    if (formProps.values.buildProvider === BuildProvider.GitHubAction && !!formProps.values.runtimeStack && runtimeStacksData.length >= 1) {
+      const appSelectedStack = runtimeStacksData.filter(
+        item => item.value.toString() === formProps.values.runtimeStack.toLocaleLowerCase()
+      );
 
       if (appSelectedStack && appSelectedStack.length === 1) {
-        const appSelectedStackKey = appSelectedStack[0].key.toString();
         setStackNotSupportedMessage('');
-        setStackMismatchMessage('');
-        setSelectedRuntime(appSelectedStackKey);
-        formProps.setFieldValue('runtimeStack', appSelectedStackKey);
-        populateVersionDropdown(appSelectedStackKey);
       } else {
         updateStackNotSupportedMessage();
       }
     }
   };
 
-  const setInitialDefaultValues = () => {
-    const defaultStackAndVersion: RuntimeStackSetting = getRuntimeStackSetting(
-      siteStateContext.isLinuxApp,
-      siteStateContext.isFunctionApp,
-      siteStateContext.isKubeApp,
-      deploymentCenterContext.siteConfig,
-      deploymentCenterContext.configMetadata,
-      deploymentCenterContext.applicationSettings
+  const getStackNotSupportedBanner = () => {
+    return (
+      <>
+        {stackNotSupportedMessage && showNotSupportedWarningBar && (
+          <div className={deploymentCenterInfoBannerDiv}>
+            <CustomBanner
+              id="stack-not-supported-message"
+              message={stackNotSupportedMessage}
+              type={MessageBarType.warning}
+              onDismiss={closeStackNotSupportedWarningBanner}
+            />
+          </div>
+        )}
+      </>
     );
-
-    setDefaultStack(defaultStackAndVersion.runtimeStack);
-    setDefaultVersion(defaultStackAndVersion.runtimeVersion);
   };
 
-  const addGitHubActionRuntimeVersionMapping = (stack: string, minorVersion: string, stackSettings: StackSettings) => {
+  const addGitHubActionRuntimeVersionMapping = (
+    stack: string,
+    minorVersion: string,
+    stackSettings: StackSettings,
+    gitHubActionRuntimeVersionMapping: KeyValue<string>
+  ) => {
     // NOTE(michinoy): Try our best to get the GitHub Action recommended version from the stacks API. At worst case,
     // select the minor version. Do not fail at this point, like this in case if a new stack is incorrectly added, we can
     // always fall back on the minor version instead of blocking or messing customers workflow file.
@@ -273,7 +242,7 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
         : minorVersion;
     }
 
-    gitHubActionRuntimeVersionMapping.current[key] = version;
+    gitHubActionRuntimeVersionMapping[key] = version;
   };
 
   const generateGitHubActionRuntimeVersionMappingKey = (isLinuxApp: boolean, stack: string, minorVersion: string): string => {
@@ -281,105 +250,50 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
     return `${os}-${stack.toLocaleLowerCase()}-${minorVersion.toLocaleLowerCase()}`;
   };
 
-  useEffect(() => {
+  const initializeFormValues = () => {
     formProps.setFieldValue('runtimeStack', '');
     formProps.setFieldValue('runtimeVersion', '');
     formProps.setFieldValue('runtimeRecommendedVersion', '');
     formProps.setFieldValue('javaContainer', '');
+  };
 
-    setInitialDefaultValues();
+  useEffect(() => {
+    initializeFormValues();
     fetchStacks();
+    setDefaultValues();
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
-    formProps.setFieldValue('runtimeStack', '');
-    formProps.setFieldValue('runtimeVersion', '');
-    formProps.setFieldValue('runtimeRecommendedVersion', '');
-    formProps.setFieldValue('javaContainer', '');
-
-    setDefaultSelectedRuntimeStack();
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [runtimeStackOptions, formProps.values.buildProvider]);
-
-  useEffect(() => {
-    formProps.setFieldValue('runtimeVersion', '');
-    formProps.setFieldValue('runtimeRecommendedVersion', '');
-
-    setDefaultSelectedRuntimeVersion();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [runtimeVersionOptions]);
-
-  useEffect(() => {
-    // Set java container as needed.
-    if (deploymentCenterContext.siteConfig && formProps.values.runtimeStack && formProps.values.runtimeStack === RuntimeStacks.java) {
-      const siteConfigJavaContainer = siteStateContext.isLinuxApp
-        ? deploymentCenterContext.siteConfig.properties.linuxFxVersion.toLowerCase().split('|')[0]
-        : deploymentCenterContext.siteConfig.properties.javaContainer &&
-          deploymentCenterContext.siteConfig.properties.javaContainer.toLowerCase();
-
-      formProps.setFieldValue('javaContainer', siteConfigJavaContainer);
-    } else {
-      formProps.setFieldValue('javaContainer', '');
+    if (!!defaultStack && runtimeStacksData.length > 0) {
+      updateJavaContainer();
+      setGitHubActionsRecommendedVersion();
+      setGitHubActionsNotSupportedMessage();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formProps.values.runtimeStack]);
 
-  const getCustomBanner = () => {
-    return (
-      <>
-        {stackNotSupportedMessage && showNotSupportedWarningBar && (
-          <div className={deploymentCenterInfoBannerDiv}>
-            <CustomBanner
-              id="stack-not-supported-message"
-              message={stackNotSupportedMessage}
-              type={MessageBarType.warning}
-              onDismiss={closeStackNotSupportedWarningBanner}
-            />
-          </div>
-        )}
-        {stackMismatchMessage && showMismatchWarningBar && (
-          <div className={deploymentCenterInfoBannerDiv}>
-            <CustomBanner
-              id="stack-mismatch-message"
-              message={stackMismatchMessage}
-              type={MessageBarType.warning}
-              onDismiss={closeStackMismatchWarningBanner}
-            />
-          </div>
-        )}
-      </>
-    );
-  };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultStack, runtimeStacksData]);
 
   return (
     <>
       <h3 className={titleWithPaddingStyle}>{t('deploymentCenterSettingsBuildTitle')}</h3>
-      {getCustomBanner()}
-      <Field
-        label={t('deploymentCenterSettingsRuntimeLabel')}
-        name="runtimeStack"
-        component={Dropdown}
-        displayInVerticalLayout={true}
-        options={runtimeStackOptions}
-        selectedKey={selectedRuntime}
-        onChange={updateSelectedRuntime}
-        required={true}
-        aria-required={true}
-      />
-      <Field
-        label={t('deploymentCenterSettingsRuntimeVersionLabel')}
-        name="runtimeVersion"
-        component={Dropdown}
-        displayInVerticalLayout={true}
-        options={runtimeVersionOptions}
-        selectedKey={selectedVersion}
-        onChange={updateSelectedVersion}
-        required={true}
-        aria-required={true}
-      />
+
+      {getStackNotSupportedBanner()}
+
+      <ReactiveFormControl id="deployment-center-code-settings-runtime-stack" label={t('deploymentCenterSettingsRuntimeLabel')}>
+        <div>{defaultStack}</div>
+      </ReactiveFormControl>
+
+      <ReactiveFormControl id="deployment-center-code-settings-runtime-version" label={t('deploymentCenterSettingsRuntimeVersionLabel')}>
+        <div>{defaultVersion}</div>
+      </ReactiveFormControl>
+
+      {javaContainer && (
+        <ReactiveFormControl id="deployment-center-code-settings-java-container" label={t('deploymentCenterJavaWebServerStack')}>
+          <div>{javaContainer}</div>
+        </ReactiveFormControl>
+      )}
     </>
   );
 };

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildRuntimeAndVersion.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildRuntimeAndVersion.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { MessageBarType } from 'office-ui-fabric-react';
-import { BuildProvider } from '../../../../models/site/config';
 import {
   DeploymentCenterFieldProps,
   DeploymentCenterCodeFormData,
@@ -18,8 +16,7 @@ import {
   getRuntimeStackSetting,
   getTelemetryInfo,
 } from '../utility/DeploymentCenterUtility';
-import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
-import { deploymentCenterInfoBannerDiv, titleWithPaddingStyle } from '../DeploymentCenter.styles';
+import { titleWithPaddingStyle } from '../DeploymentCenter.styles';
 import { SiteStateContext } from '../../../../SiteState';
 import { JavaContainers, WebAppRuntimes, WebAppStack } from '../../../../models/stacks/web-app-stacks';
 import { RuntimeStacks } from '../../../../utils/stacks-utils';
@@ -41,17 +38,11 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
   const [defaultStack, setDefaultStack] = useState<string>('');
   const [defaultVersion, setDefaultVersion] = useState<string>('');
   const [javaContainer, setJavaContainer] = useState<string>('');
-  const [stackNotSupportedMessage, setStackNotSupportedMessage] = useState<string>('');
-  const [showNotSupportedWarningBar, setShowNotSupportedWarningBar] = useState(true);
 
   const deploymentCenterContext = useContext(DeploymentCenterContext);
   const siteStateContext = useContext(SiteStateContext);
   const portalContext = useContext(PortalContext);
   const deploymentCenterData = new DeploymentCenterData();
-
-  const closeStackNotSupportedWarningBanner = () => {
-    setShowNotSupportedWarningBar(false);
-  };
 
   const fetchStacks = async () => {
     const appOs = siteStateContext.isLinuxApp || siteStateContext.isKubeApp ? AppStackOs.linux : AppStackOs.windows;
@@ -175,51 +166,6 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
     formProps.setFieldValue('runtimeRecommendedVersion', version);
   };
 
-  const updateStackNotSupportedMessage = () => {
-    if (deploymentCenterContext.siteDescriptor) {
-      const siteName = deploymentCenterContext.siteDescriptor.site;
-      const slotName = deploymentCenterContext.siteDescriptor.slot;
-      setShowNotSupportedWarningBar(true);
-      setStackNotSupportedMessage(
-        t('githubActionStackNotSupportedMessage', { appName: slotName ? `${siteName} (${slotName})` : siteName, stack: defaultStack })
-      );
-    } else {
-      setStackNotSupportedMessage('');
-    }
-  };
-
-  const setGitHubActionsNotSupportedMessage = () => {
-    // If the users app was built using a stack that is not supported, show a warning message.
-    if (formProps.values.buildProvider === BuildProvider.GitHubAction && !!formProps.values.runtimeStack && runtimeStacksData.length >= 1) {
-      const appSelectedStack = runtimeStacksData.filter(
-        item => item.value.toString() === formProps.values.runtimeStack.toLocaleLowerCase()
-      );
-
-      if (appSelectedStack && appSelectedStack.length === 1) {
-        setStackNotSupportedMessage('');
-      } else {
-        updateStackNotSupportedMessage();
-      }
-    }
-  };
-
-  const getStackNotSupportedBanner = () => {
-    return (
-      <>
-        {stackNotSupportedMessage && showNotSupportedWarningBar && (
-          <div className={deploymentCenterInfoBannerDiv}>
-            <CustomBanner
-              id="stack-not-supported-message"
-              message={stackNotSupportedMessage}
-              type={MessageBarType.warning}
-              onDismiss={closeStackNotSupportedWarningBanner}
-            />
-          </div>
-        )}
-      </>
-    );
-  };
-
   const addGitHubActionRuntimeVersionMapping = (
     stack: string,
     minorVersion: string,
@@ -269,7 +215,6 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
     if (!!defaultStack && runtimeStacksData.length > 0) {
       updateJavaContainer();
       setGitHubActionsRecommendedVersion();
-      setGitHubActionsNotSupportedMessage();
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -278,8 +223,6 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
   return (
     <>
       <h3 className={titleWithPaddingStyle}>{t('deploymentCenterSettingsBuildTitle')}</h3>
-
-      {getStackNotSupportedBanner()}
 
       <ReactiveFormControl id="deployment-center-code-settings-runtime-stack" label={t('deploymentCenterSettingsRuntimeLabel')}>
         <div>{defaultStack}</div>

--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
@@ -4,6 +4,11 @@ import {
   DeploymentCenterFormData,
   DeploymentCenterContainerFormData,
   ContainerRegistrySources,
+  RuntimeVersionOptions,
+  RuntimeVersionDisplayNames,
+  RuntimeStackOptions,
+  RuntimeStackDisplayNames,
+  JavaContainerDisplayNames,
 } from '../DeploymentCenter.types';
 import { ArmObj } from '../../../../models/arm-obj';
 import { ScmType, SiteConfig } from '../../../../models/site/config';
@@ -364,9 +369,69 @@ export const isFtpsDirty = (
 };
 
 export const getGitHubCommitMessage = (deploymentMessage: string): string => {
-  if (deploymentMessage) {
+  if (!!deploymentMessage) {
     const deploymentMessageJson = JSON.parse(deploymentMessage);
     return !!deploymentMessageJson && !!deploymentMessageJson.commitMessage ? deploymentMessageJson.commitMessage : deploymentMessage;
   }
   return deploymentMessage;
+};
+
+export const getDefaultVersionDisplayName = (version: string, isLinuxApp: boolean) => {
+  return isLinuxApp ? getLinuxDefaultVersionDisplayName(version) : getWindowsDefaultVersionDisplayName(version);
+};
+
+export const getLinuxDefaultVersionDisplayName = (version: string) => {
+  //NOTE(stpelleg): Java is different
+  if (version === RuntimeVersionOptions.Java11) {
+    return RuntimeVersionDisplayNames.Java11;
+  } else if (version === RuntimeVersionOptions.Java8) {
+    return RuntimeVersionDisplayNames.Java8;
+  }
+  const versionNameParts: string[] = version.toLocaleLowerCase().split('|');
+
+  return versionNameParts.length === 2
+    ? `${getRuntimeStackDisplayName(versionNameParts[0])} ${versionNameParts[1].replace('-', ' ').toUpperCase()}`
+    : version;
+};
+
+export const getWindowsDefaultVersionDisplayName = (version: string) => {
+  return version.replace('-', ' ');
+};
+
+export const getRuntimeStackDisplayName = (stack: string) => {
+  const stackName = stack.toLocaleLowerCase();
+  switch (stackName) {
+    case RuntimeStackOptions.Python:
+      return RuntimeStackDisplayNames.Python;
+    case RuntimeStackOptions.DotNetCore:
+      return RuntimeStackDisplayNames.DotNetCore;
+    case RuntimeStackOptions.Ruby:
+      return RuntimeStackDisplayNames.Ruby;
+    case RuntimeStackOptions.Java:
+      return RuntimeStackDisplayNames.Java;
+    case RuntimeStackOptions.Node:
+      return RuntimeStackDisplayNames.Node;
+    case RuntimeStackOptions.PHP:
+      return RuntimeStackDisplayNames.PHP;
+    case RuntimeStackOptions.AspDotNet:
+      return RuntimeStackDisplayNames.AspDotNet;
+    case RuntimeStackOptions.Dotnet:
+      return RuntimeStackDisplayNames.Dotnet;
+    default:
+      return '';
+  }
+};
+
+export const getJavaContainerDisplayName = (stack: string) => {
+  const stackName = stack.toLocaleLowerCase();
+  switch (stackName) {
+    case JavaContainers.JavaSE:
+      return JavaContainerDisplayNames.JavaSE;
+    case JavaContainers.Tomcat:
+      return JavaContainerDisplayNames.Tomcat;
+    case JavaContainers.JBoss:
+      return JavaContainerDisplayNames.JBoss;
+    default:
+      return '';
+  }
 };

--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
@@ -21,6 +21,7 @@ import { LogLevel, TelemetryInfo } from '../../../../models/telemetry';
 import { LogCategories } from '../../../../utils/LogCategories';
 import { FormikProps } from 'formik';
 import { IDeploymentCenterContext } from '../DeploymentCenterContext';
+import { CommonConstants } from '../../../../utils/CommonConstants';
 
 export const getLogId = (component: string, event: string): string => {
   return `${component}/${event}`;
@@ -390,12 +391,12 @@ export const getLinuxDefaultVersionDisplayName = (version: string) => {
   const versionNameParts: string[] = version.toLocaleLowerCase().split('|');
 
   return versionNameParts.length === 2
-    ? `${getRuntimeStackDisplayName(versionNameParts[0])} ${versionNameParts[1].replace('-', ' ').toUpperCase()}`
+    ? `${getRuntimeStackDisplayName(versionNameParts[0])} ${versionNameParts[1].replace(CommonConstants.Hyphen, ' ').toUpperCase()}`
     : version;
 };
 
 export const getWindowsDefaultVersionDisplayName = (version: string) => {
-  return version.replace('-', ' ');
+  return version.replace(CommonConstants.Hyphen, ' ');
 };
 
 export const getRuntimeStackDisplayName = (stack: string) => {

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -162,6 +162,8 @@ export class CommonConstants {
 
   public static readonly Dash = ' - ';
 
+  public static readonly Hyphen = '-';
+
   public static readonly serviceBmxUrl = 'https://service.bmx.azure.com';
 
   public static readonly MountPathValidationExamples = {

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2338,4 +2338,5 @@ export class PortalResources {
   public static staticSiteStandardBandwidthOverage = 'staticSiteStandardBandwidthOverage';
   public static configurationFeedbackCESQuestion = 'configurationFeedbackCESQuestion';
   public static configurationFeedbackCVAQuestion = 'configurationFeedbackCVAQuestion';
+  public static deploymentCenterJavaWebServerStack = 'deploymentCenterJavaWebServerStack';
 }

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7155,4 +7155,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="configurationFeedbackCVAQuestion" xml:space="preserve">
         <value>How valuable is this App Service configuration page?</value>
     </data>
+    <data name="deploymentCenterJavaWebServerStack" xml:space="preserve">
+        <value>Java web server stack</value>
+    </data>
 </root>


### PR DESCRIPTION
Fixes [AB#8405224](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/8405224)
Fixes [AB#8405240](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/8405240)

Removes build dropdowns for Linux and Windows. Hides GitHub Actions as a build provider for Ruby apps as there are no workflow files for Ruby and no plans to onboard Ruby users to use GitHub Actions.

![image](https://user-images.githubusercontent.com/35281019/125371250-306aa780-e335-11eb-8b0c-300325f568a8.png)

![image](https://user-images.githubusercontent.com/35281019/125371285-437d7780-e335-11eb-9848-7b1e9ec30e19.png)

![image](https://user-images.githubusercontent.com/35281019/125371329-63ad3680-e335-11eb-9505-c5c8d682b1a1.png)

![image](https://user-images.githubusercontent.com/35281019/125371361-7293e900-e335-11eb-9900-55d93b7a8c92.png)

![image](https://user-images.githubusercontent.com/35281019/125371380-7f184180-e335-11eb-930f-f6f6fe7a1f87.png)

![image](https://user-images.githubusercontent.com/35281019/125412135-7b0b1480-e373-11eb-9116-3c7c73242785.png)

