### PR TITLE
[DC] Update ACR url check to accommodate Mooncake ACR url

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -442,11 +442,11 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
     }
 
     const registryInfo = fxVersionParts[1];
-    return !!registryInfo && registryInfo.indexOf(DeploymentCenterConstants.acrUriHost) > -1;
+    return !!registryInfo && registryInfo.indexOf(DeploymentCenterConstants.acrUriBody) > -1;
   }
 
   private _isServerUrlAcr(serverUrl: string): boolean {
-    return !!serverUrl && serverUrl.indexOf(DeploymentCenterConstants.acrUriHost) > -1;
+    return !!serverUrl && serverUrl.indexOf(DeploymentCenterConstants.acrUriBody) > -1;
   }
 
   private _isServerUrlDockerHub(serverUrl: string): boolean {


### PR DESCRIPTION
Fixes [AB#9906660](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/9906660)
Mooncake ACR uri is azurecr.cn so the previous check for azurecr.io needed to be updated.