### PR TITLE
AB#10487619 [BYOS] Storage Mount Showing Old Access Key

### DIFF
--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
@@ -82,8 +82,8 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
     return !!accountError ? accountError : undefined;
   };
 
-  const getAccessKey = (): string => {
-    return initialValues.accountName === values.accountName ? initialValues.accessKey || '' : '';
+  const getAccessKey = (key: string): string => {
+    return initialValues.accountName === values.accountName && !!initialValues.accessKey ? initialValues.accessKey : key;
   };
 
   const updateStorageContainerErrorMessage = (): void => {
@@ -117,10 +117,7 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
           };
 
           // Keep the original key if there is one, otherwise assign data.keys[0] to access key
-          let key = getAccessKey();
-          if (key === '') {
-            key = data.keys[0].value;
-          }
+          const key = getAccessKey(data.keys[0].value);
           setAccessKey(key);
           const payload = {
             accountName: values.accountName,

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
@@ -41,7 +41,7 @@ const initializeStorageContainerErrorSchemaValue = (): StorageContainerErrorSche
 };
 
 const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMounts> & AzureStorageMountsAddEditPropsCombined> = props => {
-  const { errors, values, setValues, setFieldValue, validateForm } = props;
+  const { errors, values, initialValues, setValues, setFieldValue, validateForm } = props;
   const [accountSharesFiles, setAccountSharesFiles] = useState([]);
   const [accountSharesBlob, setAccountSharesBlob] = useState([]);
   const [sharesLoading, setSharesLoading] = useState(false);
@@ -82,6 +82,10 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
     return !!accountError ? accountError : undefined;
   };
 
+  const getAccessKey = (): string => {
+    return initialValues.accountName === values.accountName ? initialValues.accessKey || '' : '';
+  };
+
   const updateStorageContainerErrorMessage = (): void => {
     const storageType = values.type;
     const blobsContainerIsEmpty = storageContainerErrorSchema.blobsContainerIsEmpty;
@@ -112,10 +116,15 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
             setValues({ ...values, accessKey });
           };
 
-          setAccessKey(data.keys[0].value);
+          // Keep the original key if there is one, otherwise assign data.keys[0] to access key
+          let key = getAccessKey();
+          if (key === '') {
+            key = data.keys[0].value;
+          }
+          setAccessKey(key);
           const payload = {
             accountName: values.accountName,
-            accessKey: data.keys[0].value,
+            accessKey: key,
           };
           try {
             let blobsCall: any = {


### PR DESCRIPTION
Fixes [AB#10487619](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s169?workitem=10487614

When opening editing page of the storage mount with Basics configuration, switching to Advanced mode shows old access key. The problem is fixed by checking the current access key under Basics configuration to see if the initial values already has an access key under the storage account. If so, keep the original key, make an API call to get access keys otherwise.
![pr](https://user-images.githubusercontent.com/33185278/128102782-1100a025-b822-4f42-b431-727e3434a1e8.gif)
