### PR TITLE
[Cherry-pick] Adding dotnet6 as hidden and early access for Function Apps

### DIFF
--- a/server/src/stacks/2020-10-01/models/FunctionAppStackModel.ts
+++ b/server/src/stacks/2020-10-01/models/FunctionAppStackModel.ts
@@ -3,7 +3,7 @@ import { AppStack, CommonSettings, AppInsightsSettings, GitHubActionSettings } f
 export type FunctionAppStack = AppStack<FunctionAppRuntimes, FunctionAppStackValue>;
 export type FunctionAppStackValue = 'dotnet' | 'java' | 'node' | 'powershell' | 'python' | 'custom';
 
-type FunctionsExtensionVersion = '~1' | '~2' | '~3';
+type FunctionsExtensionVersion = '~1' | '~2' | '~3' | '~4';
 type FunctionsWorkerRuntime = 'dotnet' | 'node' | 'python' | 'java' | 'powershell' | 'custom' | 'dotnet-isolated';
 
 export interface FunctionAppRuntimes {

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
@@ -6,6 +6,62 @@ export const dotnetStack: FunctionAppStack = {
   preferredOs: 'windows',
   majorVersions: [
     {
+      displayText: '.NET 6',
+      value: 'dotnet6',
+      minorVersions: [
+        {
+          displayText: '.NET 6',
+          value: '6',
+          stackSettings: {
+            windowsRuntimeSettings: {
+              runtimeVersion: 'v6.0',
+              isHidden: true,
+              isEarlyAccess: true,
+              isPreview: true,
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '6.0.x',
+              },
+              appSettingsDictionary: {
+                FUNCTIONS_WORKER_RUNTIME: 'dotnet',
+              },
+              siteConfigPropertiesDictionary: {
+                use32BitWorkerProcess: true,
+                netFrameworkVersion: 'v6.0',
+              },
+              supportedFunctionsExtensionVersions: ['~4'],
+            },
+            linuxRuntimeSettings: {
+              runtimeVersion: 'DOTNET|6.0',
+              isHidden: true,
+              isEarlyAccess: true,
+              isPreview: true,
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '6.0.x',
+              },
+              appSettingsDictionary: {
+                FUNCTIONS_WORKER_RUNTIME: 'dotnet',
+              },
+              siteConfigPropertiesDictionary: {
+                use32BitWorkerProcess: true,
+                linuxFxVersion: 'DOTNET|6.0',
+              },
+              supportedFunctionsExtensionVersions: ['~4'],
+            },
+          },
+        },
+      ],
+    },
+    {
       displayText: '.NET 5 (non-LTS)',
       value: 'dotnet5',
       minorVersions: [

--- a/server/src/tests/Stacks/2020-10-01/function-app/validations.ts
+++ b/server/src/tests/Stacks/2020-10-01/function-app/validations.ts
@@ -149,7 +149,7 @@ function validateDotnetStack(dotnetStack) {
   expect(dotnetStack.displayText).to.equal('.NET');
   expect(dotnetStack.value).to.equal('dotnet');
   expect(dotnetStack.preferredOs).to.equal('windows');
-  expect(dotnetStack.majorVersions.length).to.equal(4);
+  expect(dotnetStack.majorVersions.length).to.equal(5);
   expect(dotnetStack).to.deep.equal(hardCodedDotnetStack);
 }
 


### PR DESCRIPTION
* Adding dotnet6 as hidden and early access for Function Apps

* PR feedback

Co-authored-by: Krrish Mittal <krrishmittal15@gmail.com>