### PR TITLE
AB#10559704 Enable windows container mount path validations at public cloud

### DIFF
--- a/client-react/src/utils/constants/ValidationRegex.ts
+++ b/client-react/src/utils/constants/ValidationRegex.ts
@@ -20,7 +20,7 @@ export class ValidationRegex {
     // eslint-disable-next-line no-useless-escape
     windowsCode: /^[\/\\](mounts)[\/\\][a-zA-Z0-9._\-\[\]\(\)]+[\/\\]*$/,
 
-    // Mount path for windows container can only contain can only contain letters, digits, (_), (-), (/), (\),
+    // Mount path for windows container can contain only letters, digits, (_), (-), (/), (\),
     // parentheses and square brackets. Drive letter (from c to z) is allowed as the prefix of the path. e.g c:/foo/bar/logs
     // /., \., [Cc-Zz]/. and [Cc-Zz]\. are invalid
     // /mounts, \mounts, c:/mounts, c:\mounts are invalid


### PR DESCRIPTION
Fixes [AB#10559704](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s170?workitem=10559704) Enable windows container storage mount mount path validation at public cloud

![windowscontainermountpath](https://user-images.githubusercontent.com/33185278/129761034-038c08b5-ffc9-43a6-ad4d-a6f491d13e07.gif)
