### PR TITLE
Hide .NET6 for linux

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
@@ -36,6 +36,7 @@ export const dotnetStack: FunctionAppStack = {
             },
             linuxRuntimeSettings: {
               runtimeVersion: 'DOTNET|6.0',
+              isHidden: true,
               isEarlyAccess: true,
               isPreview: true,
               remoteDebuggingSupported: false,


### PR DESCRIPTION
Fixes AB#10519952