### PR TITLE
Add Java versions in ANT 95 to the Stacks API

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Java.ts
@@ -50,6 +50,39 @@ export const javaStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java 11.0.11',
+          value: '11.0.11',
+          stackSettings: {
+            linuxRuntimeSettings: {
+              // Note (allisonm): Runtime on Linux Java is determined by the Java container
+              runtimeVersion: '',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+                isDefaultOff: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '11',
+              },
+              endOfLifeDate: java11EOL,
+            },
+            windowsRuntimeSettings: {
+              runtimeVersion: '11.0.11',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+                isDefaultOff: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '11',
+              },
+              endOfLifeDate: java11EOL,
+            },
+          },
+        },
+        {
           displayText: 'Java 11.0.9',
           value: '11.0.9',
           stackSettings: {
@@ -268,6 +301,25 @@ export const javaStack: WebAppStack = {
             windowsRuntimeSettings: {
               runtimeVersion: '1.8',
               isAutoUpdate: true,
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+                isDefaultOff: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '8',
+              },
+              endOfLifeDate: java8EOL,
+            },
+          },
+        },
+        {
+          displayText: 'Java 1.8.0_292',
+          value: '8.0.292',
+          stackSettings: {
+            windowsRuntimeSettings: {
+              runtimeVersion: '1.8.0_292',
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
@@ -26,6 +26,16 @@ export const javaContainersStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java SE 11.0.11',
+          value: '11.0.11',
+          stackSettings: {
+            linuxContainerSettings: {
+              // Note (jafreebe): This doesn't have suffix of -java11 since setting to 11.0.8 prevents auto-updates
+              java11Runtime: 'JAVA|11.0.11',
+            },
+          },
+        },
+        {
           displayText: 'Java SE 11.0.9',
           value: '11.0.9',
           stackSettings: {
@@ -62,6 +72,16 @@ export const javaContainersStack: WebAppStack = {
             linuxContainerSettings: {
               // Note (allisonm): This doesn't have suffix of -java11 since setting to 11.0.5 prevents auto-updates
               java11Runtime: 'JAVA|11.0.5',
+            },
+          },
+        },
+        {
+          displayText: 'Java SE 8u292',
+          // note (jafreebe): Java SE 8u242 is pinned version that maps to the below value
+          value: '1.8.292',
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: 'JAVA|8u292',
             },
           },
         },
@@ -151,6 +171,20 @@ export const javaContainersStack: WebAppStack = {
               java11Runtime: 'TOMCAT|9.0-java11',
               java8Runtime: 'TOMCAT|9.0-jre8',
               isAutoUpdate: true,
+            },
+          },
+        },
+        {
+          displayText: 'Tomcat 9.0.46',
+          value: '9.0.46',
+          stackSettings: {
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '9.0.46',
+            },
+            linuxContainerSettings: {
+              java11Runtime: 'TOMCAT|9.0.46-java11',
+              java8Runtime: 'TOMCAT|9.0.46-java8', // Note (allisonm): Newer Tomcat versions use java8, not jre8
             },
           },
         },
@@ -297,6 +331,20 @@ export const javaContainersStack: WebAppStack = {
               java11Runtime: 'TOMCAT|8.5-java11',
               java8Runtime: 'TOMCAT|8.5-jre8',
               isAutoUpdate: true,
+            },
+          },
+        },
+        {
+          displayText: 'Tomcat 8.5.66',
+          value: '8.5.66',
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: 'TOMCAT|8.5.66-java8',
+              java11Runtime: 'TOMCAT|8.5.66-java11',
+            },
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '8.5.66',
             },
           },
         },

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
@@ -50,6 +50,39 @@ export const javaStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java 11.0.11',
+          value: '11.0.11',
+          stackSettings: {
+            linuxRuntimeSettings: {
+              // Note (allisonm): Runtime on Linux Java is determined by the Java container
+              runtimeVersion: '',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+                isDefaultOff: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '11',
+              },
+              endOfLifeDate: java11EOL,
+            },
+            windowsRuntimeSettings: {
+              runtimeVersion: '11.0.11',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+                isDefaultOff: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '11',
+              },
+              endOfLifeDate: java11EOL,
+            },
+          },
+        },
+        {
           displayText: 'Java 11.0.9',
           value: '11.0.9',
           stackSettings: {
@@ -268,6 +301,25 @@ export const javaStack: WebAppStack = {
             windowsRuntimeSettings: {
               runtimeVersion: '1.8',
               isAutoUpdate: true,
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+                isDefaultOff: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '8',
+              },
+              endOfLifeDate: java8EOL,
+            },
+          },
+        },
+        {
+          displayText: 'Java 1.8.0_292',
+          value: '8.0.292',
+          stackSettings: {
+            windowsRuntimeSettings: {
+              runtimeVersion: '1.8.0_292',
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -26,6 +26,16 @@ export const javaContainersStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java SE 11.0.11',
+          value: '11.0.11',
+          stackSettings: {
+            linuxContainerSettings: {
+              // Note (jafreebe): This doesn't have suffix of -java11 since setting to 11.0.8 prevents auto-updates
+              java11Runtime: 'JAVA|11.0.11',
+            },
+          },
+        },
+        {
           displayText: 'Java SE 11.0.9',
           value: '11.0.9',
           stackSettings: {
@@ -62,6 +72,16 @@ export const javaContainersStack: WebAppStack = {
             linuxContainerSettings: {
               // Note (allisonm): This doesn't have suffix of -java11 since setting to 11.0.5 prevents auto-updates
               java11Runtime: 'JAVA|11.0.5',
+            },
+          },
+        },
+        {
+          displayText: 'Java SE 8u292',
+          // note (jafreebe): Java SE 8u242 is pinned version that maps to the below value
+          value: '1.8.292',
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: 'JAVA|8u292',
             },
           },
         },
@@ -151,6 +171,20 @@ export const javaContainersStack: WebAppStack = {
               java11Runtime: 'TOMCAT|9.0-java11',
               java8Runtime: 'TOMCAT|9.0-jre8',
               isAutoUpdate: true,
+            },
+          },
+        },
+        {
+          displayText: 'Tomcat 9.0.46',
+          value: '9.0.46',
+          stackSettings: {
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '9.0.46',
+            },
+            linuxContainerSettings: {
+              java8Runtime: 'TOMCAT|9.0.46-java8',
+              java11Runtime: 'TOMCAT|9.0.46-java11',
             },
           },
         },
@@ -297,6 +331,20 @@ export const javaContainersStack: WebAppStack = {
               java11Runtime: 'TOMCAT|8.5-java11',
               java8Runtime: 'TOMCAT|8.5-jre8',
               isAutoUpdate: true,
+            },
+          },
+        },
+        {
+          displayText: 'Tomcat 8.5.66',
+          value: '8.5.66',
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: 'TOMCAT|8.5.66-java8',
+              java11Runtime: 'TOMCAT|8.5.66-java11',
+            },
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '8.5.66',
             },
           },
         },


### PR DESCRIPTION
ANT 95 is done on the workers now (Aug 31) so this is OK to merge in the current sprint.

Adds these runtimes to the stacks API:

- Java 11.0.11
- Java 1.8.0_292
- Tomcat 9.0.46
- Tomcat 8.5.66