### PR TITLE
[Hotfix] Remove VirtualNetworkSubnetId property when updating config/web

### DIFF
--- a/client-react/src/ApiHelpers/SiteService.ts
+++ b/client-react/src/ApiHelpers/SiteService.ts
@@ -39,10 +39,15 @@ export default class SiteService {
     const siteConfig = !!rest && !!rest.properties && rest.properties.siteConfig;
     SiteService._removePropertiesFromSiteConfig(siteConfig, configSettingsToIgnore);
 
+    // Setting virtualNetworkSubnetId to undefined since we do a linked access check against the network RP for this property.
+    // So if the user doesn't have permissions to that RP, then this call will fail.
+    const virtualNetworkSubnetId = undefined;
+
     const payload = {
       ...rest,
       properties: {
         ...rest.properties,
+        virtualNetworkSubnetId,
         siteConfig,
       },
     };

--- a/client-react/src/models/site/site.ts
+++ b/client-react/src/models/site/site.ts
@@ -113,6 +113,7 @@ export interface Site {
   dailyMemoryTimeQuota: number;
   siteDisabledReason: SiteDisabledReason;
   possibleInboundIpAddresses?: string;
+  virtualNetworkSubnetId?: string;
 }
 
 export interface HostNameSslState {


### PR DESCRIPTION
remove virtualNetworkSubnetId property when updating config/web