### PR TITLE
[DC] Limit number of failures in getBitbucketBranches logged

### DIFF
--- a/client-react/src/ApiHelpers/BitbucketService.ts
+++ b/client-react/src/ApiHelpers/BitbucketService.ts
@@ -40,7 +40,7 @@ export default class BitbucketService {
     logger?: (page, response) => void
   ): Promise<BitbucketBranch[]> => {
     const url = `${DeploymentCenterConstants.bitbucketApiUrl}/repositories/${org}/${repo}/refs/branches?pagelen=100`;
-    return BitbucketService._getBitbucketObjectList<BitbucketRepository>(url, bitbucketToken, logger);
+    return BitbucketService._getBitbucketObjectList<BitbucketBranch>(url, bitbucketToken, logger);
   };
 
   private static _getBitbucketObjectList = async <T>(url: string, bitbucketToken: string, logger?: (page, response) => void) => {
@@ -56,6 +56,7 @@ export default class BitbucketService {
         requestUrl = pageResponse.data.next;
       } else if (logger && !pageResponse.metadata.success) {
         logger(pageNumber, pageResponse);
+        break;
       }
       ++pageNumber;
     } while (requestUrl);

--- a/client-react/src/pages/app/deployment-center/bitbucket-provider/DeploymentCenterBitbucketDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/bitbucket-provider/DeploymentCenterBitbucketDataLoader.tsx
@@ -97,7 +97,7 @@ const DeploymentCenterBitbucketDataLoader: React.FC<DeploymentCenterFieldProps> 
     if (bitbucketUser && organizationOptions && repositoryOptions) {
       const logger = (page, response) => {
         portalContext.log(
-          getTelemetryInfo('error', 'getBitbucketBranchesResponse', 'failed', {
+          getTelemetryInfo('verbose', 'getBitbucketBranchesResponse', 'failed', {
             page: page,
             error: response.metadata.error,
           })


### PR DESCRIPTION
FixesAB#[10996657 ](https://msazure.visualstudio.com/Antares/_workitems/edit/10996657)

Changed the error logging into verbose logging for failed getBitbucketBranchesResponse to stop throttling
Added break condition in while loop to stop after the first failure to prevent infinite calls