### PR TITLE
[DC] Log keypresses after debounce, update Stack props

### DIFF
--- a/client-react/src/components/form-controls/ReactiveFormControl.tsx
+++ b/client-react/src/components/form-controls/ReactiveFormControl.tsx
@@ -155,7 +155,7 @@ const ReactiveFormControl = (props: ReactiveFormControlProps) => {
           </div>
         )}
       </Stack>
-      <Stack gap={0} horizontalAlign="start">
+      <Stack tokens={{ childrenGap: 0 }} horizontalAlign="start">
         {copyValue && (
           <TooltipHost
             content={getCopiedLabel()}

--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubDataLoader.tsx
@@ -29,8 +29,9 @@ searchTermObserver
       const isGitHubActions = info.isGitHubActions;
       const org = info.org;
       const repo = info.repo;
-
       let gitHubRepositories;
+
+      portalContext.log(getTelemetryInfo('info', 'gitHubRepositories', 'submit'));
 
       if (repositoriesUrl.toLocaleLowerCase().indexOf('github.com/users/') > -1) {
         gitHubRepositories = await deploymentCenterData.getGitHubUserRepositories(
@@ -155,8 +156,6 @@ const DeploymentCenterGitHubDataLoader: React.FC<DeploymentCenterFieldProps> = p
   const fetchRepositoryOptions = (repositoriesUrl: string, searchTerm?: string) => {
     setRepositoryOptions([]);
     setBranchOptions([]);
-
-    portalContext.log(getTelemetryInfo('info', 'gitHubRepositories', 'submit'));
 
     const info: SearchTermObserverInfo = {
       searchTerm: searchTerm,


### PR DESCRIPTION
FixesAB#[12508959 ](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s176?workitem=12508959)

Each keypress in ComboBox was being logged, removed it to only log after debounce time
Fixed Stack warning to use prop tokens.childrenGap instead of deprecated prop gap for ReactiveFormControl 