### PR TITLE
AB#12528307 [HOTFIX] - Unblock .NET 6 from Github actions on create

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -28,7 +28,6 @@ export const dotnetStack: WebAppStack = {
               gitHubActionSettings: {
                 isSupported: true,
                 supportedVersion: '6.0.x',
-                notSupportedInCreates: true,
               },
               isEarlyAccess: true,
             },
@@ -41,7 +40,6 @@ export const dotnetStack: WebAppStack = {
               gitHubActionSettings: {
                 isSupported: true,
                 supportedVersion: '6.0.x',
-                notSupportedInCreates: true,
               },
               isEarlyAccess: true,
             },


### PR DESCRIPTION
Fixes [AB#12528307](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/12528307)


Will cherry-pick to release_s175 for 11/8 hotfix once tested in canary