### PR TITLE
Put portal-call behind feature -flag

### DIFF
--- a/client-react/src/ApiHelpers/FunctionsService.ts
+++ b/client-react/src/ApiHelpers/FunctionsService.ts
@@ -12,6 +12,8 @@ import { Host } from '../models/functions/host';
 import { VfsObject } from '../models/functions/vfs';
 import { KeyValue } from '../models/portal-models';
 import { ContainerItem, ShareItem } from '../pages/app/app-settings/AppSettings.types';
+import { Method } from 'axios';
+import { NetAjaxSettings } from '../models/ajax-request-model';
 
 export default class FunctionsService {
   public static getHostStatus = (resourceId: string) => {
@@ -229,6 +231,27 @@ export default class FunctionsService {
       url: `${Url.serviceHost}/api/getStorageFileShares?accountName=${accountName}`,
       method: 'POST',
     });
+  }
+
+  public static runFunction(settings: NetAjaxSettings) {
+    const url = settings.uri;
+    const method = settings.type as Method;
+    const headers = settings.headers || {};
+    const data = settings.data;
+
+    return sendHttpRequest({ url, method, headers, data }).catch(err => {
+      return this.tryPassThroughController(err, url, method, headers, data);
+    });
+  }
+
+  private static tryPassThroughController(err: any, url: string, method: Method, headers: KeyValue<string>, body: any) {
+    const passthroughBody = {
+      url,
+      headers,
+      method,
+      body,
+    };
+    return sendHttpRequest({ url: `${Url.serviceHost}api/passthrough`, method: 'POST', data: passthroughBody });
   }
 
   private static _getVfsApiForRuntimeVersion(endpoint: string, runtimeVersion?: string) {

--- a/client-react/src/pages/app/functions/function/function-editor/function-test/FunctionTest.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/function-test/FunctionTest.tsx
@@ -16,7 +16,7 @@ import { ValidationRegex } from '../../../../../../utils/constants/ValidationReg
 import CustomBanner from '../../../../../../components/CustomBanner/CustomBanner';
 import { Links } from '../../../../../../utils/FwLinks';
 import { FunctionEditorContext } from '../FunctionEditorDataLoader';
-import { OverflowBehavior } from '../../../../../../utils/CommonConstants';
+import { CommonConstants, OverflowBehavior } from '../../../../../../utils/CommonConstants';
 import Url from '../../../../../../utils/url';
 
 export interface FunctionTestProps {
@@ -192,8 +192,10 @@ const FunctionTest: React.SFC<FunctionTestProps> = props => {
     addCorsRule(getCorsRuleToRunFromBrowser());
   };
 
+  const checkCorsAndDisableTest = () => !isCorsRuleAdded() && Url.isFeatureFlagEnabled(CommonConstants.FeatureFlags.makeCallThroughPortal);
+
   const getBanner = () => {
-    if (!isCorsRuleAdded()) {
+    if (checkCorsAndDisableTest()) {
       return (
         <CustomBanner
           message={t('missingCorsMessage').format(getCorsRuleToRunFromBrowser())}
@@ -205,6 +207,7 @@ const FunctionTest: React.SFC<FunctionTestProps> = props => {
         />
       );
     }
+
     if (!!responseContent && responseContent.code === 403) {
       return (
         <CustomBanner
@@ -238,7 +241,7 @@ const FunctionTest: React.SFC<FunctionTestProps> = props => {
           id: 'run',
           title: t('run'),
           onClick: formProps.submitForm,
-          disable: !!statusMessage || !isCorsRuleAdded(),
+          disable: !!statusMessage || checkCorsAndDisableTest(),
           autoFocus: true,
         };
 

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -60,6 +60,7 @@ export class CommonConstants {
     disablePortalEditing: 'disablePortalEditing',
     enableAzureReposForLinux: 'enableAzureReposForLinux',
     enterpriseGradeEdgeItemVisible: 'enterpriseGradeEdgeItemVisible',
+    makeCallThroughPortal: 'makeCallThroughPortal',
   };
 
   public static readonly AppDensityLimit = 8;

--- a/client-react/src/utils/url.ts
+++ b/client-react/src/utils/url.ts
@@ -131,5 +131,9 @@ export default class Url {
     return CommonConstants.PortalUris.public;
   }
 
+  public static isFeatureFlagEnabled = (flag: string): boolean => {
+    return Url.getFeatureValue(flag) === 'true';
+  };
+
   private static queryStrings: KeyValue<string>;
 }


### PR DESCRIPTION
With this PR we are making the following changes :

 - Add passthrough calls back while running function
 - Putting calls via-portal behind the feature -flag so that testing is simpler
 - Putting CORS banner behind the feature flag


So, the behavior will be similar to as to what we have right now on portal