### PR TITLE
[CP] Updating functionAppStacks and webAppStacks API to use ISO date formats

### DIFF
--- a/server/src/stacks/2020-10-01/service/StackService.ts
+++ b/server/src/stacks/2020-10-01/service/StackService.ts
@@ -8,14 +8,17 @@ import { dotnetStack as dotnetFunctionAppStack } from '../stacks/function-app-st
 import { nodeStack as nodeFunctionAppStack } from '../stacks/function-app-stacks/Node';
 import { pythonStack as pythonFunctionAppStack } from '../stacks/function-app-stacks/Python';
 import { javaStack as javaFunctionAppStack } from '../stacks/function-app-stacks/Java';
-import { powershellStack as powershellFunctionappStack } from '../stacks/function-app-stacks/Powershell';
+import {
+  powershellStack as powershellFunctionappStack,
+  powershellStackNonIsoDates as powershellFunctionappStackNonIsoDates,
+} from '../stacks/function-app-stacks/Powershell';
 import { customStack as customFunctionAppStack } from '../stacks/function-app-stacks/Custom';
-import { dotnetStack as dotnetWebAppStack } from '../stacks/web-app-stacks/Dotnet';
-import { nodeStack as nodeWebAppStack } from '../stacks/web-app-stacks/Node';
-import { pythonStack as pythonWebAppStack } from '../stacks/web-app-stacks/Python';
-import { phpStack as phpWebAppStack } from '../stacks/web-app-stacks/Php';
-import { rubyStack as rubyWebAppStack } from '../stacks/web-app-stacks/Ruby';
-import { javaStack as javaWebAppStack } from '../stacks/web-app-stacks/Java';
+import { dotnetStack as dotnetWebAppStack, dotnetStackNonIsoDates as dotnetWebAppStackNonIsoDates } from '../stacks/web-app-stacks/Dotnet';
+import { nodeStack as nodeWebAppStack, nodeStackNonIsoDates as nodeWebAppStackNonIsoDates } from '../stacks/web-app-stacks/Node';
+import { pythonStack as pythonWebAppStack, pythonStackNonIsoDates as pythonWebAppStackNonIsoDates } from '../stacks/web-app-stacks/Python';
+import { phpStack as phpWebAppStack, phpStackNonIsoDates as phpWebAppStackNonIsoDates } from '../stacks/web-app-stacks/Php';
+import { rubyStack as rubyWebAppStack, rubyStackNonIsoDates as rubyWebAppStackNonIsoDates } from '../stacks/web-app-stacks/Ruby';
+import { javaStack as javaWebAppStack, javaStackNonIsoDates as javaWebAppStackNonIsoDates } from '../stacks/web-app-stacks/Java';
 import { javaContainersStack as javaContainersWebAppStack } from '../stacks/web-app-stacks/JavaContainers';
 import { staticSiteStack as staticSiteWebAppStack } from '../stacks/web-app-stacks/StaticSite';
 
@@ -27,13 +30,16 @@ export class StacksService20201001 {
     removeHiddenStacks?: boolean,
     removeDeprecatedStacks?: boolean,
     removePreviewStacks?: boolean,
-    removeNonGitHubActionStacks?: boolean
+    removeNonGitHubActionStacks?: boolean,
+    useIsoDateFormat: boolean = true
   ): FunctionAppStack[] {
     const dotnetStackCopy = JSON.parse(JSON.stringify(dotnetFunctionAppStack));
     const nodeStackCopy = JSON.parse(JSON.stringify(nodeFunctionAppStack));
     const pythonStackCopy = JSON.parse(JSON.stringify(pythonFunctionAppStack));
     const javaStackCopy = JSON.parse(JSON.stringify(javaFunctionAppStack));
-    const powershellStackCopy = JSON.parse(JSON.stringify(powershellFunctionappStack));
+    const powershellStackCopy = JSON.parse(
+      JSON.stringify(useIsoDateFormat ? powershellFunctionappStack : powershellFunctionappStackNonIsoDates)
+    );
     const customStackCopy = JSON.parse(JSON.stringify(customFunctionAppStack));
 
     let stacks: FunctionAppStack[] = [dotnetStackCopy, nodeStackCopy, pythonStackCopy, javaStackCopy, powershellStackCopy, customStackCopy];
@@ -53,14 +59,15 @@ export class StacksService20201001 {
     removeHiddenStacks?: boolean,
     removeDeprecatedStacks?: boolean,
     removePreviewStacks?: boolean,
-    removeNonGitHubActionStacks?: boolean
+    removeNonGitHubActionStacks?: boolean,
+    useIsoDateFormat: boolean = true
   ): WebAppStack[] {
-    const dotnetStackCopy = JSON.parse(JSON.stringify(dotnetWebAppStack));
-    const nodeStackCopy = JSON.parse(JSON.stringify(nodeWebAppStack));
-    const pythonStackCopy = JSON.parse(JSON.stringify(pythonWebAppStack));
-    const phpStackCopy = JSON.parse(JSON.stringify(phpWebAppStack));
-    const rubyStackCopy = JSON.parse(JSON.stringify(rubyWebAppStack));
-    const javaStackCopy = JSON.parse(JSON.stringify(javaWebAppStack));
+    const dotnetStackCopy = JSON.parse(JSON.stringify(useIsoDateFormat ? dotnetWebAppStack : dotnetWebAppStackNonIsoDates));
+    const nodeStackCopy = JSON.parse(JSON.stringify(useIsoDateFormat ? nodeWebAppStack : nodeWebAppStackNonIsoDates));
+    const pythonStackCopy = JSON.parse(JSON.stringify(useIsoDateFormat ? pythonWebAppStack : pythonWebAppStackNonIsoDates));
+    const phpStackCopy = JSON.parse(JSON.stringify(useIsoDateFormat ? phpWebAppStack : phpWebAppStackNonIsoDates));
+    const rubyStackCopy = JSON.parse(JSON.stringify(useIsoDateFormat ? rubyWebAppStack : rubyWebAppStackNonIsoDates));
+    const javaStackCopy = JSON.parse(JSON.stringify(useIsoDateFormat ? javaWebAppStack : javaWebAppStackNonIsoDates));
     const javaContainersStackCopy = JSON.parse(JSON.stringify(javaContainersWebAppStack));
     const staticSiteStackCopy = JSON.parse(JSON.stringify(staticSiteWebAppStack));
 

--- a/server/src/stacks/2020-10-01/stacks/date-utilities.ts
+++ b/server/src/stacks/2020-10-01/stacks/date-utilities.ts
@@ -1,0 +1,7 @@
+export const getDateString = (date: Date, useIsoDateFormat: boolean) => {
+  if (!date) {
+    return '';
+  }
+
+  return useIsoDateFormat ? date.toISOString() : date.toString();
+};

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
@@ -1,94 +1,101 @@
 import { FunctionAppStack } from '../../models/FunctionAppStackModel';
+import { getDateString } from '../date-utilities';
 
-const powershell6point2EOL = new Date(2020, 9, 4).toString();
+const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDateFormat: boolean) => {
+  const powershell6point2EOL = getDateString(new Date(2020, 9, 4), useIsoDateFormat);
 
-export const powershellStack: FunctionAppStack = {
-  displayText: 'PowerShell Core',
-  value: 'powershell',
-  preferredOs: 'windows',
-  majorVersions: [
-    {
-      displayText: 'PowerShell 7',
-      value: '7',
-      minorVersions: [
-        {
-          displayText: 'PowerShell 7.0',
-          value: '7.0',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '~7',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+  return {
+    displayText: 'PowerShell Core',
+    value: 'powershell',
+    preferredOs: 'windows',
+    majorVersions: [
+      {
+        displayText: 'PowerShell 7',
+        value: '7',
+        minorVersions: [
+          {
+            displayText: 'PowerShell 7.0',
+            value: '7.0',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '~7',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                appSettingsDictionary: {
+                  FUNCTIONS_WORKER_RUNTIME: 'powershell',
+                },
+                siteConfigPropertiesDictionary: {
+                  use32BitWorkerProcess: true,
+                  powerShellVersion: '~7',
+                  netFrameworkVersion: 'v6.0',
+                },
+                supportedFunctionsExtensionVersions: ['~4', '~3'],
               },
-              gitHubActionSettings: {
-                isSupported: true,
+              linuxRuntimeSettings: {
+                runtimeVersion: 'PowerShell|7',
+                isAutoUpdate: true,
+                isPreview: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                appSettingsDictionary: {
+                  FUNCTIONS_WORKER_RUNTIME: 'powershell',
+                },
+                siteConfigPropertiesDictionary: {
+                  use32BitWorkerProcess: false,
+                  linuxFxVersion: 'PowerShell|7',
+                },
+                supportedFunctionsExtensionVersions: ['~4'],
               },
-              appSettingsDictionary: {
-                FUNCTIONS_WORKER_RUNTIME: 'powershell',
-              },
-              siteConfigPropertiesDictionary: {
-                use32BitWorkerProcess: true,
-                powerShellVersion: '~7',
-                netFrameworkVersion: 'v6.0',
-              },
-              supportedFunctionsExtensionVersions: ['~4', '~3'],
-            },
-            linuxRuntimeSettings: {
-              runtimeVersion: 'PowerShell|7',
-              isAutoUpdate: true,
-              isPreview: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              appSettingsDictionary: {
-                FUNCTIONS_WORKER_RUNTIME: 'powershell',
-              },
-              siteConfigPropertiesDictionary: {
-                use32BitWorkerProcess: false,
-                linuxFxVersion: 'PowerShell|7',
-              },
-              supportedFunctionsExtensionVersions: ['~4'],
             },
           },
-        },
-      ],
-    },
-    {
-      displayText: 'PowerShell Core 6',
-      value: '6',
-      minorVersions: [
-        {
-          displayText: 'PowerShell Core 6.2',
-          value: '6.2',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '~6',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+        ],
+      },
+      {
+        displayText: 'PowerShell Core 6',
+        value: '6',
+        minorVersions: [
+          {
+            displayText: 'PowerShell Core 6.2',
+            value: '6.2',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '~6',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                appSettingsDictionary: {
+                  FUNCTIONS_WORKER_RUNTIME: 'powershell',
+                },
+                siteConfigPropertiesDictionary: {
+                  use32BitWorkerProcess: true,
+                  powerShellVersion: '~6',
+                },
+                isDeprecated: true,
+                supportedFunctionsExtensionVersions: ['~2', '~3'],
+                endOfLifeDate: powershell6point2EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              appSettingsDictionary: {
-                FUNCTIONS_WORKER_RUNTIME: 'powershell',
-              },
-              siteConfigPropertiesDictionary: {
-                use32BitWorkerProcess: true,
-                powerShellVersion: '~6',
-              },
-              isDeprecated: true,
-              supportedFunctionsExtensionVersions: ['~2', '~3'],
-              endOfLifeDate: powershell6point2EOL,
             },
           },
-        },
-      ],
-    },
-  ],
+        ],
+      },
+    ],
+  };
 };
+
+export const powershellStackNonIsoDates: FunctionAppStack = getPowershellStack(false);
+
+export const powershellStack: FunctionAppStack = getPowershellStack(true);

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -1,369 +1,376 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
+import { getDateString } from '../date-utilities';
 
-const dotnetCore3Point0EOL = new Date(2020, 3, 3).toString();
-const dotnetCore2Point2EOL = new Date(2019, 12, 23).toString();
-const dotnetCore2Point1EOL = new Date(2021, 7, 21).toString();
-const dotnetCore2Point0EOL = new Date(2018, 10, 1).toString();
-const dotnetCore1EOL = new Date(2019, 6, 27).toString();
+const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFormat: boolean) => {
+  const dotnetCore3Point0EOL = getDateString(new Date(2020, 3, 3), useIsoDateFormat);
+  const dotnetCore2Point2EOL = getDateString(new Date(2019, 12, 23), useIsoDateFormat);
+  const dotnetCore2Point1EOL = getDateString(new Date(2021, 7, 21), useIsoDateFormat);
+  const dotnetCore2Point0EOL = getDateString(new Date(2018, 10, 1), useIsoDateFormat);
+  const dotnetCore1EOL = getDateString(new Date(2019, 6, 27), useIsoDateFormat);
 
-export const dotnetStack: WebAppStack = {
-  displayText: '.NET',
-  value: 'dotnet',
-  preferredOs: 'windows',
-  majorVersions: [
-    {
-      displayText: '.NET 6',
-      value: 'dotnet6',
-      minorVersions: [
-        {
-          displayText: '.NET 6',
-          value: '6',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: 'v6.0',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+  return {
+    displayText: '.NET',
+    value: 'dotnet',
+    preferredOs: 'windows',
+    majorVersions: [
+      {
+        displayText: '.NET 6',
+        value: 'dotnet6',
+        minorVersions: [
+          {
+            displayText: '.NET 6',
+            value: '6',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: 'v6.0',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '6.0.x',
+                },
+                isEarlyAccess: true,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '6.0.x',
-              },
-              isEarlyAccess: true,
-            },
-            linuxRuntimeSettings: {
-              runtimeVersion: 'DOTNETCORE|6.0',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '6.0.x',
-              },
-              isEarlyAccess: true,
-            },
-          },
-        },
-      ],
-    },
-    {
-      displayText: '.NET 5',
-      value: 'dotnet5',
-      minorVersions: [
-        {
-          displayText: '.NET 5',
-          value: '5',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: 'v5.0',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '5.0.x',
-              },
-            },
-            linuxRuntimeSettings: {
-              runtimeVersion: 'DOTNETCORE|5.0',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '5.0.x',
+              linuxRuntimeSettings: {
+                runtimeVersion: 'DOTNETCORE|6.0',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '6.0.x',
+                },
+                isEarlyAccess: true,
               },
             },
           },
-        },
-      ],
-    },
-    {
-      displayText: '.NET Core 3',
-      value: 'dotnetcore3',
-      minorVersions: [
-        {
-          displayText: '.NET Core 3.1 (LTS)',
-          value: '3.1',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '3.1',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+        ],
+      },
+      {
+        displayText: '.NET 5',
+        value: 'dotnet5',
+        minorVersions: [
+          {
+            displayText: '.NET 5',
+            value: '5',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: 'v5.0',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '5.0.x',
+                },
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '3.1.301',
-              },
-            },
-            linuxRuntimeSettings: {
-              runtimeVersion: 'DOTNETCORE|3.1',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '3.1.301',
-              },
-            },
-          },
-        },
-        {
-          displayText: '.NET Core 3.0',
-          value: '3.0',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '3.0',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '3.0.103',
-              },
-              endOfLifeDate: dotnetCore3Point0EOL,
-            },
-            linuxRuntimeSettings: {
-              runtimeVersion: 'DOTNETCORE|3.0',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '3.0.103',
-              },
-              endOfLifeDate: dotnetCore3Point0EOL,
-            },
-          },
-        },
-      ],
-    },
-    {
-      displayText: '.NET Core 2',
-      value: 'dotnetcore2',
-      minorVersions: [
-        {
-          displayText: '.NET Core 2.2',
-          value: '2.2',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '2.2',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '2.2.207',
-              },
-              endOfLifeDate: dotnetCore2Point2EOL,
-            },
-            linuxRuntimeSettings: {
-              runtimeVersion: 'DOTNETCORE|2.2',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '2.2.207',
-              },
-              endOfLifeDate: dotnetCore2Point2EOL,
-            },
-          },
-        },
-        {
-          displayText: '.NET Core 2.1 (LTS)',
-          value: '2.1',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '2.1',
-              remoteDebuggingSupported: false,
-              isDeprecated: true,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '2.1.807',
-              },
-              endOfLifeDate: dotnetCore2Point1EOL,
-            },
-            linuxRuntimeSettings: {
-              runtimeVersion: 'DOTNETCORE|2.1',
-              remoteDebuggingSupported: false,
-              isDeprecated: true,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '2.1.807',
-              },
-              endOfLifeDate: dotnetCore2Point1EOL,
-            },
-          },
-        },
-        {
-          displayText: '.NET Core 2.0',
-          value: '2.0',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '2.0',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '2.1.202',
-              },
-              endOfLifeDate: dotnetCore2Point0EOL,
-            },
-            linuxRuntimeSettings: {
-              runtimeVersion: 'DOTNETCORE|2.0',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '2.1.202',
-              },
-              endOfLifeDate: dotnetCore2Point0EOL,
-            },
-          },
-        },
-      ],
-    },
-    {
-      displayText: '.NET Core 1',
-      value: 'dotnetcore1',
-      minorVersions: [
-        {
-          displayText: '.NET Core 1.1',
-          value: '1.1',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.1',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '1.1.14',
-              },
-              endOfLifeDate: dotnetCore1EOL,
-            },
-            linuxRuntimeSettings: {
-              runtimeVersion: 'DOTNETCORE|1.1',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '1.1.14',
-              },
-              endOfLifeDate: dotnetCore1EOL,
-            },
-          },
-        },
-        {
-          displayText: '.NET Core 1.0',
-          value: '1.0',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.0',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '1.1.14',
-              },
-              endOfLifeDate: dotnetCore1EOL,
-            },
-            linuxRuntimeSettings: {
-              runtimeVersion: 'DOTNETCORE|1.0',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '1.1.14',
-              },
-              endOfLifeDate: dotnetCore1EOL,
-            },
-          },
-        },
-      ],
-    },
-    {
-      displayText: 'ASP.NET V4',
-      value: 'aspdotnetv4',
-      minorVersions: [
-        {
-          displayText: 'ASP.NET V4.8',
-          value: 'v4.8',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: 'v4.0',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '3.1',
+              linuxRuntimeSettings: {
+                runtimeVersion: 'DOTNETCORE|5.0',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '5.0.x',
+                },
               },
             },
           },
-        },
-      ],
-    },
-    {
-      displayText: 'ASP.NET V3',
-      value: 'aspdotnetv3',
-      minorVersions: [
-        {
-          displayText: 'ASP.NET V3.5',
-          value: 'v3.5',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: 'v2.0',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+        ],
+      },
+      {
+        displayText: '.NET Core 3',
+        value: 'dotnetcore3',
+        minorVersions: [
+          {
+            displayText: '.NET Core 3.1 (LTS)',
+            value: '3.1',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '3.1',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '3.1.301',
+                },
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '2.1',
+              linuxRuntimeSettings: {
+                runtimeVersion: 'DOTNETCORE|3.1',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '3.1.301',
+                },
               },
             },
           },
-        },
-      ],
-    },
-  ],
+          {
+            displayText: '.NET Core 3.0',
+            value: '3.0',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '3.0',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '3.0.103',
+                },
+                endOfLifeDate: dotnetCore3Point0EOL,
+              },
+              linuxRuntimeSettings: {
+                runtimeVersion: 'DOTNETCORE|3.0',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '3.0.103',
+                },
+                endOfLifeDate: dotnetCore3Point0EOL,
+              },
+            },
+          },
+        ],
+      },
+      {
+        displayText: '.NET Core 2',
+        value: 'dotnetcore2',
+        minorVersions: [
+          {
+            displayText: '.NET Core 2.2',
+            value: '2.2',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '2.2',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '2.2.207',
+                },
+                endOfLifeDate: dotnetCore2Point2EOL,
+              },
+              linuxRuntimeSettings: {
+                runtimeVersion: 'DOTNETCORE|2.2',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '2.2.207',
+                },
+                endOfLifeDate: dotnetCore2Point2EOL,
+              },
+            },
+          },
+          {
+            displayText: '.NET Core 2.1 (LTS)',
+            value: '2.1',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '2.1',
+                remoteDebuggingSupported: false,
+                isDeprecated: true,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '2.1.807',
+                },
+                endOfLifeDate: dotnetCore2Point1EOL,
+              },
+              linuxRuntimeSettings: {
+                runtimeVersion: 'DOTNETCORE|2.1',
+                remoteDebuggingSupported: false,
+                isDeprecated: true,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '2.1.807',
+                },
+                endOfLifeDate: dotnetCore2Point1EOL,
+              },
+            },
+          },
+          {
+            displayText: '.NET Core 2.0',
+            value: '2.0',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '2.0',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '2.1.202',
+                },
+                endOfLifeDate: dotnetCore2Point0EOL,
+              },
+              linuxRuntimeSettings: {
+                runtimeVersion: 'DOTNETCORE|2.0',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '2.1.202',
+                },
+                endOfLifeDate: dotnetCore2Point0EOL,
+              },
+            },
+          },
+        ],
+      },
+      {
+        displayText: '.NET Core 1',
+        value: 'dotnetcore1',
+        minorVersions: [
+          {
+            displayText: '.NET Core 1.1',
+            value: '1.1',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.1',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '1.1.14',
+                },
+                endOfLifeDate: dotnetCore1EOL,
+              },
+              linuxRuntimeSettings: {
+                runtimeVersion: 'DOTNETCORE|1.1',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '1.1.14',
+                },
+                endOfLifeDate: dotnetCore1EOL,
+              },
+            },
+          },
+          {
+            displayText: '.NET Core 1.0',
+            value: '1.0',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.0',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '1.1.14',
+                },
+                endOfLifeDate: dotnetCore1EOL,
+              },
+              linuxRuntimeSettings: {
+                runtimeVersion: 'DOTNETCORE|1.0',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '1.1.14',
+                },
+                endOfLifeDate: dotnetCore1EOL,
+              },
+            },
+          },
+        ],
+      },
+      {
+        displayText: 'ASP.NET V4',
+        value: 'aspdotnetv4',
+        minorVersions: [
+          {
+            displayText: 'ASP.NET V4.8',
+            value: 'v4.8',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: 'v4.0',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '3.1',
+                },
+              },
+            },
+          },
+        ],
+      },
+      {
+        displayText: 'ASP.NET V3',
+        value: 'aspdotnetv3',
+        minorVersions: [
+          {
+            displayText: 'ASP.NET V3.5',
+            value: 'v3.5',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: 'v2.0',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '2.1',
+                },
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
 };
+
+export const dotnetStackNonIsoDates: WebAppStack = getDotnetStack(false);
+
+export const dotnetStack: WebAppStack = getDotnetStack(true);

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
@@ -1,959 +1,966 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
+import { getDateString } from '../date-utilities';
 
-// EOL source: https://docs.microsoft.com/en-us/java/azure/jdk/?view=azure-java-stable#supported-java-versions-and-update-schedule
-const java11EOL = new Date(2026, 9).toString();
-const java8EOL = new Date(2025, 3).toString();
-const java7EOL = new Date(2023, 7).toString();
+const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFormat: boolean) => {
+  // EOL source: https://docs.microsoft.com/en-us/java/azure/jdk/?view=azure-java-stable#supported-java-versions-and-update-schedule
+  const java11EOL = getDateString(new Date(2026, 9), useIsoDateFormat);
+  const java8EOL = getDateString(new Date(2025, 3), useIsoDateFormat);
+  const java7EOL = getDateString(new Date(2023, 7), useIsoDateFormat);
 
-export const javaStack: WebAppStack = {
-  displayText: 'Java',
-  value: 'java',
-  preferredOs: 'linux',
-  majorVersions: [
-    {
-      displayText: 'Java 11',
-      value: '11',
-      minorVersions: [
-        {
-          displayText: 'Java 11',
-          value: '11.0',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              // Note (allisonm): Runtime on Linux Java is determined by the Java container
-              runtimeVersion: '',
-              isAutoUpdate: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
+  return {
+    displayText: 'Java',
+    value: 'java',
+    preferredOs: 'linux',
+    majorVersions: [
+      {
+        displayText: 'Java 11',
+        value: '11',
+        minorVersions: [
+          {
+            displayText: 'Java 11',
+            value: '11.0',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (allisonm): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
+                isAutoUpdate: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '11',
-              },
-              endOfLifeDate: java11EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '11',
-              isAutoUpdate: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '11',
-              },
-              endOfLifeDate: java11EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 11.0.11',
-          value: '11.0.11',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              // Note (allisonm): Runtime on Linux Java is determined by the Java container
-              runtimeVersion: '',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '11',
-              },
-              endOfLifeDate: java11EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '11.0.11',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '11',
-              },
-              endOfLifeDate: java11EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 11.0.9',
-          value: '11.0.9',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              // Note (allisonm): Runtime on Linux Java is determined by the Java container
-              runtimeVersion: '',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '11',
-              },
-              endOfLifeDate: java11EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '11.0.9',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '11',
-              },
-              endOfLifeDate: java11EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 11.0.8',
-          value: '11.0.8',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '11.0.8',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '11',
-              },
-              endOfLifeDate: java11EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 11.0.7',
-          value: '11.0.7',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              // Note (allisonm): Runtime on Linux Java is determined by the Java container
-              runtimeVersion: '',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '11',
-              },
-              endOfLifeDate: java11EOL,
-            },
-            windowsRuntimeSettings: {
-              // Note (allisonm): ZULU suffix was removed after Java 11.0.5
-              runtimeVersion: '11.0.7',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '11',
-              },
-              endOfLifeDate: java11EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 11.0.6',
-          value: '11.0.6',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              // Note (allisonm): Runtime on Linux Java is determined by the Java container
-              runtimeVersion: '',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '11',
-              },
-              endOfLifeDate: java11EOL,
-            },
-            windowsRuntimeSettings: {
-              // Note (allisonm): ZULU suffix was removed after Java 11.0.5
-              runtimeVersion: '11.0.6',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '11',
-              },
-              endOfLifeDate: java11EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 11.0.5',
-          value: '11.0.5',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              // Note (allisonm): Runtime on Linux Java is determined by the Java container
-              runtimeVersion: '',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '11',
-              },
-              endOfLifeDate: java11EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '11.0.5_ZULU',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '11',
-              },
-              endOfLifeDate: java11EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 11.0.3',
-          value: '11.0.3',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '11.0.3_ZULU',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '11',
-              },
-              endOfLifeDate: java11EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 11.0.2',
-          value: '11.0.2',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '11.0.2_ZULU',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '11',
-              },
-              endOfLifeDate: java11EOL,
-            },
-          },
-        },
-      ],
-    },
-    {
-      displayText: 'Java 8',
-      value: '8',
-      minorVersions: [
-        {
-          displayText: 'Java 8',
-          value: '8.0',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              // Note (allisonm): Runtime on Linux Java is determined by the Java container
-              runtimeVersion: '',
-              isAutoUpdate: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8',
-              isAutoUpdate: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_292',
-          value: '8.0.292',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_292',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_282',
-          value: '8.0.282',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_282',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_275',
-          value: '8.0.275',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              // Note (jafreebe): Runtime on Linux Java is determined by the Java container
-              runtimeVersion: '',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_265',
-          value: '8.0.265',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_265',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_252',
-          value: '8.0.252',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              // Note (allisonm): Runtime on Linux Java is determined by the Java container
-              runtimeVersion: '',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_252',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_242',
-          value: '8.0.242',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              // Note (allisonm): Runtime on Linux Java is determined by the Java container
-              runtimeVersion: '',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_242',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_232',
-          value: '8.0.232',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              // Note (allisonm): Runtime on Linux Java is determined by the Java container
-              runtimeVersion: '',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_232_ZULU',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_212',
-          value: '8.0.212',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_212_ZULU',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_202',
-          value: '8.0.202',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_202_ZULU',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_202 (Oracle)',
-          value: '8.0.202 (Oracle)',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_202',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
+              windowsRuntimeSettings: {
+                runtimeVersion: '11',
+                isAutoUpdate: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
               },
             },
           },
-        },
-        {
-          displayText: 'Java 1.8.0_181',
-          value: '8.0.181',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_181_ZULU',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
+          {
+            displayText: 'Java 11.0.11',
+            value: '11.0.11',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (allisonm): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_181 (Oracle)',
-          value: '8.0.181 (Oracle)',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_181',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
+              windowsRuntimeSettings: {
+                runtimeVersion: '11.0.11',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
               },
             },
           },
-        },
-        {
-          displayText: 'Java 1.8.0_172',
-          value: '8.0.172',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_172_ZULU',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
+          {
+            displayText: 'Java 11.0.9',
+            value: '11.0.9',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (allisonm): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_172 (Oracle)',
-          value: '8.0.172 (Oracle)',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_172',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
+              windowsRuntimeSettings: {
+                runtimeVersion: '11.0.9',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
               },
             },
           },
-        },
-        {
-          displayText: 'Java 1.8.0_144',
-          value: '8.0.144',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_144', // NOTE (allisonm): Azul 8 runtimes versions here and lower omit the suffix: _ZULU
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_111 (Oracle)',
-          value: '8.0.111 (Oracle)',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_111',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
+          {
+            displayText: 'Java 11.0.8',
+            value: '11.0.8',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '11.0.8',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
               },
             },
           },
-        },
-        {
-          displayText: 'Java 1.8.0_102',
-          value: '8.0.102',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_102',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
+          {
+            displayText: 'Java 11.0.7',
+            value: '11.0.7',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (allisonm): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_92',
-          value: '8.0.92',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_92',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-              endOfLifeDate: java8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_73 (Oracle)',
-          value: '8.0.73 (Oracle)',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_73',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
+              windowsRuntimeSettings: {
+                // Note (allisonm): ZULU suffix was removed after Java 11.0.5
+                runtimeVersion: '11.0.7',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
               },
             },
           },
-        },
-        {
-          displayText: 'Java 1.8.0_60 (Oracle)',
-          value: '8.0.60 (Oracle)',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_60',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
+          {
+            displayText: 'Java 11.0.6',
+            value: '11.0.6',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (allisonm): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
-              },
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.8.0_25 (Oracle)',
-          value: '8.0.25 (Oracle)',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.8.0_25',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8',
+              windowsRuntimeSettings: {
+                // Note (allisonm): ZULU suffix was removed after Java 11.0.5
+                runtimeVersion: '11.0.6',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
               },
             },
           },
-        },
-      ],
-    },
-    {
-      displayText: 'Java 7',
-      value: '7',
-      minorVersions: [
-        {
-          displayText: 'Java 7',
-          value: '7.0',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.7',
-              isAutoUpdate: true,
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-                isDefaultOff: true,
+          {
+            displayText: 'Java 11.0.5',
+            value: '11.0.5',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (allisonm): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: java7EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.7.0_292',
-          value: '7.0.292',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.7.0_292',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: java7EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.7.0_272',
-          value: '7.0.272',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.7.0_272',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: java7EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.7.0_262',
-          value: '7.0.262',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.7.0_262',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: java7EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.7.0_242',
-          value: '7.0.242',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.7.0_242_ZULU',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: java7EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.7.0_222',
-          value: '7.0.222',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.7.0_222_ZULU',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: java7EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.7.0_191',
-          value: '7.0.191',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.7.0_191_ZULU',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: java7EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.7.0_80 (Oracle)',
-          value: '7.0.80 (Oracle)',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.7.0_80',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
+              windowsRuntimeSettings: {
+                runtimeVersion: '11.0.5_ZULU',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
               },
             },
           },
-        },
-        {
-          displayText: 'Java 1.7.0_71 (Oracle)',
-          value: '7.0.71 (Oracle)',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.7.0_71',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-            },
-          },
-        },
-        {
-          displayText: 'Java 1.7.0_51 (Oracle)',
-          value: '7.0.51 (Oracle)',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '1.7.0_51',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-                isDefaultOff: true,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
+          {
+            displayText: 'Java 11.0.3',
+            value: '11.0.3',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '11.0.3_ZULU',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
               },
             },
           },
-        },
-      ],
-    },
-  ],
+          {
+            displayText: 'Java 11.0.2',
+            value: '11.0.2',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '11.0.2_ZULU',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
+              },
+            },
+          },
+        ],
+      },
+      {
+        displayText: 'Java 8',
+        value: '8',
+        minorVersions: [
+          {
+            displayText: 'Java 8',
+            value: '8.0',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (allisonm): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
+                isAutoUpdate: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8',
+                isAutoUpdate: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_292',
+            value: '8.0.292',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_292',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_282',
+            value: '8.0.282',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_282',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_275',
+            value: '8.0.275',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (jafreebe): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_265',
+            value: '8.0.265',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_265',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_252',
+            value: '8.0.252',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (allisonm): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_252',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_242',
+            value: '8.0.242',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (allisonm): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_242',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_232',
+            value: '8.0.232',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (allisonm): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_232_ZULU',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_212',
+            value: '8.0.212',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_212_ZULU',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_202',
+            value: '8.0.202',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_202_ZULU',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_202 (Oracle)',
+            value: '8.0.202 (Oracle)',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_202',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_181',
+            value: '8.0.181',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_181_ZULU',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_181 (Oracle)',
+            value: '8.0.181 (Oracle)',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_181',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_172',
+            value: '8.0.172',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_172_ZULU',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_172 (Oracle)',
+            value: '8.0.172 (Oracle)',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_172',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_144',
+            value: '8.0.144',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_144', // NOTE (allisonm): Azul 8 runtimes versions here and lower omit the suffix: _ZULU
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_111 (Oracle)',
+            value: '8.0.111 (Oracle)',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_111',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_102',
+            value: '8.0.102',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_102',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_92',
+            value: '8.0.92',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_92',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_73 (Oracle)',
+            value: '8.0.73 (Oracle)',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_73',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_60 (Oracle)',
+            value: '8.0.60 (Oracle)',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_60',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_25 (Oracle)',
+            value: '8.0.25 (Oracle)',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_25',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+              },
+            },
+          },
+        ],
+      },
+      {
+        displayText: 'Java 7',
+        value: '7',
+        minorVersions: [
+          {
+            displayText: 'Java 7',
+            value: '7.0',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.7',
+                isAutoUpdate: true,
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: java7EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.7.0_292',
+            value: '7.0.292',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.7.0_292',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: java7EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.7.0_272',
+            value: '7.0.272',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.7.0_272',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: java7EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.7.0_262',
+            value: '7.0.262',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.7.0_262',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: java7EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.7.0_242',
+            value: '7.0.242',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.7.0_242_ZULU',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: java7EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.7.0_222',
+            value: '7.0.222',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.7.0_222_ZULU',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: java7EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.7.0_191',
+            value: '7.0.191',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.7.0_191_ZULU',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: java7EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.7.0_80 (Oracle)',
+            value: '7.0.80 (Oracle)',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.7.0_80',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.7.0_71 (Oracle)',
+            value: '7.0.71 (Oracle)',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.7.0_71',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.7.0_51 (Oracle)',
+            value: '7.0.51 (Oracle)',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.7.0_51',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
 };
+
+export const javaStackNonIsoDates: WebAppStack = getJavaStack(false);
+
+export const javaStack: WebAppStack = getJavaStack(true);

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
@@ -1,851 +1,858 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
+import { getDateString } from '../date-utilities';
 
-const node14EOL = new Date(2023, 4, 30).toString();
-const node12EOL = new Date(2022, 4, 1).toString();
-const node10EOL = new Date(2021, 4, 1).toString();
-const node9EOL = new Date(2019, 6, 30).toString();
-const node8EOL = new Date(2019, 12, 31).toString();
-const node7EOL = new Date(2017, 6, 30).toString();
-const node6EOL = new Date(2019, 4, 30).toString();
-const node4EOL = new Date(2018, 4, 30).toString();
+const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFormat: boolean) => {
+  const node14EOL = getDateString(new Date(2023, 4, 30), useIsoDateFormat);
+  const node12EOL = getDateString(new Date(2022, 4, 1), useIsoDateFormat);
+  const node10EOL = getDateString(new Date(2021, 4, 1), useIsoDateFormat);
+  const node9EOL = getDateString(new Date(2019, 6, 30), useIsoDateFormat);
+  const node8EOL = getDateString(new Date(2019, 12, 31), useIsoDateFormat);
+  const node7EOL = getDateString(new Date(2017, 6, 30), useIsoDateFormat);
+  const node6EOL = getDateString(new Date(2019, 4, 30), useIsoDateFormat);
+  const node4EOL = getDateString(new Date(2018, 4, 30), useIsoDateFormat);
 
-export const nodeStack: WebAppStack = {
-  displayText: 'Node',
-  value: 'node',
-  preferredOs: 'linux',
-  majorVersions: [
-    {
-      displayText: 'Node LTS',
-      value: 'lts',
-      minorVersions: [
-        {
-          displayText: 'Node LTS',
-          value: 'lts',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|lts',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
+  return {
+    displayText: 'Node',
+    value: 'node',
+    preferredOs: 'linux',
+    majorVersions: [
+      {
+        displayText: 'Node LTS',
+        value: 'lts',
+        minorVersions: [
+          {
+            displayText: 'Node LTS',
+            value: 'lts',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|lts',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
               },
             },
           },
-        },
-      ],
-    },
-    {
-      displayText: 'Node 14',
-      value: '14',
-      minorVersions: [
-        {
-          displayText: 'Node 14 LTS',
-          value: '14-lts',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|14-lts',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+        ],
+      },
+      {
+        displayText: 'Node 14',
+        value: '14',
+        minorVersions: [
+          {
+            displayText: 'Node 14 LTS',
+            value: '14-lts',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|14-lts',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '14.x',
+                },
+                endOfLifeDate: node14EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '14.x',
+              windowsRuntimeSettings: {
+                runtimeVersion: '~14',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '14.x',
+                },
+                endOfLifeDate: node14EOL,
               },
-              endOfLifeDate: node14EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '~14',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '14.x',
-              },
-              endOfLifeDate: node14EOL,
-            },
-          },
-        },
-      ],
-    },
-    {
-      displayText: 'Node 12',
-      value: '12',
-      minorVersions: [
-        {
-          displayText: 'Node 12 LTS',
-          value: '12-lts',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|12-lts',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '12.x',
-              },
-              endOfLifeDate: node12EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '12.13.0',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node12EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 12.9',
-          value: '12.9',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|12.9',
-              isDeprecated: true,
-              remoteDebuggingSupported: true,
-              appInsightsSettings: {
-                isSupported: true,
+        ],
+      },
+      {
+        displayText: 'Node 12',
+        value: '12',
+        minorVersions: [
+          {
+            displayText: 'Node 12 LTS',
+            value: '12-lts',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|12-lts',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '12.x',
+                },
+                endOfLifeDate: node12EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '12.x',
+              windowsRuntimeSettings: {
+                runtimeVersion: '12.13.0',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node12EOL,
               },
-              endOfLifeDate: node12EOL,
             },
           },
-        },
-      ],
-    },
-    {
-      displayText: 'Node 10',
-      value: '10',
-      minorVersions: [
-        {
-          displayText: 'Node 10 LTS',
-          value: '10-LTS',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|10-lts',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 12.9',
+            value: '12.9',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|12.9',
+                isDeprecated: true,
+                remoteDebuggingSupported: true,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '12.x',
+                },
+                endOfLifeDate: node12EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '10.x',
-              },
-              endOfLifeDate: node10EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 10.16',
-          value: '10.16',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|10.16',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+        ],
+      },
+      {
+        displayText: 'Node 10',
+        value: '10',
+        minorVersions: [
+          {
+            displayText: 'Node 10 LTS',
+            value: '10-LTS',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|10-lts',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '10.x',
+                },
+                endOfLifeDate: node10EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '10.x',
-              },
-              endOfLifeDate: node10EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 10.15',
-          value: '10.15',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '10.15.2',
-              isDeprecated: true,
-              isPreview: true,
-              isHidden: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'Node 10.16',
+            value: '10.16',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|10.16',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '10.x',
+                },
+                endOfLifeDate: node10EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '10.x',
-              },
-              endOfLifeDate: node10EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 10.14',
-          value: '10.14',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|10.14',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 10.15',
+            value: '10.15',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '10.15.2',
+                isDeprecated: true,
+                isPreview: true,
+                isHidden: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '10.x',
+                },
+                endOfLifeDate: node10EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '10.x',
-              },
-              endOfLifeDate: node10EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '10.14.1',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '10.x',
-              },
-              endOfLifeDate: node10EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 10.12',
-          value: '10.12',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|10.12',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 10.14',
+            value: '10.14',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|10.14',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '10.x',
+                },
+                endOfLifeDate: node10EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '10.x',
+              windowsRuntimeSettings: {
+                runtimeVersion: '10.14.1',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '10.x',
+                },
+                endOfLifeDate: node10EOL,
               },
-              endOfLifeDate: node10EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 10.10',
-          value: '10.10',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|10.10',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 10.12',
+            value: '10.12',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|10.12',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '10.x',
+                },
+                endOfLifeDate: node10EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '10.x',
-              },
-              endOfLifeDate: node10EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '10.0.0',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '10.x',
-              },
-              endOfLifeDate: node10EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 10.6',
-          value: '10.6',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|10.6',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 10.10',
+            value: '10.10',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|10.10',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '10.x',
+                },
+                endOfLifeDate: node10EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '10.x',
+              windowsRuntimeSettings: {
+                runtimeVersion: '10.0.0',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '10.x',
+                },
+                endOfLifeDate: node10EOL,
               },
-              endOfLifeDate: node10EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '10.6.0',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node10EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Node 10.1',
-          value: '10.1',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|10.1',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '10.x',
-              },
-              endOfLifeDate: node10EOL,
             },
           },
-        },
-      ],
-    },
-    {
-      displayText: 'Node 9',
-      value: '9',
-      minorVersions: [
-        {
-          displayText: 'Node 9.4',
-          value: '9.4',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|9.4',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 10.6',
+            value: '10.6',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|10.6',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '10.x',
+                },
+                endOfLifeDate: node10EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
+              windowsRuntimeSettings: {
+                runtimeVersion: '10.6.0',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node10EOL,
               },
-              endOfLifeDate: node9EOL,
             },
           },
-        },
-      ],
-    },
-    {
-      displayText: 'Node 8',
-      value: '8',
-      minorVersions: [
-        {
-          displayText: 'Node 8 LTS',
-          value: '8-lts',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|8-lts',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 10.1',
+            value: '10.1',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|10.1',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '10.x',
+                },
+                endOfLifeDate: node10EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node8EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 8.12',
-          value: '8.12',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|8.12',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+        ],
+      },
+      {
+        displayText: 'Node 9',
+        value: '9',
+        minorVersions: [
+          {
+            displayText: 'Node 9.4',
+            value: '9.4',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|9.4',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node9EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node8EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 8.11',
-          value: '8.11',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|8.11',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+        ],
+      },
+      {
+        displayText: 'Node 8',
+        value: '8',
+        minorVersions: [
+          {
+            displayText: 'Node 8 LTS',
+            value: '8-lts',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|8-lts',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node8EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node8EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '8.11',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: node8EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 8.10',
-          value: '8.10',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '8.10',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'Node 8.12',
+            value: '8.12',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|8.12',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node8EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: node8EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 8.9',
-          value: '8.9',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|8.9',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 8.11',
+            value: '8.11',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|8.11',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node8EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
+              windowsRuntimeSettings: {
+                runtimeVersion: '8.11',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: node8EOL,
               },
-              endOfLifeDate: node8EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '8.9',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: node8EOL,
-            },
-          },
-        },
-        {
-          displayText: 'Node 8.8',
-          value: '8.8',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|8.8',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node8EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 8.5',
-          value: '8.5',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '8.5',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'Node 8.10',
+            value: '8.10',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '8.10',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: node8EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: node8EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 8.4',
-          value: '8.4',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '8.4',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'Node 8.9',
+            value: '8.9',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|8.9',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node8EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
+              windowsRuntimeSettings: {
+                runtimeVersion: '8.9',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: node8EOL,
               },
-              endOfLifeDate: node8EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 8.2',
-          value: '8.2',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|8.2',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 8.8',
+            value: '8.8',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|8.8',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node8EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node8EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 8.1',
-          value: '8.1',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|8.1',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 8.5',
+            value: '8.5',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '8.5',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: node8EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node8EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '8.1.4',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node8EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 8.0',
-          value: '8.0',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|8.0',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 8.4',
+            value: '8.4',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '8.4',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: node8EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node8EOL,
             },
           },
-        },
-      ],
-    },
-    {
-      displayText: 'Node 7',
-      value: '7',
-      minorVersions: [
-        {
-          displayText: 'Node 7.10',
-          value: '7.10',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '7.10.1',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'Node 8.2',
+            value: '8.2',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|8.2',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node8EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: node7EOL,
             },
           },
-        },
-      ],
-    },
-    {
-      displayText: 'Node 6',
-      value: '6',
-      minorVersions: [
-        {
-          displayText: 'Node 6 LTS',
-          value: '6-LTS',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|6-lts',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 8.1',
+            value: '8.1',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|8.1',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node8EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
+              windowsRuntimeSettings: {
+                runtimeVersion: '8.1.4',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node8EOL,
               },
-              endOfLifeDate: node6EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 6.12',
-          value: '6.12',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '6.12',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 8.0',
+            value: '8.0',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|8.0',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node8EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: node6EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 6.11',
-          value: '6.11',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|6.11',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+        ],
+      },
+      {
+        displayText: 'Node 7',
+        value: '7',
+        minorVersions: [
+          {
+            displayText: 'Node 7.10',
+            value: '7.10',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '7.10.1',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: node7EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node6EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 6.10',
-          value: '6.10',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|6.10',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+        ],
+      },
+      {
+        displayText: 'Node 6',
+        value: '6',
+        minorVersions: [
+          {
+            displayText: 'Node 6 LTS',
+            value: '6-LTS',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|6-lts',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node6EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node6EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 6.9',
-          value: '6.9',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|6.9',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 6.12',
+            value: '6.12',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '6.12',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: node6EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node6EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '6.9.5',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node6EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 6.6',
-          value: '6.6',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|6.6',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 6.11',
+            value: '6.11',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|6.11',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node6EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node6EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 6.5',
-          value: '6.5',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '6.5.0',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 6.10',
+            value: '6.10',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|6.10',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node6EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: node6EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 6.2',
-          value: '6.2',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|6.2',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 6.9',
+            value: '6.9',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|6.9',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node6EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
+              windowsRuntimeSettings: {
+                runtimeVersion: '6.9.5',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node6EOL,
               },
-              endOfLifeDate: node6EOL,
             },
           },
-        },
-      ],
-    },
-    {
-      displayText: 'Node 4',
-      value: '4',
-      minorVersions: [
-        {
-          displayText: 'Node 4.8',
-          value: '4.8',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|4.8',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 6.6',
+            value: '6.6',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|6.6',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node6EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node4EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '4.8',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: node4EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 4.5',
-          value: '4.5',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|4.5',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 6.5',
+            value: '6.5',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '6.5.0',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: node6EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node4EOL,
             },
           },
-        },
-        {
-          displayText: 'Node 4.4',
-          value: '4.4',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'NODE|4.4',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
+          {
+            displayText: 'Node 6.2',
+            value: '6.2',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|6.2',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node6EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: node4EOL,
             },
           },
-        },
-      ],
-    },
-  ],
+        ],
+      },
+      {
+        displayText: 'Node 4',
+        value: '4',
+        minorVersions: [
+          {
+            displayText: 'Node 4.8',
+            value: '4.8',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|4.8',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node4EOL,
+              },
+              windowsRuntimeSettings: {
+                runtimeVersion: '4.8',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: node4EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Node 4.5',
+            value: '4.5',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|4.5',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node4EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Node 4.4',
+            value: '4.4',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|4.4',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: node4EOL,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
 };
+
+export const nodeStackNonIsoDates: WebAppStack = getNodeStack(false);
+
+export const nodeStack: WebAppStack = getNodeStack(true);

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Php.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Php.ts
@@ -1,227 +1,234 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
+import { getDateString } from '../date-utilities';
 
-const php8Point0EOL = new Date(2023, 11, 26).toString();
-const php7Point4EOL = new Date(2022, 11, 28).toString();
-const php7Point3EOL = new Date(2021, 12, 6).toString();
-const php7Point2EOL = new Date(2020, 11, 30).toString();
-const php7Point1EOL = new Date(2020, 2, 1).toString();
-const php7Point0EOL = new Date(2020, 2, 1).toString();
-const php5Point6EOL = new Date(2021, 2, 1).toString();
+const getPhpStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFormat: boolean) => {
+  const php8Point0EOL = getDateString(new Date(2023, 11, 26), useIsoDateFormat);
+  const php7Point4EOL = getDateString(new Date(2022, 11, 28), useIsoDateFormat);
+  const php7Point3EOL = getDateString(new Date(2021, 12, 6), useIsoDateFormat);
+  const php7Point2EOL = getDateString(new Date(2020, 11, 30), useIsoDateFormat);
+  const php7Point1EOL = getDateString(new Date(2020, 2, 1), useIsoDateFormat);
+  const php7Point0EOL = getDateString(new Date(2020, 2, 1), useIsoDateFormat);
+  const php5Point6EOL = getDateString(new Date(2021, 2, 1), useIsoDateFormat);
 
-export const phpStack: WebAppStack = {
-  displayText: 'PHP',
-  value: 'php',
-  preferredOs: 'linux',
-  majorVersions: [
-    {
-      displayText: 'PHP 8',
-      value: '8',
-      minorVersions: [
-        {
-          displayText: 'PHP 8.0',
-          value: '8.0',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'PHP|8.0',
-              isHidden: false,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+  return {
+    displayText: 'PHP',
+    value: 'php',
+    preferredOs: 'linux',
+    majorVersions: [
+      {
+        displayText: 'PHP 8',
+        value: '8',
+        minorVersions: [
+          {
+            displayText: 'PHP 8.0',
+            value: '8.0',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'PHP|8.0',
+                isHidden: false,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8.0',
+                  notSupportedInCreates: true,
+                },
+                endOfLifeDate: php8Point0EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '8.0',
-                notSupportedInCreates: true,
-              },
-              endOfLifeDate: php8Point0EOL,
             },
           },
-        },
-      ],
-    },
-    {
-      displayText: 'PHP 7',
-      value: '7',
-      minorVersions: [
-        {
-          displayText: 'PHP 7.4',
-          value: '7.4',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '7.4',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+        ],
+      },
+      {
+        displayText: 'PHP 7',
+        value: '7',
+        minorVersions: [
+          {
+            displayText: 'PHP 7.4',
+            value: '7.4',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '7.4',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '7.4',
+                  notSupportedInCreates: true,
+                },
+                endOfLifeDate: php7Point4EOL,
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '7.4',
-                notSupportedInCreates: true,
+              linuxRuntimeSettings: {
+                runtimeVersion: 'PHP|7.4',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '7.4',
+                  notSupportedInCreates: true,
+                },
+                endOfLifeDate: php7Point4EOL,
               },
-              endOfLifeDate: php7Point4EOL,
-            },
-            linuxRuntimeSettings: {
-              runtimeVersion: 'PHP|7.4',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '7.4',
-                notSupportedInCreates: true,
-              },
-              endOfLifeDate: php7Point4EOL,
-            },
-          },
-        },
-        {
-          displayText: 'PHP 7.3',
-          value: '7.3',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'PHP|7.3',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '7.3',
-                notSupportedInCreates: true,
-              },
-              endOfLifeDate: php7Point3EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '7.3',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '7.3',
-                notSupportedInCreates: true,
-              },
-              endOfLifeDate: php7Point3EOL,
             },
           },
-        },
-        {
-          displayText: 'PHP 7.2',
-          value: '7.2',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'PHP|7.2',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'PHP 7.3',
+            value: '7.3',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'PHP|7.3',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '7.3',
+                  notSupportedInCreates: true,
+                },
+                endOfLifeDate: php7Point3EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
+              windowsRuntimeSettings: {
+                runtimeVersion: '7.3',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '7.3',
+                  notSupportedInCreates: true,
+                },
+                endOfLifeDate: php7Point3EOL,
               },
-              endOfLifeDate: php7Point2EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '7.2',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-              },
-              endOfLifeDate: php7Point2EOL,
-            },
-          },
-        },
-        {
-          displayText: 'PHP 7.1',
-          value: '7.1',
-          stackSettings: {
-            windowsRuntimeSettings: {
-              runtimeVersion: '7.1',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: php7Point1EOL,
             },
           },
-        },
-        {
-          displayText: '7.0',
-          value: '7.0',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'PHP|7.0',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'PHP 7.2',
+            value: '7.2',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'PHP|7.2',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: php7Point2EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
+              windowsRuntimeSettings: {
+                runtimeVersion: '7.2',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                endOfLifeDate: php7Point2EOL,
               },
-              endOfLifeDate: php7Point0EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '7.0',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: php7Point0EOL,
-            },
-          },
-        },
-      ],
-    },
-    {
-      displayText: 'PHP 5',
-      value: '5',
-      minorVersions: [
-        {
-          displayText: 'PHP 5.6',
-          value: '5.6',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'PHP|5.6',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: php5Point6EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '5.6',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: php5Point6EOL,
             },
           },
-        },
-      ],
-    },
-  ],
+          {
+            displayText: 'PHP 7.1',
+            value: '7.1',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '7.1',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: php7Point1EOL,
+              },
+            },
+          },
+          {
+            displayText: '7.0',
+            value: '7.0',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'PHP|7.0',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: php7Point0EOL,
+              },
+              windowsRuntimeSettings: {
+                runtimeVersion: '7.0',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: php7Point0EOL,
+              },
+            },
+          },
+        ],
+      },
+      {
+        displayText: 'PHP 5',
+        value: '5',
+        minorVersions: [
+          {
+            displayText: 'PHP 5.6',
+            value: '5.6',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'PHP|5.6',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: php5Point6EOL,
+              },
+              windowsRuntimeSettings: {
+                runtimeVersion: '5.6',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: php5Point6EOL,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
 };
+
+export const phpStackNonIsoDates: WebAppStack = getPhpStack(false);
+
+export const phpStack: WebAppStack = getPhpStack(true);

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Python.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Python.ts
@@ -1,136 +1,143 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
+import { getDateString } from '../date-utilities';
 
-const python2EOL = new Date(2020, 1, 1).toString();
+const getPythonStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFormat: boolean) => {
+  const python2EOL = getDateString(new Date(2020, 1, 1), useIsoDateFormat);
 
-export const pythonStack: WebAppStack = {
-  displayText: 'Python',
-  value: 'python',
-  preferredOs: 'linux',
-  majorVersions: [
-    {
-      displayText: 'Python 3',
-      value: '3',
-      minorVersions: [
-        {
-          displayText: 'Python 3.9',
-          value: '3.9',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'PYTHON|3.9',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '3.9',
-              },
-              isHidden: false,
-              isEarlyAccess: true,
-            },
-          },
-        },
-        {
-          displayText: 'Python 3.8',
-          value: '3.8',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'PYTHON|3.8',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '3.8',
+  return {
+    displayText: 'Python',
+    value: 'python',
+    preferredOs: 'linux',
+    majorVersions: [
+      {
+        displayText: 'Python 3',
+        value: '3',
+        minorVersions: [
+          {
+            displayText: 'Python 3.9',
+            value: '3.9',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'PYTHON|3.9',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '3.9',
+                },
+                isHidden: false,
+                isEarlyAccess: true,
               },
             },
           },
-        },
-        {
-          displayText: 'Python 3.7',
-          value: '3.7',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'PYTHON|3.7',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '3.7',
-              },
-            },
-          },
-        },
-        {
-          displayText: 'Python 3.6',
-          value: '3.6',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'PYTHON|3.6',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '3.6',
-              },
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '3.4.0',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: true,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '3.6',
+          {
+            displayText: 'Python 3.8',
+            value: '3.8',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'PYTHON|3.8',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '3.8',
+                },
               },
             },
           },
-        },
-      ],
-    },
-    {
-      displayText: 'Python 2',
-      value: '2',
-      minorVersions: [
-        {
-          displayText: 'Python 2.7',
-          value: '2.7',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'PYTHON|2.7',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'Python 3.7',
+            value: '3.7',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'PYTHON|3.7',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '3.7',
+                },
               },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '2.7',
-              },
-              endOfLifeDate: python2EOL,
-            },
-            windowsRuntimeSettings: {
-              runtimeVersion: '2.7.3',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
-              },
-              gitHubActionSettings: {
-                isSupported: true,
-                supportedVersion: '2.7',
-              },
-              endOfLifeDate: python2EOL,
             },
           },
-        },
-      ],
-    },
-  ],
+          {
+            displayText: 'Python 3.6',
+            value: '3.6',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'PYTHON|3.6',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '3.6',
+                },
+              },
+              windowsRuntimeSettings: {
+                runtimeVersion: '3.4.0',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '3.6',
+                },
+              },
+            },
+          },
+        ],
+      },
+      {
+        displayText: 'Python 2',
+        value: '2',
+        minorVersions: [
+          {
+            displayText: 'Python 2.7',
+            value: '2.7',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'PYTHON|2.7',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '2.7',
+                },
+                endOfLifeDate: python2EOL,
+              },
+              windowsRuntimeSettings: {
+                runtimeVersion: '2.7.3',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '2.7',
+                },
+                endOfLifeDate: python2EOL,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
 };
+
+export const pythonStackNonIsoDates: WebAppStack = getPythonStack(false);
+
+export const pythonStack: WebAppStack = getPythonStack(true);

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Ruby.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Ruby.ts
@@ -1,180 +1,187 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
+import { getDateString } from '../date-utilities';
 
-const ruby2Point6EOL = new Date(2022, 3, 31).toString();
-const ruby2Point5EOL = new Date(2021, 3, 31).toString();
-const ruby2Point4EOL = new Date(2020, 4, 1).toString();
-const ruby2Point3EOL = new Date(2019, 3, 31).toString();
+const getRubyStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFormat: boolean) => {
+  const ruby2Point6EOL = getDateString(new Date(2022, 3, 31), useIsoDateFormat);
+  const ruby2Point5EOL = getDateString(new Date(2021, 3, 31), useIsoDateFormat);
+  const ruby2Point4EOL = getDateString(new Date(2020, 4, 1), useIsoDateFormat);
+  const ruby2Point3EOL = getDateString(new Date(2019, 3, 31), useIsoDateFormat);
 
-export const rubyStack: WebAppStack = {
-  displayText: 'Ruby',
-  value: 'ruby',
-  preferredOs: 'linux',
-  majorVersions: [
-    {
-      displayText: 'Ruby 2',
-      value: '2',
-      minorVersions: [
-        {
-          displayText: 'Ruby 2.6',
-          value: '2.6',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'RUBY|2.6',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+  return {
+    displayText: 'Ruby',
+    value: 'ruby',
+    preferredOs: 'linux',
+    majorVersions: [
+      {
+        displayText: 'Ruby 2',
+        value: '2',
+        minorVersions: [
+          {
+            displayText: 'Ruby 2.6',
+            value: '2.6',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'RUBY|2.6',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: ruby2Point6EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: ruby2Point6EOL,
             },
           },
-        },
-        {
-          displayText: 'Ruby 2.6.2',
-          value: '2.6.2',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'RUBY|2.6.2',
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'Ruby 2.6.2',
+            value: '2.6.2',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'RUBY|2.6.2',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: ruby2Point6EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: ruby2Point6EOL,
             },
           },
-        },
-        {
-          displayText: 'Ruby 2.5',
-          value: '2.5',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'RUBY|2.5',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'Ruby 2.5',
+            value: '2.5',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'RUBY|2.5',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: ruby2Point5EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: ruby2Point5EOL,
             },
           },
-        },
-        {
-          displayText: 'Ruby 2.5.5',
-          value: '2.5.5',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'RUBY|2.5.5',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'Ruby 2.5.5',
+            value: '2.5.5',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'RUBY|2.5.5',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: ruby2Point5EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: ruby2Point5EOL,
             },
           },
-        },
-        {
-          displayText: 'Ruby 2.4',
-          value: '2.4',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'RUBY|2.4',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'Ruby 2.4',
+            value: '2.4',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'RUBY|2.4',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: ruby2Point4EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: ruby2Point4EOL,
             },
           },
-        },
-        {
-          displayText: 'Ruby 2.4.5',
-          value: '2.4.5',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'RUBY|2.4.5',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'Ruby 2.4.5',
+            value: '2.4.5',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'RUBY|2.4.5',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: ruby2Point4EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: ruby2Point4EOL,
             },
           },
-        },
-        {
-          displayText: 'Ruby 2.3',
-          value: '2.3',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'RUBY|2.3',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'Ruby 2.3',
+            value: '2.3',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'RUBY|2.3',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: ruby2Point3EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: ruby2Point3EOL,
             },
           },
-        },
-        {
-          displayText: 'Ruby 2.3.8',
-          value: '2.3.8',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'RUBY|2.3.8',
-              isDeprecated: true,
-              remoteDebuggingSupported: false,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'Ruby 2.3.8',
+            value: '2.3.8',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'RUBY|2.3.8',
+                isDeprecated: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: ruby2Point3EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: ruby2Point3EOL,
             },
           },
-        },
-        {
-          displayText: 'Ruby 2.3.3',
-          value: '2.3.3',
-          stackSettings: {
-            linuxRuntimeSettings: {
-              runtimeVersion: 'RUBY|2.3.3',
-              remoteDebuggingSupported: false,
-              isDeprecated: true,
-              appInsightsSettings: {
-                isSupported: false,
+          {
+            displayText: 'Ruby 2.3.3',
+            value: '2.3.3',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'RUBY|2.3.3',
+                remoteDebuggingSupported: false,
+                isDeprecated: true,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: ruby2Point3EOL,
               },
-              gitHubActionSettings: {
-                isSupported: false,
-              },
-              endOfLifeDate: ruby2Point3EOL,
             },
           },
-        },
-      ],
-    },
-  ],
+        ],
+      },
+    ],
+  };
 };
+
+export const rubyStackNonIsoDates: WebAppStack = getRubyStack(false);
+
+export const rubyStack: WebAppStack = getRubyStack(true);

--- a/server/src/stacks/stacks.controller.ts
+++ b/server/src/stacks/stacks.controller.ts
@@ -37,7 +37,15 @@ export class StacksController {
     @Query('removePreviewStacks') removePreviewStacks?: string,
     @Query('removeNonGitHubActionStacks') removeNonGitHubActionStacks?: string
   ) {
-    validateApiVersion(apiVersion, [Versions.version20200601, Versions.version20201001, Versions.version20201201]);
+    validateApiVersion(apiVersion, [
+      Versions.version20200601,
+      Versions.version20201001,
+      Versions.version20201201,
+      Versions.version20210101,
+      Versions.version20210115,
+      Versions.version20210201,
+      Versions.version20210301,
+    ]);
     validateOs(os);
     validateFunctionAppStack(apiVersion, stack);
     validateRemoveHiddenStacks(removeHiddenStacks);
@@ -68,6 +76,20 @@ export class StacksController {
           removeHidden,
           removeDeprecated,
           removePreview,
+          removeNonGitHubAction,
+          false /*useIsoDateFormat*/
+        );
+      }
+      case Versions.version20210101:
+      case Versions.version20210115:
+      case Versions.version20210201:
+      case Versions.version20210301: {
+        return this._stackService20201001.getFunctionAppStacks(
+          os,
+          stack as FunctionAppStack20201001Value,
+          removeHidden,
+          removeDeprecated,
+          removePreview,
           removeNonGitHubAction
         );
       }
@@ -84,7 +106,15 @@ export class StacksController {
     @Query('removePreviewStacks') removePreviewStacks?: string,
     @Query('removeNonGitHubActionStacks') removeNonGitHubActionStacks?: string
   ) {
-    validateApiVersion(apiVersion, [Versions.version20200601, Versions.version20201001, Versions.version20201201]);
+    validateApiVersion(apiVersion, [
+      Versions.version20200601,
+      Versions.version20201001,
+      Versions.version20201201,
+      Versions.version20210101,
+      Versions.version20210115,
+      Versions.version20210201,
+      Versions.version20210301,
+    ]);
     validateOs(os);
     validateWebAppStack(apiVersion, stack);
     validateRemoveHiddenStacks(removeHiddenStacks);
@@ -109,6 +139,20 @@ export class StacksController {
       }
       case Versions.version20201001:
       case Versions.version20201201: {
+        return this._stackService20201001.getWebAppStacks(
+          os,
+          stack as WebAppStack20201001Value,
+          removeHidden,
+          removeDeprecated,
+          removePreview,
+          removeNonGitHubAction,
+          false /*useIsoDateFormat*/
+        );
+      }
+      case Versions.version20210101:
+      case Versions.version20210115:
+      case Versions.version20210201:
+      case Versions.version20210301: {
         return this._stackService20201001.getWebAppStacks(
           os,
           stack as WebAppStack20201001Value,

--- a/server/src/stacks/versions.ts
+++ b/server/src/stacks/versions.ts
@@ -6,4 +6,5 @@ export enum Versions {
   version20210101 = '2021-01-01',
   version20210115 = '2021-01-15',
   version20210201 = '2021-02-01',
+  version20210301 = '2021-03-01',
 }


### PR DESCRIPTION
For API version 2021-01-01 and higher, return endOfLifeDate in ISO format (e.g. "2020-10-04T07:00:00.000Z") instead of the current format (e.g. "Sun Oct 04 2020 00:00:00 GMT+0000 (Greenwich Mean Time)").

Cherry-pick from #6364 