### PR TITLE
[DC] Add link to identity blade in managed identities dropdown

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.styles.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.styles.ts
@@ -181,6 +181,10 @@ export const changeAccountInfoButtonStyle = style({
   paddingBottom: '10px',
 });
 
+export const addIdentityLinkStyle = style({
+  padding: '10px 10px 10px 9px',
+});
+
 export const buttonFooterStyle = (theme: ThemeExtended): string =>
   style({
     backgroundColor: `${theme.semanticColors.background}`,

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -626,6 +626,7 @@ export interface DeploymentCenterContainerAcrSettingsProps extends DeploymentCen
   fetchImages: (loginServer: string) => void;
   fetchTags: (image: string) => void;
   fetchRegistriesInSub(subscription: string);
+  fetchManagedIdentityOptions: () => void;
   acrSubscriptionOptions: IDropdownOption[];
   acrRegistryOptions: IDropdownOption[];
   acrImageOptions: IDropdownOption[];
@@ -640,6 +641,7 @@ export interface DeploymentCenterContainerAcrSettingsProps extends DeploymentCen
   managedIdentityOptions: IDropdownOption[];
   loadingManagedIdentities: boolean;
   learnMoreLink?: string;
+  openIdentityBlade: () => void;
 }
 
 export interface DeploymentCenterOneDriveProviderProps<T = DeploymentCenterContainerFormData | DeploymentCenterCodeFormData>

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
@@ -443,6 +443,22 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
     setSubscription(subscription);
   };
 
+  const openIdentityBlade = () => {
+    portalContext.openBlade(
+      {
+        detailBlade: 'AzureResourceIdentitiesBladeV2',
+        extension: 'Microsoft_Azure_ManagedServiceIdentity',
+        detailBladeInputs: {
+          resourceId: deploymentCenterContext.resourceId,
+          apiVersion: CommonConstants.ApiVersions.antaresApiVersion20181101,
+          systemAssignedStatus: 2, // IdentityStatus.Supported
+          userAssignedStatus: 2, // IdentityStatus.Supported
+        },
+      },
+      'deployment-center'
+    );
+  };
+
   useEffect(() => {
     if (deploymentCenterContext.siteDescriptor && deploymentCenterContext.applicationSettings) {
       fetchData();
@@ -481,9 +497,7 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
 
   useEffect(() => {
     setAcrUseManagedIdentities(formProps.values.acrCredentialType === ACRCredentialType.managedIdentity);
-    if (managedIdentityOptions.length < 1) {
-      fetchManagedIdentityOptions();
-    }
+    fetchManagedIdentityOptions();
   }, [formProps.values.acrCredentialType]);
 
   useEffect(() => {
@@ -496,6 +510,7 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
       fetchImages={fetchRepositories}
       fetchTags={fetchTags}
       fetchRegistriesInSub={setRegistriesInSub}
+      fetchManagedIdentityOptions={fetchManagedIdentityOptions}
       acrSubscriptionOptions={subscriptionOptions}
       acrRegistryOptions={acrRegistryOptions}
       acrImageOptions={acrImageOptions}
@@ -510,6 +525,7 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
       managedIdentityOptions={managedIdentityOptions}
       loadingManagedIdentities={loadingManagedIdentities}
       learnMoreLink={learnMoreLink}
+      openIdentityBlade={openIdentityBlade}
     />
   );
 };

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrSettings.tsx
@@ -8,10 +8,10 @@ import DeploymentCenterContainerComposeFileUploader from './DeploymentCenterCont
 import ComboBox from '../../../../components/form-controls/ComboBox';
 import { ScmType } from '../../../../models/site/config';
 import ReactiveFormControl from '../../../../components/form-controls/ReactiveFormControl';
-import { IDropdownOption, MessageBar, MessageBarType } from '@fluentui/react';
+import { IDropdownOption, Link, MessageBar, MessageBarType } from '@fluentui/react';
 import ComboBoxNoFormik from '../../../../components/form-controls/ComboBoxnoFormik';
 import RadioButton from '../../../../components/form-controls/RadioButton';
-import { deploymentCenterAcrBannerDiv } from '../DeploymentCenter.styles';
+import { addIdentityLinkStyle, deploymentCenterAcrBannerDiv } from '../DeploymentCenter.styles';
 
 const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAcrSettingsProps> = props => {
   const {
@@ -31,6 +31,8 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
     loadingManagedIdentities,
     learnMoreLink,
     fetchRegistriesInSub,
+    fetchManagedIdentityOptions,
+    openIdentityBlade,
   } = props;
   const { t } = useTranslation();
 
@@ -85,16 +87,6 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [acrTagOptions]);
 
-  const acrInfoMessageBanner = acrUseManagedIdentities ? (
-    <div id="acr-managed-identities-info-banner" className={deploymentCenterAcrBannerDiv}>
-      <MessageBar id="acr-info-message-bar" messageBarType={MessageBarType.info} isMultiline={true}>
-        {t('managedIdentityInfoMessage')}
-      </MessageBar>
-    </div>
-  ) : (
-    <></>
-  );
-
   // NOTE(michinoy): In case of GitHub Action, we will always need to get the user credentials for their ACR
   // registry. This is because the workflow would need to use those credentials to push the images and app service
   // would use the same credentials to pull the images.
@@ -105,7 +97,13 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
 
   return (
     <>
-      {acrInfoMessageBanner}
+      {acrUseManagedIdentities && (
+        <div id="acr-managed-identities-info-banner" className={deploymentCenterAcrBannerDiv}>
+          <MessageBar id="acr-info-message-bar" messageBarType={MessageBarType.info} isMultiline={true}>
+            {t('managedIdentityInfoMessage')}
+          </MessageBar>
+        </div>
+      )}
 
       {acrStatusMessage && acrStatusMessageType && (
         <div id="acr-status-message-type-div" className={deploymentCenterAcrBannerDiv}>
@@ -141,6 +139,12 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
         component={ComboBox}
         placeholder={t('managedIdentityTypePlaceholder')}
         options={managedIdentityOptions}
+        onMenuOpen={fetchManagedIdentityOptions}
+        onRenderLowerContent={() => (
+          <Link id="container-acr-add-identity-link" className={addIdentityLinkStyle} onClick={openIdentityBlade}>
+            {t('addIdentity')}
+          </Link>
+        )}
         disabled={!acrUseManagedIdentities || loadingManagedIdentities}
       />
       <Field

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2363,4 +2363,5 @@ export class PortalResources {
   public static managedIdentityTypePlaceholder = 'managedIdentityTypePlaceholder';
   public static managedIdentityInfoMessage = 'managedIdentityInfoMessage';
   public static acrCredentialsWarningMessage = 'acrCredentialsWarningMessage';
+  public static addIdentity = 'addIdentity';
 }

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7216,10 +7216,10 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>Invalid Cron Expression. Please consult the &lt;a href="{0}" target="_blank"&gt;documentation&lt;/a&gt; to learn more.</value>
     </data>
     <data name="systemAssigned" xml:space="preserve">
-        <value>System assigned</value>
+        <value>System-assigned</value>
     </data>
     <data name="userAssigned" xml:space="preserve">
-        <value>User assigned</value>
+        <value>User-assigned</value>
     </data>
     <data name="managedIdentityTypePlaceholder" xml:space="preserve">
         <value>Select managed identity</value>
@@ -7229,5 +7229,8 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     </data>
     <data name="acrCredentialsWarningMessage" xml:space="preserve">
         <value>Cannot access ACR '{0}' because admin credentials on ACR are disabled, and no managed identity is assigned. Either enable admin credentials, or assign a managed identity below.</value>
+    </data>
+    <data name="addIdentity" xml:space="preserve">
+        <value>Add identity</value>
     </data>
 </root>


### PR DESCRIPTION
Task [12677408](https://msazure.visualstudio.com/Antares/_workitems/edit/12677408)

**Before**: 
![image](https://user-images.githubusercontent.com/29874289/143327200-1f675cae-7782-4ec1-9ed3-dbe8ae92ecd2.png)

**After**:
![add identity example usage](https://user-images.githubusercontent.com/29874289/143327472-5adcd4f9-ee75-414a-b163-4fca173897d5.gif)

Accessibility consideration:
- Add identity link not reachable through tabbing, also makes screen reader unable to read it