### PR TITLE
Stacks updates for ANT96

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
@@ -1,5 +1,6 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
 
+const node16EOL = new Date(2024, 4, 30).toString();
 const node14EOL = new Date(2023, 4, 30).toString();
 const node12EOL = new Date(2022, 4, 1).toString();
 const node10EOL = new Date(2021, 4, 1).toString();
@@ -32,6 +33,44 @@ export const nodeStack: WebAppStack = {
               gitHubActionSettings: {
                 isSupported: true,
               },
+            },
+          },
+        },
+      ],
+    },
+    {
+      displayText: 'Node 16',
+      value: '16',
+      minorVersions: [
+        {
+          displayText: 'Node 16 LTS',
+          value: '16-lts',
+          stackSettings: {
+            linuxRuntimeSettings: {
+              runtimeVersion: 'NODE|16-lts',
+              isHidden: true,
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: false,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '16.x',
+              },
+              endOfLifeDate: node16EOL,
+            },
+            windowsRuntimeSettings: {
+              runtimeVersion: '~16',
+              isHidden: true,
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: false,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '16.x',
+              },
+              endOfLifeDate: node16EOL,
             },
           },
         },

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Python.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Python.ts
@@ -26,7 +26,6 @@ export const pythonStack: WebAppStack = {
                 supportedVersion: '3.9',
               },
               isHidden: false,
-              isEarlyAccess: true,
             },
           },
         },

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Ruby.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Ruby.ts
@@ -1,5 +1,6 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
 
+const ruby2Point7EOL = new Date(2023, 3, 31).toString();
 const ruby2Point6EOL = new Date(2022, 3, 31).toString();
 const ruby2Point5EOL = new Date(2021, 3, 31).toString();
 const ruby2Point4EOL = new Date(2020, 4, 1).toString();
@@ -14,6 +15,40 @@ export const rubyStack: WebAppStack = {
       displayText: 'Ruby 2',
       value: '2',
       minorVersions: [
+        {
+          displayText: 'Ruby 2.7',
+          value: '2.7',
+          stackSettings: {
+            linuxRuntimeSettings: {
+              runtimeVersion: 'RUBY|2.7',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: false,
+              },
+              gitHubActionSettings: {
+                isSupported: false,
+              },
+              endOfLifeDate: ruby2Point7EOL,
+            },
+          },
+        },
+        {
+          displayText: 'Ruby 2.7.3',
+          value: '2.7.3',
+          stackSettings: {
+            linuxRuntimeSettings: {
+              runtimeVersion: 'RUBY|2.7.3',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: false,
+              },
+              gitHubActionSettings: {
+                isSupported: false,
+              },
+              endOfLifeDate: ruby2Point7EOL,
+            },
+          },
+        },
         {
           displayText: 'Ruby 2.6',
           value: '2.6',

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
@@ -2,6 +2,7 @@ import { WebAppStack } from '../../models/WebAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFormat: boolean) => {
+  const node16EOL = getDateString(new Date(2024, 4, 30), useIsoDateFormat);
   const node14EOL = getDateString(new Date(2023, 4, 30), useIsoDateFormat);
   const node12EOL = getDateString(new Date(2022, 4, 1), useIsoDateFormat);
   const node10EOL = getDateString(new Date(2021, 4, 1), useIsoDateFormat);
@@ -34,6 +35,44 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 gitHubActionSettings: {
                   isSupported: true,
                 },
+              },
+            },
+          },
+        ],
+      },
+      {
+        displayText: 'Node 16',
+        value: '16',
+        minorVersions: [
+          {
+            displayText: 'Node 16 LTS',
+            value: '16-lts',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'NODE|16-lts',
+                isHidden: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '16.x',
+                },
+                endOfLifeDate: node16EOL,
+              },
+              windowsRuntimeSettings: {
+                runtimeVersion: '~16',
+                isHidden: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '16.x',
+                },
+                endOfLifeDate: node16EOL,
               },
             },
           },

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Python.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Python.ts
@@ -28,7 +28,6 @@ const getPythonStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                   supportedVersion: '3.9',
                 },
                 isHidden: false,
-                isEarlyAccess: true,
               },
             },
           },

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Ruby.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Ruby.ts
@@ -2,6 +2,7 @@ import { WebAppStack } from '../../models/WebAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getRubyStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFormat: boolean) => {
+  const ruby2Point7EOL = getDateString(new Date(2023, 3, 31), useIsoDateFormat);
   const ruby2Point6EOL = getDateString(new Date(2022, 3, 31), useIsoDateFormat);
   const ruby2Point5EOL = getDateString(new Date(2021, 3, 31), useIsoDateFormat);
   const ruby2Point4EOL = getDateString(new Date(2020, 4, 1), useIsoDateFormat);
@@ -16,6 +17,40 @@ const getRubyStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
         displayText: 'Ruby 2',
         value: '2',
         minorVersions: [
+          {
+            displayText: 'Ruby 2.7',
+            value: '2.7',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'RUBY|2.7',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: ruby2Point7EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Ruby 2.7.3',
+            value: '2.7.3',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'RUBY|2.7.3',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: false,
+                },
+                endOfLifeDate: ruby2Point7EOL,
+              },
+            },
+          },
           {
             displayText: 'Ruby 2.6',
             value: '2.6',

--- a/server/src/tests/Stacks/2020-06-01/web-app/validations.ts
+++ b/server/src/tests/Stacks/2020-06-01/web-app/validations.ts
@@ -185,7 +185,7 @@ function validateNodeStack(nodeStack) {
   expect(nodeStack.displayText).to.equal('Node');
   expect(nodeStack.value).to.equal('node');
   expect(nodeStack.preferredOs).to.equal('linux');
-  expect(nodeStack.majorVersions.length).to.equal(9);
+  expect(nodeStack.majorVersions.length).to.equal(10);
   expect(nodeStack).to.deep.equal(hardCodedNodeStack);
 }
 

--- a/server/src/tests/Stacks/2020-10-01/web-app/validations.ts
+++ b/server/src/tests/Stacks/2020-10-01/web-app/validations.ts
@@ -184,7 +184,7 @@ function validateNodeStack(nodeStack) {
   expect(nodeStack.displayText).to.equal('Node');
   expect(nodeStack.value).to.equal('node');
   expect(nodeStack.preferredOs).to.equal('linux');
-  expect(nodeStack.majorVersions.length).to.equal(9);
+  expect(nodeStack.majorVersions.length).to.equal(10);
   expect(nodeStack).to.deep.equal(hardCodedNodeStack);
 }
 


### PR DESCRIPTION
Fixes [AB#10469540](https://msazure.visualstudio.com/Antares/_workitems/edit/10469540) - Python 3.9 (Baked in Stack) ANT96
Fixes [AB#10469640](https://msazure.visualstudio.com/Antares/_workitems/edit/10469640) - Add RUBY 2.7 as Baked In
Fixes [AB#10469604](https://msazure.visualstudio.com/Antares/_workitems/edit/10469604) - NODE 16 (EARLY ACCESS) behind hide key