### PR TITLE
[DC] Check for ACRPull Permissions and set for user if not present

### DIFF
--- a/client-react/src/ApiHelpers/ACRService.ts
+++ b/client-react/src/ApiHelpers/ACRService.ts
@@ -1,11 +1,13 @@
 import MakeArmCall from './ArmHelper';
 import { ArmArray, ArmObj } from '../models/arm-obj';
 import { ACRRegistry, ACRWebhookPayload, ACRCredential, ACRRepositories, ACRTags } from '../models/acr';
-import { CommonConstants } from '../utils/CommonConstants';
+import { CommonConstants, RBACRoleId } from '../utils/CommonConstants';
 import { HttpResponseObject } from '../ArmHelper.types';
 import { getLastItemFromLinks, getLinksFromLinkHeader, sendHttpRequest } from './HttpClient';
 import Url from '../utils/url';
 import { Method } from 'axios';
+import { getArmEndpoint, getArmToken } from '../pages/app/deployment-center/utility/DeploymentCenterUtility';
+import { RoleAssignment } from '../pages/app/deployment-center/DeploymentCenter.types';
 
 export default class ACRService {
   public static getRegistries(subscriptionId: string) {
@@ -71,6 +73,50 @@ export default class ACRService {
     };
 
     return ACRService._dispatchSpecificPageableRequest<ACRTags>(data, 'getTags', 'POST', logger);
+  }
+
+  public static async hasAcrPullPermission(acrResourceId: string, principalId: string) {
+    let hasAcrPullPermission = false;
+
+    const roleAssignments = await this.getRoleAssignments(acrResourceId, principalId);
+
+    if (!!roleAssignments && roleAssignments.length > 0) {
+      for (let i = 0; i < roleAssignments.length; i++) {
+        const roleDefinitionSplit = roleAssignments[i].properties.roleDefinitionId.split('/');
+        const roleId = roleDefinitionSplit[roleDefinitionSplit.length - 1];
+        if (roleId === RBACRoleId.acrPull) {
+          hasAcrPullPermission = true;
+        }
+      }
+    }
+
+    return hasAcrPullPermission;
+  }
+
+  public static async getRoleAssignments(scope: string, principalId: string) {
+    const armEndpoint = getArmEndpoint();
+    const armToken = getArmToken();
+    const apiVersion = CommonConstants.ApiVersions.roleAssignmentApiVersion20180701;
+
+    const response = await sendHttpRequest<RoleAssignment[]>({
+      data: { armEndpoint, armToken, apiVersion, scope, principalId },
+      url: `${Url.serviceHost}api/acr/getRoleAssignments`,
+      method: 'POST',
+    });
+    return response.data;
+  }
+
+  public static async setAcrPullPermission(acrResourceId: string, principalId: string) {
+    const armEndpoint = getArmEndpoint();
+    const armToken = getArmToken();
+    const apiVersion = CommonConstants.ApiVersions.roleAssignmentApiVersion20180701;
+    const roleId = RBACRoleId.acrPull;
+
+    await sendHttpRequest<RoleAssignment[]>({
+      data: { armEndpoint, armToken, apiVersion, scope: acrResourceId, principalId, roleId },
+      url: `${Url.serviceHost}api/acr/setRoleAssignment`,
+      method: 'POST',
+    });
   }
 
   private static async _dispatchSpecificPageableRequest<T>(

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
@@ -270,6 +270,14 @@ export default class DeploymentCenterData {
     return ACRService.getTags(loginServer, repository, username, password, logger);
   };
 
+  public hasAcrPullPermission = (acrResourceId: string, principalId: string) => {
+    return ACRService.hasAcrPullPermission(acrResourceId, principalId);
+  };
+
+  public setAcrPullPermission = (acrResourceId: string, principalId: string) => {
+    return ACRService.setAcrPullPermission(acrResourceId, principalId);
+  };
+
   public updateSiteConfig = (resourceId: string, config: ArmObj<SiteConfig>) => {
     return SiteService.updateWebConfig(resourceId, config);
   };

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -157,6 +157,7 @@ export enum ACRManagedIdentityType {
 
 export enum ManagedIdentityInfo {
   clientId = 'clientId',
+  principalId = 'principalId',
 }
 
 export interface AzureDevOpsUrl {
@@ -323,6 +324,7 @@ export interface AcrFormData {
   acrLocation: string;
   acrCredentialType: string;
   acrManagedIdentityType: string | null;
+  acrManagedIdentityPrincipalId: string;
 }
 
 export interface DockerHubFormData {
@@ -734,4 +736,20 @@ export interface SearchTermObserverInfo {
   deploymentCenterContext: IDeploymentCenterContext;
   portalContext: PortalCommunicator;
   isGitHubActions: boolean | undefined;
+}
+
+export interface RoleAssignment {
+  properties: {
+    roleDefinitionId: string;
+    principalId: string;
+    scope: string;
+  };
+  id: string;
+  type: string;
+  name: string;
+}
+export interface UserAssignedIdentity {
+  clientId: string;
+  principalId: string;
+  name: string;
 }

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -297,6 +297,19 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
       ) {
         siteConfigResponse.data.properties.acrUserManagedIdentityID = '';
       } else {
+        const acrResourceId = values.acrResourceId;
+        const identityPrincipalId = values.acrManagedIdentityPrincipalId;
+
+        const hasAcrPullPermissions = await deploymentCenterData.hasAcrPullPermission(acrResourceId, identityPrincipalId);
+        if (!hasAcrPullPermissions) {
+          portalContext.log(
+            getTelemetryInfo('info', 'setAcrPullPermission', 'submit', {
+              resourceId: identityPrincipalId,
+            })
+          );
+          await deploymentCenterData.setAcrPullPermission(acrResourceId, identityPrincipalId);
+        }
+
         siteConfigResponse.data.properties.acrUserManagedIdentityID = values.acrManagedIdentityType;
       }
 

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -307,7 +307,14 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
               resourceId: identityPrincipalId,
             })
           );
-          await deploymentCenterData.setAcrPullPermission(acrResourceId, identityPrincipalId);
+          const setPermissionResponse = await deploymentCenterData.setAcrPullPermission(acrResourceId, identityPrincipalId);
+          if (!setPermissionResponse) {
+            portalContext.log(
+              getTelemetryInfo('error', 'setAcrPullPermission', 'failed', {
+                resourceId: identityPrincipalId,
+              })
+            );
+          }
         }
 
         siteConfigResponse.data.properties.acrUserManagedIdentityID = values.acrManagedIdentityType;

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -111,6 +111,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
       acrLocation: Yup.mixed().notRequired(),
       acrCredentialType: Yup.mixed().notRequired(),
       acrManagedIdentityType: Yup.mixed().notRequired(),
+      acrManagedIdentityPrincipalId: Yup.mixed().notRequired(),
     };
   }
 
@@ -376,6 +377,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
         acrLocation: '',
         acrCredentialType,
         acrManagedIdentityType,
+        acrManagedIdentityPrincipalId: '',
       };
     } else {
       return {
@@ -389,6 +391,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
         acrLocation: '',
         acrCredentialType,
         acrManagedIdentityType,
+        acrManagedIdentityPrincipalId: '',
       };
     }
   }

--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.ts
@@ -197,6 +197,10 @@ export const getArmToken = () => {
   return window.appsvc && window.appsvc.env.armToken ? `bearer ${window.appsvc.env.armToken}` : '';
 };
 
+export const getArmEndpoint = () => {
+  return window.appsvc && window.appsvc.env && window.appsvc.env.azureResourceManagerEndpoint;
+};
+
 export const getWorkflowFileName = (branch: string, siteName: string, slotName?: string): string => {
   const normalizedBranchName = branch.split('/').join('-');
   return slotName ? `${normalizedBranchName}_${siteName}(${slotName}).yml` : `${normalizedBranchName}_${siteName}.yml`;

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -231,6 +231,8 @@ export class CommonConstants {
   public static readonly production = 'production';
 
   public static readonly master = 'master';
+
+  public static readonly singleForwardSlash = '/';
 }
 
 export enum WorkerRuntimeLanguages {

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -38,6 +38,7 @@ export class CommonConstants {
     argApiVersion20210301: '2021-03-01',
     argApiVersion20180901Preview: '2018-09-01-preview',
     workflowApiVersion20201201: '2020-12-01',
+    roleAssignmentApiVersion20180701: '2018-07-01',
   };
 
   public static readonly NonThemeColors = {
@@ -251,6 +252,10 @@ export enum OverflowBehavior {
 
 export enum TextFieldType {
   password = 'password',
+}
+
+export enum RBACRoleId {
+  acrPull = '7f951dda-4ed3-4680-a7ca-43fe172d538d',
 }
 
 export class SubscriptionQuotaIds {

--- a/server/src/deployment-center/acr/acr.controller.ts
+++ b/server/src/deployment-center/acr/acr.controller.ts
@@ -46,10 +46,11 @@ export class ACRController {
       const urlString = `${armEndpoint}${scope}/providers/Microsoft.Authorization/roleAssignments?api-version=${apiVersion}`;
       const queryString = `&$filter=atScope()+and+assignedTo('{${principalId}}')`;
       const url = urlString + queryString;
-      const header = { Authorization: `${armToken}` };
 
-      const r = await this.httpService.get(url, { headers: header });
-      return r.data.value;
+      const r = await this.httpService.get(url, { headers: this._getARMAuthHeader(armToken) });
+      if (!!r.data) {
+        return r.data.value;
+      }
     } catch (err) {
       if (err.response) {
         throw new HttpException(err.response.statusText, err.response.status);
@@ -73,7 +74,6 @@ export class ACRController {
       const urlString = `${armEndpoint}${scope}/providers/Microsoft.Authorization/roleAssignments/${roleGuid}?api-version=${apiVersion}`;
       const queryString = `&$filter=atScope()+and+assignedTo('{${principalId}}')`;
       const url = urlString + queryString;
-      const header = { Authorization: `${armToken}` };
       const data = {
         properties: {
           roleDefinitionId: `${scope}/providers/Microsoft.Authorization/roleDefinitions/${roleId}`,
@@ -81,8 +81,10 @@ export class ACRController {
         },
       };
 
-      const r = await this.httpService.put(url, data, { headers: header });
-      return r.data.value;
+      const r = await this.httpService.put(url, data, { headers: this._getARMAuthHeader(armToken) });
+      if (!!r.data) {
+        return r.data.value;
+      }
     } catch (err) {
       if (err.response) {
         throw new HttpException(err.response.statusText, err.response.status);
@@ -94,6 +96,12 @@ export class ACRController {
   private _getACRAuthHeader(encodedUserInfo: string) {
     return {
       Authorization: `Basic ${encodedUserInfo}`,
+    };
+  }
+
+  private _getARMAuthHeader(armToken: string) {
+    return {
+      Authorization: `${armToken}`,
     };
   }
 

--- a/server/src/deployment-center/acr/acr.controller.ts
+++ b/server/src/deployment-center/acr/acr.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Post, Body, HttpException, HttpCode, Res } from '@nestjs/common';
 import { HttpService } from '../../shared/http/http.service';
+import { GUID } from '../../utilities/guid';
 
 @Controller()
 export class ACRController {
@@ -30,6 +31,64 @@ export class ACRController {
       ? `https://${loginServer}/v2/${repository}/tags/list`
       : `https://${loginServer}/v2/${repository}/tags/list?last=${last}&n=100&orderby=`;
     await this._makeGetCallWithLinkHeader(url, encodedUserInfo, res);
+  }
+
+  @Post('api/acr/getRoleAssignments')
+  @HttpCode(200)
+  async getRoleAssignments(
+    @Body('armEndpoint') armEndpoint: string,
+    @Body('armToken') armToken: string,
+    @Body('apiVersion') apiVersion: string,
+    @Body('scope') scope: string,
+    @Body('principalId') principalId?: string
+  ) {
+    try {
+      const urlString = `${armEndpoint}${scope}/providers/Microsoft.Authorization/roleAssignments?api-version=${apiVersion}`;
+      const queryString = `&$filter=atScope()+and+assignedTo('{${principalId}}')`;
+      const url = urlString + queryString;
+      const header = { Authorization: `${armToken}` };
+
+      const r = await this.httpService.get(url, { headers: header });
+      return r.data.value;
+    } catch (err) {
+      if (err.response) {
+        throw new HttpException(err.response.statusText, err.response.status);
+      }
+      throw new HttpException(err, 500);
+    }
+  }
+
+  @Post('api/acr/setRoleAssignment')
+  @HttpCode(200)
+  async setRoleAssignments(
+    @Body('armEndpoint') armEndpoint: string,
+    @Body('armToken') armToken: string,
+    @Body('apiVersion') apiVersion: string,
+    @Body('scope') scope: string,
+    @Body('principalId') principalId: string,
+    @Body('roleId') roleId: string
+  ) {
+    try {
+      const roleGuid = GUID.newGuid();
+      const urlString = `${armEndpoint}${scope}/providers/Microsoft.Authorization/roleAssignments/${roleGuid}?api-version=${apiVersion}`;
+      const queryString = `&$filter=atScope()+and+assignedTo('{${principalId}}')`;
+      const url = urlString + queryString;
+      const header = { Authorization: `${armToken}` };
+      const data = {
+        properties: {
+          roleDefinitionId: `${scope}/providers/Microsoft.Authorization/roleDefinitions/${roleId}`,
+          principalId: `${principalId}`,
+        },
+      };
+
+      const r = await this.httpService.put(url, data, { headers: header });
+      return r.data.value;
+    } catch (err) {
+      if (err.response) {
+        throw new HttpException(err.response.statusText, err.response.status);
+      }
+      throw new HttpException(err, 500);
+    }
   }
 
   private _getACRAuthHeader(encodedUserInfo: string) {


### PR DESCRIPTION
Task [12677090](https://msazure.visualstudio.com/Antares/_workitems/edit/12677090)

- Gets role assignments on ACR scope for the selected user-assigned managed identity
  - If it has ACR Pull permissions, great :)
  - If not, we assign it ACR Pull permissions

**Role assignments before:**
![image](https://user-images.githubusercontent.com/29874289/144470884-26f194da-897b-414c-bf04-a892567719fb.png)

Checking to see if yo-user-assigned-mi2 has AcrPull permissions, which it doesn't, so it sets AcrPull permissions.
![change ua identity](https://user-images.githubusercontent.com/29874289/144471462-950d7cf4-b465-4463-9326-c2462af8a8fb.gif)

**Role assignments after:**
![image](https://user-images.githubusercontent.com/29874289/144471324-686b3e75-6b26-4a0c-b69b-ba6e8550cc1a.png)
 
