### PR TITLE
[DC] Unhide enabling azure repos for linux and fix add identity string

### DIFF
--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -59,7 +59,6 @@ export class CommonConstants {
     enableKubeScenarioForTesting: 'enableKubeScenarioForTesting',
     enablePortalEditing: 'enablePortalEditing',
     disablePortalEditing: 'disablePortalEditing',
-    enableAzureReposForLinux: 'enableAzureReposForLinux',
     enterpriseGradeEdgeItemVisible: 'enterpriseGradeEdgeItemVisible',
     makeCallThroughPortal: 'makeCallThroughPortal',
     useStackApiForRuntimeVersion: 'useStackApiForRuntimeVersion',

--- a/client-react/src/utils/scenario-checker/linux-site.environment.ts
+++ b/client-react/src/utils/scenario-checker/linux-site.environment.ts
@@ -1,8 +1,6 @@
 import { ScenarioIds } from './scenario-ids';
 import { ScenarioCheckInput, ScenarioResult, Environment } from './scenario.models';
 import { isLinuxApp } from '../arm-utils';
-import Url from '../url';
-import { CommonConstants } from '../CommonConstants';
 
 export class LinuxSiteEnvironment extends Environment {
   public name = 'LinuxSite';
@@ -86,9 +84,7 @@ export class LinuxSiteEnvironment extends Environment {
 
     this.scenarioChecks[ScenarioIds.vstsKuduSource] = {
       id: ScenarioIds.vstsKuduSource,
-      runCheck: () => ({
-        status: !!Url.getFeatureValue(CommonConstants.FeatureFlags.enableAzureReposForLinux) ? 'enabled' : 'disabled',
-      }),
+      runCheck: () => ({ status: 'enabled' }),
     };
 
     this.scenarioChecks[ScenarioIds.onedriveSource] = {

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7230,4 +7230,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="acrCredentialsWarningMessage" xml:space="preserve">
         <value>Cannot access ACR '{0}' because admin credentials on ACR are disabled, and no managed identity is assigned. Either enable admin credentials, or assign a managed identity below.</value>
     </data>
+    <data name="addIdentity" xml:space="preserve">
+        <value>Add identity</value>
+    </data>
 </root>


### PR DESCRIPTION
Completed testing for https://github.com/Azure/azure-functions-ux/pull/6312 and removing the feature flag

Fixed addIdentity link string in Identity ComboBox
Before: 
![image](https://user-images.githubusercontent.com/29874289/145308241-8208ce6f-aaff-4a90-85bf-ecc29f7749d9.png)


After:
![image](https://user-images.githubusercontent.com/29874289/145308207-a0e1b4fc-96b1-416f-b778-475fd8527655.png)
