### PR TITLE
12843728 [Daily Feedback] [Config Blade] Exclusion path spelling miss on the config blade

### DIFF
--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -5025,7 +5025,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>Certificate exclusion paths</value>
     </data>
     <data name="editCertificateExlusionPaths" xml:space="preserve">
-        <value>edit client eclusion paths</value>
+        <value>edit client exclusion paths</value>
         <comment>This is meant for aria-labeling, not visual</comment>
     </data>
     <data name="noExclusionRulesDefined" xml:space="preserve">


### PR DESCRIPTION
**Fixed spelling here:**
![image](https://user-images.githubusercontent.com/30202258/146090555-0459e9fd-1589-4662-a943-8c3cec8aa01c.png)


**Before:**
![image](https://user-images.githubusercontent.com/30202258/146090786-97b5c929-e3ce-4dc8-991c-39a19b181740.png)
