### PR TITLE
[DC] Enable System Assigned Identity and fix hasAcrPullPermission return value

### DIFF
--- a/client-react/src/ApiHelpers/ACRService.ts
+++ b/client-react/src/ApiHelpers/ACRService.ts
@@ -129,24 +129,37 @@ export default class ACRService {
     return response.metadata.success;
   }
 
-  public static async enableSystemAssignedIdentity(resourceId: string, userAssignedIdentities: KeyValue<KeyValue<string>>) {
-    const userAssignedIdentitiesObj = {};
-    for (const identity in userAssignedIdentities) {
-      userAssignedIdentitiesObj[identity] = {};
-    }
-
+  public static async enableSystemAssignedIdentity(
+    resourceId: string,
+    userAssignedIdentities?: KeyValue<KeyValue<string>>,
+    apiVersion: string = CommonConstants.ApiVersions.enableSystemAssignedIdentityApiVersion20210201
+  ) {
     return MakeArmCall({
       resourceId: resourceId,
       commandName: 'enableSystemAssignedIdentity',
       method: 'PATCH',
-      apiVersion: CommonConstants.ApiVersions.enableSystemAssignedIdentityApiVersion20210201,
+      apiVersion: apiVersion,
       body: {
-        identity: {
-          type: ACRManagedIdentityType.systemAssigned + ', ' + ACRManagedIdentityType.userAssigned,
-          userAssignedIdentities: userAssignedIdentitiesObj,
-        },
+        identity: this._getIdentity(userAssignedIdentities),
       },
     });
+  }
+
+  private static _getIdentity(userAssignedIdentities?: KeyValue<KeyValue<string>>) {
+    if (!!userAssignedIdentities) {
+      const userAssignedIdentitiesObj = {};
+      for (const identity in userAssignedIdentities) {
+        userAssignedIdentitiesObj[identity] = {};
+      }
+      return {
+        type: ACRManagedIdentityType.systemAssigned + ', ' + ACRManagedIdentityType.userAssigned,
+        userAssignedIdentities: userAssignedIdentitiesObj,
+      };
+    } else {
+      return {
+        type: ACRManagedIdentityType.systemAssigned,
+      };
+    }
   }
 
   private static async _dispatchSpecificPageableRequest<T>(

--- a/client-react/src/ApiHelpers/ACRService.ts
+++ b/client-react/src/ApiHelpers/ACRService.ts
@@ -7,7 +7,8 @@ import { getLastItemFromLinks, getLinksFromLinkHeader, sendHttpRequest } from '.
 import Url from '../utils/url';
 import { Method } from 'axios';
 import { getArmEndpoint, getArmToken } from '../pages/app/deployment-center/utility/DeploymentCenterUtility';
-import { RoleAssignment } from '../pages/app/deployment-center/DeploymentCenter.types';
+import { ACRManagedIdentityType, RoleAssignment } from '../pages/app/deployment-center/DeploymentCenter.types';
+import { KeyValue } from '../models/portal-models';
 
 export default class ACRService {
   public static getRegistries(subscriptionId: string) {
@@ -76,18 +77,19 @@ export default class ACRService {
   }
 
   public static async hasAcrPullPermission(acrResourceId: string, principalId: string) {
+    let hasAcrPullPermission = false;
     const roleAssignments = await this.getRoleAssignments(acrResourceId, principalId);
     if (!!roleAssignments && roleAssignments.length > 0) {
       roleAssignments.forEach(roleAssignment => {
         const roleDefinitionSplit = roleAssignment.properties.roleDefinitionId.split(CommonConstants.singleForwardSlash);
         const roleId = roleDefinitionSplit[roleDefinitionSplit.length - 1];
         if (roleId === RBACRoleId.acrPull) {
-          return true;
+          hasAcrPullPermission = true;
         }
       });
     }
 
-    return false;
+    return hasAcrPullPermission;
   }
 
   public static async getRoleAssignments(
@@ -125,6 +127,26 @@ export default class ACRService {
     });
 
     return response.metadata.success;
+  }
+
+  public static async enableSystemAssignedIdentity(resourceId: string, userAssignedIdentities: KeyValue<KeyValue<string>>) {
+    const userAssignedIdentitiesObj = {};
+    for (const identity in userAssignedIdentities) {
+      userAssignedIdentitiesObj[identity] = {};
+    }
+
+    return MakeArmCall({
+      resourceId: resourceId,
+      commandName: 'enableSystemAssignedIdentity',
+      method: 'PATCH',
+      apiVersion: CommonConstants.ApiVersions.enableSystemAssignedIdentityApiVersion20210201,
+      body: {
+        identity: {
+          type: ACRManagedIdentityType.systemAssigned + ', ' + ACRManagedIdentityType.userAssigned,
+          userAssignedIdentities: userAssignedIdentitiesObj,
+        },
+      },
+    });
   }
 
   private static async _dispatchSpecificPageableRequest<T>(

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
@@ -278,7 +278,7 @@ export default class DeploymentCenterData {
     return ACRService.setAcrPullPermission(acrResourceId, principalId);
   };
 
-  public enableSystemAssignedIdentity = (resourceId: string, userAssignedIdentities: KeyValue<KeyValue<string>>) => {
+  public enableSystemAssignedIdentity = (resourceId: string, userAssignedIdentities?: KeyValue<KeyValue<string>>) => {
     return ACRService.enableSystemAssignedIdentity(resourceId, userAssignedIdentities);
   };
 

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
@@ -278,6 +278,10 @@ export default class DeploymentCenterData {
     return ACRService.setAcrPullPermission(acrResourceId, principalId);
   };
 
+  public enableSystemAssignedIdentity = (resourceId: string, userAssignedIdentities: KeyValue<KeyValue<string>>) => {
+    return ACRService.enableSystemAssignedIdentity(resourceId, userAssignedIdentities);
+  };
+
   public updateSiteConfig = (resourceId: string, config: ArmObj<SiteConfig>) => {
     return SiteService.updateWebConfig(resourceId, config);
   };

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -151,8 +151,8 @@ export enum ACRCredentialType {
 }
 
 export enum ACRManagedIdentityType {
-  systemAssigned = 'systemAssigned',
-  userAssigned = 'userAssigned',
+  systemAssigned = 'SystemAssigned',
+  userAssigned = 'UserAssigned',
 }
 
 export enum ManagedIdentityInfo {

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -39,6 +39,7 @@ export class CommonConstants {
     argApiVersion20180901Preview: '2018-09-01-preview',
     workflowApiVersion20201201: '2020-12-01',
     roleAssignmentApiVersion20180701: '2018-07-01',
+    enableSystemAssignedIdentityApiVersion20210201: '2021-02-01',
   };
 
   public static readonly NonThemeColors = {
@@ -234,6 +235,10 @@ export class CommonConstants {
   public static readonly master = 'master';
 
   public static readonly singleForwardSlash = '/';
+
+  public static readonly comma = ',';
+
+  public static readonly space = ' ';
 }
 
 export enum WorkerRuntimeLanguages {


### PR DESCRIPTION
Task [12677872 ](https://msazure.visualstudio.com/Antares/_workitems/edit/12677872)

**Changes summary:**

- If System Assigned identity type has been selected, it will check to see if System Assigned identity is enabled.
- If not enabled, it will enable through a PATCH call, making sure any added User Assigned identities are also included.
- hasAcrPullPermission previously returned false all the time because in the forEach bracket of roleAssignments returned true within that bracket instead of the entire function (replaced with hasAcrPullPermission boolean)

**Tested:**

- When no managed identities are assigned to app
- When only user assigned identities are assigned to app
- When system assigned identity is already enabled on app