### PR TITLE
[DC] Add break condition in while loop for ACR requests

### DIFF
--- a/client-react/src/ApiHelpers/ACRService.ts
+++ b/client-react/src/ApiHelpers/ACRService.ts
@@ -185,6 +185,7 @@ export default class ACRService {
         }
       } else if (logger) {
         logger(nextLink, pageResponse);
+        break;
       }
     } while (nextLink);
 


### PR DESCRIPTION
FixesAB#[12875797 ](https://msazure.visualstudio.com/Antares/_workitems/edit/12875797)

Telemetry throttling thought to be produced by while loop in _dispatchSpecificPageableRequest(), which is used in getAcrRegistries, getAcrRepositories, and getAcrTags