### PR TITLE
Remove preview from PowerShell on Linux runtime

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/function-app-stacks/Powershell.ts
+++ b/server/src/stacks/2020-06-01/stacks/function-app-stacks/Powershell.ts
@@ -36,7 +36,7 @@ export const powershellStack: FunctionAppStack = {
             linuxRuntimeSettings: {
               runtimeVersion: 'PowerShell|7',
               remoteDebuggingSupported: false,
-              isPreview: true,
+              isPreview: false,
               isHidden: false,
               appInsightsSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
@@ -39,7 +39,7 @@ const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (use
               linuxRuntimeSettings: {
                 runtimeVersion: 'PowerShell|7',
                 isAutoUpdate: true,
-                isPreview: true,
+                isPreview: false,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,


### PR DESCRIPTION
This PR contains the following changes:

* Removed Preview from PowerShell on Linux stack definition for 2020-06-01 
* Removed Preview from PowerShell on Linux stack definition for 2020-10-01 