### PR TITLE
ANT 96 Java stacks update

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Java.ts
@@ -50,6 +50,39 @@ export const javaStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java 11.0.12',
+          value: '11.0.12',
+          stackSettings: {
+            linuxRuntimeSettings: {
+              // Note (allisonm): Runtime on Linux Java is determined by the Java container
+              runtimeVersion: '',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+                isDefaultOff: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '11',
+              },
+              endOfLifeDate: java11EOL,
+            },
+            windowsRuntimeSettings: {
+              runtimeVersion: '11.0.12',
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+                isDefaultOff: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '11',
+              },
+              endOfLifeDate: java11EOL,
+            },
+          },
+        },
+        {
           displayText: 'Java 11.0.11',
           value: '11.0.11',
           stackSettings: {
@@ -301,6 +334,25 @@ export const javaStack: WebAppStack = {
             windowsRuntimeSettings: {
               runtimeVersion: '1.8',
               isAutoUpdate: true,
+              remoteDebuggingSupported: false,
+              appInsightsSettings: {
+                isSupported: true,
+                isDefaultOff: true,
+              },
+              gitHubActionSettings: {
+                isSupported: true,
+                supportedVersion: '8',
+              },
+              endOfLifeDate: java8EOL,
+            },
+          },
+        },
+        {
+          displayText: 'Java 1.8.0_302',
+          value: '8.0.302',
+          stackSettings: {
+            windowsRuntimeSettings: {
+              runtimeVersion: '1.8.0_302',
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
@@ -26,6 +26,16 @@ export const javaContainersStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java SE 11.0.12',
+          value: '11.0.12',
+          stackSettings: {
+            linuxContainerSettings: {
+              // Note (jafreebe): This doesn't have suffix of -java11 since setting to 11.0.8 prevents auto-updates
+              java11Runtime: 'JAVA|11.0.12',
+            },
+          },
+        },
+        {
           displayText: 'Java SE 11.0.11',
           value: '11.0.11',
           stackSettings: {
@@ -76,8 +86,18 @@ export const javaContainersStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java SE 8u302',
+          // note (jafreebe): Java SE 8u302 is pinned version that maps to the below value
+          value: '1.8.302',
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: 'JAVA|8u302',
+            },
+          },
+        },
+        {
           displayText: 'Java SE 8u292',
-          // note (jafreebe): Java SE 8u242 is pinned version that maps to the below value
+          // note (jafreebe): Java SE 8u292 is pinned version that maps to the below value
           value: '1.8.292',
           stackSettings: {
             linuxContainerSettings: {
@@ -87,7 +107,7 @@ export const javaContainersStack: WebAppStack = {
         },
         {
           displayText: 'Java SE 8u275',
-          // note (jafreebe): Java SE 8u272 is pinned version that maps to the below value
+          // note (jafreebe): Java SE 8u275 is pinned version that maps to the below value
           value: '1.8.275',
           stackSettings: {
             linuxContainerSettings: {
@@ -181,6 +201,20 @@ export const javaContainersStack: WebAppStack = {
               java11Runtime: 'TOMCAT|9.0-java11',
               java8Runtime: 'TOMCAT|9.0-jre8',
               isAutoUpdate: true,
+            },
+          },
+        },
+        {
+          displayText: 'Tomcat 9.0.52',
+          value: '9.0.52',
+          stackSettings: {
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '9.0.52',
+            },
+            linuxContainerSettings: {
+              java8Runtime: 'TOMCAT|9.0.52-java8',
+              java11Runtime: 'TOMCAT|9.0.52-java11',
             },
           },
         },
@@ -341,6 +375,20 @@ export const javaContainersStack: WebAppStack = {
               java11Runtime: 'TOMCAT|8.5-java11',
               java8Runtime: 'TOMCAT|8.5-jre8',
               isAutoUpdate: true,
+            },
+          },
+        },
+        {
+          displayText: 'Tomcat 8.5.69',
+          value: '8.5.69',
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: 'TOMCAT|8.5.69-java8',
+              java11Runtime: 'TOMCAT|8.5.69-java11',
+            },
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '8.5.69',
             },
           },
         },

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
@@ -52,6 +52,39 @@ const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
             },
           },
           {
+            displayText: 'Java 11.0.12',
+            value: '11.0.12',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (allisonm): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
+              },
+              windowsRuntimeSettings: {
+                runtimeVersion: '11.0.12',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
+              },
+            },
+          },
+          {
             displayText: 'Java 11.0.11',
             value: '11.0.11',
             stackSettings: {
@@ -303,6 +336,25 @@ const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
               windowsRuntimeSettings: {
                 runtimeVersion: '1.8',
                 isAutoUpdate: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_302',
+            value: '8.0.302',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_302',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -26,6 +26,16 @@ export const javaContainersStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java SE 11.0.12',
+          value: '11.0.12',
+          stackSettings: {
+            linuxContainerSettings: {
+              // Note (jafreebe): This doesn't have suffix of -java11 since setting to 11.0.8 prevents auto-updates
+              java11Runtime: 'JAVA|11.0.12',
+            },
+          },
+        },
+        {
           displayText: 'Java SE 11.0.11',
           value: '11.0.11',
           stackSettings: {
@@ -76,8 +86,18 @@ export const javaContainersStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java SE 8u302',
+          // note (jafreebe): Java SE 8u302 is pinned version that maps to the below value
+          value: '1.8.302',
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: 'JAVA|8u302',
+            },
+          },
+        },
+        {
           displayText: 'Java SE 8u292',
-          // note (jafreebe): Java SE 8u242 is pinned version that maps to the below value
+          // note (jafreebe): Java SE 8u292 is pinned version that maps to the below value
           value: '1.8.292',
           stackSettings: {
             linuxContainerSettings: {
@@ -128,7 +148,7 @@ export const javaContainersStack: WebAppStack = {
       ],
     },
     {
-      displayText: 'JBoss EAP',
+      displayText: 'Red Hat JBoss EAP',
       value: 'jbosseap',
       minorVersions: [
         {
@@ -165,7 +185,7 @@ export const javaContainersStack: WebAppStack = {
       ],
     },
     {
-      displayText: 'Tomcat 9.0',
+      displayText: 'Apache Tomcat 9.0',
       value: 'tomcat9.0',
       minorVersions: [
         {
@@ -181,6 +201,20 @@ export const javaContainersStack: WebAppStack = {
               java11Runtime: 'TOMCAT|9.0-java11',
               java8Runtime: 'TOMCAT|9.0-jre8',
               isAutoUpdate: true,
+            },
+          },
+        },
+        {
+          displayText: 'Tomcat 9.0.52',
+          value: '9.0.52',
+          stackSettings: {
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '9.0.52',
+            },
+            linuxContainerSettings: {
+              java8Runtime: 'TOMCAT|9.0.52-java8',
+              java11Runtime: 'TOMCAT|9.0.52-java11',
             },
           },
         },
@@ -325,7 +359,7 @@ export const javaContainersStack: WebAppStack = {
       ],
     },
     {
-      displayText: 'Tomcat 8.5',
+      displayText: 'Apache Tomcat 8.5',
       value: 'tomcat8.5',
       minorVersions: [
         {
@@ -341,6 +375,20 @@ export const javaContainersStack: WebAppStack = {
               java11Runtime: 'TOMCAT|8.5-java11',
               java8Runtime: 'TOMCAT|8.5-jre8',
               isAutoUpdate: true,
+            },
+          },
+        },
+        {
+          displayText: 'Tomcat 8.5.69',
+          value: '8.5.69',
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: 'TOMCAT|8.5.69-java8',
+              java11Runtime: 'TOMCAT|8.5.69-java11',
+            },
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '8.5.69',
             },
           },
         },
@@ -495,7 +543,7 @@ export const javaContainersStack: WebAppStack = {
       ],
     },
     {
-      displayText: 'Tomcat 8.0',
+      displayText: 'Apache Tomcat 8.0',
       value: 'tomcat8.0',
       minorVersions: [
         {
@@ -557,6 +605,7 @@ export const javaContainersStack: WebAppStack = {
               javaContainer: 'TOMCAT',
               javaContainerVersion: '7.0',
               isAutoUpdate: true,
+              isDeprecated: true,
             },
           },
         },
@@ -567,6 +616,7 @@ export const javaContainersStack: WebAppStack = {
             windowsContainerSettings: {
               javaContainer: 'TOMCAT',
               javaContainerVersion: '7.0.94',
+              isDeprecated: true,
             },
           },
         },
@@ -577,6 +627,7 @@ export const javaContainersStack: WebAppStack = {
             windowsContainerSettings: {
               javaContainer: 'TOMCAT',
               javaContainerVersion: '7.0.81',
+              isDeprecated: true,
             },
           },
         },
@@ -587,6 +638,7 @@ export const javaContainersStack: WebAppStack = {
             windowsContainerSettings: {
               javaContainer: 'TOMCAT',
               javaContainerVersion: '7.0.62',
+              isDeprecated: true,
             },
           },
         },
@@ -597,6 +649,7 @@ export const javaContainersStack: WebAppStack = {
             windowsContainerSettings: {
               javaContainer: 'TOMCAT',
               javaContainerVersion: '7.0.50',
+              isDeprecated: true,
             },
           },
         },


### PR DESCRIPTION
Add entries for these stacks:
- Java 1.8.0_302 and 11.0.12
- Tomcat 8.5.69 and 9.0.52

Also, add "Apache" branding to Tomcat, and "Red Hat" branding to JBoss

(JBoss 7.3.8 was added in ANT 96, but only for the Auto-Update 7.3 lane. There's no entry for it in Available Stacks. Starting in ANT 97 we will update the available stacks for JBoss to match Tomcat's format: we'll Jave an auto-update lane for "JBoss 7" which will patch version options (7.3.8, 7.3.9, 7.4.0, 7.4.1, etc.)