### PR TITLE
[HOTFIX] Unhide Node 16 LTS for Windows and remove earlyAccess flag for Linux

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
@@ -48,7 +48,6 @@ export const nodeStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'NODE|16-lts',
-              isHidden: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
@@ -61,7 +60,6 @@ export const nodeStack: WebAppStack = {
             },
             windowsRuntimeSettings: {
               runtimeVersion: '~16',
-              isHidden: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
@@ -59,11 +59,9 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                   supportedVersion: '16.x',
                 },
                 endOfLifeDate: node16EOL,
-                isEarlyAccess: true,
               },
               windowsRuntimeSettings: {
                 runtimeVersion: '~16',
-                isHidden: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,


### PR DESCRIPTION
**BEFORE**

![image](https://user-images.githubusercontent.com/5387224/150212418-f8dba36e-63fa-448d-8916-87ed3ea9eeae.png)


**AFTER**

![image](https://user-images.githubusercontent.com/5387224/150212512-62b57ffb-2fed-4d65-8647-46706b04e33c.png)
