### PR TITLE
[DC] Remove server url from full image and tag if present

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -117,16 +117,30 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
 
   const getDockerFxVersion = (prefix: string, values: DeploymentCenterFormData<DeploymentCenterContainerFormData>) => {
     if (values.registrySource === ContainerRegistrySources.acr) {
-      return `${prefix}|${values.acrLoginServer}/${values.acrImage}:${values.acrTag}`;
+      const serverImageTag = formatServerImageTag(values.acrLoginServer, `${values.acrImage}:${values.acrTag}`);
+      return `${prefix}|${serverImageTag}`;
     } else if (values.registrySource === ContainerRegistrySources.privateRegistry) {
       const server = values.privateRegistryServerUrl
         .toLocaleLowerCase()
-        .replace('https://', '')
+        .replace(CommonConstants.DeploymentCenterConstants.https, '')
         .replace(/\/+$/, '');
-      return `${prefix}|${server}/${values.privateRegistryImageAndTag}`;
+      const serverImageTag = formatServerImageTag(server, values.privateRegistryImageAndTag);
+      return `${prefix}|${serverImageTag}`;
     } else {
       return `${prefix}|${values.dockerHubImageAndTag}`;
     }
+  };
+
+  const formatServerImageTag = (server: string, imageAndTag: string) => {
+    const imageAndTagWithoutScheme = imageAndTag
+      .replace(CommonConstants.DeploymentCenterConstants.https, '')
+      .replace(CommonConstants.DeploymentCenterConstants.http, '');
+    const imageAndTagParts = imageAndTagWithoutScheme.split(CommonConstants.singleForwardSlash);
+    let formattedImageAndTag = imageAndTagWithoutScheme;
+    if (imageAndTagParts[0] === server) {
+      formattedImageAndTag = imageAndTagParts.slice(1).join(CommonConstants.singleForwardSlash);
+    }
+    return `${server}/${formattedImageAndTag}`;
   };
 
   const getFxVersionPrefix = (values: DeploymentCenterFormData<DeploymentCenterContainerFormData>): string => {


### PR DESCRIPTION
Task [11716779](https://msazure.visualstudio.com/Antares/_workitems/edit/11716779)

**Before:**
- if user included server url for image and tag, the fx version would have the server url appended twice

for server url: https://mcr.microsoft.com
for image and tag: mcr.microsoft.com/windows/servercore/iis:windowsservercore-20H2

**Without https://**
![image](https://user-images.githubusercontent.com/29874289/151423597-c7e2136d-a597-49d5-b1e7-3dffa2ee1aad.png)
![image](https://user-images.githubusercontent.com/29874289/151423625-713d1abd-2bfc-47b0-851a-6edfc4fcb5a1.png)

**With https://**
![image](https://user-images.githubusercontent.com/29874289/151423654-1212a44d-6e9c-41f3-a0bd-615ca218a756.png)
![image](https://user-images.githubusercontent.com/29874289/151423666-d1774051-57a6-4ea9-8017-1a7870549e50.png)

**After:**
- for with and without https:// or http:// 
![image](https://user-images.githubusercontent.com/29874289/151423703-0867dac3-03bf-4083-8838-c172e68febc3.png)

Also tested with ACR registry source