### PR TITLE
Update primary and default buttons to use disabledText color when disabled

### DIFF
--- a/client-react/src/theme/light.ts
+++ b/client-react/src/theme/light.ts
@@ -156,7 +156,7 @@ const semanticColors = {
   buttonTextChecked: AzurePortalColors.background,
   buttonTextCheckedHovered: AzurePortalColors.background,
   buttonTextPressed: AzurePortalColors.background,
-  buttonTextDisabled: AzurePortalColors.background,
+  buttonTextDisabled: AzurePortalColors.disabledText,
   buttonBorderDisabled: 'transparent',
 
   primaryButtonBackground: AzurePortalColors.buttonRest,
@@ -169,7 +169,7 @@ const semanticColors = {
   primaryButtonText: AzurePortalColors.background,
   primaryButtonTextHovered: AzurePortalColors.background,
   primaryButtonTextPressed: AzurePortalColors.background,
-  primaryButtonTextDisabled: AzurePortalColors.background,
+  primaryButtonTextDisabled: AzurePortalColors.disabledText,
 
   menuBackground: AzurePortalColors.background,
   menuDivider: AzurePortalColors.sectionDividerScrollbar,


### PR DESCRIPTION
FixesAB #[13113757](https://msazure.visualstudio.com/Antares/_workitems/edit/13113757)

**Before:**
**Light**
<img width="1120" alt="before light" src="https://user-images.githubusercontent.com/29874289/152242098-55b6b89b-9e2c-4c86-b20a-f37b3b619e8b.png">

**Dark**  (making sure it's readable, and it already was)
<img width="1120" alt="before dark" src="https://user-images.githubusercontent.com/29874289/152242123-2a118122-2f4f-465b-a258-f783bfbaa71c.png">


**After:
DC buttons**
![after light](https://user-images.githubusercontent.com/29874289/152242167-ab8f0693-5c26-49b3-a986-0b07a63700b4.png)

**Create App Plan buttons** (making sure other pages' buttons when disabled are readable)
<img width="1274" alt="after asp" src="https://user-images.githubusercontent.com/29874289/152242182-73d04fa8-5067-41eb-9c51-bd9c31fc62fb.png">

Function blade buttons when disabled
![image](https://user-images.githubusercontent.com/29874289/152247577-4c8c7170-3248-46e2-9094-01367c068ac9.png)