### PR TITLE
12677951[Daily mail] Uploading empty functions.json file breaks code+test

### DIFF
--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
@@ -115,7 +115,8 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
   const [logPanelHeight, setLogPanelHeight] = useState(0);
   const [selectedLoggingOption, setSelectedLoggingOption] = useState<LoggingOptions | undefined>(undefined);
   const [liveLogsSessionId, setLiveLogsSessionId] = useState<undefined | string>(undefined);
-  const [isValidFileSelected, setIsValidFileSelected] = useState<boolean | undefined>(undefined);
+  const [showInvalidFileSelectedWarning, setShowInvalidFileSelectedWarning] = useState<boolean | undefined>(undefined);
+  const [selectedFileName, setSelectedFileName] = useState<string>('');
 
   const { t } = useTranslation();
 
@@ -137,7 +138,7 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
       return;
     }
 
-    resetIsValidFileSelectedValue();
+    resetInvalidFileSelectedWarningAndFileName();
 
     portalCommunicator.log({
       action: 'functionEditor',
@@ -173,7 +174,7 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
   };
 
   const test = () => {
-    resetIsValidFileSelectedValue();
+    resetInvalidFileSelectedWarningAndFileName();
     setShowTestPanel(true);
   };
 
@@ -334,7 +335,7 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
   const onCancelButtonClick = () => {
     setSelectedDropdownOption(undefined);
     setShowDiscardConfirmDialog(false);
-    resetIsValidFileSelectedValue();
+    resetInvalidFileSelectedWarningAndFileName();
   };
 
   const getHeaderContent = (): JSX.Element => {
@@ -452,9 +453,10 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
     return SiteHelper.isFunctionAppReadOnly(appEditState);
   };
 
-  const resetIsValidFileSelectedValue = () => {
-    if (isValidFileSelected !== undefined) {
-      setIsValidFileSelected(undefined);
+  const resetInvalidFileSelectedWarningAndFileName = () => {
+    if (showInvalidFileSelectedWarning !== undefined) {
+      setShowInvalidFileSelectedWarning(undefined);
+      setSelectedFileName('');
     }
   };
 
@@ -478,8 +480,13 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
           learnMoreLink={Links.setupLocalFunctionEnvironment}
         />
       );
-    } else if (isValidFileSelected !== undefined && !isValidFileSelected) {
-      return <CustomBanner message={t('invalidFileSelectedWarning')} type={MessageBarType.warning} />;
+    } else if (showInvalidFileSelectedWarning !== undefined && showInvalidFileSelectedWarning) {
+      return (
+        <CustomBanner
+          message={!!selectedFileName ? t('invalidFileSelectedWarning').format(selectedFileName) : t('validFileShouldBeSelectedWarning')}
+          type={MessageBarType.warning}
+        />
+      );
     } else {
       return <></>;
     }
@@ -502,7 +509,7 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
       fetchData();
     }
 
-    resetIsValidFileSelectedValue();
+    resetInvalidFileSelectedWarningAndFileName();
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isRefreshing]);
@@ -530,8 +537,9 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
           functionInfo={functionInfo}
           runtimeVersion={runtimeVersion}
           upload={uploadFile}
-          setIsValidFileSelected={setIsValidFileSelected}
-          resetIsValidFileSelectedValue={resetIsValidFileSelectedValue}
+          setShowInvalidFileSelectedWarning={setShowInvalidFileSelectedWarning}
+          setSelectedFileName={setSelectedFileName}
+          resetInvalidFileSelectedWarningAndFileName={resetInvalidFileSelectedWarningAndFileName}
         />
         <ConfirmDialog
           primaryActionButton={{

--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
@@ -115,6 +115,7 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
   const [logPanelHeight, setLogPanelHeight] = useState(0);
   const [selectedLoggingOption, setSelectedLoggingOption] = useState<LoggingOptions | undefined>(undefined);
   const [liveLogsSessionId, setLiveLogsSessionId] = useState<undefined | string>(undefined);
+  const [isValidFileSelected, setIsValidFileSelected] = useState<boolean | undefined>(undefined);
 
   const { t } = useTranslation();
 
@@ -135,6 +136,8 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
     if (!selectedFile) {
       return;
     }
+
+    resetIsValidFileSelectedValue();
 
     portalCommunicator.log({
       action: 'functionEditor',
@@ -170,6 +173,7 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
   };
 
   const test = () => {
+    resetIsValidFileSelectedValue();
     setShowTestPanel(true);
   };
 
@@ -330,6 +334,7 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
   const onCancelButtonClick = () => {
     setSelectedDropdownOption(undefined);
     setShowDiscardConfirmDialog(false);
+    resetIsValidFileSelectedValue();
   };
 
   const getHeaderContent = (): JSX.Element => {
@@ -447,6 +452,12 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
     return SiteHelper.isFunctionAppReadOnly(appEditState);
   };
 
+  const resetIsValidFileSelectedValue = () => {
+    if (isValidFileSelected !== undefined) {
+      setIsValidFileSelected(undefined);
+    }
+  };
+
   const getBanner = (): JSX.Element => {
     /* NOTE (krmitta): Show the read-only banner first, instead of showing the Generic Runtime failure method */
     if (isAppReadOnly(siteStateContext.siteAppEditState)) {
@@ -467,6 +478,8 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
           learnMoreLink={Links.setupLocalFunctionEnvironment}
         />
       );
+    } else if (isValidFileSelected !== undefined && !isValidFileSelected) {
+      return <CustomBanner message={t('invalidFileSelectedWarning')} type={MessageBarType.warning} />;
     } else {
       return <></>;
     }
@@ -488,6 +501,8 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
     if (!isRefreshing && !initialLoading) {
       fetchData();
     }
+
+    resetIsValidFileSelectedValue();
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isRefreshing]);
@@ -515,6 +530,8 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
           functionInfo={functionInfo}
           runtimeVersion={runtimeVersion}
           upload={uploadFile}
+          setIsValidFileSelected={setIsValidFileSelected}
+          resetIsValidFileSelectedValue={resetIsValidFileSelectedValue}
         />
         <ConfirmDialog
           primaryActionButton={{

--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditorCommandBar.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditorCommandBar.tsx
@@ -22,8 +22,9 @@ interface FunctionEditorCommandBarProps {
   testFunction: () => void;
   refreshFunction: () => void;
   upload: (file: any) => void;
-  setIsValidFileSelected: (isValid: boolean | undefined) => void;
-  resetIsValidFileSelectedValue: () => void;
+  setShowInvalidFileSelectedWarning: (isValid: boolean | undefined) => void;
+  setSelectedFileName: (fileName: string) => void;
+  resetInvalidFileSelectedWarningAndFileName: () => void;
   isGetFunctionUrlVisible: boolean;
   dirty: boolean;
   disabled: boolean;
@@ -47,8 +48,9 @@ const FunctionEditorCommandBar: React.FC<FunctionEditorCommandBarProps> = props 
     functionInfo,
     runtimeVersion,
     upload,
-    setIsValidFileSelected,
-    resetIsValidFileSelectedValue,
+    setShowInvalidFileSelectedWarning,
+    resetInvalidFileSelectedWarningAndFileName,
+    setSelectedFileName,
   } = props;
   const { t } = useTranslation();
   const portalCommunicator = useContext(PortalContext);
@@ -58,7 +60,7 @@ const FunctionEditorCommandBar: React.FC<FunctionEditorCommandBarProps> = props 
   const [isDialogVisible, setIsDialogVisible] = useState<boolean>(false);
 
   const onClickGetFunctionUrlCommand = () => {
-    resetIsValidFileSelectedValue();
+    resetInvalidFileSelectedWarningAndFileName();
     setIsDialogVisible(true);
   };
 
@@ -73,11 +75,13 @@ const FunctionEditorCommandBar: React.FC<FunctionEditorCommandBarProps> = props 
 
   const uploadFile = e => {
     const file = e.target && e.target.files && e.target.files.length > 0 && e.target.files[0];
-    const isValid = !!file && !!file.size;
-    if (isValid) {
+    const isValidFile = !!file && !!file.size;
+    if (isValidFile) {
       upload(file);
     }
-    setIsValidFileSelected(isValid);
+
+    setSelectedFileName((!!file && file.name) || '');
+    setShowInvalidFileSelectedWarning(!isValidFile);
   };
 
   const onTestItemRender = (item: any, dismissMenu: () => void) => {

--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditorCommandBar.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditorCommandBar.tsx
@@ -22,6 +22,8 @@ interface FunctionEditorCommandBarProps {
   testFunction: () => void;
   refreshFunction: () => void;
   upload: (file: any) => void;
+  setIsValidFileSelected: (isValid: boolean | undefined) => void;
+  resetIsValidFileSelectedValue: () => void;
   isGetFunctionUrlVisible: boolean;
   dirty: boolean;
   disabled: boolean;
@@ -45,6 +47,8 @@ const FunctionEditorCommandBar: React.FC<FunctionEditorCommandBarProps> = props 
     functionInfo,
     runtimeVersion,
     upload,
+    setIsValidFileSelected,
+    resetIsValidFileSelectedValue,
   } = props;
   const { t } = useTranslation();
   const portalCommunicator = useContext(PortalContext);
@@ -54,6 +58,7 @@ const FunctionEditorCommandBar: React.FC<FunctionEditorCommandBarProps> = props 
   const [isDialogVisible, setIsDialogVisible] = useState<boolean>(false);
 
   const onClickGetFunctionUrlCommand = () => {
+    resetIsValidFileSelectedValue();
     setIsDialogVisible(true);
   };
 
@@ -68,9 +73,11 @@ const FunctionEditorCommandBar: React.FC<FunctionEditorCommandBarProps> = props 
 
   const uploadFile = e => {
     const file = e.target && e.target.files && e.target.files.length > 0 && e.target.files[0];
-    if (file) {
+    const isValid = !!file && !!file.size;
+    if (isValid) {
       upload(file);
     }
+    setIsValidFileSelected(isValid);
   };
 
   const onTestItemRender = (item: any, dismissMenu: () => void) => {

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2352,6 +2352,7 @@ export class PortalResources {
   public static missingWorkflowDispatchTrigger = 'missingWorkflowDispatchTrigger';
   public static deploymentCenterWorkflowError = 'deploymentCenterWorkflowError';
   public static enablePortalEditingForLinuxConsumptionWarning = 'enablePortalEditingForLinuxConsumptionWarning';
+  public static validFileShouldBeSelectedWarning = 'validFileShouldBeSelectedWarning';
   public static invalidFileSelectedWarning = 'invalidFileSelectedWarning';
   public static switchToJbossWarningBaner = 'switchToJbossWarningBaner';
   public static staticSiteEnterpriseGradeEdge = 'staticSiteEnterpriseGradeEdge';

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2352,6 +2352,7 @@ export class PortalResources {
   public static missingWorkflowDispatchTrigger = 'missingWorkflowDispatchTrigger';
   public static deploymentCenterWorkflowError = 'deploymentCenterWorkflowError';
   public static enablePortalEditingForLinuxConsumptionWarning = 'enablePortalEditingForLinuxConsumptionWarning';
+  public static invalidFileSelectedWarning = 'invalidFileSelectedWarning';
   public static switchToJbossWarningBaner = 'switchToJbossWarningBaner';
   public static staticSiteEnterpriseGradeEdge = 'staticSiteEnterpriseGradeEdge';
   public static staticSiteEnterpriseGradeEdgePrice = 'staticSiteEnterpriseGradeEdgePrice';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7197,8 +7197,11 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="enablePortalEditingForLinuxConsumptionWarning" xml:space="preserve">
         <value>Adding third party dependencies in the Azure portal is currently not supported for Linux Consumption Function Apps. Click here to setup local environment.</value>
     </data>
+    <data name="validFileShouldBeSelectedWarning" xml:space="preserve">
+        <value>Please select a valid file to upload.</value>
+    </data>
     <data name="invalidFileSelectedWarning" xml:space="preserve">
-        <value>Invalid functions.json file was selected. Please upload a valid file.</value>
+        <value>Invalid {0} file was selected. Please upload a valid file.</value>
     </data>
     <data name="switchToJbossWarningBaner" xml:space="preserve">
         <value>JBoss EAP is jointly supported by Red Hat, switching your web app to JBoss will incur an additional cost per month. </value>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7197,6 +7197,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="enablePortalEditingForLinuxConsumptionWarning" xml:space="preserve">
         <value>Adding third party dependencies in the Azure portal is currently not supported for Linux Consumption Function Apps. Click here to setup local environment.</value>
     </data>
+    <data name="invalidFileSelectedWarning" xml:space="preserve">
+        <value>Invalid functions.json file was selected. Please upload a valid file.</value>
+    </data>
     <data name="switchToJbossWarningBaner" xml:space="preserve">
         <value>JBoss EAP is jointly supported by Red Hat, switching your web app to JBoss will incur an additional cost per month. </value>
     </data>


### PR DESCRIPTION
If the selected file is empty (file size is 0), we display warning message. Reset the warning message if:
- User selected non-empty file
- User clicks other commands (Save, Discard, Refresh, Test + Code and Get function URL)

**Selected invalid file has file name:**
![image](https://user-images.githubusercontent.com/30202258/152450732-24279e69-6664-4e96-b1ab-3f8483976d04.png)

**Generic warning:**
![image](https://user-images.githubusercontent.com/30202258/152450710-8cef0c59-baf7-41e7-89b6-07adb8c2e8fd.png)

**GIF:**
![jasonFileWarning](https://user-images.githubusercontent.com/30202258/152450657-078e1f4d-34f0-4ec8-baec-c5f4d791d8af.gif)

