### PR TITLE
[DC] Hide dialog immediately after pressing OK for disconnecting Kudu apps

### DIFF
--- a/client-react/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/client-react/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -3,8 +3,9 @@ import React from 'react';
 import { modalFooterStyles, modalContentStyles, modalStyles } from './ConfirmDialog.styles';
 
 interface ConfirmDialogProps {
-  primaryActionButton: { title: string; onClick: () => void };
-  defaultActionButton: { title: string; onClick: () => void };
+  primaryActionButton: { title: string; onClick: () => void; disabled?: boolean };
+  defaultActionButton: { title: string; onClick: () => void; disabled?: boolean };
+  hideDefaultActionButton?: boolean;
   title: string;
   content: string;
   modalStyles?: any;
@@ -15,6 +16,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps & IDialogProps> = props => {
   const {
     primaryActionButton,
     defaultActionButton,
+    hideDefaultActionButton,
     hidden,
     title,
     content,
@@ -40,8 +42,12 @@ const ConfirmDialog: React.FC<ConfirmDialogProps & IDialogProps> = props => {
         <p>{content}</p>
       </div>
       <DialogFooter styles={modalFooterStyles}>
-        <PrimaryButton onClick={primaryActionButton.onClick} text={primaryActionButton.title} />
-        <DefaultButton onClick={defaultActionButton.onClick} text={defaultActionButton.title} />
+        <PrimaryButton onClick={primaryActionButton.onClick} text={primaryActionButton.title} disabled={primaryActionButton.disabled} />
+        {!hideDefaultActionButton ? (
+          <DefaultButton onClick={defaultActionButton.onClick} text={defaultActionButton.title} disabled={defaultActionButton.disabled} />
+        ) : (
+          <></>
+        )}
       </DialogFooter>
     </Dialog>
   );

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSourceKuduConfiguredView.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSourceKuduConfiguredView.tsx
@@ -30,6 +30,7 @@ const DeploymentCenterCodeSourceKuduConfiguredView: React.FC<DeploymentCenterFie
   };
 
   const disconnect = async () => {
+    hideRefreshConfirmDialog();
     const notificationId = portalContext.startNotification(t('disconnectingDeployment'), t('disconnectingDeployment'));
     portalContext.log(
       getTelemetryInfo('info', 'disconnectSourceControl', 'submit', {

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSourceKuduConfiguredView.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSourceKuduConfiguredView.tsx
@@ -16,6 +16,7 @@ const DeploymentCenterCodeSourceKuduConfiguredView: React.FC<DeploymentCenterFie
   const { formProps } = props;
   const { t } = useTranslation();
   const [isRefreshConfirmDialogVisible, setIsRefreshConfirmDialogVisible] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
 
   const deploymentCenterData = new DeploymentCenterData();
   const deploymentCenterContext = useContext(DeploymentCenterContext);
@@ -30,7 +31,7 @@ const DeploymentCenterCodeSourceKuduConfiguredView: React.FC<DeploymentCenterFie
   };
 
   const disconnect = async () => {
-    hideRefreshConfirmDialog();
+    setIsDisconnecting(true);
     const notificationId = portalContext.startNotification(t('disconnectingDeployment'), t('disconnectingDeployment'));
     portalContext.log(
       getTelemetryInfo('info', 'disconnectSourceControl', 'submit', {
@@ -133,13 +134,15 @@ const DeploymentCenterCodeSourceKuduConfiguredView: React.FC<DeploymentCenterFie
         </Link>
         <ConfirmDialog
           primaryActionButton={{
-            title: t('ok'),
+            title: isDisconnecting ? t('disconnecting') : t('ok'),
             onClick: disconnect,
+            disabled: isDisconnecting,
           }}
           defaultActionButton={{
             title: t('cancel'),
             onClick: hideRefreshConfirmDialog,
           }}
+          hideDefaultActionButton={isDisconnecting}
           title={t('kuduDisconnectConfirmationTitle')}
           content={t('disconnectConfirm')}
           hidden={!isRefreshConfirmDialogVisible}

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2372,4 +2372,5 @@ export class PortalResources {
   public static functionsSupportedRuntimeVersionMissingWarningWithVersionList =
     'functionsSupportedRuntimeVersionMissingWarningWithVersionList';
   public static functionsSupportedRuntimeVersionMissingWarning = 'functionsSupportedRuntimeVersionMissingWarning';
+  public static disconnecting = 'disconnecting';
 }

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7254,4 +7254,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="functionsSupportedRuntimeVersionMissingWarning" xml:space="preserve">
         <value>The runtime version is not configured for your app. As a result the runtime cannot be started. Please use a valid runtime version (e.g. ~3).</value>
     </data>
+    <data name="disconnecting" xml:space="preserve">
+        <value>Disconnecting...</value>
+    </data>
 </root>


### PR DESCRIPTION
FixesAB#[13195106 ](https://msazure.visualstudio.com/Antares/_workitems/edit/13195106)

**Before:**
![before hidedialog](https://user-images.githubusercontent.com/29874289/152455268-83caabf5-504a-4139-8e76-f632ba2fa903.gif)

**After:**
Hide immediately after pressing ok
![hide dialog](https://user-images.githubusercontent.com/29874289/152455273-32b17b25-aa28-48f0-baed-2a26b514c7e4.gif)

Disable ok button and hide cancel button, replace ok with disconnecting
![disconnect](https://user-images.githubusercontent.com/29874289/153671203-b235c629-57a0-4d89-ac90-6bdd296a9582.gif)

