### PR TITLE
AB#12989832 BYOS - Fix mount path prefix for windows code + enable mount path validations for windows container on national clouds

### DIFF
--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
@@ -12,11 +12,9 @@ import { addEditFormStyle } from '../../../../components/form-controls/formContr
 import RadioButton from '../../../../components/form-controls/RadioButton';
 import * as Yup from 'yup';
 import { ValidationRegex } from '../../../../utils/constants/ValidationRegex';
-import Url from '../../../../utils/url';
 import { CommonConstants } from '../../../../utils/CommonConstants';
 import { style } from 'typestyle';
 import { ISiteState, SiteStateContext } from '../../../../SiteState';
-import { NationalCloudEnvironment } from '../../../../utils/scenario-checker/national-cloud.environment';
 
 const MountPathValidationRegex = ValidationRegex.StorageMountPath;
 const MountPathExamples = CommonConstants.MountPathValidationExamples;
@@ -56,7 +54,6 @@ const AzureStorageMountsAddEdit: React.SFC<AzureStorageMountsAddEditPropsCombine
   azureStorageMount.mountPath = getMountPathDisplayValue(siteState, azureStorageMount.mountPath);
 
   // eslint-disable-next-line no-useless-escape
-  const mountPathRegex = /^\/[a-zA-Z0-9.\[\]\(\)\-_\/]*$/;
   const shareNameMaxLength = 64;
   const mountPathMaxLength = isLinuxOrContainer(siteState) ? 256 : 256 - CommonConstants.windowsCodeMountPathPrefix.length;
 

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
@@ -28,18 +28,6 @@ export interface AzureStorageMountsAddEditProps {
   enableValidation: boolean;
 }
 
-const isLinuxOrContainer = (siteState: ISiteState) => {
-  return !!siteState && (!!siteState.isLinuxApp || !!siteState.isContainerApp);
-};
-
-const getMountPathDisplayValue = (siteState: ISiteState, mountPath: string): string => {
-  if (isLinuxOrContainer(siteState)) {
-    return mountPath;
-  }
-  const startIndex = CommonConstants.windowsCodeMountPathPrefix.length;
-  return startIndex < mountPath.length ? mountPath.substring(startIndex) : mountPath;
-};
-
 export type AzureStorageMountsAddEditPropsCombined = AzureStorageMountsAddEditProps;
 const AzureStorageMountsAddEdit: React.SFC<AzureStorageMountsAddEditPropsCombined> = props => {
   const { closeBlade, otherAzureStorageMounts, azureStorageMount, updateAzureStorageMount, enableValidation } = props;
@@ -51,12 +39,24 @@ const AzureStorageMountsAddEdit: React.SFC<AzureStorageMountsAddEditPropsCombine
   const [initialName] = useState(azureStorageMount.name);
   const [initialMountPath] = useState(azureStorageMount.mountPath);
 
-  azureStorageMount.mountPath = getMountPathDisplayValue(siteState, azureStorageMount.mountPath);
+  const isLinuxOrContainer = () => {
+    return !!siteState && (!!siteState.isLinuxApp || !!siteState.isContainerApp);
+  };
+
+  const getMountPathDisplayValue = (mountPath: string): string => {
+    if (isLinuxOrContainer()) {
+      return mountPath;
+    }
+    const startIndex = CommonConstants.windowsCodeMountPathPrefix.length;
+    return startIndex < mountPath.length ? mountPath.substring(startIndex) : mountPath;
+  };
+
+  azureStorageMount.mountPath = getMountPathDisplayValue(azureStorageMount.mountPath);
 
   // eslint-disable-next-line no-useless-escape
   const shareNameMaxLength = 64;
   const mountPathDefaultMaxLength = 256;
-  const mountPathMaxLength = isLinuxOrContainer(siteState)
+  const mountPathMaxLength = isLinuxOrContainer()
     ? mountPathDefaultMaxLength
     : mountPathDefaultMaxLength - CommonConstants.windowsCodeMountPathPrefix.length;
 
@@ -125,11 +125,11 @@ const AzureStorageMountsAddEdit: React.SFC<AzureStorageMountsAddEditPropsCombine
   };
 
   const setMountPathPrefix = (): string | undefined => {
-    return isLinuxOrContainer(siteState) ? undefined : CommonConstants.windowsCodeMountPathPrefix;
+    return isLinuxOrContainer() ? undefined : CommonConstants.windowsCodeMountPathPrefix;
   };
 
   const getMountPathInputValue = (input: string): string => {
-    return isLinuxOrContainer(siteState) ? input : `${CommonConstants.windowsCodeMountPathPrefix}${input}`;
+    return isLinuxOrContainer() ? input : `${CommonConstants.windowsCodeMountPathPrefix}${input}`;
   };
 
   const mountPathValidation = Yup.string()

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
@@ -15,13 +15,11 @@ import { ValidationRegex } from '../../../../utils/constants/ValidationRegex';
 import Url from '../../../../utils/url';
 import { CommonConstants } from '../../../../utils/CommonConstants';
 import { style } from 'typestyle';
-import { SiteStateContext } from '../../../../SiteState';
+import { ISiteState, SiteStateContext } from '../../../../SiteState';
 import { NationalCloudEnvironment } from '../../../../utils/scenario-checker/national-cloud.environment';
 
 const MountPathValidationRegex = ValidationRegex.StorageMountPath;
 const MountPathExamples = CommonConstants.MountPathValidationExamples;
-
-const isValidationEnabled = !!Url.getFeatureValue(CommonConstants.FeatureFlags.enableAzureMountPathValidation);
 
 export interface AzureStorageMountsAddEditProps {
   updateAzureStorageMount: (item: FormAzureStorageMounts) => any;
@@ -31,6 +29,18 @@ export interface AzureStorageMountsAddEditProps {
   // TODO (refortie): Temporary until xenon validation is put in
   enableValidation: boolean;
 }
+
+const isLinuxOrContainer = (siteState: ISiteState) => {
+  return !!siteState && (!!siteState.isLinuxApp || !!siteState.isContainerApp);
+};
+
+const getMountPathDisplayValue = (siteState: ISiteState, mountPath: string): string => {
+  if (isLinuxOrContainer(siteState)) {
+    return mountPath;
+  }
+  const startIndex = CommonConstants.windowsCodeMountPathPrefix.length;
+  return startIndex < mountPath.length ? mountPath.substring(startIndex) : mountPath;
+};
 
 export type AzureStorageMountsAddEditPropsCombined = AzureStorageMountsAddEditProps;
 const AzureStorageMountsAddEdit: React.SFC<AzureStorageMountsAddEditPropsCombined> = props => {
@@ -43,22 +53,17 @@ const AzureStorageMountsAddEdit: React.SFC<AzureStorageMountsAddEditPropsCombine
   const [initialName] = useState(azureStorageMount.name);
   const [initialMountPath] = useState(azureStorageMount.mountPath);
 
+  azureStorageMount.mountPath = getMountPathDisplayValue(siteState, azureStorageMount.mountPath);
+
   // eslint-disable-next-line no-useless-escape
   const mountPathRegex = /^\/[a-zA-Z0-9.\[\]\(\)\-_\/]*$/;
   const shareNameMaxLength = 64;
-  const mountPathMaxLength = 256;
+  const mountPathMaxLength = isLinuxOrContainer(siteState) ? 256 : 256 - CommonConstants.windowsCodeMountPathPrefix.length;
 
   // eslint-disable-next-line no-useless-escape
   const shareNameRegex = /^[a-zA-Z0-9\[\]\(\)\-_]+$/;
   const cancel = () => {
     closeBlade();
-  };
-
-  const isContainerAtPublicCloud = () => {
-    const isPublicCloud = !NationalCloudEnvironment.isNationalCloud();
-    const isContainer = !!siteState ? siteState.isContainerApp : false;
-
-    return isPublicCloud && isContainer;
   };
 
   const getLinuxMountPathValidation = (value: string): boolean => {
@@ -86,6 +91,7 @@ const AzureStorageMountsAddEdit: React.SFC<AzureStorageMountsAddEditPropsCombine
   };
 
   const validateMountPath = (value: string): string | undefined => {
+    value = getMountPathInputValue(value);
     if (!siteState) {
       return undefined;
     }
@@ -96,7 +102,7 @@ const AzureStorageMountsAddEdit: React.SFC<AzureStorageMountsAddEditPropsCombine
     let valid = true;
     if (siteState.isLinuxApp) {
       valid = getLinuxMountPathValidation(value);
-    } else if (isContainerAtPublicCloud() || isValidationEnabled) {
+    } else {
       valid = getWindowsMountPathValidation(value);
     }
     return valid ? undefined : t('validation_invalidMountPath');
@@ -109,44 +115,39 @@ const AzureStorageMountsAddEdit: React.SFC<AzureStorageMountsAddEditPropsCombine
     let mountPathInfoBubble;
     if (siteState.isLinuxApp) {
       mountPathInfoBubble = MountPathExamples.linux;
-    } else if (isContainerAtPublicCloud()) {
+    } else if (siteState.isContainerApp) {
       mountPathInfoBubble = MountPathExamples.windowsContainer;
-    } else if (isValidationEnabled) {
-      mountPathInfoBubble = siteState.isContainerApp ? MountPathExamples.windowsContainer : MountPathExamples.windowsCode;
     } else {
-      return '';
+      mountPathInfoBubble = MountPathExamples.windowsCode;
     }
     const { valid, invalid } = mountPathInfoBubble;
     return t('mountPath_info').format(valid, invalid);
   };
 
-  const setMountPathPrefix = (): string => {
-    if (!!siteState) {
-      return siteState.isLinuxApp || siteState.isContainerApp ? '' : CommonConstants.windowsCodeMountPathPrefix;
-    }
-    return '';
+  const setMountPathPrefix = (): string | undefined => {
+    return isLinuxOrContainer(siteState) ? undefined : CommonConstants.windowsCodeMountPathPrefix;
   };
 
-  let mountPathValidation = Yup.string()
+  const getMountPathInputValue = (input: string): string => {
+    return isLinuxOrContainer(siteState) ? input : `${CommonConstants.windowsCodeMountPathPrefix}${input}`;
+  };
+
+  const mountPathValidation = Yup.string()
     .required(t('validation_requiredError'))
     .max(mountPathMaxLength, t('validation_fieldMaxCharacters').format(mountPathMaxLength))
     .test('cannotMountHomeDirectory', t('validation_mountPathNotHome'), (value: string) => {
+      value = getMountPathInputValue(value);
       const homeDir = ValidationRegex.StorageMountPath.homeDir;
       return !homeDir.test(value);
     })
     .test('uniqueMountPath', t('validation_mouthPathMustBeUnique'), value => {
+      value = getMountPathInputValue(value);
       return (
         !value ||
         value === initialMountPath ||
         !otherAzureStorageMounts.some(storageMount => storageMount.mountPath.toLowerCase() === value.toLowerCase())
       );
     });
-
-  if (!isValidationEnabled && !!siteState && !siteState.isLinuxApp && !isContainerAtPublicCloud()) {
-    mountPathValidation = mountPathValidation
-      .matches(mountPathRegex, t('validation_mountNameAllowedCharacters'))
-      .test('cannotMountRootDirectory', t('validation_mountPathNotRoot'), (value: string) => value !== '/');
-  }
 
   const validationSchema = Yup.object().shape({
     name: Yup.string()
@@ -181,6 +182,7 @@ const AzureStorageMountsAddEdit: React.SFC<AzureStorageMountsAddEditPropsCombine
     <Formik
       initialValues={{ ...azureStorageMount }}
       onSubmit={values => {
+        values.mountPath = getMountPathInputValue(values.mountPath);
         updateAzureStorageMount(values);
       }}
       validationSchema={enableValidation && validationSchema}
@@ -238,7 +240,7 @@ const AzureStorageMountsAddEdit: React.SFC<AzureStorageMountsAddEditPropsCombine
               label={t('mountPath')}
               component={TextField}
               id={`azure-storage-mounts-path`}
-              defaultValue={setMountPathPrefix()}
+              prefix={setMountPathPrefix()}
               mouseOverToolTip={displayMountPathInfoBubble()}
               errorMessage={formProps.errors && formProps.errors.mountPath}
               required={true}

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
@@ -55,7 +55,10 @@ const AzureStorageMountsAddEdit: React.SFC<AzureStorageMountsAddEditPropsCombine
 
   // eslint-disable-next-line no-useless-escape
   const shareNameMaxLength = 64;
-  const mountPathMaxLength = isLinuxOrContainer(siteState) ? 256 : 256 - CommonConstants.windowsCodeMountPathPrefix.length;
+  const mountPathDefaultMaxLength = 256;
+  const mountPathMaxLength = isLinuxOrContainer(siteState)
+    ? mountPathDefaultMaxLength
+    : mountPathDefaultMaxLength - CommonConstants.windowsCodeMountPathPrefix.length;
 
   // eslint-disable-next-line no-useless-escape
   const shareNameRegex = /^[a-zA-Z0-9\[\]\(\)\-_]+$/;

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
@@ -14,7 +14,7 @@ import * as Yup from 'yup';
 import { ValidationRegex } from '../../../../utils/constants/ValidationRegex';
 import { CommonConstants } from '../../../../utils/CommonConstants';
 import { style } from 'typestyle';
-import { ISiteState, SiteStateContext } from '../../../../SiteState';
+import { SiteStateContext } from '../../../../SiteState';
 
 const MountPathValidationRegex = ValidationRegex.StorageMountPath;
 const MountPathExamples = CommonConstants.MountPathValidationExamples;

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -55,7 +55,6 @@ export class CommonConstants {
     targetAzDevDeployment: 'targetAzDevDeployment',
     authTokenOverride: 'authTokenOverride',
     enableAzureMount: 'enableAzureMount',
-    enableAzureMountPathValidation: 'enableAzureMountPathValidation',
     showServiceLinkerConnector: 'showServiceLinkerConnector',
     enableGitHubOnNationalCloud: 'enableGitHubOnNationalCloud',
     treatAsKubeApp: 'treatAsKubeApp', // websitesextension_ext=appsvc.treatAsKubeApp%3Dtrue

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -687,7 +687,6 @@ export class PortalResources {
   public static validation_slotNameReserved = 'validation_slotNameReserved';
   public static validation_fieldMaxCharacters = 'validation_fieldMaxCharacters';
   public static validation_shareNameAllowedCharacters = 'validation_shareNameAllowedCharacters';
-  public static validation_mountNameAllowedCharacters = 'validation_mountNameAllowedCharacters';
   public static mountPath_info = 'mountPath_info';
   public static validation_invalidMountPath = 'validation_invalidMountPath';
   public static validation_mountPathNotHome = 'validation_mountPathNotHome';
@@ -2252,7 +2251,6 @@ export class PortalResources {
   public static createKeyNotificationFailedDetails = 'createKeyNotificationFailedDetails';
   public static stackVersionDeprecated = 'stackVersionDeprecated';
   public static stackVersionPreview = 'stackVersionPreview';
-  public static validation_mountPathNotRoot = 'validation_mountPathNotRoot';
   public static workflowRuntimeSettings = 'workflowRuntimeSettings';
   public static uploadingFile = 'uploadingFile';
   public static uploadingFileWithName = 'uploadingFileWithName';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -2173,9 +2173,6 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="validation_shareNameAllowedCharacters" xml:space="preserve">
         <value>Share name can only include alphanumeric characters, underscores, hyphens, square brackets, and parenthesis</value>
     </data>
-    <data name="validation_mountNameAllowedCharacters" xml:space="preserve">
-        <value>Mount path must be a fully qualified path and can only include alphanumeric characters, underscores, hyphens, forward slashes, square brackets, and parenthesis</value>
-    </data>
     <data name="mountPath_info" xml:space="preserve">
         <value>Following are examples of valid mount paths: {0}. Following are examples of invalid mount paths: {1}</value>
     </data>
@@ -6899,9 +6896,6 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     </data>
     <data name="stackVersionPreview" xml:space="preserve">
         <value>{0} (preview)</value>
-    </data>
-    <data name="validation_mountPathNotRoot" xml:space="preserve">
-        <value>Mount path cannot be '/'</value>
     </data>
     <data name="workflowRuntimeSettings" xml:space="preserve">
         <value>Workflow runtime settings</value>


### PR DESCRIPTION
Fixes: [AB#12989832](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s182?workitem=12989832)
![mountpath](https://user-images.githubusercontent.com/33185278/152878185-fb872c53-be97-4d04-b37c-ea131cb1841e.png)
