### PR TITLE
#AB12104205 Set stack as empty if the windows code app does not have metadata or …

### DIFF
--- a/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
@@ -236,6 +236,7 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
           basicPublishingCredentialsPolicies: basicPublishingCredentialsPolicies.metadata.success
             ? basicPublishingCredentialsPolicies.data
             : null,
+          appPermissions: appPermissions,
         }),
       });
     }

--- a/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
+++ b/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
@@ -59,7 +59,7 @@ interface StateToFormParams {
   slotConfigNames: ArmObj<SlotConfigNames> | null;
   metadata: ArmObj<KeyValue<string>> | null;
   basicPublishingCredentialsPolicies: ArmObj<PublishingCredentialPolicies> | null;
-  appPermissions: boolean;
+  appPermissions?: boolean;
 }
 export const convertStateToForm = (props: StateToFormParams): AppSettingsFormValues => {
   const {
@@ -82,7 +82,7 @@ export const convertStateToForm = (props: StateToFormParams): AppSettingsFormVal
     appSettings: formAppSetting,
     connectionStrings: getFormConnectionStrings(connectionStrings, slotConfigNames),
     virtualApplications: config && config.properties && flattenVirtualApplicationsList(config.properties.virtualApplications),
-    currentlySelectedStack: getCurrentStackString(config, appPermissions, metadata, appSettings, isFunctionApp(site), isWindowsCode(site)),
+    currentlySelectedStack: getCurrentStackString(config, metadata, appSettings, isFunctionApp(site), isWindowsCode(site), appPermissions),
     azureStorageMounts: getFormAzureStorageMount(azureStorageMounts),
   };
 };
@@ -361,11 +361,11 @@ export function flattenVirtualApplicationsList(virtualApps: VirtualApplication[]
 
 export function getCurrentStackString(
   config: ArmObj<SiteConfig>,
-  appPermissions: boolean,
   metadata?: ArmObj<KeyValue<string>> | null,
   appSettings?: ArmObj<KeyValue<string>> | null,
   isFunctionApp?: boolean,
-  isWindowsCodeApp?: boolean
+  isWindowsCodeApp?: boolean,
+  appPermissions?: boolean
 ): string {
   if (
     !!isFunctionApp &&

--- a/client-react/src/pages/app/app-settings/GeneralSettings/WindowsStacks/WindowsStacks.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/WindowsStacks/WindowsStacks.tsx
@@ -74,6 +74,7 @@ const WindowsStacks: React.FC<StackProps> = props => {
         id="app-settings-stack-dropdown"
         onChange={onStackDropdownChange}
         selectedKey={stackDropdownValue}
+        infoBubbleMessage={!!initialValues.currentlySelectedStack ? undefined : t('stackInfoMessage')}
       />
       {values.currentlySelectedStack === RuntimeStacks.dotnet ||
       values.currentlySelectedStack === RuntimeStacks.dotnetcore ||

--- a/client-react/src/pages/app/app-settings/GeneralSettings/WindowsStacks/WindowsStacks.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/WindowsStacks/WindowsStacks.tsx
@@ -74,7 +74,7 @@ const WindowsStacks: React.FC<StackProps> = props => {
         id="app-settings-stack-dropdown"
         onChange={onStackDropdownChange}
         selectedKey={stackDropdownValue}
-        infoBubbleMessage={!!initialValues.currentlySelectedStack ? undefined : t('stackInfoMessage')}
+        infoBubbleMessage={!!stackDropdownValue ? undefined : t('stackInfoMessage')}
       />
       {values.currentlySelectedStack === RuntimeStacks.dotnet ||
       values.currentlySelectedStack === RuntimeStacks.dotnetcore ||

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1460,6 +1460,7 @@ export class PortalResources {
   public static argumentsRes = 'argumentsRes';
   public static newHandlerMapping = 'newHandlerMapping';
   public static stack = 'stack';
+  public static stackInfoMessage = 'stackInfoMessage';
   public static slots = 'slots';
   public static autoSwapEnabled = 'autoSwapEnabled';
   public static autoSwapSlot = 'autoSwapSlot';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -4523,6 +4523,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="stack" xml:space="preserve">
         <value>Stack</value>
     </data>
+    <data name="stackInfoMessage" xml:space="preserve">
+        <value>Select a stack to see how it is currently configured for your app.</value>
+    </data>
     <data name="slots" xml:space="preserve">
         <value>Deployment Slot</value>
     </data>


### PR DESCRIPTION
[#AB12104205](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s182?workitem=12104205)

![emptyStack](https://user-images.githubusercontent.com/33185278/153287929-3f64d439-0b17-490c-ab97-e6fe2cd68160.png)
