### PR TITLE
AB#12447585 [Spec Picker] [Accessibility] Change button and link color contrast ratio

### DIFF
--- a/client/src/app/site/spec-picker/spec-picker.component.scss
+++ b/client/src/app/site/spec-picker/spec-picker.component.scss
@@ -163,7 +163,7 @@ $center-column-max-width: calc(#{$spec-card-max-width}* 4 - 40px);
     text-align: center;
 
     span:focus {
-      outline: #323130 solid 1px;
+      outline: #000000 solid 1px;
     }
 
     a {
@@ -283,7 +283,7 @@ $center-column-max-width: calc(#{$spec-card-max-width}* 4 - 40px);
     }
 
     button:focus {
-      outline: #323130 solid 1px;
+      outline: #000000 solid 1px;
     }
 
     .icon-medium {
@@ -345,9 +345,15 @@ $center-column-max-width: calc(#{$spec-card-max-width}* 4 - 40px);
     background-color: $body-bg-color-dark;
   }
 
+  #spec-picker-footer {
+    button:focus {
+      outline: #ffffff solid 1px;
+    }
+  }
+
   .spec-expander {
     span:focus {
-      outline: #155f99 dashed 1px;
+      outline: #ffffff solid 1px;
     }
   }
 }

--- a/client/src/app/site/spec-picker/spec-picker.component.scss
+++ b/client/src/app/site/spec-picker/spec-picker.component.scss
@@ -163,7 +163,7 @@ $center-column-max-width: calc(#{$spec-card-max-width}* 4 - 40px);
     text-align: center;
 
     span:focus {
-      outline: #1f97f2 dashed 1px;
+      outline: #323130 solid 1px;
     }
 
     a {
@@ -280,6 +280,10 @@ $center-column-max-width: calc(#{$spec-card-max-width}* 4 - 40px);
     .message-icon,
     .message-text {
       height: 27px;
+    }
+
+    button:focus {
+      outline: #323130 solid 1px;
     }
 
     .icon-medium {


### PR DESCRIPTION
[AB#12447585](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s182?workitem=12447585)

Change link button and apply button contrast color to black and white(dark theme) for increase luminosity ratio of the focus indicator to go above 3:1
![applybuttondark](https://user-images.githubusercontent.com/33185278/153479992-caee4fe0-e93f-4403-9439-1c73b52cba88.png)
![linkbuttondark](https://user-images.githubusercontent.com/33185278/153480003-e5ac9cef-47c6-4cc1-80e2-e01cfa980836.png)
![linkbutton](https://user-images.githubusercontent.com/33185278/153480031-01f74f03-c03b-4f54-b55f-720d41e4e411.png)
![applybutton](https://user-images.githubusercontent.com/33185278/153480033-ca31265c-04f1-44e0-ae59-8c3f2af7b40a.png)

