### PR TITLE
[Functions] Passthrough API only accepts a “content-type” header of “application/json

### DIFF
--- a/server/src/proxy/proxy.controller.ts
+++ b/server/src/proxy/proxy.controller.ts
@@ -4,9 +4,7 @@ import { LoggingService } from '../shared/logging/logging.service';
 import { Response } from 'express';
 import { Method } from 'axios';
 
-export interface KeyValue<T> {
-  [key: string]: T;
-}
+export type KeyValue<T> = Record<string, T>;
 
 @Controller('api')
 export class ProxyController {

--- a/server/src/proxy/proxy.controller.ts
+++ b/server/src/proxy/proxy.controller.ts
@@ -1,8 +1,12 @@
-import { Controller, Post, Body, Res } from '@nestjs/common';
+import { Controller, Post, Body, Res, HttpException } from '@nestjs/common';
 import { HttpService } from '../shared/http/http.service';
 import { LoggingService } from '../shared/logging/logging.service';
 import { Response } from 'express';
 import { Method } from 'axios';
+
+export interface KeyValue<T> {
+  [key: string]: T;
+}
 
 @Controller('api')
 export class ProxyController {
@@ -30,8 +34,14 @@ export class ProxyController {
     return this.makeCall(proxyMethod, proxyHeaders, proxyUrl, proxyBody, res);
   }
 
-  private async makeCall(method: Method, headers: any, url: string, body: any, res: Response) {
+  private async makeCall(method: Method, headers: KeyValue<string>, url: string, body: any, res: Response) {
     try {
+      Object.keys(headers).forEach(key => {
+        if (key.toLocaleLowerCase() === 'content-type' && headers[key].toLocaleLowerCase() !== 'application/json') {
+          throw new HttpException('Only content-type of application/json is accepted.', 500);
+        }
+      });
+
       const result = await this.httpService.request({
         method,
         url,
@@ -47,7 +57,9 @@ export class ProxyController {
 
       res.status(result.status).send(result.data);
     } catch (err) {
-      if (err.response) {
+      if (!!err.response && !!err.status) {
+        res.status(err.status).send(err.response);
+      } else if (err.response) {
         res.status(err.response.status).send(err.response.data);
       } else {
         res.sendStatus(500);


### PR DESCRIPTION
Fixes [AB#13257707](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/13257707)

![image](https://user-images.githubusercontent.com/35281019/154395846-db90b527-7f23-4e91-b683-237e15141b51.png)

![image](https://user-images.githubusercontent.com/35281019/154395945-a7913c51-ddda-4809-8216-14b8a3d2f7e4.png)

![image](https://user-images.githubusercontent.com/35281019/154538123-cc87a769-2b45-476d-979a-df7f60a18ba7.png)

![image](https://user-images.githubusercontent.com/35281019/154554437-a0e41e53-7d43-499f-8f43-c35c1fdfb4b2.png)
