### PR TITLE
AB#12446369 Accessibility - change 'add additional options' link to a button

### DIFF
--- a/client/src/app/site/spec-picker/spec-picker.component.html
+++ b/client/src/app/site/spec-picker/spec-picker.component.html
@@ -72,8 +72,9 @@
               [attr.aria-expanded]="specManager.selectedSpecGroup.isExpanded"
               [attr.aria-controls]="specManager.selectedSpecGroup.id + specManager.selectedSpecGroup.selectedSpec?.skuCode">
 
-          <span [load-image]="!specManager.selectedSpecGroup.isExpanded ? 'image/caret-down.svg' : 'image/caret-up.svg'" class="expand-icon"></span>
-          <a>{{ (!specManager.selectedSpecGroup.isExpanded ? 'seeAllOptions' : 'seeRecommendedOptions') | translate}}</a>
+          <button class="custom-button">
+            {{(!specManager.selectedSpecGroup.isExpanded ? 'seeAllOptions' : 'seeRecommendedOptions') | translate}}
+          </button>
         </span>
       </div>
 

--- a/client/src/app/site/spec-picker/spec-picker.component.scss
+++ b/client/src/app/site/spec-picker/spec-picker.component.scss
@@ -162,7 +162,7 @@ $center-column-max-width: calc(#{$spec-card-max-width}* 4 - 40px);
   .spec-expander {
     text-align: center;
 
-    span:focus {
+    button:focus {
       outline: #000000 solid 1px;
     }
 
@@ -352,7 +352,7 @@ $center-column-max-width: calc(#{$spec-card-max-width}* 4 - 40px);
   }
 
   .spec-expander {
-    span:focus {
+    button:focus {
       outline: #ffffff solid 1px;
     }
   }


### PR DESCRIPTION
Fixes [AB#12446369](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s183?workitem=12446369)

Users with low vision and keyboard users will get confused to access information if the button is appearing as a link which is visual as a link but performing as a button.

![additionaloptions](https://user-images.githubusercontent.com/33185278/155375878-bd82f6f6-5e18-4a92-9a81-befe9084606c.png)

