### PR TITLE
Add V4 PowerShell 7.2 stack definition for function apps

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
@@ -10,6 +10,59 @@ const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (use
     preferredOs: 'windows',
     majorVersions: [
       {
+        displayText: 'PowerShell 7.2',
+        value: '7.2',
+        minorVersions: [
+          {
+            displayText: 'PowerShell 7.2',
+            value: '7.2',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '7.2',
+                isPreview: true,
+                isHidden: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                appSettingsDictionary: {
+                  FUNCTIONS_WORKER_RUNTIME: 'powershell',
+                },
+                siteConfigPropertiesDictionary: {
+                  use32BitWorkerProcess: true,
+                  powerShellVersion: '7.2',
+                  netFrameworkVersion: 'v6.0',
+                },
+                supportedFunctionsExtensionVersions: ['~4'],
+              },
+              linuxRuntimeSettings: {
+                runtimeVersion: 'PowerShell|7.2',
+                isPreview: true,
+                isHidden: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                },
+                appSettingsDictionary: {
+                  FUNCTIONS_WORKER_RUNTIME: 'powershell',
+                },
+                siteConfigPropertiesDictionary: {
+                  use32BitWorkerProcess: false,
+                  linuxFxVersion: 'PowerShell|7.2',
+                },
+                supportedFunctionsExtensionVersions: ['~4'],
+              },
+            },
+          },
+        ],
+      },
+      {
         displayText: 'PowerShell 7',
         value: '7',
         minorVersions: [

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
@@ -10,8 +10,8 @@ const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (use
     preferredOs: 'windows',
     majorVersions: [
       {
-        displayText: 'PowerShell 7.2',
-        value: '7.2',
+        displayText: 'PowerShell 7',
+        value: '7',
         minorVersions: [
           {
             displayText: 'PowerShell 7.2',
@@ -36,7 +36,7 @@ const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (use
                   powerShellVersion: '7.2',
                   netFrameworkVersion: 'v6.0',
                 },
-                supportedFunctionsExtensionVersions: ['~4'],
+                supportedFunctionsExtensionVersions: ['~4']
               },
               linuxRuntimeSettings: {
                 runtimeVersion: 'PowerShell|7.2',
@@ -60,12 +60,6 @@ const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (use
               },
             },
           },
-        ],
-      },
-      {
-        displayText: 'PowerShell 7',
-        value: '7',
-        minorVersions: [
           {
             displayText: 'PowerShell 7.0',
             value: '7.0',

--- a/server/src/tests/Stacks/2020-10-01/function-app/validations.ts
+++ b/server/src/tests/Stacks/2020-10-01/function-app/validations.ts
@@ -221,7 +221,7 @@ function validatePowershellStack(powershellStack) {
   expect(powershellStack.displayText).to.equal('PowerShell Core');
   expect(powershellStack.value).to.equal('powershell');
   expect(powershellStack.preferredOs).to.equal('windows');
-  expect(powershellStack.majorVersions.length).to.equal(3);
+  expect(powershellStack.majorVersions.length).to.equal(2);
   expect(powershellStack).to.deep.equal(hardCodedPowershellStack);
 }
 

--- a/server/src/tests/Stacks/2020-10-01/function-app/validations.ts
+++ b/server/src/tests/Stacks/2020-10-01/function-app/validations.ts
@@ -221,7 +221,7 @@ function validatePowershellStack(powershellStack) {
   expect(powershellStack.displayText).to.equal('PowerShell Core');
   expect(powershellStack.value).to.equal('powershell');
   expect(powershellStack.preferredOs).to.equal('windows');
-  expect(powershellStack.majorVersions.length).to.equal(2);
+  expect(powershellStack.majorVersions.length).to.equal(3);
   expect(powershellStack).to.deep.equal(hardCodedPowershellStack);
 }
 


### PR DESCRIPTION
This PR contains the following changes:
* Add V4 `hidden` and `preview` PowerShell 7.2 stack definition for function apps as 
* Update PowerShell validation stacks to include 7.2