### PR TITLE
[Configurations] bug -  keyToReferenceStatuses undefined

### DIFF
--- a/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
+++ b/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
@@ -408,15 +408,16 @@ export function getConfigWithStackSettings(config: SiteConfig, values: AppSettin
 }
 
 export function getCleanedReferences(references: ArmObj<ConfigKeyVaultReferenceList>) {
-  if (!references.properties.keyToReferenceStatuses) {
+  const keyToReferenceStatuses = !!references && !!references.properties && references.properties.keyToReferenceStatuses;
+  if (!keyToReferenceStatuses) {
     return [];
   }
-  const keyReferenceStatuses = references.properties.keyToReferenceStatuses;
-  return Object.keys(keyReferenceStatuses).map((key, i) => ({
+
+  return Object.keys(keyToReferenceStatuses).map((key, i) => ({
     name: key,
-    reference: keyReferenceStatuses[key].reference,
-    status: keyReferenceStatuses[key].status,
-    details: keyReferenceStatuses[key].details,
+    reference: keyToReferenceStatuses[key].reference,
+    status: keyToReferenceStatuses[key].status,
+    details: keyToReferenceStatuses[key].details,
   }));
 }
 


### PR DESCRIPTION
keyToRefernceStatus property is not on kube env. Add a null check on this property to prevent loading failure

behaviors on prod:
![kubeprod](https://user-images.githubusercontent.com/33185278/155628559-7e1f2584-bd05-425c-9c7b-e23b233b957a.png)

local:
![kubelocal](https://user-images.githubusercontent.com/33185278/155628514-74423274-3691-4ebd-92c8-35a929577db2.png)

