### PR TITLE
chore: Update prettier to 1.19.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2965,9 +2965,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.16.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
-      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+      "version": "1.19.1",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha1-99f1/4qc2HKnvkyhQglZVqYHl8s=",
       "dev": true
     },
     "pretty-hrtime": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gulp-inline-source": "~4.0.0",
     "gulp-prompt": "^1.1.0",
     "husky": "^1.1.0",
-    "prettier": "^1.14.3",
+    "prettier": "^1.19.1",
     "pretty-quick": "^1.7.0"
   },
   "prettier": {


### PR DESCRIPTION
Add support for TypeScript 3.7 features including [optional chaining](https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#optional-chaining) and [nullish coalescing](https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#nullish-coalescing).