### PR TITLE
fix: Return `FunctionAppEditMode.ReadOnlyLock` when resource has read-only lock

### DIFF
--- a/client-react/src/utils/app-state-utils.tsx
+++ b/client-react/src/utils/app-state-utils.tsx
@@ -25,7 +25,7 @@ export async function resolveState(
 ) {
   const readOnlyLock = await portalContext.hasLock(resourceId, 'ReadOnly');
   if (readOnlyLock) {
-    FunctionAppEditMode.ReadOnlyLock;
+    return FunctionAppEditMode.ReadOnlyLock;
   }
 
   const writePermission = await portalContext.hasPermission(resourceId, [RbacConstants.writeScope]);


### PR DESCRIPTION
Address `@typescript-eslint/no-unused-expressions` lint error.