### PR TITLE
fix: Call instead of declaring no-op function in Deployment Center GitHub Provider click handler

### DIFF
--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubProvider.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubProvider.tsx
@@ -58,7 +58,7 @@ const DeploymentCenterGitHubProvider: React.FC<DeploymentCenterGitHubProviderPro
                 <PrimaryButton
                   onClick={() => {
                     toggleHideDialog(true);
-                    resetToken ? resetToken() : () => {};
+                    (resetToken ? resetToken : () => {})(); // resetToken?.();
                   }}
                   text={`${t('update')}`}
                 />

--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubProvider.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubProvider.tsx
@@ -58,7 +58,7 @@ const DeploymentCenterGitHubProvider: React.FC<DeploymentCenterGitHubProviderPro
                 <PrimaryButton
                   onClick={() => {
                     toggleHideDialog(true);
-                    (resetToken ? resetToken : () => {})(); // resetToken?.();
+                    resetToken?.();
                   }}
                   text={`${t('update')}`}
                 />


### PR DESCRIPTION
Address `@typescript-eslint/no-unused-expressions` lint error.