### PR TITLE
fix: Address `prefer-as-const` lint errors in /client-react

### DIFF
--- a/client-react/src/components/ConfirmDialog/ConfirmDialog.styles.ts
+++ b/client-react/src/components/ConfirmDialog/ConfirmDialog.styles.ts
@@ -1,18 +1,19 @@
-/** @type {{main: React.CSSProperties}} */
-export const modalStyles = {
+import { IDialogContentStyles, IDialogFooterStyles, IModalStyles } from '@fluentui/react';
+
+export const modalStyles: Pick<IModalStyles, 'main'> = {
   main: {
-    position: 'absolute' as 'absolute',
+    position: 'absolute',
     top: '0px',
     minWidth: '100% !important',
   },
 };
 
-export const modalContentStyles = {
+export const modalContentStyles: Pick<IDialogContentStyles, 'header' | 'inner' | 'innerContent' | 'title'> = {
   inner: {
     paddingLeft: '0px',
     paddingBottom: '10px',
     paddingRight: '3px',
-    overflow: 'hidden' as 'hidden',
+    overflow: 'hidden',
   },
   header: {
     zIndex: 1,
@@ -28,7 +29,7 @@ export const modalContentStyles = {
   },
 };
 
-export const modalFooterStyles = {
+export const modalFooterStyles: Pick<IDialogFooterStyles, 'actionsRight'> = {
   actionsRight: {
     width: 'calc(100vw - 25px)',
     borderTop: '1px solid rgba(204,204,204,.8)',

--- a/client-react/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/client-react/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -1,6 +1,16 @@
-import { DefaultButton, Dialog, DialogFooter, DialogType, IDialogProps, PrimaryButton } from '@fluentui/react';
+import {
+  DefaultButton,
+  Dialog,
+  DialogFooter,
+  DialogType,
+  IDialogProps,
+  IModalStyleProps,
+  IModalStyles,
+  IStyleFunctionOrObject,
+  PrimaryButton,
+} from '@fluentui/react';
 import React from 'react';
-import { modalFooterStyles, modalContentStyles, modalStyles } from './ConfirmDialog.styles';
+import { modalContentStyles, modalFooterStyles, modalStyles } from './ConfirmDialog.styles';
 
 interface ConfirmDialogProps {
   primaryActionButton: { title: string; onClick: () => void; disabled?: boolean };
@@ -8,7 +18,7 @@ interface ConfirmDialogProps {
   hideDefaultActionButton?: boolean;
   title: string;
   content: string;
-  modalStyles?: any;
+  modalStyles?: IStyleFunctionOrObject<IModalStyleProps, IModalStyles>;
   showCloseModal?: boolean;
 }
 

--- a/client-react/src/components/CustomBanner/CustomBanner.styles.ts
+++ b/client-react/src/components/CustomBanner/CustomBanner.styles.ts
@@ -1,9 +1,9 @@
-import { MessageBarType } from '@fluentui/react';
+import { IMessageBarStyles, MessageBarType } from '@fluentui/react';
 import { style } from 'typestyle';
 import { ThemeExtended } from '../../theme/SemanticColorsExtended';
 
 export const messageBannerStyles = (isCustomIcon: boolean, undocked?: boolean) => {
-  const styles = {
+  const styles: IMessageBarStyles = {
     root: {},
     content: {
       paddingLeft: '15px',
@@ -17,13 +17,13 @@ export const messageBannerStyles = (isCustomIcon: boolean, undocked?: boolean) =
       marginRight: isCustomIcon ? '5px' : undefined,
     },
     iconContainer: {
-      display: isCustomIcon ? ('none' as 'none') : ('contents' as 'contents'),
+      display: isCustomIcon ? 'none' : 'contents',
     },
     icon: {},
     dismissal: {
       height: '16px',
       width: '16px',
-      position: 'relative' as 'relative',
+      position: 'relative',
       top: '8px',
       right: '15px',
     },

--- a/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.style.ts
+++ b/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.style.ts
@@ -1,3 +1,4 @@
+import { IModalStyles } from '@fluentui/react';
 import { style } from 'typestyle';
 import { ThemeExtended } from '../../../../../theme/SemanticColorsExtended';
 import { SVGAttributes } from 'react';
@@ -39,9 +40,9 @@ export const smallPageStyle = style({
   padding: '20px',
 });
 
-export const dialogModelStyle = {
+export const dialogModelStyle: Pick<IModalStyles, 'main'> = {
   main: {
-    position: 'absolute' as 'absolute',
+    position: 'absolute',
     top: '125px',
     right: '0px',
     minWidth: '340px !important',


### PR DESCRIPTION
Use Fluent UI type definitions to improve type declarations.