### PR TITLE
13766742[FunctionApp V1/V2][Stage]:Unable to Save the API Proxy after Editing

### DIFF
--- a/client/src/app/api/api-details/api-details.component.ts
+++ b/client/src/app/api/api-details/api-details.component.ts
@@ -235,14 +235,11 @@ export class ApiDetailsComponent extends NavigableComponent implements OnDestroy
             this.apiProxies[index] = this.apiProxyEdit;
           }
 
-          return this._functionAppService.saveApiProxy(
-            this.context,
-            ApiProxy.toJson(this.apiProxies, this._translateService),
-            this._runtimeVersion
-          );
-        })
-        .finally(() => {
-          this._disableSubmit = false;
+          return this._functionAppService
+            .saveApiProxy(this.context, ApiProxy.toJson(this.apiProxies, this._translateService), this._runtimeVersion)
+            .finally(() => {
+              this._disableSubmit = false;
+            });
         })
         .subscribe(() => {
           this.clearBusy();


### PR DESCRIPTION
This is a bug introduced by this PR >>>  https://github.com/Azure/azure-functions-ux/pull/6523

It is giving error if we try to call .finally on .concatMap. I moved finally call within .contactMap to handle at least "save" scenario.

This was the error shown in the console log:
<img width="652" alt="image" src="https://user-images.githubusercontent.com/30202258/157301033-6e186646-1dcf-4fd2-a35f-6ba3f3bc9ae3.png">
