### PR TITLE
Java Stacks Bug Fix

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
@@ -231,6 +231,7 @@ export const javaContainersStack: WebAppStack = {
               java8Runtime: 'JBOSSEAP|7.3-java8',
               java11Runtime: 'JBOSSEAP|7.3-java11',
               isAutoUpdate: true,
+              isDeprecated: true,  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
               isHidden: true // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x) 
             }
           }
@@ -243,6 +244,7 @@ export const javaContainersStack: WebAppStack = {
               java8Runtime: 'JBOSSEAP|7.4-java8',
               java11Runtime: 'JBOSSEAP|7.4-java11',
               isAutoUpdate: true,
+              isDeprecated: true,  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
               isHidden: true  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
             }
           }

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
@@ -313,6 +313,7 @@ export const javaContainersStack: WebAppStack = {
               isAutoUpdate: true,
             },
             linuxContainerSettings: {
+              java17Runtime: 'TOMCAT|9.0-java17',
               java11Runtime: 'TOMCAT|9.0-java11',
               java8Runtime: 'TOMCAT|9.0-jre8',
               isAutoUpdate: true,
@@ -330,6 +331,7 @@ export const javaContainersStack: WebAppStack = {
             linuxContainerSettings: {
               java8Runtime: 'TOMCAT|9.0.54-java8',
               java11Runtime: 'TOMCAT|9.0.54-java11',
+              java17Runtime: 'TOMCAT|9.0.54-java17'
             },
           },
         },

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/JavaContainers.ts
@@ -231,7 +231,6 @@ export const javaContainersStack: WebAppStack = {
               java8Runtime: 'JBOSSEAP|7.3-java8',
               java11Runtime: 'JBOSSEAP|7.3-java11',
               isAutoUpdate: true,
-              isDeprecated: true,  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
               isHidden: true // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x) 
             }
           }
@@ -244,7 +243,6 @@ export const javaContainersStack: WebAppStack = {
               java8Runtime: 'JBOSSEAP|7.4-java8',
               java11Runtime: 'JBOSSEAP|7.4-java11',
               isAutoUpdate: true,
-              isDeprecated: true,  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
               isHidden: true  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
             }
           }

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -231,7 +231,7 @@ export const javaContainersStack: WebAppStack = {
               java8Runtime: 'JBOSSEAP|7.3-java8',
               java11Runtime: 'JBOSSEAP|7.3-java11',
               isAutoUpdate: true,
-              isHidden: true,  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
+              isHidden: true  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
             }
           }
         },
@@ -243,7 +243,7 @@ export const javaContainersStack: WebAppStack = {
               java8Runtime: 'JBOSSEAP|7.4-java8',
               java11Runtime: 'JBOSSEAP|7.4-java11',
               isAutoUpdate: true,
-              isHidden: true,  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
+              isHidden: true  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
             }
           }
         },

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -313,6 +313,7 @@ export const javaContainersStack: WebAppStack = {
               isAutoUpdate: true,
             },
             linuxContainerSettings: {
+              java17Runtime: 'TOMCAT|9.0-java17',
               java11Runtime: 'TOMCAT|9.0-java11',
               java8Runtime: 'TOMCAT|9.0-jre8',
               isAutoUpdate: true,
@@ -330,6 +331,7 @@ export const javaContainersStack: WebAppStack = {
             linuxContainerSettings: {
               java8Runtime: 'TOMCAT|9.0.54-java8',
               java11Runtime: 'TOMCAT|9.0.54-java11',
+              java17Runtime: 'TOMCAT|9.0.54-java17'
             },
           },
         },

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -231,7 +231,8 @@ export const javaContainersStack: WebAppStack = {
               java8Runtime: 'JBOSSEAP|7.3-java8',
               java11Runtime: 'JBOSSEAP|7.3-java11',
               isAutoUpdate: true,
-              isHidden: true  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
+              isHidden: true,  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
+              isDeprecated: true  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
             }
           }
         },
@@ -243,7 +244,8 @@ export const javaContainersStack: WebAppStack = {
               java8Runtime: 'JBOSSEAP|7.4-java8',
               java11Runtime: 'JBOSSEAP|7.4-java11',
               isAutoUpdate: true,
-              isHidden: true  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
+              isHidden: true,  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
+              isDeprecated: true  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
             }
           }
         },

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -232,7 +232,6 @@ export const javaContainersStack: WebAppStack = {
               java11Runtime: 'JBOSSEAP|7.3-java11',
               isAutoUpdate: true,
               isHidden: true,  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
-              isDeprecated: true  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
             }
           }
         },
@@ -245,7 +244,6 @@ export const javaContainersStack: WebAppStack = {
               java11Runtime: 'JBOSSEAP|7.4-java11',
               isAutoUpdate: true,
               isHidden: true,  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
-              isDeprecated: true  // note (jafreebe) March 2022: Only have 1 auto-update lane at the major version (7.x.x)
             }
           }
         },


### PR DESCRIPTION
Adds Java 17 support for Tomcat 9.0.54. This was missed in my original PR.