### PR TITLE
AB#12436048 Make texts within the parent component

### DIFF
--- a/client/src/app/controls/group-tabs/group-tabs.component.scss
+++ b/client/src/app/controls/group-tabs/group-tabs.component.scss
@@ -15,7 +15,7 @@ nav {
 .group-tab {
   background-color: #bbb;
   text-align: center;
-  height: 83px;
+  min-height: 83px;
   padding-top: 7px;
   box-shadow: $card-box-shadow;
   outline-offset: -2px;
@@ -35,9 +35,9 @@ nav {
 
 .group-tab-description {
   font-size: 12px;
-  line-height: 0px;
   white-space: nowrap;
   color: #161514;
+  white-space: initial;
 }
 
 :host-context(#app-root[theme='dark']) {


### PR DESCRIPTION
Before:
![overflow-before](https://user-images.githubusercontent.com/33185278/157985993-a2279243-6867-4e40-afe1-a9d6a35476d1.png)

Now:
![overflowNow](https://user-images.githubusercontent.com/33185278/157986009-236e3c04-9621-4749-8501-a22d32b325e0.png)

