### PR TITLE
Un-deprecating Python 3.6 for Functions

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Python.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Python.ts
@@ -92,7 +92,6 @@ export const pythonStack: FunctionAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'Python|3.6',
-              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,


### PR DESCRIPTION
Python 3.6 deprecation notification was sent on Sept. 2021. We have to wait for a year before deprecating it.

Un-deprecating it and this will reflect in 3.6 to show up in the portal and AzCLI.