### PR TITLE
Update the styles of text field with prefix

### DIFF
--- a/client-react/src/components/form-controls/TextFieldNoFormik.tsx
+++ b/client-react/src/components/form-controls/TextFieldNoFormik.tsx
@@ -72,11 +72,7 @@ const TextFieldNoFormik: FC<ITextFieldProps & CustomTextFieldProps> = props => {
   };
 
   const getTextFieldStyles = () => {
-    if (!!styles && typeof styles === 'function') {
-      return styles;
-    } else {
-      return textFieldStyleOverrides(theme, fullpage, widthOverride, styles);
-    }
+    return styles ?? textFieldStyleOverrides(theme, fullpage, widthOverride);
   };
 
   const getTextFieldProps = (): ITextFieldProps => {

--- a/client-react/src/components/form-controls/TextFieldNoFormik.tsx
+++ b/client-react/src/components/form-controls/TextFieldNoFormik.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useState } from 'react';
+import React, { FC, useCallback, useContext, useState } from 'react';
 import { TextField as OfficeTextField, ITextFieldProps } from '@fluentui/react';
 import ReactiveFormControl from './ReactiveFormControl';
 import { useWindowSize } from 'react-use';
@@ -71,9 +71,9 @@ const TextFieldNoFormik: FC<ITextFieldProps & CustomTextFieldProps> = props => {
     );
   };
 
-  const getTextFieldStyles = () => {
+  const getTextFieldStyles = useCallback(() => {
     return styles ?? textFieldStyleOverrides(theme, fullpage, widthOverride);
-  };
+  }, [styles, theme, fullpage, widthOverride]);
 
   const getTextFieldProps = (): ITextFieldProps => {
     const textFieldProps: ITextFieldProps = {

--- a/client-react/src/components/form-controls/formControl.override.styles.tsx
+++ b/client-react/src/components/form-controls/formControl.override.styles.tsx
@@ -4,7 +4,6 @@ import { style } from 'typestyle';
 import { ThemeExtended } from '../../theme/SemanticColorsExtended';
 import { TextFieldStyles } from '../../theme/CustomOfficeFabric/AzurePortal/TextField.styles';
 import { ComboBoxStyles } from '../../theme/CustomOfficeFabric/AzurePortal/ComboBox.styles';
-import { DeepPartial } from '@uifabric/merge-styles/lib/DeepPartial';
 
 const FORM_DEFAULT_WIDTH = '275px';
 const FULL_PAGE_WIDTH = '220px';
@@ -50,20 +49,20 @@ export const comboboxStyleOverrides = (theme: ThemeExtended, fullpage: boolean, 
   } as IDropdownStyles;
 };
 
-export const textFieldPrefixStylesOverride = () => {
-  return {
-    field: {
-      paddingLeft: '0px',
-    },
-  };
+export const textFieldPrefixStylesOverride = (hasPrefix: boolean) => {
+  return hasPrefix
+    ? {
+        field: {
+          paddingLeft: '0px',
+        },
+        prefix: {
+          paddingRight: '0px',
+        },
+      }
+    : undefined;
 };
 
-export const textFieldStyleOverrides = (
-  theme: ThemeExtended,
-  fullpage: boolean,
-  widthOverride?: string,
-  stylesOverride?: DeepPartial<ITextFieldStyles>
-) => styleProps => {
+export const textFieldStyleOverrides = (theme: ThemeExtended, fullpage: boolean, widthOverride?: string) => styleProps => {
   const baseStyle = TextFieldStyles(styleProps);
   return {
     ...baseStyle,
@@ -76,10 +75,6 @@ export const textFieldStyleOverrides = (
     suffix: {
       paddingRight: '0px',
     },
-    prefix: {
-      paddingRight: '0px',
-    },
-    ...stylesOverride,
   } as ITextFieldStyles;
 };
 

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
@@ -243,7 +243,7 @@ const AzureStorageMountsAddEdit: React.SFC<AzureStorageMountsAddEditPropsCombine
               errorMessage={formProps.errors && formProps.errors.mountPath}
               required={true}
               validate={validateMountPath}
-              styles={textFieldPrefixStylesOverride()}
+              styles={textFieldPrefixStylesOverride(!isLinuxOrContainer())}
             />
             <ActionBar
               id="handler-mappings-edit-footer"


### PR DESCRIPTION
Keep the padding left if the field does not have prefix

Before:
![before](https://user-images.githubusercontent.com/33185278/159342106-b5ad63c2-466e-4d9e-8a0c-3f9cc4e397fe.png)

After:
![after](https://user-images.githubusercontent.com/33185278/159342128-709f9963-4c26-4c2b-8d19-558d3635aed2.png)

