### PR TITLE
Config Menu Change Only - 10023302 [SWA] - Additional Changes request- stable environments

### DIFF
--- a/client-react/src/pages/static-app/StaticSiteUtility.tsx
+++ b/client-react/src/pages/static-app/StaticSiteUtility.tsx
@@ -1,6 +1,8 @@
 import { KeyValue } from '../../models/portal-models';
 import { LogLevel, TelemetryInfo } from '../../models/telemetry';
 import { PasswordProtectionTypes } from './configuration/Configuration.types';
+import { ArmObj } from '../../models/arm-obj';
+import { Environment } from '../../models/static-site/environment';
 
 export const getTelemetryInfo = (
   logLevel: LogLevel,
@@ -41,4 +43,11 @@ export const stringToPasswordProtectionType = (passwordProtection: string) => {
     default:
       return PasswordProtectionTypes.Disabled;
   }
+};
+
+// NOTE: This is for non-stable and stable environment (non-prod). 'buildId' property value should be available for both stable and non-stable,
+// but not 'pullRequestTitle' property value. Stable env's 'pullRequestTitle' will be 'null'.
+// If 'pullRequestTitle' has value, we would like to display the title. Otherwise, we will display buildId.
+export const getPreviewsTitleValue = (environment: ArmObj<Environment>) => {
+  return environment.properties.pullRequestTitle || environment.properties.buildId;
 };

--- a/client-react/src/pages/static-app/configuration/Configuration.data.ts
+++ b/client-react/src/pages/static-app/configuration/Configuration.data.ts
@@ -2,6 +2,7 @@ import { KeyValue } from '../../../models/portal-models';
 import { EnvironmentVariable } from './Configuration.types';
 import { ArmObj } from '../../../models/arm-obj';
 import { Environment } from '../../../models/static-site/environment';
+import { getPreviewsTitleValue } from '../StaticSiteUtility';
 
 export default class ConfigurationData {
   public static convertEnvironmentVariablesObjectToArray(environmentVariableObject: KeyValue<string>) {
@@ -20,8 +21,6 @@ export default class ConfigurationData {
   }
 
   public static getEnvironmentName(environment: ArmObj<Environment>) {
-    return environment.name.toLocaleLowerCase() === 'default'
-      ? 'Production'
-      : `#${environment.name} - ${environment.properties.pullRequestTitle}`;
+    return environment.name.toLocaleLowerCase() === 'default' ? 'Production' : getPreviewsTitleValue(environment);
   }
 }


### PR DESCRIPTION
Updating how to display Prod/Non-stable and stable environment's value.

**Left side is AFTER and right side is BEFORE:**
<img width="917" alt="image" src="https://user-images.githubusercontent.com/30202258/159813192-77667df2-3993-4bcc-af01-08d53db0800d.png">
![image](https://user-images.githubusercontent.com/30202258/159813274-49d06ef9-d77b-4fca-a08f-5675a1d32f41.png)

