### PR TITLE
AB#13923254 Remove the check on equality of secret name and setting name

### DIFF
--- a/client-react/src/pages/app/app-settings/ApplicationSettings/AppSettingAddEdit.tsx
+++ b/client-react/src/pages/app/app-settings/ApplicationSettings/AppSettingAddEdit.tsx
@@ -78,8 +78,7 @@ const AppSettingAddEdit: React.SFC<AppSettingAddEditProps> = props => {
       appSetting.name === currentAppSetting.name &&
       appSetting.value === currentAppSetting.value &&
       !!currentAppSettingReference &&
-      !!currentAppSettingReference.secretName &&
-      currentAppSetting.name.toLowerCase() === currentAppSettingReference.secretName.toLowerCase()
+      !!currentAppSettingReference.secretName
     );
   };
 


### PR DESCRIPTION
Fixes: [AB#13923254](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s185?workitem=13923254)
Remove the check on equality of app setting reference secret name and app setting name

Before:
![keyVaultBefore](https://user-images.githubusercontent.com/33185278/159985196-021e1b23-7aec-4589-bb71-d14f9680a3d0.png)

After:
![keyvault](https://user-images.githubusercontent.com/33185278/159985219-79409f31-5ec1-407a-8b38-510a99bed882.png)

