### PR TITLE
Configuration Blade string change - 10023302 [SWA] - Additional Changes request - stable environments

### DIFF
--- a/client-react/src/pages/static-app/StaticSiteUtility.tsx
+++ b/client-react/src/pages/static-app/StaticSiteUtility.tsx
@@ -49,5 +49,8 @@ export const stringToPasswordProtectionType = (passwordProtection: string) => {
 // but not 'pullRequestTitle' property value. Stable env's 'pullRequestTitle' will be 'null'.
 // If 'pullRequestTitle' has value, we would like to display the title. Otherwise, we will display buildId.
 export const getPreviewsTitleValue = (environment: ArmObj<Environment>) => {
-  return environment.properties.pullRequestTitle || environment.properties.buildId;
+  const { pullRequestTitle, buildId } = environment.properties;
+  const { name } = environment;
+
+  return pullRequestTitle ? `#${name} - ${pullRequestTitle}` : buildId;
 };


### PR DESCRIPTION
If `pullRequestTitle` value exists (which mean it is non-stable env), we would like to display `#{env name} - {pullRequestTitle}`.

**AFTER**
<img width="460" alt="image" src="https://user-images.githubusercontent.com/30202258/160146803-73128b3b-f28b-4807-b5c7-bf6ea3ecb475.png">

**BEFORE**
<img width="522" alt="image" src="https://user-images.githubusercontent.com/30202258/160146948-03f61c7c-06ab-465d-afc6-85ecf7c06471.png">
