### PR TITLE
Marking Ruby 2.6 as deprecated

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Ruby.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Ruby.ts
@@ -55,6 +55,7 @@ export const rubyStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'RUBY|2.6',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
@@ -72,6 +73,7 @@ export const rubyStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'RUBY|2.6.2',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Ruby.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Ruby.ts
@@ -57,6 +57,7 @@ const getRubyStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
             stackSettings: {
               linuxRuntimeSettings: {
                 runtimeVersion: 'RUBY|2.6',
+                isDeprecated: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
@@ -74,6 +75,7 @@ const getRubyStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
             stackSettings: {
               linuxRuntimeSettings: {
                 runtimeVersion: 'RUBY|2.6.2',
+                isDeprecated: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,


### PR DESCRIPTION
Fixes [AB#13875370](https://msazure.visualstudio.com/Antares/_workitems/edit/13875370)