### PR TITLE
[AI Logs] Default to AI Logs behind FF

### DIFF
--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
@@ -518,8 +518,13 @@ export const FunctionEditor: React.SFC<FunctionEditorProps> = props => {
   useEffect(() => {
     fetchData();
     setLiveLogsSessionId(Guid.newGuid());
-    setSelectedLoggingOption(showAppInsightsLogs ? LoggingOptions.appInsights : LoggingOptions.fileBased);
-    expandLogPanel();
+    if (Url.isFeatureFlagEnabled(CommonConstants.FeatureFlags.useNewFunctionLogsApi)) {
+      setSelectedLoggingOption(showAppInsightsLogs ? LoggingOptions.appInsights : LoggingOptions.fileBased);
+      expandLogPanel();
+    } else {
+      setSelectedLoggingOption(isFileSystemLoggingAvailable ? LoggingOptions.fileBased : LoggingOptions.appInsights);
+    }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
Hiding AI as the default behind the feature flag after further discussion.

No FF:
![image](https://user-images.githubusercontent.com/35281019/160728595-39d4d5b0-0ac8-45d8-805d-6411e26dfd65.png)

with FF:
![image](https://user-images.githubusercontent.com/35281019/160728638-1e1fe059-b7a1-454f-a63d-391a20c66ae8.png)
