### PR TITLE
fix: Report error if container configuration did not succeed

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -644,9 +644,11 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
       const updateApplicationPropertiesResponse = await updateApplicationProperties(values);
 
       if (!updateApplicationPropertiesResponse.success) {
+        containerConfigurationSucceeded = false;
         errorMessage = getErrorMessage(updateApplicationPropertiesResponse.error);
       }
     } else {
+      containerConfigurationSucceeded = false;
       errorMessage = getErrorMessage(updateGitHubActionSettingsResponse.error);
     }
 


### PR DESCRIPTION
Linter detected this bug as a `prefer-const` error in line 640. The code never changed `containerConfigurationSucceeded` to indicate failure.