### PR TITLE
Revert ComboBox, RadioButton, and TextField changes for styling

### DIFF
--- a/client-react/src/components/form-controls/ComboBox.tsx
+++ b/client-react/src/components/form-controls/ComboBox.tsx
@@ -24,7 +24,7 @@ interface CustomComboBoxProps {
 }
 
 const ComboBox = (props: FieldProps & IComboBoxProps & CustomComboBoxProps) => {
-  const { field, form, options, setOptions, allowFreeform, isLoading, searchable, clearComboBox, ...rest } = props;
+  const { field, form, options, styles, setOptions, allowFreeform, isLoading, searchable, text, clearComboBox, ...rest } = props;
   const theme = useContext(ThemeContext);
   const [searchTerm, setSearchTerm] = useState<string | undefined>(undefined);
 

--- a/client-react/src/components/form-controls/ComboBoxnoFormik.tsx
+++ b/client-react/src/components/form-controls/ComboBoxnoFormik.tsx
@@ -18,7 +18,7 @@ interface CustomComboboxProps {
 }
 
 const ComboBoxNoFormik = (props: IComboBoxProps & CustomComboboxProps) => {
-  const { value, onChange, errorMessage, options, ...rest } = props;
+  const { value, onChange, errorMessage, options, label, ...rest } = props;
   const theme = useContext(ThemeContext);
   const { width } = useWindowSize();
 

--- a/client-react/src/components/form-controls/RadioButton.tsx
+++ b/client-react/src/components/form-controls/RadioButton.tsx
@@ -18,7 +18,7 @@ interface RadioButtonProps {
 }
 
 const RadioButton: React.SFC<IChoiceGroupProps & FieldProps & RadioButtonProps> = props => {
-  const { field, form, options, displayInVerticalLayout, ...rest } = props;
+  const { field, form, options, theme, displayInVerticalLayout, ...rest } = props;
   const onChange = (e: unknown, option: IChoiceGroupOption) => {
     form.setFieldValue(field.name, option.key);
   };

--- a/client-react/src/components/form-controls/RadioButtonNoFormik.tsx
+++ b/client-react/src/components/form-controls/RadioButtonNoFormik.tsx
@@ -22,7 +22,7 @@ const fieldStyle = style({
   marginRight: '10px',
 });
 const RadioButtonNoFormik: React.SFC<IChoiceGroupProps & RadioButtonProps> = props => {
-  const { options, onChange, displayInVerticalLayout, ...rest } = props;
+  const { options, learnMore, label, subLabel, upsellMessage, theme, onChange, displayInVerticalLayout, ...rest } = props;
   const optionsWithMargin: IChoiceGroupOption[] | undefined =
     options &&
     options.map(option => {

--- a/client-react/src/components/form-controls/TextFieldNoFormik.tsx
+++ b/client-react/src/components/form-controls/TextFieldNoFormik.tsx
@@ -17,6 +17,7 @@ const TextFieldNoFormik: FC<ITextFieldProps & CustomTextFieldProps> = props => {
     onChange,
     onBlur,
     errorMessage,
+    label,
     widthOverride,
     styles,
     id,


### PR DESCRIPTION
Removal of label and theme props to components resulted in adding another label for ComboBox, RadioButton, and TextField controls

**Before:**
![image](https://user-images.githubusercontent.com/29874289/163873603-4db5c8ba-c818-4feb-b67e-a3b79370b642.png)


**After:**
![image](https://user-images.githubusercontent.com/29874289/163873608-62f67694-7f5f-4510-8a9b-866c13c11480.png)
