### PR TITLE
[DC] Remove placeholder text for image and tag for windows containers

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDockerHubSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDockerHubSettings.tsx
@@ -73,8 +73,6 @@ const DeploymentCenterContainerDockerHubSettings: React.FC<DeploymentCenterField
       return t('containerImageNamePlaceHolder');
     } else if (siteStateContext.isLinuxApp) {
       return t('containerImageAndTagPlaceholder');
-    } else {
-      return t('containerImageAndTagPlaceholderForWindows');
     }
   };
 


### PR DESCRIPTION
FixesAB#[14124282](https://msazure.visualstudio.com/Antares/_workitems/edit/14124282)
- Using an obsolete image + tag name
- Removing placeholder text completely as all Windows images are now in MCR

**Before:** 
![image](https://user-images.githubusercontent.com/29874289/163874980-feac0b28-2ecf-4942-b6a6-3243b64b6d2f.png)

**After:**
![image](https://user-images.githubusercontent.com/29874289/163874988-b5532200-ad24-4ce5-9292-93bf2a527a65.png)
