### PR TITLE
Show version number for custom runtime version in parentheses

### DIFF
--- a/client-react/src/pages/app/app-settings/FunctionRuntimeSettings/RuntimeVersionNew.tsx
+++ b/client-react/src/pages/app/app-settings/FunctionRuntimeSettings/RuntimeVersionNew.tsx
@@ -1,5 +1,5 @@
 // TODO (krmitta):  Rename the file after this version is tested
-import { MessageBarType } from '@fluentui/react';
+import { IDropdownOption, MessageBarType } from '@fluentui/react';
 import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
@@ -22,7 +22,7 @@ const RuntimeVersion: React.FC<AppSettingsFormProps> = props => {
   const { values, initialValues, setFieldValue } = props;
   const { t } = useTranslation();
 
-  const [stackSupportedRuntimeVersions, setStackSupportedRuntimeVersions] = useState<RuntimeExtensionMajorVersions[]>([]);
+  const [stackSupportedRuntimeVersions, setStackSupportedRuntimeVersions] = useState<IDropdownOption[]>([]);
   const [selectedRuntimeVersion, setselectedRuntimeVersion] = useState<string>(RuntimeExtensionMajorVersions.custom);
   const [showWarningBannerForNonSupportedVersion, setShowWarningBannerForNonSupportedVersion] = useState(false);
 
@@ -54,11 +54,14 @@ const RuntimeVersion: React.FC<AppSettingsFormProps> = props => {
 
     if (isCustomVersion) {
       setShowWarningBannerForNonSupportedVersion(true);
+      setStackSupportedRuntimeVersions([
+        ...supportedExtensionVersionsFromStacksData.map(key => ({ key, text: key })),
+        { key: RuntimeExtensionMajorVersions.custom, text: `${RuntimeExtensionMajorVersions.custom} (${runtimeVersion})` },
+      ]);
       runtimeVersion = RuntimeExtensionMajorVersions.custom;
-      setStackSupportedRuntimeVersions([...supportedExtensionVersionsFromStacksData, RuntimeExtensionMajorVersions.custom]);
     } else {
       setShowWarningBannerForNonSupportedVersion(false);
-      setStackSupportedRuntimeVersions([...supportedExtensionVersionsFromStacksData]);
+      setStackSupportedRuntimeVersions(supportedExtensionVersionsFromStacksData.map(key => ({ key, text: key })));
     }
 
     if (selectedRuntimeVersion !== runtimeVersion) {
@@ -160,10 +163,7 @@ const RuntimeVersion: React.FC<AppSettingsFormProps> = props => {
           {getBannerComponents()}
           <DropdownNoFormik
             onChange={(_e, option) => onDropdownChange(!!option && option.key)}
-            options={stackSupportedRuntimeVersions.map(version => ({
-              key: version.toLocaleLowerCase(),
-              text: version.toLocaleLowerCase(),
-            }))}
+            options={stackSupportedRuntimeVersions}
             selectedKey={selectedRuntimeVersion}
             disabled={false}
             label={t('runtimeVersion')}


### PR DESCRIPTION
[#13984110](https://msazure.visualstudio.com/Antares/_workitems/edit/13984110/)

![Screenshot 2022-04-19 121107](https://user-images.githubusercontent.com/26208574/164048548-0083e48b-c215-4351-9521-1f6b3ce89abe.png)