### PR TITLE
Customize system key function URL for authentication event triggers

### DIFF
--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.data.ts
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.data.ts
@@ -70,6 +70,10 @@ export default class FunctionEditorData {
     return BindingManager.getEventGridTriggerInfo(functionInfo.properties);
   }
 
+  public isAuthenticationEventTriggerFunction(functionInfo: ArmObj<FunctionInfo>) {
+    return BindingManager.getAuthenticationEventTriggerTypeInfo(functionInfo.properties);
+  }
+
   public getSaveFileHeaders(mime: string) {
     return {
       'Content-Type': mime,

--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditorCommandBar.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditorCommandBar.tsx
@@ -212,9 +212,33 @@ const FunctionEditorCommandBar: React.FC<FunctionEditorCommandBarProps> = props 
       .sort((urlObj1, urlObj2) => urlObj1.text.localeCompare(urlObj2.text));
   };
 
+  const getAuthenticationEventSubscriptionUrl = (code: string) => {
+    return siteStateContext.site
+      ? `${Url.getMainUrl(siteStateContext.site)}/runtime/webhooks/customauthenticationextension?functionName=${
+          functionInfo.properties.name
+        }&code=${code}`
+      : '';
+  };
+
+  const getUrlObjsForAuthenticationEventTriggerFunction = () => {
+    return urlObjs
+      .filter(urlObj => {
+        return urlObj.type === UrlType.System && urlObj.text === CommonConstants.AppKeys.authenticationEvent;
+      })
+      .map(urlObj => {
+        return {
+          ...urlObj,
+          url: getAuthenticationEventSubscriptionUrl(urlObj.data),
+        };
+      })
+      .sort((urlObj1, urlObj2) => urlObj1.text.localeCompare(urlObj2.text));
+  };
+
   const getFilteredUrlObj = (): UrlObj[] => {
     if (functionEditorContext.isEventGridTriggerFunction(functionInfo)) {
       return getUrlObjsForEventGridTriggerFunction();
+    } else if (functionEditorContext.isAuthenticationEventTriggerFunction(functionInfo)) {
+      return getUrlObjsForAuthenticationEventTriggerFunction();
     } else {
       return urlObjs;
     }

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -171,6 +171,7 @@ export class CommonConstants {
     master: 'master',
     eventGridV1: 'eventgridextensionconfig_extension',
     eventGridV2: 'eventgrid_extension',
+    authenticationEvent: 'customauthenticationextension_extension',
   };
 
   public static EventGridSubscriptionEndpoints = {


### PR DESCRIPTION
Customize the functions URL we build for system key for the new `authenticationEventTrigger` type trigger.

Example
https://authenticationeventtrigger.azurewebsites.net/runtime/webhooks/customauthenticationextension?functionName=[REDACTED]&code=[REDACTED]