### PR TITLE
Show error message after incomplete save

### DIFF
--- a/client-react/src/components/form-controls/ComboBox.tsx
+++ b/client-react/src/components/form-controls/ComboBox.tsx
@@ -60,7 +60,7 @@ const ComboBox = (props: FieldProps & IComboBoxProps & CustomComboBoxProps) => {
     }
   }, [options]);
 
-  const errorMessage = get(form.errors, field.name, '') as string;
+  const errorMessage = get(form.touched, field.name, false) ? (get(form.errors, field.name, '') as string) : undefined;
 
   return (
     <div className={loadingComboBoxStyle}>

--- a/client-react/src/components/form-controls/DropDown.tsx
+++ b/client-react/src/components/form-controls/DropDown.tsx
@@ -55,7 +55,7 @@ const Dropdown = (props: FieldProps & IDropdownProps & CustomDropdownProps) => {
         ...props,
       };
 
-  const errorMessage = get(form.errors, field.name, '') as string;
+  const errorMessage = get(form.touched, field.name, false) ? (get(form.errors, field.name, '') as string) : undefined;
 
   const loadingProps = isLoading
     ? {

--- a/client-react/src/components/form-controls/TextField.tsx
+++ b/client-react/src/components/form-controls/TextField.tsx
@@ -32,7 +32,7 @@ const TextField: React.FC<FieldProps & ITextFieldProps & CustomTextFieldProps> =
   };
 
   const getErrorMessage = () => {
-    return cronErrorMessage(get(form.errors, field.name, '') as string);
+    return get(form.touched, field.name, false) ? cronErrorMessage(get(form.errors, field.name, '') as string) : undefined;
   };
 
   // TODO (refortie): Temporary hard-coding of the documentation link.

--- a/client-react/src/components/form-controls/Toggle.tsx
+++ b/client-react/src/components/form-controls/Toggle.tsx
@@ -18,7 +18,7 @@ const Toggle = (props: FieldProps & IToggleProps & CustomToggleProps) => {
   };
 
   const checked = field.value;
-  const errorMessage = get(form.errors, field.name, '') as string;
+  const errorMessage = get(form.touched, field.name, false) ? (get(form.errors, field.name, '') as string) : undefined;
 
   return <ToggleNoFormik checked={checked} onChange={onChange} onBlur={field.onBlur} errorMessage={errorMessage} {...props} />;
 };


### PR DESCRIPTION
[#10184885](https://msazure.visualstudio.com/Antares/_workitems/edit/10184885/)

Show error message on Formik fields only when they are touched (focus lost or form submitting).

![10184885](https://user-images.githubusercontent.com/26208574/165427425-65af6a20-e1a9-4ebb-9ce7-e7fefa7e70f9.gif)

