### PR TITLE
Marking .Net 5 and Node 12 as deprecated

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/AspDotnet.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/AspDotnet.ts
@@ -91,6 +91,7 @@ export const aspDotnetStack: WebAppStack = {
           stackSettings: {
             windowsRuntimeSettings: {
               runtimeVersion: 'v5.0',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
@@ -102,6 +103,7 @@ export const aspDotnetStack: WebAppStack = {
             },
             linuxRuntimeSettings: {
               runtimeVersion: 'DOTNETCORE|5.0',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
@@ -120,6 +120,7 @@ export const nodeStack: WebAppStack = {
           stackSettings: {
             linuxRuntimeSettings: {
               runtimeVersion: 'NODE|12-lts',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
@@ -132,6 +133,7 @@ export const nodeStack: WebAppStack = {
             },
             windowsRuntimeSettings: {
               runtimeVersion: '12.13.0',
+              isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -2,7 +2,9 @@ import { WebAppStack } from '../../models/WebAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFormat: boolean) => {
+  const dotnet5EOL = getDateString(new Date(2022, 5, 8), useIsoDateFormat);
   const dotnetCore3Point0EOL = getDateString(new Date(2020, 3, 3), useIsoDateFormat);
+  const dotnetCore3Point1EOL = getDateString(new Date(2022, 12, 3), useIsoDateFormat);
   const dotnetCore2Point2EOL = getDateString(new Date(2019, 12, 23), useIsoDateFormat);
   const dotnetCore2Point1EOL = getDateString(new Date(2021, 7, 21), useIsoDateFormat);
   const dotnetCore2Point0EOL = getDateString(new Date(2018, 10, 1), useIsoDateFormat);
@@ -95,6 +97,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
             stackSettings: {
               windowsRuntimeSettings: {
                 runtimeVersion: 'v5.0',
+                isDeprecated: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -103,9 +106,11 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                   isSupported: true,
                   supportedVersion: '5.0.x',
                 },
+                endOfLifeDate: dotnet5EOL,
               },
               linuxRuntimeSettings: {
                 runtimeVersion: 'DOTNETCORE|5.0',
+                isDeprecated: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -114,6 +119,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                   isSupported: true,
                   supportedVersion: '5.0.x',
                 },
+                endOfLifeDate: dotnet5EOL,
               },
             },
           },
@@ -137,6 +143,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                   isSupported: true,
                   supportedVersion: '3.1.301',
                 },
+                endOfLifeDate: dotnetCore3Point1EOL,
               },
               linuxRuntimeSettings: {
                 runtimeVersion: 'DOTNETCORE|3.1',
@@ -148,6 +155,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                   isSupported: true,
                   supportedVersion: '3.1.301',
                 },
+                endOfLifeDate: dotnetCore3Point1EOL,
               },
             },
           },

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
@@ -122,6 +122,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
             stackSettings: {
               linuxRuntimeSettings: {
                 runtimeVersion: 'NODE|12-lts',
+                isDeprecated: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -134,6 +135,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
               },
               windowsRuntimeSettings: {
                 runtimeVersion: '12.13.0',
+                isDeprecated: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,


### PR DESCRIPTION
Fixes [AB#10469592](https://msazure.visualstudio.com/Antares/_workitems/edit/10469592)
Fixes [AB#10469461](https://msazure.visualstudio.com/Antares/_workitems/edit/10469461)