### PR TITLE
Fix URL used when testing Authentication Event triggers

### DIFF
--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.data.ts
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.data.ts
@@ -80,4 +80,8 @@ export default class FunctionEditorData {
       'If-Match': '*',
     };
   }
+
+  public getAuthenticationTriggerUrl(baseUrl: string, functionInfo: ArmObj<FunctionInfo>, code: string) {
+    return `${baseUrl}/runtime/webhooks/customauthenticationextension?function=${functionInfo.properties.name}&code=${code}`;
+  }
 }

--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.data.ts
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.data.ts
@@ -82,6 +82,6 @@ export default class FunctionEditorData {
   }
 
   public getAuthenticationTriggerUrl(baseUrl: string, functionInfo: ArmObj<FunctionInfo>, code: string) {
-    return `${baseUrl}/runtime/webhooks/customauthenticationextension?function=${functionInfo.properties.name}&code=${code}`;
+    return `${baseUrl}/runtime/webhooks/customauthenticationextension?functionName=${functionInfo.properties.name}&code=${code}`;
   }
 }

--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditorCommandBar.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditorCommandBar.tsx
@@ -214,7 +214,7 @@ const FunctionEditorCommandBar: React.FC<FunctionEditorCommandBarProps> = props 
 
   const getAuthenticationEventSubscriptionUrl = (code: string) => {
     return siteStateContext.site
-      ? `${Url.getMainUrl(siteStateContext.site)}/runtime/webhooks/customauthenticationextension?functionName=${
+      ? `${Url.getMainUrl(siteStateContext.site)}/runtime/webhooks/customauthenticationextension?function=${
           functionInfo.properties.name
         }&code=${code}`
       : '';

--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditorCommandBar.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditorCommandBar.tsx
@@ -214,7 +214,7 @@ const FunctionEditorCommandBar: React.FC<FunctionEditorCommandBarProps> = props 
 
   const getAuthenticationEventSubscriptionUrl = (code: string) => {
     return siteStateContext.site
-      ? `${Url.getMainUrl(siteStateContext.site)}/runtime/webhooks/customauthenticationextension?function=${
+      ? `${Url.getMainUrl(siteStateContext.site)}/runtime/webhooks/customauthenticationextension?functionName=${
           functionInfo.properties.name
         }&code=${code}`
       : '';

--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditorDataLoader.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditorDataLoader.tsx
@@ -375,14 +375,30 @@ const FunctionEditorDataLoader: React.FC<FunctionEditorDataLoaderProps> = props 
     liveLogsSessionId?: string
   ): NetAjaxSettings | undefined => {
     if (site) {
-      const url = `${Url.getMainUrl(site)}/admin/functions/${newFunctionInfo.properties.name.toLowerCase()}`;
+      const baseUrl = Url.getMainUrl(site);
+      const input = newFunctionInfo.properties.test_data || '';
+
+      let data: unknown = { input };
+      let url = `${baseUrl}/admin/functions/${newFunctionInfo.properties.name.toLowerCase()}`;
+      if (functionEditorData.isAuthenticationEventTriggerFunction(newFunctionInfo)) {
+        try {
+          data = JSON.parse(input);
+        } catch {
+          /** @note (joechung): Treat invalid JSON as string input. */
+        }
+
+        const functionKey = xFunctionKey ?? functionKeys.default;
+        const code = [...functionUrls, ...hostUrls, ...systemUrls].find(urlObj => urlObj.key === functionKey)?.data;
+        url = functionEditorData.getAuthenticationTriggerUrl(baseUrl, newFunctionInfo, code);
+      }
+
       const headers = getHeaders([], xFunctionKey);
 
       return {
         uri: url,
         type: 'POST',
         headers: { ...headers, ...getHeadersForLiveLogsSessionId(liveLogsSessionId) },
-        data: { input: newFunctionInfo.properties.test_data || '' },
+        data,
       };
     }
     return undefined;


### PR DESCRIPTION
Use webhook endpoint for Authentication trigger test runs.
- Pass input as-is (when validated as JSON) without packaging it into an `input` property.

![image](https://user-images.githubusercontent.com/26208574/169420024-9735b4ab-8589-4a10-b34e-7667744f12b5.png)
