### PR TITLE
[AB#14531951][Configurations]remove check on container key differences between inital value and cu…

### DIFF
--- a/client-react/src/pages/app/app-settings/GeneralSettings/LinuxStacks/JavaStack.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/LinuxStacks/JavaStack.tsx
@@ -223,17 +223,15 @@ const JavaStack: React.SFC<StackProps> = props => {
   };
 
   const onContainerKeyChange = (newMajorVersion: string, newContainerKey: string) => {
-    if (newContainerKey !== currentContainerKey) {
-      const containerVersionDropdownOptions = getJavaContainerVersionDropdownOptionsForSelectedJavaContainer(
-        newMajorVersion,
-        newContainerKey
-      );
-      setCurrentContainerVersionDropdownOptions(containerVersionDropdownOptions);
-      if (containerVersionDropdownOptions.length > 0) {
-        setFieldValue('config.properties.linuxFxVersion', containerVersionDropdownOptions[0].key);
-      }
-      setCurrentContainerKey(newContainerKey);
+    const containerVersionDropdownOptions = getJavaContainerVersionDropdownOptionsForSelectedJavaContainer(
+      newMajorVersion,
+      newContainerKey
+    );
+    setCurrentContainerVersionDropdownOptions(containerVersionDropdownOptions);
+    if (containerVersionDropdownOptions.length > 0) {
+      setFieldValue('config.properties.linuxFxVersion', containerVersionDropdownOptions[0].key);
     }
+    setCurrentContainerKey(newContainerKey);
   };
 
   const isMajorVersionDirty = () => {


### PR DESCRIPTION
Fixes [AB#14531951](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s189?workitem=14531951)

Remove the check on container key differences to makes sure each time onContainerKeyChange is called, the container version change is always triggered.

Before:
![stackBefore](https://user-images.githubusercontent.com/33185278/169882026-5400667f-86df-42d5-9226-4101256736cf.gif)

After:
![stackAfter](https://user-images.githubusercontent.com/33185278/169882042-87ed7737-3dbf-423e-916b-9d7e0c40c35c.gif)

