### PR TITLE
[Configuration][Function Settings] Runtime Scale Monitoring should be supported for v4

### DIFF
--- a/client-react/src/pages/app/app-settings/FunctionRuntimeSettings/RuntimeScaleMonitoring.tsx
+++ b/client-react/src/pages/app/app-settings/FunctionRuntimeSettings/RuntimeScaleMonitoring.tsx
@@ -17,7 +17,7 @@ const RuntimeScaleMonitoring: React.FC<AppSettingsFormProps & WithTranslation> =
   const disableAllControls = !app_write || !editable || saving;
 
   const scaleMonitoringSupported = () => {
-    let isSupported = false;
+    let isSupported = true;
     const initialRuntimeVersion = findFormAppSettingValue(
       initialValues.appSettings,
       CommonConstants.AppSettingNames.functionsExtensionVersion
@@ -28,10 +28,10 @@ const RuntimeScaleMonitoring: React.FC<AppSettingsFormProps & WithTranslation> =
       const exactRuntimeVersionParsed = FunctionsRuntimeVersionHelper.parseExactRuntimeVersion(exactRuntimeVersion || null);
       const initialRuntimeVersionParsed = FunctionsRuntimeVersionHelper.parseConfiguredRuntimeVersion(initialRuntimeVersion);
 
-      const supportedVersions = [RuntimeExtensionMajorVersions.v2, RuntimeExtensionMajorVersions.v3, RuntimeExtensionMajorVersions.v4];
-      supportedVersions.forEach(version => {
+      const nonSupportedVersions = [RuntimeExtensionMajorVersions.v1];
+      nonSupportedVersions.forEach(version => {
         if (initialRuntimeVersionParsed === version || exactRuntimeVersionParsed === version) {
-          isSupported = true;
+          isSupported = false;
         }
       });
     }

--- a/client-react/src/pages/app/app-settings/FunctionRuntimeSettings/RuntimeScaleMonitoring.tsx
+++ b/client-react/src/pages/app/app-settings/FunctionRuntimeSettings/RuntimeScaleMonitoring.tsx
@@ -28,7 +28,7 @@ const RuntimeScaleMonitoring: React.FC<AppSettingsFormProps & WithTranslation> =
       const exactRuntimeVersionParsed = FunctionsRuntimeVersionHelper.parseExactRuntimeVersion(exactRuntimeVersion || null);
       const initialRuntimeVersionParsed = FunctionsRuntimeVersionHelper.parseConfiguredRuntimeVersion(initialRuntimeVersion);
 
-      const supportedVersions = [RuntimeExtensionMajorVersions.v2, RuntimeExtensionMajorVersions.v3];
+      const supportedVersions = [RuntimeExtensionMajorVersions.v2, RuntimeExtensionMajorVersions.v3, RuntimeExtensionMajorVersions.v4];
       supportedVersions.forEach(version => {
         if (initialRuntimeVersionParsed === version || exactRuntimeVersionParsed === version) {
           isSupported = true;


### PR DESCRIPTION
Fixes [AB#14496559](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/14496559)

NOTE: Updating this such that any future Function runtime introductions doesn't require the change. Old versions still support this with the exception of v1. Also, not being supported is a rare phenomenon in comparison to newer versions being introduced and being supported.

 