### PR TITLE
[Function Collateral] Create new Cosmos DB trigger (1)

### DIFF
--- a/client-react/src/components/form-controls/ComboBox.tsx
+++ b/client-react/src/components/form-controls/ComboBox.tsx
@@ -1,11 +1,11 @@
-import React, { useContext, useEffect, useState } from 'react';
+import { css, IComboBox, IComboBoxOption, IComboBoxProps, IDropdownOption, Spinner, SpinnerSize } from '@fluentui/react';
 import { FieldProps } from 'formik';
 import get from 'lodash-es/get';
+import { useContext, useEffect, useState } from 'react';
+import { comboBoxSpinnerStyle, loadingComboBoxStyle } from '../../pages/app/deployment-center/DeploymentCenter.styles';
 import { ComboBoxStyles } from '../../theme/CustomOfficeFabric/AzurePortal/ComboBox.styles';
 import { ThemeContext } from '../../ThemeContext';
 import ComboBoxNoFormik from './ComboBoxnoFormik';
-import { IComboBoxProps, IComboBoxOption, IComboBox, IDropdownOption, Spinner, SpinnerSize } from '@fluentui/react';
-import { comboBoxSpinnerStyle, loadingComboBoxStyle } from '../../pages/app/deployment-center/DeploymentCenter.styles';
 
 interface CustomComboBoxProps {
   id: string;
@@ -21,10 +21,24 @@ interface CustomComboBoxProps {
   isLoading?: boolean;
   searchable?: boolean;
   clearComboBox?: boolean;
+  overrideLoadingComboboxStyles?: string;
 }
 
 const ComboBox = (props: FieldProps & IComboBoxProps & CustomComboBoxProps) => {
-  const { field, form, options, styles, setOptions, allowFreeform, isLoading, searchable, text, clearComboBox, ...rest } = props;
+  const {
+    allowFreeform,
+    clearComboBox,
+    field,
+    form,
+    isLoading,
+    options,
+    overrideLoadingComboboxStyles,
+    searchable,
+    setOptions,
+    styles,
+    text,
+    ...rest
+  } = props;
   const theme = useContext(ThemeContext);
   const [searchTerm, setSearchTerm] = useState<string | undefined>(undefined);
 
@@ -58,12 +72,14 @@ const ComboBox = (props: FieldProps & IComboBoxProps & CustomComboBoxProps) => {
       form.setFieldValue(field.name, undefined);
       setSearchTerm(undefined);
     }
+
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [options]);
 
   const errorMessage = get(form.touched, field.name, false) ? (get(form.errors, field.name, '') as string) : undefined;
 
   return (
-    <div className={loadingComboBoxStyle}>
+    <div className={css(loadingComboBoxStyle, overrideLoadingComboboxStyles)}>
       <ComboBoxNoFormik
         selectedKey={field.value === undefined ? 'null' : field.value}
         text={searchTerm}

--- a/client-react/src/models/functions/binding.ts
+++ b/client-react/src/models/functions/binding.ts
@@ -29,11 +29,12 @@ export interface BindingSetting {
   defaultValue: string;
   required: boolean;
   label: string;
-  help: string;
+  help?: string;
   validators?: BindingValidator[];
   enum?: BindingEnum[];
   placeholder?: string;
   resource?: BindingSettingResource;
+  options?: any[];
 }
 
 export interface BindingRule {
@@ -65,6 +66,7 @@ export enum BindingSettingValue {
   enum = 'enum',
   checkBoxList = 'checkBoxList',
   boolean = 'boolean',
+  radioButtons = 'radioButtons',
 }
 
 export enum BindingSettingResource {

--- a/client-react/src/pages/app/functions/common/BindingFormBuilder.styles.ts
+++ b/client-react/src/pages/app/functions/common/BindingFormBuilder.styles.ts
@@ -1,0 +1,6 @@
+import { style } from 'typestyle';
+
+export const horizontalLabelStyle = style({
+  maxWidth: '1500px !important',
+  width: '1500px',
+});

--- a/client-react/src/pages/app/functions/common/BindingFormBuilder.tsx
+++ b/client-react/src/pages/app/functions/common/BindingFormBuilder.tsx
@@ -1,53 +1,48 @@
+import { IDropdownOption } from '@fluentui/react';
 import { Field, FormikProps } from 'formik';
 import i18next from 'i18next';
-import { IDropdownOption } from '@fluentui/react';
 import Dropdown from '../../../../components/form-controls/DropDown';
 import { Layout } from '../../../../components/form-controls/ReactiveFormControl';
 import TextField from '../../../../components/form-controls/TextField';
 import Toggle from '../../../../components/form-controls/Toggle';
 import { Binding, BindingSetting, BindingSettingValue, BindingValidator } from '../../../../models/functions/binding';
 import { BindingInfo, BindingType } from '../../../../models/functions/function-binding';
+import { IArmResourceTemplate, TSetArmResourceTemplates } from '../../../../utils/ArmTemplateHelper';
 import { BindingManager } from '../../../../utils/BindingManager';
 import { getFunctionBindingDirection } from '../function/integrate/FunctionIntegrate.utils';
 import { FunctionIntegrateConstants } from '../function/integrate/FunctionIntegrateConstants';
+import { horizontalLabelStyle } from './BindingFormBuilder.styles';
 import HttpMethodMultiDropdown from './HttpMethodMultiDropdown';
 import ResourceDropdown from './ResourceDropdown';
-import { style } from 'typestyle';
 
-export interface BindingEditorFormValues {
-  [key: string]: any;
-}
+export type BindingEditorFormValues = Record<string, any>;
 
-export const horizontalLabelStyle = style({
-  width: '1500px',
-  maxWidth: '1500px !important',
-});
-
-export class BindingFormBuilder {
+export class BindingFormBuilder<TOptions> {
   public static getBindingTypeName = (currentBinding: BindingInfo, bindings: Binding[]): string | undefined => {
     return bindings.find(binding => BindingManager.isBindingTypeEqual(binding.type, currentBinding.type))?.displayName;
   };
 
   constructor(
     private _bindingInfoList: BindingInfo[],
-    private _bindingList: Binding[],
-    private _resourceId: string,
-    private _t: i18next.TFunction,
-    private _areCreateFunctionFieldsHorizontal: boolean
+    protected bindingList: Binding[],
+    protected resourceId: string,
+    protected t: i18next.TFunction,
+    private _areCreateFunctionFieldsHorizontal: boolean,
+    protected options?: TOptions
   ) {}
 
   public getInitialFormValues(): BindingEditorFormValues {
     const initialFormValues: BindingEditorFormValues = {};
 
     let i = 0;
-    for (const binding of this._bindingList) {
-      for (const setting of binding.settings || []) {
+    for (const binding of this.bindingList) {
+      for (const setting of binding.settings ?? []) {
         let value = this._bindingInfoList[i][setting.name];
 
         // If the stored value is empty, then make the assumption that everything is selected.
         // That's how it works for HTTP, so for now let's assume that's how it works for all checkBoxLists
         if (setting.value === BindingSettingValue.checkBoxList && !value) {
-          value = setting.enum ? setting.enum.map(e => e.value) : [];
+          value = setting.enum?.map(e => e.value) ?? [];
         }
 
         initialFormValues[setting.name] = value;
@@ -57,15 +52,22 @@ export class BindingFormBuilder {
       initialFormValues.type = binding.type;
       i += 1;
     }
+
     return initialFormValues;
   }
 
-  public getFields(formProps: FormikProps<BindingEditorFormValues>, isDisabled: boolean, includeRules: boolean) {
+  public getFields(
+    formProps: FormikProps<BindingEditorFormValues>,
+    isDisabled: boolean,
+    includeRules: boolean,
+    armResources?: IArmResourceTemplate[],
+    setArmResources?: TSetArmResourceTemplates
+  ) {
     const fields: JSX.Element[] = [];
     const ignoredFields: string[] = [];
 
     let i = 0;
-    for (const binding of this._bindingList) {
+    for (const binding of this.bindingList) {
       // We don't want to use the rule for HTTP as it doesn't offer the user anything
       // and we can't restore the state of the rule properly on a second load
       if (includeRules && formProps.values['type'] !== FunctionIntegrateConstants.httpType) {
@@ -74,11 +76,11 @@ export class BindingFormBuilder {
 
       for (const setting of binding.settings || []) {
         if (!ignoredFields.includes(setting.name)) {
-          this._addField(fields, setting, formProps, isDisabled, i);
+          this._addField(fields, setting, formProps, isDisabled, i, armResources, setArmResources);
         }
       }
 
-      i = +1;
+      i += 1;
     }
 
     return fields;
@@ -150,14 +152,16 @@ export class BindingFormBuilder {
     setting: BindingSetting,
     formProps: FormikProps<BindingEditorFormValues>,
     isDisabled: boolean,
-    i: number
+    i: number,
+    armResources?: IArmResourceTemplate[],
+    setArmResources?: TSetArmResourceTemplates
   ) {
     switch (setting.value) {
       case BindingSettingValue.string:
         if (setting.resource) {
-          fields.push(this._getResourceField(setting, formProps, isDisabled, this._resourceId));
+          fields.push(this.getResourceField(setting, formProps, isDisabled, this.resourceId, armResources, setArmResources));
         } else {
-          fields.push(this._getTextField(setting, formProps, isDisabled));
+          fields.push(this.getTextField(setting, formProps, isDisabled));
         }
         break;
       case BindingSettingValue.enum:
@@ -180,15 +184,15 @@ export class BindingFormBuilder {
     return this._getFieldLayout() === Layout.Horizontal ? horizontalLabelStyle : undefined;
   }
 
-  private _getTextField(setting: BindingSetting, formProps: FormikProps<BindingEditorFormValues>, isDisabled: boolean) {
+  protected getTextField(setting: BindingSetting, formProps: FormikProps<BindingEditorFormValues>, disabled: boolean) {
     return (
       <Field
         label={setting.label}
         name={setting.name}
         id={setting.name}
         component={TextField}
-        disabled={isDisabled}
-        validate={value => this._validateText(value, setting.required, setting.validators)}
+        disabled={disabled}
+        validate={value => this.validateText(value, setting.required, setting.validators)}
         layout={this._getFieldLayout()}
         mouseOverToolTip={setting.help}
         required={setting.required}
@@ -220,7 +224,7 @@ export class BindingFormBuilder {
         component={Dropdown}
         options={options}
         disabled={isDisabled}
-        validate={value => this._validateText(value, setting.required, setting.validators)}
+        validate={value => this.validateText(value, setting.required, setting.validators)}
         onPanel={true}
         layout={this._getFieldLayout()}
         mouseOverToolTip={setting.help}
@@ -242,8 +246,8 @@ export class BindingFormBuilder {
         id={setting.name}
         component={Toggle}
         disabled={isDisabled}
-        onText={this._t('yes')}
-        offText={this._t('no')}
+        onText={this.t('yes')}
+        offText={this.t('no')}
         validate={(value: boolean) => this._validateBoolean(value, setting.required)}
         layout={this._getFieldLayout()}
         mouseOverToolTip={setting.help}
@@ -257,11 +261,13 @@ export class BindingFormBuilder {
     );
   }
 
-  private _getResourceField(
+  protected getResourceField(
     setting: BindingSetting,
     formProps: FormikProps<BindingEditorFormValues>,
-    isDisabled: boolean,
-    resourceId: string
+    disabled: boolean,
+    resourceId: string,
+    armResources?: IArmResourceTemplate[],
+    setArmResources?: TSetArmResourceTemplates
   ) {
     return (
       <Field
@@ -271,8 +277,8 @@ export class BindingFormBuilder {
         component={ResourceDropdown}
         setting={setting}
         resourceId={resourceId}
-        disabled={isDisabled}
-        validate={value => this._validateText(value, setting.required, setting.validators)}
+        disabled={disabled}
+        validate={value => this.validateText(value, setting.required, setting.validators)}
         onPanel={true}
         layout={this._getFieldLayout()}
         mouseOverToolTip={setting.help}
@@ -282,6 +288,8 @@ export class BindingFormBuilder {
         dirty={false}
         customLabelClassName={this._getHorizontalLabelStyle()}
         customLabelStackClassName={this._getHorizontalLabelStyle()}
+        armResources={armResources}
+        setArmResources={setArmResources}
       />
     );
   }
@@ -301,7 +309,7 @@ export class BindingFormBuilder {
           component={HttpMethodMultiDropdown}
           setting={setting}
           disabled={isDisabled}
-          validate={value => this._validateText(value, setting.required, setting.validators)}
+          validate={value => this.validateText(value, setting.required, setting.validators)}
           onPanel={true}
           layout={this._getFieldLayout()}
           mouseOverToolTip={setting.help}
@@ -330,7 +338,7 @@ export class BindingFormBuilder {
         options={options}
         multiSelect
         disabled={isDisabled}
-        validate={value => this._validateText(value, setting.required, setting.validators)}
+        validate={value => this.validateText(value, setting.required, setting.validators)}
         onPanel={true}
         layout={this._getFieldLayout()}
         mouseOverToolTip={setting.help}
@@ -344,13 +352,13 @@ export class BindingFormBuilder {
     );
   }
 
-  private _validateText(value: string, required: boolean, validators?: BindingValidator[]): string | undefined {
+  protected validateText(value: string, required: boolean, validators: BindingValidator[] = []): string | undefined {
     let error: string | undefined;
     if (required && !value) {
-      error = this._t('fieldRequired');
+      error = this.t('fieldRequired');
     }
 
-    if (value && validators) {
+    if (value) {
       validators.forEach(validator => {
         if (!value.match(validator.expression)) {
           error = validator.errorText;
@@ -364,7 +372,7 @@ export class BindingFormBuilder {
   private _validateBoolean(value: boolean, required: boolean): string | undefined {
     let error: string | undefined;
     if (required && value === undefined) {
-      error = this._t('fieldRequired');
+      error = this.t('fieldRequired');
     }
 
     return error;

--- a/client-react/src/pages/app/functions/common/BindingFormBuilder.tsx
+++ b/client-react/src/pages/app/functions/common/BindingFormBuilder.tsx
@@ -22,14 +22,29 @@ export class BindingFormBuilder<TOptions> {
     return bindings.find(binding => BindingManager.isBindingTypeEqual(binding.type, currentBinding.type))?.displayName;
   };
 
+  protected bindingList: Binding[];
+  protected options?: TOptions;
+  protected resourceId: string;
+  protected t: i18next.TFunction;
+
+  private _areCreateFunctionFieldsHorizontal: boolean;
+  private _bindingInfoList: BindingInfo[];
+
   constructor(
-    private _bindingInfoList: BindingInfo[],
-    protected bindingList: Binding[],
-    protected resourceId: string,
-    protected t: i18next.TFunction,
-    private _areCreateFunctionFieldsHorizontal: boolean,
-    protected options?: TOptions
-  ) {}
+    bindingInfoList: BindingInfo[],
+    bindingList: Binding[],
+    resourceId: string,
+    t: i18next.TFunction,
+    areCreateFunctionFieldsHorizontal: boolean,
+    options?: TOptions
+  ) {
+    this.bindingList = bindingList;
+    this.options = options;
+    this.resourceId = resourceId;
+    this.t = t;
+    this._areCreateFunctionFieldsHorizontal = areCreateFunctionFieldsHorizontal;
+    this._bindingInfoList = bindingInfoList;
+  }
 
   public getInitialFormValues(): BindingEditorFormValues {
     const initialFormValues: BindingEditorFormValues = {};

--- a/client-react/src/pages/app/functions/common/Common.styles.ts
+++ b/client-react/src/pages/app/functions/common/Common.styles.ts
@@ -1,0 +1,17 @@
+import { style } from 'typestyle';
+import { Layout } from '../../../../components/form-controls/ReactiveFormControl';
+
+export const getCalloutContainerStyles = (layout: Layout): string => {
+  return layout === Layout.Horizontal
+    ? style({
+        marginBottom: '15px',
+        marginRight: '162px',
+        marginTop: '-15px',
+        minWidth: '235px',
+        textAlign: 'right',
+      })
+    : style({
+        marginBottom: '15px',
+        marginTop: '-15px',
+      });
+};

--- a/client-react/src/pages/app/functions/common/CosmosDbFunctionFormBuilder.styles.ts
+++ b/client-react/src/pages/app/functions/common/CosmosDbFunctionFormBuilder.styles.ts
@@ -1,0 +1,11 @@
+import { IMessageBarStyles } from '@fluentui/react';
+
+export const messageBarStyles: IMessageBarStyles = {
+  iconContainer: {
+    marginLeft: '0px',
+  },
+  root: {
+    marginTop: '-20px',
+    paddingLeft: '0px',
+  },
+};

--- a/client-react/src/pages/app/functions/common/CosmosDbFunctionFormBuilder.tsx
+++ b/client-react/src/pages/app/functions/common/CosmosDbFunctionFormBuilder.tsx
@@ -1,0 +1,348 @@
+import { MessageBar, MessageBarType } from '@fluentui/react';
+import { Field, FormikProps } from 'formik';
+import i18next from 'i18next';
+import RadioButtonNoFormik from '../../../../components/form-controls/RadioButtonNoFormik';
+import { Layout } from '../../../../components/form-controls/ReactiveFormControl';
+import { ArmObj } from '../../../../models/arm-obj';
+import { Binding, BindingSetting, BindingSettingValue, BindingValidator } from '../../../../models/functions/binding';
+import { BindingInfo, BindingType } from '../../../../models/functions/function-binding';
+import { FunctionInfo } from '../../../../models/functions/function-info';
+import { IArmResourceTemplate, TSetArmResourceTemplates } from '../../../../utils/ArmTemplateHelper';
+import { CommonConstants } from '../../../../utils/CommonConstants';
+import { ValidationRegex } from '../../../../utils/constants/ValidationRegex';
+import { horizontalLabelStyle } from './BindingFormBuilder.styles';
+import CosmosDbContainerComboBox from './combobox-with-link/cosmos-db/CosmosDbContainerComboBox';
+import CosmosDbDatabaseComboBox from './combobox-with-link/cosmos-db/CosmosDbDatabaseComboBox';
+import { messageBarStyles } from './CosmosDbFunctionFormBuilder.styles';
+import CosmosDbResourceDropdown from './CosmosDbResourceDropdown';
+import { CreateFunctionFormBuilder, CreateFunctionFormValues } from './CreateFunctionFormBuilder';
+
+interface CreateCosmosDbFunctionFormBuilderOptions {
+  hasResourceGroupWritePermission: boolean;
+  hasSubscriptionWritePermission: boolean;
+}
+
+class CosmosDbFunctionFormBuilder extends CreateFunctionFormBuilder<CreateCosmosDbFunctionFormBuilderOptions> {
+  private _metadataHasBeenUpdated: boolean;
+
+  constructor(
+    bindingInfo: BindingInfo[],
+    bindings: Binding[],
+    resourceId: string,
+    functionsInfo: ArmObj<FunctionInfo>[],
+    defaultName: string,
+    t: i18next.TFunction,
+    options: CreateCosmosDbFunctionFormBuilderOptions
+  ) {
+    super(bindingInfo, bindings, resourceId, functionsInfo, defaultName, t, options);
+
+    this._modifyMetadata();
+  }
+
+  public getFields(
+    formProps: FormikProps<CreateFunctionFormValues>,
+    disabled: boolean,
+    _includeRules: boolean,
+    armResources: IArmResourceTemplate[],
+    setArmResources: TSetArmResourceTemplates
+  ) {
+    if (!this._metadataHasBeenUpdated || !this.bindingList[0].settings?.[0]) {
+      return [];
+    }
+
+    const formFields: JSX.Element[] = [
+      this.getFunctionNameTextField(formProps, disabled),
+      this._getRadioButtonField(this.bindingList[0].settings[0], formProps, disabled),
+    ];
+
+    if (!(this.options?.hasSubscriptionWritePermission && this.options?.hasSubscriptionWritePermission)) {
+      formFields.push(
+        <MessageBar messageBarType={MessageBarType.warning} styles={messageBarStyles}>
+          {this.t('cosmosDb_error_writePermissionsRequired')}
+        </MessageBar>
+      );
+    }
+
+    formFields.push(this._getProgressiveDisclosureFields(formProps, disabled, armResources, setArmResources));
+
+    return formFields;
+  }
+
+  public getInitialFormValues(): CreateFunctionFormValues {
+    const functionNameValue = { functionName: this.getInitialFunctionName() };
+    if (!this._metadataHasBeenUpdated) {
+      return {
+        ...functionNameValue,
+      };
+    }
+
+    const { direction, type, ...bindingFormValues } = super.getInitialFormValues();
+    bindingFormValues.connectionType = !(this.options?.hasResourceGroupWritePermission && this.options?.hasSubscriptionWritePermission)
+      ? 'manual'
+      : 'automatic';
+    bindingFormValues.partitionKeyPath = CommonConstants.CosmosDbDefaults.partitionKeyPath;
+
+    return {
+      ...functionNameValue,
+      ...bindingFormValues,
+    };
+  }
+
+  protected getResourceField(
+    setting: BindingSetting,
+    formProps: FormikProps<CreateFunctionFormValues>,
+    disabled: boolean,
+    resourceId: string,
+    armResources: IArmResourceTemplate[],
+    setArmResources: TSetArmResourceTemplates
+  ) {
+    /**
+     * @todo Make sure that the styles are updated for the resource dropdown here inline with the
+     * "onload-validation-errors" PR style update (#10184885).
+     */
+    return (
+      <Field
+        component={CosmosDbResourceDropdown}
+        disabled={disabled}
+        id={setting.name}
+        key={setting.name}
+        label={setting.label}
+        layout={Layout.Horizontal}
+        mouseOverToolTip={setting.help}
+        name={setting.name}
+        onPanel={true}
+        required={setting.required}
+        resourceId={resourceId}
+        setting={setting}
+        validate={value => this.validateText(value, setting.required, setting.validators)}
+        {...formProps}
+        armResources={armResources}
+        customLabelClassName={horizontalLabelStyle}
+        customLabelStackClassName={horizontalLabelStyle}
+        dirty={false}
+        setArmResources={setArmResources}
+      />
+    );
+  }
+
+  private _getComboBoxField(
+    setting: BindingSetting,
+    formProps: FormikProps<CreateFunctionFormValues>,
+    disabled: boolean,
+    resourceId: string,
+    armResources: IArmResourceTemplate[],
+    setArmResources: TSetArmResourceTemplates
+  ) {
+    const component =
+      setting.name === 'databaseName'
+        ? CosmosDbDatabaseComboBox
+        : setting.name === 'collectionName'
+        ? CosmosDbContainerComboBox
+        : undefined;
+
+    return (
+      <Field
+        component={component}
+        disabled={disabled}
+        id={setting.name}
+        key={setting.name}
+        label={setting.label}
+        layout={Layout.Horizontal}
+        mouseOverToolTip={setting.help}
+        name={setting.name}
+        onPanel={true}
+        required={setting.required}
+        resourceId={resourceId}
+        setting={setting}
+        validate={value => this._validateComboBox(value, setting.required, setting.validators)}
+        {...formProps}
+        armResources={armResources}
+        customLabelClassName={horizontalLabelStyle}
+        customLabelStackClassName={horizontalLabelStyle}
+        dirty={false}
+        setArmResources={setArmResources}
+      />
+    );
+  }
+
+  private _getProgressiveDisclosureFields(
+    formProps: FormikProps<CreateFunctionFormValues>,
+    disabled: boolean,
+    armResources: IArmResourceTemplate[],
+    setArmResources: TSetArmResourceTemplates
+  ) {
+    return (
+      <>
+        {!!this.bindingList[0].settings && formProps.values.connectionType === 'automatic' && (
+          <>
+            {this.getResourceField(this.bindingList[0].settings[1], formProps, disabled, this.resourceId, armResources, setArmResources)}
+            {formProps.values[this.bindingList[0].settings[1].name] &&
+              this._getComboBoxField(this.bindingList[0].settings[2], formProps, disabled, this.resourceId, armResources, setArmResources)}
+            {formProps.values[this.bindingList[0].settings[2].name] &&
+              this._getComboBoxField(this.bindingList[0].settings[3], formProps, disabled, this.resourceId, armResources, setArmResources)}
+            {!!formProps.status?.isNewContainer && this.getTextField(this.bindingList[0].settings[4], formProps, disabled)}
+          </>
+        )}
+        {!!this.bindingList[0].settings && formProps.values.connectionType === 'manual' && (
+          <>
+            <h3>{this.t('cosmosDb_header_customAppSetting')}</h3>
+            {this.getTextField(
+              {
+                defaultValue: '',
+                help: this.t('cosmosDb_tooltip_customAppSettingKey'),
+                label: this.t('cosmosDb_label_customAppSettingKey'),
+                name: 'customAppSettingKey',
+                required: true,
+                value: BindingSettingValue.string,
+              },
+              formProps,
+              disabled
+            )}
+            {this.getTextField(
+              {
+                defaultValue: '',
+                label: this.t('cosmosDb_label_customAppSettingValue'),
+                name: 'customAppSettingValue',
+                required: true,
+                value: BindingSettingValue.string,
+              },
+              formProps,
+              disabled
+            )}
+            <h3>{this.t('cosmosDb_header_details')}</h3>
+            {this.getTextField(this.bindingList[0].settings[2], formProps, disabled)}
+            {this.getTextField(this.bindingList[0].settings[3], formProps, disabled)}
+          </>
+        )}
+      </>
+    );
+  }
+
+  private _getRadioButtonField(setting: BindingSetting, formProps: FormikProps<CreateFunctionFormValues>, disabled: boolean) {
+    return (
+      <Field
+        component={RadioButtonNoFormik}
+        defaultSelectedKey={setting.defaultValue}
+        disabled={disabled}
+        id={setting.name}
+        key={setting.name}
+        label={setting.label}
+        layout={Layout.Horizontal}
+        mouseOverToolTip={setting.help}
+        name={setting.name}
+        onChange={(_, option) => {
+          formProps.setFieldValue(setting.name, option.key);
+          /** @todo (joechung): #14260766 - Log telemetry. */
+        }}
+        onPanel={true}
+        options={setting.options}
+        required={setting.required}
+        selectedKey={formProps.values[setting.name]}
+        validate={value => this._validateRadioButton(value, setting.required)}
+        {...formProps}
+        customLabelClassName={horizontalLabelStyle}
+        customLabelStackClassName={horizontalLabelStyle}
+        dirty={false}
+      />
+    );
+  }
+
+  private _modifyMetadata() {
+    // This functionality works on the assumption that the indices don't change (6/29/2021)
+    if (!!this.bindingList?.[0] && !!this.bindingList[0].settings && this.bindingList[0].type === BindingType.cosmosDBTrigger) {
+      // Modify existing fields
+      this.bindingList[0].settings[0].label = this.t('cosmosDb_label_cosmosDbAccount');
+      delete this.bindingList[0].settings[0].help;
+
+      this.bindingList[0].settings[1].label = this.t('cosmosDb_label_database');
+      this.bindingList[0].settings[1].validators = [
+        {
+          expression: ValidationRegex.specialCharacters.source,
+          errorText: this.t('cosmosDb_error_databaseNameCharacters'),
+        },
+        {
+          expression: ValidationRegex.noSpacesAtEnd.source,
+          errorText: this.t('cosmosDb_error_databaseNameSpace'),
+        },
+      ];
+
+      this.bindingList[0].settings[2].label = this.t('cosmosDb_label_container');
+      this.bindingList[0].settings[2].validators = [
+        {
+          expression: ValidationRegex.specialCharacters.source,
+          errorText: this.t('cosmosDb_error_containerNameCharacters'),
+        },
+        {
+          expression: ValidationRegex.noSpacesAtEnd.source,
+          errorText: this.t('cosmosDb_error_containerNameSpace'),
+        },
+      ];
+
+      // Remove unneeded fields
+      this.bindingList[0].settings.splice(3, 2);
+
+      // Add new fields
+      this.bindingList[0].settings.unshift({
+        defaultValue: 'automatic',
+        label: this.t('cosmosDb_label_connection'),
+        name: 'connectionType',
+        options: [
+          {
+            disabled: !(this.options?.hasResourceGroupWritePermission && this.options?.hasSubscriptionWritePermission),
+            key: 'automatic',
+            text: this.t('automatic'),
+          },
+          {
+            key: 'manual',
+            text: this.t('manual'),
+          },
+        ],
+        required: true,
+        value: BindingSettingValue.radioButtons,
+      });
+
+      this.bindingList[0].settings.push({
+        defaultValue: CommonConstants.CosmosDbDefaults.partitionKeyPath,
+        help: this.t('cosmosDb_tooltip_partitionKeyPath'),
+        label: this.t('cosmosDb_label_partitionKeyPath'),
+        name: 'partitionKeyPath',
+        required: true,
+        validators: [
+          {
+            expression: '^[/].*',
+            errorText: this.t('cosmosDb_error_partitionKeyPathSlash'),
+          },
+        ],
+        value: BindingSettingValue.string,
+      });
+
+      this._metadataHasBeenUpdated = true;
+    }
+  }
+
+  private _validateComboBox(value: string, required: boolean, validators: BindingValidator[] = []): string | undefined {
+    if (required && value === '') {
+      return this.t('fieldRequired');
+    }
+
+    if (value) {
+      for (const validator of validators) {
+        if (!value.match(validator.expression)) {
+          return validator.errorText;
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  private _validateRadioButton(value: boolean | undefined, required: boolean): string | undefined {
+    if (required && value === undefined) {
+      return this.t('fieldRequired');
+    }
+
+    return undefined;
+  }
+}
+
+export default CosmosDbFunctionFormBuilder;

--- a/client-react/src/pages/app/functions/common/CosmosDbResourceDropdown.styles.ts
+++ b/client-react/src/pages/app/functions/common/CosmosDbResourceDropdown.styles.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { style } from 'typestyle';
 import { Layout } from '../../../../components/form-controls/ReactiveFormControl';
+import { getCalloutContainerStyles } from './Common.styles';
 
 const callout = style({
   boxSizing: 'border-box',
@@ -8,22 +9,7 @@ const callout = style({
 });
 
 export const useStyles = (layout: Layout = Layout.Horizontal) => {
-  const calloutContainer = useMemo(
-    () =>
-      layout === Layout.Horizontal
-        ? style({
-            marginBottom: '15px',
-            marginRight: '162px',
-            marginTop: '-15px',
-            minWidth: '235px',
-            textAlign: 'right',
-          })
-        : style({
-            marginBottom: '15px',
-            marginTop: '-15px',
-          }),
-    [layout]
-  );
+  const calloutContainer = useMemo(() => getCalloutContainerStyles(layout), [layout]);
 
   return {
     callout,

--- a/client-react/src/pages/app/functions/common/CosmosDbResourceDropdown.styles.ts
+++ b/client-react/src/pages/app/functions/common/CosmosDbResourceDropdown.styles.ts
@@ -10,12 +10,18 @@ const callout = style({
 export const useStyles = (layout: Layout = Layout.Horizontal) => {
   const calloutContainer = useMemo(
     () =>
-      style({
-        marginTop: '-15px',
-        marginRight: '0px',
-        marginBottom: '15px',
-        marginLeft: layout === Layout.Horizontal ? '200px' : '0px',
-      }),
+      layout === Layout.Horizontal
+        ? style({
+            marginBottom: '15px',
+            marginRight: '162px',
+            marginTop: '-15px',
+            minWidth: '235px',
+            textAlign: 'right',
+          })
+        : style({
+            marginBottom: '15px',
+            marginTop: '-15px',
+          }),
     [layout]
   );
 

--- a/client-react/src/pages/app/functions/common/CreateFunctionFormBuilder.tsx
+++ b/client-react/src/pages/app/functions/common/CreateFunctionFormBuilder.tsx
@@ -6,39 +6,52 @@ import { ArmObj } from '../../../../models/arm-obj';
 import { Binding } from '../../../../models/functions/binding';
 import { BindingInfo } from '../../../../models/functions/function-binding';
 import { FunctionInfo } from '../../../../models/functions/function-info';
-import { BindingEditorFormValues, BindingFormBuilder, horizontalLabelStyle } from './BindingFormBuilder';
+import { IArmResourceTemplate, TSetArmResourceTemplates } from '../../../../utils/ArmTemplateHelper';
+import { BindingEditorFormValues, BindingFormBuilder } from './BindingFormBuilder';
+import { horizontalLabelStyle } from './BindingFormBuilder.styles';
 
 export interface CreateFunctionFormValues extends BindingEditorFormValues {
   functionName: string;
 }
 
-export class CreateFunctionFormBuilder extends BindingFormBuilder {
+const validNameRegExp = new RegExp('^[a-zA-Z][a-zA-Z0-9_-]{0,127}$');
+
+export class CreateFunctionFormBuilder<TOptions = any> extends BindingFormBuilder<TOptions> {
   constructor(
     bindingInfo: BindingInfo[],
     bindings: Binding[],
     resourceId: string,
     private _functionsInfo: ArmObj<FunctionInfo>[],
     private _defaultName: string,
-    private t: i18next.TFunction
+    protected t: i18next.TFunction,
+    options?: TOptions
   ) {
-    super(bindingInfo, bindings, resourceId, t, true);
+    super(bindingInfo, bindings, resourceId, t, true, options);
   }
 
-  public getInitialFormValues() {
-    const functionNameValue = { functionName: this._getInitialFunctionName() };
-    const bindingFormValues = super.getInitialFormValues();
-    delete bindingFormValues.direction;
-    delete bindingFormValues.type;
-    return Object.assign({}, functionNameValue, bindingFormValues) as CreateFunctionFormValues;
+  public getInitialFormValues(): CreateFunctionFormValues {
+    const { direction, type, ...bindingFormValues } = super.getInitialFormValues();
+
+    return {
+      functionName: this.getInitialFunctionName(),
+      ...bindingFormValues,
+    };
   }
 
-  public getFields(formProps: FormikProps<CreateFunctionFormValues>, isDisabled: boolean) {
-    const nameField: JSX.Element[] = [this._getFunctionNameTextField(formProps, isDisabled)];
-    const bindingFields: JSX.Element[] = super.getFields(formProps, isDisabled, false);
-    return nameField.concat(bindingFields);
+  public getFields(
+    formProps: FormikProps<CreateFunctionFormValues>,
+    disabled: boolean,
+    _includeRules: boolean,
+    armResources?: IArmResourceTemplate[],
+    setArmResources?: TSetArmResourceTemplates
+  ): JSX.Element[] {
+    const nameField = this.getFunctionNameTextField(formProps, disabled);
+    const bindingFields = super.getFields(formProps, disabled, false, armResources, setArmResources);
+
+    return [nameField, ...bindingFields];
   }
 
-  private _getInitialFunctionName(): string {
+  protected getInitialFunctionName(): string {
     let i = 1;
     while (
       this._functionsInfo.find(value => {
@@ -48,20 +61,20 @@ export class CreateFunctionFormBuilder extends BindingFormBuilder {
       i = i + 1;
     }
 
-    return this._defaultName + i;
+    return `${this._defaultName}${i}`;
   }
 
-  private _getFunctionNameTextField(formProps: FormikProps<CreateFunctionFormValues>, isDisabled: boolean) {
+  protected getFunctionNameTextField(formProps: FormikProps<CreateFunctionFormValues>, disabled: boolean): JSX.Element {
     return (
       <Field
         label={this.t('functionCreate_newFunction')}
-        name={'functionName'}
-        id={'functionName'}
+        name="functionName"
+        id="functionName"
         component={TextField}
-        disabled={isDisabled}
-        validate={(value: string) => this._validateFunctionName(value)}
+        disabled={disabled}
+        validate={(value: string) => this.validateFunctionName(value)}
         layout={Layout.Horizontal}
-        required={true}
+        required
         key={0}
         {...formProps}
         dirty={false}
@@ -71,23 +84,18 @@ export class CreateFunctionFormBuilder extends BindingFormBuilder {
     );
   }
 
-  private _validateFunctionName(name: string): string | undefined {
-    let error: string | undefined;
-    const validNameRegExp = new RegExp('^[a-zA-Z][a-zA-Z0-9_-]{0,127}$');
-
-    if (!name) {
-      error = this.t('fieldRequired');
-    } else if (!validNameRegExp.test(name) || name.toLowerCase() === 'host') {
-      error = this.t('functionNew_nameError');
+  protected validateFunctionName(value: string): string | undefined {
+    if (!value) {
+      return this.t('fieldRequired');
+    } else if (!validNameRegExp.test(value) || value.toLowerCase() === 'host') {
+      return this.t('functionNew_nameError');
     } else {
-      const nameAlreadyUsed = this._functionsInfo.find(f => {
-        return f.properties.name.toLowerCase() === name.toLowerCase();
-      });
+      const nameAlreadyUsed = this._functionsInfo.find(f => f.properties.name.toLowerCase() === value.toLowerCase());
       if (nameAlreadyUsed) {
-        error = this.t('functionNew_functionExists', { name });
+        return this.t('functionNew_functionExists', { name: value });
       }
     }
 
-    return error;
+    return undefined;
   }
 }

--- a/client-react/src/pages/app/functions/common/callout-content/BindingCalloutContent.tsx
+++ b/client-react/src/pages/app/functions/common/callout-content/BindingCalloutContent.tsx
@@ -11,7 +11,11 @@ interface BindingCalloutContentProps<TValues> {
   initialValues: TValues;
   onCancel: () => void;
   onCreate: (values: TValues, formikActions: FormikActions<TValues>) => void;
-  onRenderCreator: (formProps: FormikProps<TValues>, setTemplate: React.Dispatch<string>, template?: string) => React.ReactNode;
+  onRenderCreator: (
+    formProps: FormikProps<TValues>,
+    setTemplate: React.Dispatch<React.SetStateAction<string>>,
+    template?: string
+  ) => React.ReactNode;
 }
 
 const BindingCalloutContent = <T,>({

--- a/client-react/src/pages/app/functions/common/callout/NewCosmosDbAccountCallout.tsx
+++ b/client-react/src/pages/app/functions/common/callout/NewCosmosDbAccountCallout.tsx
@@ -2,7 +2,7 @@ import { Link } from '@fluentui/react';
 import { Formik, FormikProps } from 'formik';
 import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { IArmResourceTemplate } from '../../../../../utils/ArmTemplateHelper';
+import { IArmResourceTemplate, TSetArmResourceTemplates } from '../../../../../utils/ArmTemplateHelper';
 import { CommonConstants } from '../../../../../utils/CommonConstants';
 import {
   getNewContainerArmTemplate,
@@ -24,7 +24,7 @@ interface NewCosmosDBAccountCalloutProps {
   armResources: IArmResourceTemplate[];
   form: FormikProps<unknown>;
   resourceId: string;
-  setArmResources: React.Dispatch<React.SetStateAction<IArmResourceTemplate[]>>;
+  setArmResources: TSetArmResourceTemplates;
   setIsDialogVisible: React.Dispatch<React.SetStateAction<boolean>>;
   setNewDatabaseAccountName: React.Dispatch<React.SetStateAction<string>>;
   setNewDbAcctType: React.Dispatch<React.SetStateAction<string>>;

--- a/client-react/src/pages/app/functions/common/combobox-with-link/ComboBoxWithLink.styles.ts
+++ b/client-react/src/pages/app/functions/common/combobox-with-link/ComboBoxWithLink.styles.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { style } from 'typestyle';
 import { Layout } from '../../../../../components/form-controls/ReactiveFormControl';
+import { getCalloutContainerStyles } from '../Common.styles';
 
 const buttonContainer = style({
   display: 'flex',
@@ -38,22 +39,7 @@ const section = style({
 });
 
 export const useStyles = (layout: Layout) => {
-  const calloutContainer = useMemo(
-    () =>
-      layout === Layout.Horizontal
-        ? style({
-            marginBottom: '15px',
-            marginRight: '162px',
-            marginTop: '-15px',
-            minWidth: '235px',
-            textAlign: 'right',
-          })
-        : style({
-            marginBottom: '15px',
-            marginTop: '-15px',
-          }),
-    [layout]
-  );
+  const calloutContainer = useMemo(() => getCalloutContainerStyles(layout), [layout]);
 
   return {
     buttonContainer,

--- a/client-react/src/pages/app/functions/common/combobox-with-link/ComboBoxWithLink.styles.ts
+++ b/client-react/src/pages/app/functions/common/combobox-with-link/ComboBoxWithLink.styles.ts
@@ -27,6 +27,10 @@ const header = style({
   marginBlock: 0,
 });
 
+const overrideLoadingComboboxStyles = style({
+  display: 'block',
+});
+
 const section = style({
   display: 'flex',
   flexDirection: 'column',
@@ -36,12 +40,18 @@ const section = style({
 export const useStyles = (layout: Layout) => {
   const calloutContainer = useMemo(
     () =>
-      style({
-        marginBottom: '15px',
-        marginLeft: layout === Layout.Horizontal ? '200px' : '0px',
-        marginRight: '0px',
-        marginTop: '-15px',
-      }),
+      layout === Layout.Horizontal
+        ? style({
+            marginBottom: '15px',
+            marginRight: '162px',
+            marginTop: '-15px',
+            minWidth: '235px',
+            textAlign: 'right',
+          })
+        : style({
+            marginBottom: '15px',
+            marginTop: '-15px',
+          }),
     [layout]
   );
 
@@ -51,6 +61,7 @@ export const useStyles = (layout: Layout) => {
     calloutContainer,
     container,
     header,
+    overrideLoadingComboboxStyles,
     section,
   };
 };

--- a/client-react/src/pages/app/functions/new-create-preview/FunctionCreateDataLoader.tsx
+++ b/client-react/src/pages/app/functions/new-create-preview/FunctionCreateDataLoader.tsx
@@ -1,44 +1,45 @@
-import React, { useState, useEffect, useContext } from 'react';
+import { Icon, IDropdownOption, Link, registerIcons, ResponsiveMode } from '@fluentui/react';
+import { Formik, FormikProps } from 'formik';
+import { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, IDropdownOption, ResponsiveMode, registerIcons, Icon } from '@fluentui/react';
-import {
-  containerStyle,
-  developmentEnvironmentStyle,
-  selectDevelopmentEnvironmentDescriptionStyle,
-  selectDevelopmentEnvironmentHeaderStyle,
-  formContainerStyle,
-  formContainerDivStyle,
-  dropdownIconStyle,
-  developInPortalIconStyle,
-} from './FunctionCreate.styles';
+import { getErrorMessage, getErrorMessageOrStringify } from '../../../../ApiHelpers/ArmHelper';
+import SiteService from '../../../../ApiHelpers/SiteService';
+import ActionBar from '../../../../components/ActionBar';
 import DropdownNoFormik from '../../../../components/form-controls/DropDownnoFormik';
 import { Layout } from '../../../../components/form-controls/ReactiveFormControl';
-import ActionBar from '../../../../components/ActionBar';
-import TemplateList from './portal-create/TemplateList';
-import { Formik, FormikProps } from 'formik';
-import { CreateFunctionFormValues, CreateFunctionFormBuilder } from '../common/CreateFunctionFormBuilder';
-import { DevelopmentExperience } from './FunctionCreate.types';
-import { ReactComponent as VSCodeIconSvg } from '../../../../images/Functions/vs_code.svg';
 import { ReactComponent as TerminalIconSvg } from '../../../../images/Functions/terminal.svg';
 import { ReactComponent as VisualStudioIconSvg } from '../../../../images/Functions/visual_studio.svg';
-import { SiteStateContext } from '../../../../SiteState';
-import SiteService from '../../../../ApiHelpers/SiteService';
-import { CommonConstants, WorkerRuntimeLanguages } from '../../../../utils/CommonConstants';
-import LogService from '../../../../utils/LogService';
-import { LogCategories } from '../../../../utils/LogCategories';
-import { getErrorMessageOrStringify, getErrorMessage } from '../../../../ApiHelpers/ArmHelper';
-import { isLinuxApp, isElastic, isKubeApp } from '../../../../utils/arm-utils';
-import SiteHelper from '../../../../utils/SiteHelper';
-import LocalCreateInstructions from './local-create/LocalCreateInstructions';
-import { PortalContext } from '../../../../PortalContext';
-import FunctionCreateData from './FunctionCreate.data';
-import { FunctionTemplate } from '../../../../models/functions/function-template';
+import { ReactComponent as VSCodeIconSvg } from '../../../../images/Functions/vs_code.svg';
 import { ArmObj } from '../../../../models/arm-obj';
-import { KeyValue } from '../../../../models/portal-models';
-import Url from '../../../../utils/url';
+import { FunctionTemplate } from '../../../../models/functions/function-template';
 import { HostStatus } from '../../../../models/functions/host-status';
-import { FunctionCreateContext, IFunctionCreateContext } from './FunctionCreateContext';
+import { KeyValue } from '../../../../models/portal-models';
+import { PortalContext } from '../../../../PortalContext';
+import { SiteStateContext } from '../../../../SiteState';
+import { isElastic, isKubeApp, isLinuxApp } from '../../../../utils/arm-utils';
+import { IArmResourceTemplate } from '../../../../utils/ArmTemplateHelper';
+import { CommonConstants, WorkerRuntimeLanguages } from '../../../../utils/CommonConstants';
 import { Links } from '../../../../utils/FwLinks';
+import { LogCategories } from '../../../../utils/LogCategories';
+import LogService from '../../../../utils/LogService';
+import SiteHelper from '../../../../utils/SiteHelper';
+import Url from '../../../../utils/url';
+import { CreateFunctionFormBuilder, CreateFunctionFormValues } from '../common/CreateFunctionFormBuilder';
+import FunctionCreateData from './FunctionCreate.data';
+import {
+  containerStyle,
+  developInPortalIconStyle,
+  developmentEnvironmentStyle,
+  dropdownIconStyle,
+  formContainerDivStyle,
+  formContainerStyle,
+  selectDevelopmentEnvironmentDescriptionStyle,
+  selectDevelopmentEnvironmentHeaderStyle,
+} from './FunctionCreate.styles';
+import { DevelopmentExperience } from './FunctionCreate.types';
+import { FunctionCreateContext, IFunctionCreateContext } from './FunctionCreateContext';
+import LocalCreateInstructions from './local-create/LocalCreateInstructions';
+import TemplateList from './portal-create/TemplateList';
 
 registerIcons({
   icons: {
@@ -52,7 +53,7 @@ export interface FunctionCreateDataLoaderProps {
   resourceId: string;
 }
 
-const FunctionCreateDataLoader: React.SFC<FunctionCreateDataLoaderProps> = props => {
+const FunctionCreateDataLoader: React.FC<FunctionCreateDataLoaderProps> = (props: FunctionCreateDataLoaderProps) => {
   const { resourceId } = props;
 
   const siteStateContext = useContext(SiteStateContext);
@@ -68,8 +69,9 @@ const FunctionCreateDataLoader: React.SFC<FunctionCreateDataLoaderProps> = props
   const [templates, setTemplates] = useState<FunctionTemplate[] | undefined | null>(undefined);
   const [hostStatus, setHostStatus] = useState<ArmObj<HostStatus> | undefined>(undefined);
   const [creatingFunction, setCreatingFunction] = useState(false);
+  const [armResources, setArmResources] = useState<IArmResourceTemplate[]>([]);
 
-  const onDevelopmentEnvironmentChange = (event: any, option: IDropdownOption) => {
+  const onDevelopmentEnvironmentChange = (_: React.FormEvent<HTMLElement>, option: IDropdownOption) => {
     setSelectedTemplate(undefined);
     setTemplateDetailFormBuilder(undefined);
 
@@ -350,6 +352,8 @@ const FunctionCreateDataLoader: React.SFC<FunctionCreateDataLoaderProps> = props
                   setTemplates={setTemplates}
                   hostStatus={hostStatus}
                   setHostStatus={setHostStatus}
+                  armResources={armResources}
+                  setArmResources={setArmResources}
                 />
               </div>
               <ActionBar

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create/TemplateDetail.tsx
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create/TemplateDetail.tsx
@@ -1,22 +1,23 @@
-import React, { useEffect, useState, useContext } from 'react';
-import { useTranslation } from 'react-i18next';
 import { Link } from '@fluentui/react';
-import { FunctionTemplate } from '../../../../../models/functions/function-template';
-import { getBindingDirection } from '../../function/integrate/FunctionIntegrate.utils';
-import { FunctionInfo } from '../../../../../models/functions/function-info';
+import { FormikProps } from 'formik';
+import { useContext, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getErrorMessageOrStringify } from '../../../../../ApiHelpers/ArmHelper';
+import FunctionsService from '../../../../../ApiHelpers/FunctionsService';
+import BasicShimmerLines from '../../../../../components/shimmer/BasicShimmerLines';
 import { ArmObj } from '../../../../../models/arm-obj';
 import { Binding } from '../../../../../models/functions/binding';
-import FunctionsService from '../../../../../ApiHelpers/FunctionsService';
-import LogService from '../../../../../utils/LogService';
-import { LogCategories } from '../../../../../utils/LogCategories';
-import { getErrorMessageOrStringify } from '../../../../../ApiHelpers/ArmHelper';
-import FunctionCreateData from '../FunctionCreate.data';
-import { CreateFunctionFormBuilder, CreateFunctionFormValues } from '../../common/CreateFunctionFormBuilder';
-import { FormikProps } from 'formik';
-import { detailContainerStyle } from '../FunctionCreate.styles';
-import BasicShimmerLines from '../../../../../components/shimmer/BasicShimmerLines';
-import { FunctionCreateContext } from '../FunctionCreateContext';
+import { FunctionInfo } from '../../../../../models/functions/function-info';
+import { FunctionTemplate } from '../../../../../models/functions/function-template';
+import { IArmResourceTemplate, TSetArmResourceTemplates } from '../../../../../utils/ArmTemplateHelper';
 import { Links } from '../../../../../utils/FwLinks';
+import { LogCategories } from '../../../../../utils/LogCategories';
+import LogService from '../../../../../utils/LogService';
+import { CreateFunctionFormBuilder, CreateFunctionFormValues } from '../../common/CreateFunctionFormBuilder';
+import { getBindingDirection } from '../../function/integrate/FunctionIntegrate.utils';
+import FunctionCreateData from '../FunctionCreate.data';
+import { detailContainerStyle } from '../FunctionCreate.styles';
+import { FunctionCreateContext } from '../FunctionCreateContext';
 
 export interface TemplateDetailProps {
   resourceId: string;
@@ -24,10 +25,12 @@ export interface TemplateDetailProps {
   formProps: FormikProps<CreateFunctionFormValues>;
   setBuilder: (builder?: CreateFunctionFormBuilder) => void;
   builder?: CreateFunctionFormBuilder;
+  armResources?: IArmResourceTemplate[];
+  setArmResources?: TSetArmResourceTemplates;
 }
 
-const TemplateDetail: React.FC<TemplateDetailProps> = props => {
-  const { resourceId, selectedTemplate, formProps, builder, setBuilder } = props;
+const TemplateDetail: React.FC<TemplateDetailProps> = (props: TemplateDetailProps) => {
+  const { resourceId, selectedTemplate, formProps, builder, setBuilder, armResources, setArmResources } = props;
   const { t } = useTranslation();
 
   const [functionsInfo, setFunctionsInfo] = useState<ArmObj<FunctionInfo>[] | undefined | null>(undefined);
@@ -110,10 +113,11 @@ const TemplateDetail: React.FC<TemplateDetailProps> = props => {
   };
 
   const createBuilder = () => {
-    if (functionsInfo && bindings) {
+    if (!!functionsInfo && !!bindings && !!resourceId) {
+      /** @todo (joechung): Use CosmosDbFunctionFormBuilder instead for Cosmos DB triggers. */
       setBuilder(
         new CreateFunctionFormBuilder(
-          selectedTemplate.bindings || [],
+          selectedTemplate.bindings ?? [],
           bindings,
           resourceId,
           functionsInfo,
@@ -128,7 +132,7 @@ const TemplateDetail: React.FC<TemplateDetailProps> = props => {
     return !functionsInfo || !bindings || !builder ? (
       <BasicShimmerLines />
     ) : (
-      builder.getFields(formProps, !!functionCreateContext.creatingFunction)
+      builder.getFields(formProps, !!functionCreateContext.creatingFunction, false, armResources, setArmResources)
     );
   };
 
@@ -136,7 +140,7 @@ const TemplateDetail: React.FC<TemplateDetailProps> = props => {
     createBuilder();
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [functionsInfo, bindings]);
+  }, [functionsInfo, bindings, resourceId]);
 
   useEffect(() => {
     setBindings(undefined);

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create/TemplateDetail.tsx
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create/TemplateDetail.tsx
@@ -113,7 +113,7 @@ const TemplateDetail: React.FC<TemplateDetailProps> = (props: TemplateDetailProp
   };
 
   const createBuilder = () => {
-    if (!!functionsInfo && !!bindings && !!resourceId) {
+    if (!!functionsInfo && !!bindings) {
       /** @todo (joechung): Use CosmosDbFunctionFormBuilder instead for Cosmos DB triggers. */
       setBuilder(
         new CreateFunctionFormBuilder(

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create/TemplateList.tsx
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create/TemplateList.tsx
@@ -1,26 +1,27 @@
-import React, { useEffect, useState, useMemo, useContext } from 'react';
-import { FunctionTemplate } from '../../../../../models/functions/function-template';
-import { useTranslation } from 'react-i18next';
-import TemplateDetail from './TemplateDetail';
-import LogService from '../../../../../utils/LogService';
-import { LogCategories } from '../../../../../utils/LogCategories';
-import { getErrorMessageOrStringify } from '../../../../../ApiHelpers/ArmHelper';
-import FunctionCreateData from '../FunctionCreate.data';
-import { Link, DetailsListLayoutMode, SelectionMode, CheckboxVisibility, IColumn, Selection, MessageBarType } from '@fluentui/react';
-import DisplayTableWithCommandBar from '../../../../../components/DisplayTableWithCommandBar/DisplayTableWithCommandBar';
-import { templateListStyle, templateListNameColumnStyle, containerStyle, tableRowStyle } from '../FunctionCreate.styles';
-import { CreateFunctionFormBuilder, CreateFunctionFormValues } from '../../common/CreateFunctionFormBuilder';
+import { CheckboxVisibility, DetailsListLayoutMode, IColumn, Link, MessageBarType, Selection, SelectionMode } from '@fluentui/react';
 import { FormikProps } from 'formik';
+import { useContext, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getErrorMessageOrStringify } from '../../../../../ApiHelpers/ArmHelper';
+import CustomBanner from '../../../../../components/CustomBanner/CustomBanner';
+import DisplayTableWithCommandBar from '../../../../../components/DisplayTableWithCommandBar/DisplayTableWithCommandBar';
+import { getSearchFilter } from '../../../../../components/form-controls/SearchBox';
 import { ArmObj } from '../../../../../models/arm-obj';
+import { FunctionTemplate } from '../../../../../models/functions/function-template';
 import { HostStatus } from '../../../../../models/functions/host-status';
-import StringUtils from '../../../../../utils/string';
 import { RuntimeExtensionMajorVersions } from '../../../../../models/functions/runtime-extension';
+import { ThemeContext } from '../../../../../ThemeContext';
+import { IArmResourceTemplate, TSetArmResourceTemplates } from '../../../../../utils/ArmTemplateHelper';
+import { Links } from '../../../../../utils/FwLinks';
+import { LogCategories } from '../../../../../utils/LogCategories';
+import LogService from '../../../../../utils/LogService';
+import StringUtils from '../../../../../utils/string';
+import { CreateFunctionFormBuilder, CreateFunctionFormValues } from '../../common/CreateFunctionFormBuilder';
+import FunctionCreateData from '../FunctionCreate.data';
+import { containerStyle, tableRowStyle, templateListNameColumnStyle, templateListStyle } from '../FunctionCreate.styles';
 import { sortTemplate } from '../FunctionCreate.types';
 import { FunctionCreateContext } from '../FunctionCreateContext';
-import { ThemeContext } from '../../../../../ThemeContext';
-import { Links } from '../../../../../utils/FwLinks';
-import CustomBanner from '../../../../../components/CustomBanner/CustomBanner';
-import { getSearchFilter } from '../../../../../components/form-controls/SearchBox';
+import TemplateDetail from './TemplateDetail';
 
 export interface TemplateListProps {
   resourceId: string;
@@ -33,9 +34,11 @@ export interface TemplateListProps {
   hostStatus?: ArmObj<HostStatus>;
   selectedTemplate?: FunctionTemplate;
   builder?: CreateFunctionFormBuilder;
+  armResources?: IArmResourceTemplate[];
+  setArmResources?: TSetArmResourceTemplates;
 }
 
-const TemplateList: React.FC<TemplateListProps> = props => {
+const TemplateList: React.FC<TemplateListProps> = (props: TemplateListProps) => {
   const {
     resourceId,
     formProps,
@@ -47,6 +50,8 @@ const TemplateList: React.FC<TemplateListProps> = props => {
     setTemplates,
     hostStatus,
     setHostStatus,
+    armResources,
+    setArmResources,
   } = props;
   const { t } = useTranslation();
 
@@ -117,7 +122,7 @@ const TemplateList: React.FC<TemplateListProps> = props => {
       );
     }
 
-    return <div>{item[column.fieldName!]}</div>;
+    return column.fieldName ? <div>{item[column.fieldName]}</div> : null;
   };
 
   const getColumns = () => {
@@ -230,6 +235,8 @@ const TemplateList: React.FC<TemplateListProps> = props => {
           formProps={formProps}
           setBuilder={setBuilder}
           builder={builder}
+          armResources={armResources}
+          setArmResources={setArmResources}
         />
       )}
     </div>

--- a/client-react/src/utils/ArmTemplateHelper.ts
+++ b/client-react/src/utils/ArmTemplateHelper.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 interface IArmDeploymentTemplate {
   $schema: string;
   contentVersion: '1.0.0.0'; // This isn't a "recurring setup" type of template, so this can stay constant
@@ -15,6 +17,10 @@ export interface IArmResourceTemplate {
   dependsOn?: string[];
   properties?: Record<string, any>;
 }
+
+export type TSetArmResourceTemplate = React.Dispatch<React.SetStateAction<IArmResourceTemplate>>;
+
+export type TSetArmResourceTemplates = React.Dispatch<React.SetStateAction<IArmResourceTemplate[]>>;
 
 // Makes ARM deployment to resource group
 // https://docs.microsoft.com/en-us/rest/api/resources/deployments/create-or-update

--- a/client-react/src/utils/CosmosDbArmTemplateHelper.ts
+++ b/client-react/src/utils/CosmosDbArmTemplateHelper.ts
@@ -1,12 +1,11 @@
 import { FormikProps } from 'formik';
-import React from 'react';
 import { ArmObj } from '../models/arm-obj';
-import { getArmDeploymentTemplate, IArmResourceTemplate } from './ArmTemplateHelper';
+import { getArmDeploymentTemplate, IArmResourceTemplate, TSetArmResourceTemplate, TSetArmResourceTemplates } from './ArmTemplateHelper';
 import { CommonConstants } from './CommonConstants';
 
 export const addDatabaseAccountType = (
   endpoint: string,
-  databaseAccountType: string,
+  databaseAccountType: string = CommonConstants.CosmosDbTypes.globalDocumentDb,
   isContainer: boolean = false,
   databaseName?: string
 ): string => {
@@ -16,7 +15,7 @@ export const addDatabaseAccountType = (
 
   switch (databaseAccountType) {
     case CommonConstants.CosmosDbTypes.globalDocumentDb:
-      return endpoint + !isContainer ? 'sqlDatabases' : `sqlDatabases/${databaseName}/containers`;
+      return endpoint + (!isContainer ? 'sqlDatabases' : `sqlDatabases/${databaseName}/containers`);
 
     default:
       return '';
@@ -196,8 +195,8 @@ export const getNewDatabaseArmTemplate = (
 
 export const removeCurrentContainerArmTemplate = (
   armResources: IArmResourceTemplate[],
-  setArmResources: React.Dispatch<React.SetStateAction<IArmResourceTemplate[]>>,
-  setStoredArmTemplate?: React.Dispatch<React.SetStateAction<IArmResourceTemplate>>
+  setArmResources: TSetArmResourceTemplates,
+  setStoredArmTemplate?: TSetArmResourceTemplate
 ) => {
   removeTemplateConditionally(
     armResources,
@@ -209,8 +208,8 @@ export const removeCurrentContainerArmTemplate = (
 
 export const removeCurrentDatabaseAccountArmTemplate = (
   armResources: IArmResourceTemplate[],
-  setArmResources: React.Dispatch<React.SetStateAction<IArmResourceTemplate[]>>,
-  setStoredArmTemplate?: React.Dispatch<React.SetStateAction<IArmResourceTemplate>>
+  setArmResources: TSetArmResourceTemplates,
+  setStoredArmTemplate?: TSetArmResourceTemplate
 ) => {
   removeTemplateConditionally(
     armResources,
@@ -222,8 +221,8 @@ export const removeCurrentDatabaseAccountArmTemplate = (
 
 export const removeCurrentDatabaseArmTemplate = (
   armResources: IArmResourceTemplate[],
-  setArmResources: React.Dispatch<React.SetStateAction<IArmResourceTemplate[]>>,
-  setStoredArmTemplate?: React.Dispatch<React.SetStateAction<IArmResourceTemplate>>
+  setArmResources: TSetArmResourceTemplates,
+  setStoredArmTemplate?: TSetArmResourceTemplate
 ) => {
   removeTemplateConditionally(
     armResources,
@@ -235,9 +234,9 @@ export const removeCurrentDatabaseArmTemplate = (
 
 export const removeTemplateConditionally = (
   armResources: IArmResourceTemplate[],
-  setArmResources: React.Dispatch<React.SetStateAction<IArmResourceTemplate[]>>,
+  setArmResources: TSetArmResourceTemplates,
   condition: (resource: IArmResourceTemplate) => boolean,
-  setStoredArmTemplate?: React.Dispatch<React.SetStateAction<IArmResourceTemplate>>
+  setStoredArmTemplate?: TSetArmResourceTemplate
 ) => {
   const modifiableArmResources = armResources;
 
@@ -252,8 +251,8 @@ export const removeTemplateConditionally = (
 
 export const storeTemplateAndClearResources = (
   armResources: IArmResourceTemplate[],
-  setArmResources: React.Dispatch<React.SetStateAction<IArmResourceTemplate[]>>,
-  setStoredArmTemplate: React.Dispatch<React.SetStateAction<IArmResourceTemplate>>
+  setArmResources: TSetArmResourceTemplates,
+  setStoredArmTemplate: TSetArmResourceTemplate
 ) => {
   for (const armResource of armResources) {
     if (armResource.type.toLowerCase().includes('databaseaccounts') && armResource.name.split('/').length === 1) {

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2428,6 +2428,8 @@ export class PortalResources {
   public static containerApp_console_connect = 'containerApp_console_connect';
   public static containerApp_console_custom = 'containerApp_console_custom';
   public static new_parenthesized = 'new_parenthesized';
+  public static automatic = 'automatic';
+  public static manual = 'manual';
   public static cosmosDb_apiType_coreSql = 'cosmosDb_apiType_coreSql';
   public static cosmosDb_error_accountNameRequired = 'cosmosDb_error_accountNameRequired';
   public static cosmosDb_error_accountNameInvalid = 'cosmosDb_error_accountNameInvalid';
@@ -2439,15 +2441,23 @@ export class PortalResources {
   public static cosmosDb_error_databaseNameCharacters = 'cosmosDb_error_databaseNameCharacters';
   public static cosmosDb_error_databaseNameSpace = 'cosmosDb_error_databaseNameSpace';
   public static cosmosDb_error_fieldRequired = 'cosmosDb_error_fieldRequired';
+  public static cosmosDb_error_partitionKeyPathSlash = 'cosmosDb_error_partitionKeyPathSlash';
+  public static cosmosDb_error_writePermissionsRequired = 'cosmosDb_error_writePermissionsRequired';
+  public static cosmosDb_header_customAppSetting = 'cosmosDb_header_customAppSetting';
+  public static cosmosDb_header_details = 'cosmosDb_header_details';
   public static cosmosDb_label_accountName = 'cosmosDb_label_accountName';
   public static cosmosDb_label_apiType = 'cosmosDb_label_apiType';
   public static nodeStackLearnMore = 'nodeStackLearnMore';
+  public static cosmosDb_label_connection = 'cosmosDb_label_connection';
   public static cosmosDb_label_container = 'cosmosDb_label_container';
   public static cosmosDb_label_cosmosDbAccount = 'cosmosDb_label_cosmosDbAccount';
   public static cosmosDb_label_createAContainer = 'cosmosDb_label_createAContainer';
   public static cosmosDb_label_createADatabase = 'cosmosDb_label_createADatabase';
   public static cosmosDb_label_createAnAccount = 'cosmosDb_label_createAnAccount';
+  public static cosmosDb_label_customAppSettingKey = 'cosmosDb_label_customAppSettingKey';
+  public static cosmosDb_label_customAppSettingValue = 'cosmosDb_label_customAppSettingValue';
   public static cosmosDb_label_database = 'cosmosDb_label_database';
+  public static cosmosDb_label_partitionKeyPath = 'cosmosDb_label_partitionKeyPath';
   public static cosmosDb_newAccountDialog_description = 'cosmosDb_newAccountDialog_description';
   public static cosmosDb_newAccountDialog_link = 'cosmosDb_newAccountDialog_link';
   public static cosmosDb_newAccountDialog_title = 'cosmosDb_newAccountDialog_title';
@@ -2455,6 +2465,8 @@ export class PortalResources {
   public static cosmosDb_placeholder_selectAContainer = 'cosmosDb_placeholder_selectAContainer';
   public static cosmosDb_placeholder_selectADatabase = 'cosmosDb_placeholder_selectADatabase';
   public static cosmosDb_placeholder_selectAnAccount = 'cosmosDb_placeholder_selectAnAccount';
+  public static cosmosDb_tooltip_customAppSettingKey = 'cosmosDb_tooltip_customAppSettingKey';
+  public static cosmosDb_tooltip_partitionKeyPath = 'cosmosDb_tooltip_partitionKeyPath';
   public static containerApp_console_startUpCommandAriaLabel = 'containerApp_console_startUpCommandAriaLabel';
   public static containerApp_console_cancel = 'containerApp_console_cancel';
 }

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7423,6 +7423,12 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>(new)</value>
         <comment>Prefix for dropdown option text indicating their newness, e.g., (new) CosmosDatabase</comment>
     </data>
+    <data name="automatic" xml:space="preserve">
+        <value>Automatic</value>
+    </data>
+    <data name="manual" xml:space="preserve">
+        <value>Manual</value>
+    </data>
     <data name="cosmosDb_apiType_coreSql" xml:space="preserve">
         <value>Core (SQL)</value>
     </data>
@@ -7456,6 +7462,18 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="cosmosDb_error_fieldRequired" xml:space="preserve">
         <value>The field is required.</value>
     </data>
+    <data name="cosmosDb_error_partitionKeyPathSlash" xml:space="preserve">
+        <value>The partition key path must contain at least one \'/\' at the beginning of the string.</value>
+    </data>
+    <data name="cosmosDb_error_writePermissionsRequired" xml:space="preserve">
+        <value>Automatic mode is disabled for users with read-only permissions in their subscription or resource group.</value>
+    </data>
+    <data name="cosmosDb_header_customAppSetting" xml:space="preserve">
+        <value>Custom app setting</value>
+    </data>
+    <data name="cosmosDb_header_details" xml:space="preserve">
+        <value>Cosmos DB details</value>
+    </data>
     <data name="cosmosDb_label_accountName" xml:space="preserve">
         <value>Account name</value>
     </data>
@@ -7464,6 +7482,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     </data>
     <data name="nodeStackLearnMore" xml:space="preserve">
         <value>Node version is defined through the {0} app setting.</value>
+    </data>
+    <data name="cosmosDb_label_connection" xml:space="preserve">
+        <value>Cosmos DB connection</value>
     </data>
     <data name="cosmosDb_label_container" xml:space="preserve">
         <value>Container</value>
@@ -7480,8 +7501,17 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="cosmosDb_label_createAnAccount" xml:space="preserve">
         <value>Create an account</value>
     </data>
+    <data name="cosmosDb_label_customAppSettingKey" xml:space="preserve">
+        <value>Name</value>
+    </data>
+    <data name="cosmosDb_label_customAppSettingValue" xml:space="preserve">
+        <value>Connection string setting</value>
+    </data>
     <data name="cosmosDb_label_database" xml:space="preserve">
         <value>Database</value>
+    </data>
+    <data name="cosmosDb_label_partitionKeyPath" xml:space="preserve">
+        <value>Partition key path</value>
     </data>
     <data name="cosmosDb_newAccountDialog_description" xml:space="preserve">
         <value>Create a new serverless account in the same Azure region and resource group as the function. For more options, go to </value>
@@ -7503,6 +7533,12 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     </data>
     <data name="cosmosDb_placeholder_selectAnAccount" xml:space="preserve">
         <value>Select an account</value>
+    </data>
+    <data name="cosmosDb_tooltip_customAppSettingKey" xml:space="preserve">
+        <value>Enter the key/value pair for the Cosmos DB custom app setting.</value>
+    </data>
+    <data name="cosmosDb_tooltip_partitionKeyPath" xml:space="preserve">
+        <value>The partition key is used to automatically distribute data across partitions for scalability. Choose a property in your JSON document that has a wide range of values and evenly distributes request volume. Select /id for either small read-heavy workloads or write-heavy workloads of any size.</value>
     </data>
     <data name="containerApp_console_startUpCommandAriaLabel" xml:space="preserve">
         <value>Custom start up command</value>


### PR DESCRIPTION
Refactor common code to support the custom Cosmos DB form builder to be enableable in the next PR.
- `BindingFormBuilder`
- `CreateFunctionFormBuilder`
- `FunctionCreateDataLoader`
- `TemplateDetail`
- `TemplateList`

Automatic
![cosmosdb-automatic](https://user-images.githubusercontent.com/26208574/171912353-e8ab0848-d71e-4f55-a028-a5a1060e5ae4.png)

Manual
![cosmosdb-manual](https://user-images.githubusercontent.com/26208574/171912379-0420d491-85fb-455d-8503-2edb9d236eef.png)
