### PR TITLE
14818314[ASEv3][USSec] Enable ASEv3 in US Sec and allow ASEv3 create from Web App create

### DIFF
--- a/client/src/app/shared/Utilities/arm-utils.ts
+++ b/client/src/app/shared/Utilities/arm-utils.ts
@@ -54,15 +54,10 @@ export namespace ArmUtil {
   }
 
   export function isASEV3GenerallyAccessible(): boolean {
-    // NOTE(miabebax): ASEv3 is available in Public, Fairfax, USNat and USSec environment only.
+    // NOTE(miabebax): ASEv3 is available in Public, Fairfax and USSec environment only.
     // We use this helper function to decide whether we display ASEv3 or ASEv2 features.
     // Ex: In spec picker blade, we hide isolatedV2 specs if it is not ASEv3 supported regions.
-    return (
-      !NationalCloudEnvironment.isNationalCloud() ||
-      NationalCloudEnvironment.isFairFax() ||
-      NationalCloudEnvironment.isUSNat() ||
-      NationalCloudEnvironment.isUSSec()
-    );
+    return !NationalCloudEnvironment.isNationalCloud() || NationalCloudEnvironment.isFairFax() || NationalCloudEnvironment.isUSSec();
   }
 
   export function mapArmSiteToContext(obj: ArmObj<Site>, injector: Injector): FunctionAppContext {

--- a/client/src/app/shared/Utilities/arm-utils.ts
+++ b/client/src/app/shared/Utilities/arm-utils.ts
@@ -54,10 +54,15 @@ export namespace ArmUtil {
   }
 
   export function isASEV3GenerallyAccessible(): boolean {
-    // NOTE(miabebax): ASEv3 is available in Public and Fairfax environment only.
+    // NOTE(miabebax): ASEv3 is available in Public, Fairfax, USNat and USSec environment only.
     // We use this helper function to decide whether we display ASEv3 or ASEv2 features.
     // Ex: In spec picker blade, we hide isolatedV2 specs if it is not ASEv3 supported regions.
-    return !NationalCloudEnvironment.isNationalCloud() || NationalCloudEnvironment.isFairFax();
+    return (
+      !NationalCloudEnvironment.isNationalCloud() ||
+      NationalCloudEnvironment.isFairFax() ||
+      NationalCloudEnvironment.isUSNat() ||
+      NationalCloudEnvironment.isUSSec()
+    );
   }
 
   export function mapArmSiteToContext(obj: ArmObj<Site>, injector: Injector): FunctionAppContext {

--- a/client/src/app/site/spec-picker/spec-picker.component.ts
+++ b/client/src/app/site/spec-picker/spec-picker.component.ts
@@ -218,7 +218,7 @@ export class SpecPickerComponent extends FeatureComponent<TreeViewInfo<SpecPicke
     const selectedSpecGroup = this.specManager.selectedSpecGroup;
     const isEmpty = selectedSpecGroup.recommendedSpecs.length === 0 && this.specManager.selectedSpecGroup.additionalSpecs.length === 0;
 
-    //When user is trying to create a new ASP, we will provide a link to 'ASE' create page if it falls into one one of two conditions below
+    //When user is trying to create a new ASP, we will provide a link to 'ASE' create page if it falls into one of two conditions below
     //Condition 1: ASEv3 is supported, but no recommendation or additional specs are available
     //Condition 2: ASEv3 is not supported.
     const isNewPlan = this._input.data && !this._input.data.selectedSkuCode;


### PR DESCRIPTION
Ibiza side code change PR: https://msazure.visualstudio.com/One/_git/AAPT-Antares-AntUX/pullrequest/6253979
Even though one side of code changes goes to prod sooner than the other, Web App create experience will not break. However, user will be blocked from creating new ASEv3 or new ASP on existing ASEv3 until both Fusion and Ibiza changes go into prod.