### PR TITLE
Ensure Authorization Level is populated for read-only Python triggers

### DIFF
--- a/client-react/src/pages/app/functions/common/BindingFormBuilder.tsx
+++ b/client-react/src/pages/app/functions/common/BindingFormBuilder.tsx
@@ -60,6 +60,17 @@ export class BindingFormBuilder<TOptions> {
           value = setting.enum?.map(e => e.value) ?? [];
         }
 
+        // Ensure that value is set correctly when a case-insensitive match is found,
+        // e.g., 'ANONYMOUS' authorization level should match 'anonymous' enum option value.
+        if (setting.value === BindingSettingValue.enum && !!value) {
+          const match = setting.enum?.find(
+            option => value.localeCompare(option.value, /* locales */ undefined, { sensitivity: 'base' }) === 0
+          )?.value;
+          if (match) {
+            value = match;
+          }
+        }
+
         initialFormValues[setting.name] = value;
       }
 


### PR DESCRIPTION
[#14811716](https://msazure.visualstudio.com/Antares/_workitems/edit/14811716)

![14811716-authorization-level](https://user-images.githubusercontent.com/26208574/176502533-958c5613-da69-48e0-8b52-6cd1a74b9355.png)
