### PR TITLE
Fix mis-matched Preview releases between GHA and runtime (#6766)

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -31,7 +31,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 },
                 gitHubActionSettings: {
                   isSupported: true,
-                  supportedVersion: '7.0.x',
+                  supportedVersion: '7.0.100-preview.5.22307.18',
                 },
                 isPreview: true,
               },
@@ -43,7 +43,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 },
                 gitHubActionSettings: {
                   isSupported: true,
-                  supportedVersion: '7.0.x',
+                  supportedVersion: '7.0.100-preview.5.22307.18',
                 },
                 isPreview: true,
               },


### PR DESCRIPTION
There's a lot of breaking changes between .NET 7 preview releases (relative to .NET 5 or 6 preview releases). So we want to "pin" this version in the workflow to Preview 5 so that it matches the runtime version. The runtime version is currently on Preview 5, but the SDK release feed is on Preview 6. So if we continue using the "7.0.x" string, the build with Preview 6 won't work on with the runtime on Preview 5. This also means we'll need to update this string when we update the runtime to Preview 6.

Co-authored-by: Krrish Mittal <krrishmittal15@gmail.com>