### PR TITLE
[Starshot] Update call to create repo from GitHub template

### DIFF
--- a/server/src/deployment-center/github/github.controller.ts
+++ b/server/src/deployment-center/github/github.controller.ts
@@ -110,8 +110,6 @@ export class GithubController {
   ) {
     const url = `${this.githubApiUrl}/repos/${templateOwner}/${templateRepo}/generate`;
     await this._makePostCallWithLinkAndOAuthHeaders(url, gitHubToken, res, {
-      template_owner: templateOwner,
-      template_repo: templateRepo,
       owner: gitHubUserName,
       name: gitHubRepositoryName,
     });


### PR DESCRIPTION
Updated inputs to create user/organization repo from GitHub template. Previously had parameters not needed in the call. Using [this API](https://docs.github.com/en/rest/repos/repos#create-a-repository-using-a-template) as reference