### PR TITLE
AB#15250813 Show confirmation dialog when deleting system app keys for functionApp

### DIFF
--- a/client-react/src/pages/app/functions/app-keys/AppKeys.styles.ts
+++ b/client-react/src/pages/app/functions/app-keys/AppKeys.styles.ts
@@ -80,14 +80,14 @@ export const tableValueTextFieldStyle = style({
   width: '100%',
 });
 
-export const hostKeyDeleteConfirmDialogInnerDivStyle = style({
+export const appKeyDeleteConfirmDialogInnerDivStyle = style({
   width: '250px',
   display: 'block',
   justifyContent: 'center',
   margin: '10px',
 });
 
-export const hostKeyDeleteConfirmButtonStyle = style({
+export const appKeyDeleteConfirmButtonStyle = style({
   marginRight: '10px',
   marginTop: '10px',
 });

--- a/client-react/src/pages/app/functions/app-keys/HostKeys.tsx
+++ b/client-react/src/pages/app/functions/app-keys/HostKeys.tsx
@@ -18,8 +18,8 @@ import {
   tableValueIconStyle,
   tableValueFormFieldStyle,
   tableValueTextFieldStyle,
-  hostKeyDeleteConfirmDialogInnerDivStyle,
-  hostKeyDeleteConfirmButtonStyle,
+  appKeyDeleteConfirmDialogInnerDivStyle,
+  appKeyDeleteConfirmButtonStyle,
 } from './AppKeys.styles';
 import { useTranslation } from 'react-i18next';
 import { defaultCellStyle } from '../../../../components/DisplayTableWithEmptyMessage/DisplayTableWithEmptyMessage';
@@ -153,7 +153,11 @@ const HostKeys: React.FC<HostKeysProps> = props => {
     setIsDeleteConfirmationDialogVisible(true);
   };
 
-  const onCalloutDismiss = (itemKey: string) => {
+  const onCalloutDismiss = () => {
+    setIsDeleteConfirmationDialogVisible(false);
+  };
+
+  const onConfirmDelete = (itemKey: string) => {
     setIsDeleteConfirmationDialogVisible(false);
     appKeysContext.deleteKey(resourceId, itemKey, AppKeysTypes.functionKeys);
     refreshData();
@@ -237,16 +241,16 @@ const HostKeys: React.FC<HostKeysProps> = props => {
           </TooltipHost>
           <Callout
             hidden={!isDeleteConfirmationDialogVisible}
-            onDismiss={() => onCalloutDismiss(itemKey)}
+            onDismiss={() => onCalloutDismiss()}
             setInitialFocus={true}
             target={`#${appSettingsDeleteIconButtonId}`}>
-            <div className={hostKeyDeleteConfirmDialogInnerDivStyle}>
+            <div className={appKeyDeleteConfirmDialogInnerDivStyle}>
               {t('functionHostKeyDeleteConfirmMessage')}
               <div>
                 <PrimaryButton
                   id={`confirmDeleteButton`}
-                  className={hostKeyDeleteConfirmButtonStyle}
-                  onClick={() => onCalloutDismiss(itemKey)}>
+                  className={appKeyDeleteConfirmButtonStyle}
+                  onClick={() => onConfirmDelete(itemKey)}>
                   {t('continue')}
                 </PrimaryButton>
                 <DefaultButton text={t('cancel')} onClick={onCancelDelete} />

--- a/client-react/src/pages/app/functions/app-keys/SystemKeys.tsx
+++ b/client-react/src/pages/app/functions/app-keys/SystemKeys.tsx
@@ -1,6 +1,17 @@
 import React, { useState, useContext } from 'react';
 import { AppKeysModel, AppKeysTypes } from './AppKeys.types';
-import { ActionButton, DetailsListLayoutMode, SelectionMode, IColumn, TooltipHost, ICommandBarItemProps, PanelType } from '@fluentui/react';
+import {
+  ActionButton,
+  DetailsListLayoutMode,
+  SelectionMode,
+  IColumn,
+  TooltipHost,
+  ICommandBarItemProps,
+  PanelType,
+  Callout,
+  PrimaryButton,
+  DefaultButton,
+} from '@fluentui/react';
 import { useTranslation } from 'react-i18next';
 import {
   renewTextStyle,
@@ -8,6 +19,8 @@ import {
   tableValueIconStyle,
   tableValueFormFieldStyle,
   tableValueTextFieldStyle,
+  appKeyDeleteConfirmDialogInnerDivStyle,
+  appKeyDeleteConfirmButtonStyle,
 } from './AppKeys.styles';
 import { defaultCellStyle } from '../../../../components/DisplayTableWithEmptyMessage/DisplayTableWithEmptyMessage';
 import { emptyKey } from './AppKeys';
@@ -41,6 +54,7 @@ const SystemKeys: React.FC<SystemKeysProps> = props => {
   const [panelItem, setPanelItem] = useState('');
   const [currentKey, setCurrentKey] = useState(emptyKey);
   const [shownValues, setShownValues] = useState<string[]>([]);
+  const [isDeleteConfirmationDialogVisible, setIsDeleteConfirmationDialogVisible] = useState(false);
 
   const { t } = useTranslation();
   const appKeysContext = useContext(AppKeysContext);
@@ -159,9 +173,22 @@ const SystemKeys: React.FC<SystemKeysProps> = props => {
     setShownValues([...newShownValues]);
   };
 
-  const deleteSystemKey = (itemKey: string) => {
+  const deleteSystemKey = () => {
+    setIsDeleteConfirmationDialogVisible(true);
+  };
+
+  const onCalloutDismiss = () => {
+    setIsDeleteConfirmationDialogVisible(false);
+  };
+
+  const onConfirmDelete = (itemKey: string) => {
+    setIsDeleteConfirmationDialogVisible(false);
     appKeysContext.deleteKey(resourceId, itemKey, AppKeysTypes.systemKeys);
     refreshData();
+  };
+
+  const onCancelDelete = () => {
+    setIsDeleteConfirmationDialogVisible(false);
   };
 
   const onRenderColumnItem = (item: AppKeysModel, index: number, column: IColumn) => {
@@ -216,21 +243,42 @@ const SystemKeys: React.FC<SystemKeysProps> = props => {
       );
     }
     if (column.key === 'delete') {
+      const appSettingsDeleteIconButtonId = `app-settings-application-settings-delete-${index}`;
       return (
-        <TooltipHost
-          content={t('delete')}
-          id={`app-keys-host-keys-delete-tooltip-${index}`}
-          calloutProps={{ gapSpace: 0 }}
-          closeDelay={500}>
-          <IconButton
-            className={defaultCellStyle}
-            disabled={readOnlyPermission}
-            id={`app-settings-application-settings-delete-${index}`}
-            iconProps={{ iconName: 'Delete' }}
-            ariaLabel={t('delete')}
-            onClick={() => deleteSystemKey(itemKey)}
-          />
-        </TooltipHost>
+        <div>
+          <TooltipHost
+            content={t('delete')}
+            id={`app-keys-host-keys-delete-tooltip-${index}`}
+            calloutProps={{ gapSpace: 0 }}
+            closeDelay={500}>
+            <IconButton
+              className={defaultCellStyle}
+              disabled={readOnlyPermission}
+              id={appSettingsDeleteIconButtonId}
+              iconProps={{ iconName: 'Delete' }}
+              ariaLabel={t('delete')}
+              onClick={() => deleteSystemKey()}
+            />
+          </TooltipHost>
+          <Callout
+            hidden={!isDeleteConfirmationDialogVisible}
+            onDismiss={() => onCalloutDismiss()}
+            setInitialFocus={true}
+            target={`#${appSettingsDeleteIconButtonId}`}>
+            <div className={appKeyDeleteConfirmDialogInnerDivStyle}>
+              {t('functionHostKeyDeleteConfirmMessage')}
+              <div>
+                <PrimaryButton
+                  id={`confirmDeleteButton`}
+                  className={appKeyDeleteConfirmButtonStyle}
+                  onClick={() => onConfirmDelete(itemKey)}>
+                  {t('continue')}
+                </PrimaryButton>
+                <DefaultButton text={t('cancel')} onClick={onCancelDelete} />
+              </div>
+            </div>
+          </Callout>
+        </div>
       );
     }
     if (column.key === 'renew') {


### PR DESCRIPTION
Fixes [AB#15250813](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/15250813)

Also made a change to reuse styles and make sure the key is deleted only on explicit click on continue rather than just callout dismiss.


![image](https://user-images.githubusercontent.com/14221995/184416498-31753e08-5313-485a-bff9-02d780b1da73.png)
