### PR TITLE
[DC] Set VnetImagePullEnabled for ACR image pulls to true

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
@@ -51,6 +51,10 @@ export default class DeploymentCenterData {
     return SiteService.fetchSite(resourceId);
   };
 
+  public patchSite = (resourceId: string, body: any) => {
+    return SiteService.patchSite(resourceId, body);
+  };
+
   public getSiteConfig = (resourceId: string) => {
     return SiteService.fetchWebConfig(resourceId);
   };

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -362,14 +362,11 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
     } else {
       let principalId = '';
       const acrResourceId = values.acrResourceId;
-      const siteResponse = await deploymentCenterData.fetchSite(deploymentCenterContext.resourceId);
+      const siteIdentity = siteContext.site?.identity;
 
       if (values.acrManagedIdentityClientId === ACRManagedIdentityType.systemAssigned) {
         portalContext.log(getTelemetryInfo('info', 'enableSystemAssignedIdentity', 'submit'));
-        const response = await deploymentCenterData.enableSystemAssignedIdentity(
-          deploymentCenterContext.resourceId,
-          siteResponse.data.identity
-        );
+        const response = await deploymentCenterData.enableSystemAssignedIdentity(deploymentCenterContext.resourceId, siteIdentity);
         if (response.metadata.success) {
           principalId = response.data.identity.principalId;
         } else {
@@ -430,7 +427,7 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
     });
 
     if (!updateSiteResponse.metadata.success) {
-      portalContext.log(getTelemetryInfo('error', 'settingVnetImagePullEnabledTrue', 'failed'));
+      portalContext.log(getTelemetryInfo('error', 'settingVnetImagePullEnabledTrue', 'failed', updateSiteResponse.metadata.error));
     }
   };
 

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -362,13 +362,13 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
     } else {
       let principalId = '';
       const acrResourceId = values.acrResourceId;
-      const siteIdentityResponse = await deploymentCenterData.fetchSite(deploymentCenterContext.resourceId);
+      const siteResponse = await deploymentCenterData.fetchSite(deploymentCenterContext.resourceId);
 
       if (values.acrManagedIdentityClientId === ACRManagedIdentityType.systemAssigned) {
         portalContext.log(getTelemetryInfo('info', 'enableSystemAssignedIdentity', 'submit'));
         const response = await deploymentCenterData.enableSystemAssignedIdentity(
           deploymentCenterContext.resourceId,
-          siteIdentityResponse.data.identity
+          siteResponse.data.identity
         );
         if (response.metadata.success) {
           principalId = response.data.identity.principalId;
@@ -421,6 +421,19 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
     };
   };
 
+  const setVnetImagePullEnabledTrue = async () => {
+    portalContext.log(getTelemetryInfo('info', 'settingVnetImagePullEnabledTrue', 'submit'));
+    const updateSiteResponse = await deploymentCenterData.patchSite(deploymentCenterContext.resourceId, {
+      properties: {
+        vnetImagePullEnabled: true,
+      },
+    });
+
+    if (!updateSiteResponse.metadata.success) {
+      portalContext.log(getTelemetryInfo('error', 'settingVnetImagePullEnabledTrue', 'failed'));
+    }
+  };
+
   const saveDirectRegistrySettings = async (
     values: DeploymentCenterFormData<DeploymentCenterContainerFormData>,
     deploymentProperties: KeyValue<any>
@@ -439,9 +452,12 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
       portalContext.stopNotification(notificationId, true, t('savingContainerConfigurationSuccess'));
       logSaveConclusion(true, deploymentProperties);
     } else {
-      let errorMessage = !updateAppSettingsResponse.success ? getErrorMessage(updateAppSettingsResponse.error) : '';
-
-      errorMessage = !errorMessage && !updateSiteConfigResponse.success ? getErrorMessage(updateSiteConfigResponse.error) : '';
+      let errorMessage = '';
+      if (!updateAppSettingsResponse.success) {
+        errorMessage = getErrorMessage(updateAppSettingsResponse.error);
+      } else if (!updateSiteConfigResponse.success) {
+        errorMessage = getErrorMessage(updateSiteConfigResponse.error);
+      }
 
       if (errorMessage) {
         portalContext.stopNotification(
@@ -717,6 +733,12 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
       startTime: new Date().getTime(),
     };
     portalContext.log(getTelemetryInfo('info', 'saveDeploymentSettings', 'start', deploymentProperties));
+
+    // Setting site property vnetImagePullEnabled true always when pulling image from ACR
+    // Property set to false on few occasions, so in those cases, we'll route customers to CLI/ARM
+    if (values.registrySource === ContainerRegistrySources.acr) {
+      await setVnetImagePullEnabledTrue();
+    }
 
     // Only do the save if scmType in the config is set to none.
     // If the scmType in the config is not none, the user should be doing a disconnect operation first.


### PR DESCRIPTION
Task [12451262](https://msazure.visualstudio.com/Antares/_workitems/edit/12451262)
- Setting vnetImagePullEnabled = true always for acr image pulls, current default is false
- Few scenarios require the property to be set to false, so in those cases, we'll route customers to CLI/ARM for special configurations