### PR TITLE
[Function integration] Delete multiple instances of same storage account

### DIFF
--- a/client-react/src/pages/app/functions/common/callout/storageAccountPivot/StorageAccountPivot.tsx
+++ b/client-react/src/pages/app/functions/common/callout/storageAccountPivot/StorageAccountPivot.tsx
@@ -134,11 +134,17 @@ const setStorageAccountConnection = (
   setKeyList: React.Dispatch<React.SetStateAction<StorageAccountKeys | undefined>>
 ) => {
   if (formValues.storageAccount && keyList) {
-    const appSettingName = generateAppSettingName(appSettingKeys, `${formValues.storageAccount.name}_STORAGE`);
+    var appSettingName = generateAppSettingName(appSettingKeys, `${formValues.storageAccount.name}_STORAGE`);
     const appSettingValue = `DefaultEndpointsProtocol=https;AccountName=${formValues.storageAccount.name};AccountKey=${
       keyList.keys[0].value
     }${appendEndpoint()}`;
-    setNewAppSetting({ key: appSettingName, value: appSettingValue });
+
+    if (appSettingName != `${formValues.storageAccount.name}_STORAGE`) {
+      appSettingName = `${formValues.storageAccount.name}_STORAGE`;
+    } else {
+      setNewAppSetting({ key: appSettingName, value: appSettingValue });
+    }
+
     setSelectedItem({ key: appSettingName, text: appSettingName, data: appSettingValue });
     setKeyList(undefined);
     setIsDialogVisible(false);

--- a/client-react/src/pages/app/functions/common/callout/storageAccountPivot/StorageAccountPivot.tsx
+++ b/client-react/src/pages/app/functions/common/callout/storageAccountPivot/StorageAccountPivot.tsx
@@ -134,12 +134,12 @@ const setStorageAccountConnection = (
   setKeyList: React.Dispatch<React.SetStateAction<StorageAccountKeys | undefined>>
 ) => {
   if (formValues.storageAccount && keyList) {
-    var appSettingName = generateAppSettingName(appSettingKeys, `${formValues.storageAccount.name}_STORAGE`);
+    let appSettingName = generateAppSettingName(appSettingKeys, `${formValues.storageAccount.name}_STORAGE`);
     const appSettingValue = `DefaultEndpointsProtocol=https;AccountName=${formValues.storageAccount.name};AccountKey=${
       keyList.keys[0].value
     }${appendEndpoint()}`;
 
-    if (appSettingName != `${formValues.storageAccount.name}_STORAGE`) {
+    if (appSettingName !== `${formValues.storageAccount.name}_STORAGE`) {
       appSettingName = `${formValues.storageAccount.name}_STORAGE`;
     } else {
       setNewAppSetting({ key: appSettingName, value: appSettingValue });


### PR DESCRIPTION
[BUG 15286519] 

Before: 
When trying to create a new storage in Function -> integration -> input -> New storage. It created n-number of different storage instances which are unnecessary. 
<img width="396" alt="Screen Shot 2022-08-18 at 2 18 46 PM" src="https://user-images.githubusercontent.com/45466137/185484865-f8fb3f92-b28e-4426-83b1-f879278f9b8e.png">


After:
It creates a new instance only when one already isn't there, and when trying to create multiple one. Clicking ok, will point to the first instance created and not create any new one. There is still the okay bug. I am working on that.
<img width="639" alt="Screen Shot 2022-08-18 at 2 33 21 PM" src="https://user-images.githubusercontent.com/45466137/185484898-71ad8a11-9f44-47ef-a715-74a7d170cabf.png">

