### PR TITLE
[DC] Reduce number of calls to fetchRegistries

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
@@ -64,7 +64,6 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
     setAcrStatusMessage(undefined);
     setAcrStatusMessageType(undefined);
     setLearnMoreLink(undefined);
-    fetchRegistries();
   };
 
   const fetchRegistries = async () => {
@@ -243,7 +242,8 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
 
             const repositoryOptions: IDropdownOption[] = [];
             repositoriesResponse.forEach(response => {
-              const dropdownOptions = response?.repositories?.map(repository => ({ key: repository.toLocaleLowerCase(), text: repository })) ?? [];
+              const dropdownOptions =
+                response?.repositories?.map(repository => ({ key: repository.toLocaleLowerCase(), text: repository })) ?? [];
               repositoryOptions.push(...dropdownOptions);
             });
 
@@ -493,38 +493,24 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
     if (deploymentCenterContext.siteDescriptor && deploymentCenterContext.applicationSettings) {
       fetchData();
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deploymentCenterContext.siteDescriptor, deploymentCenterContext.applicationSettings]);
+
+  useEffect(() => {
+    fetchRegistries();
+  }, [subscription]);
 
   useEffect(() => {
     if (registryIdentifiers.current[formProps.values.acrLoginServer]) {
       fetchRepositories(formProps.values.acrLoginServer);
       setAcrResourceId();
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formProps.values.acrLoginServer]);
 
   useEffect(() => {
     if (registryIdentifiers.current[formProps.values.acrLoginServer] && formProps.values.acrImage) {
       fetchTags(formProps.values.acrImage);
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formProps.values.acrLoginServer, formProps.values.acrImage]);
-
-  useEffect(() => {
-    fetchRegistries();
-    if (acrUseManagedIdentities) {
-      portalContext.log(
-        getTelemetryInfo('info', 'acrUseManagedIdentityCredsConfigured', 'submit', {
-          resourceId: deploymentCenterContext.resourceId,
-        })
-      );
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [subscription]);
 
   useEffect(() => {
     setAcrUseManagedIdentities(formProps.values.acrCredentialType === ACRCredentialType.managedIdentity);
@@ -534,10 +520,6 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
   useEffect(() => {
     setManagedIdentityPrincipalId();
   }, [formProps.values.acrManagedIdentityClientId]);
-
-  useEffect(() => {
-    fetchRegistries();
-  }, [acrUseManagedIdentities]);
 
   return (
     <DeploymentCenterContainerAcrSettings


### PR DESCRIPTION
FixesAB#[14097241](https://msazure.visualstudio.com/Antares/_workitems/edit/14097241)

FetchRegistries was being called 3 times in the initial load because the call was dependent on siteDescriptor (called in fetchData) and subscription, which is already dependent on siteDescriptor. It was also dependent on acrUseManagedIdentities. The call should only be dependent on subscription changes. 