### PR TITLE
[DC] Prevent fetchTag calls if fetchImages fails

### DIFF
--- a/client-react/src/ApiHelpers/AuthService.ts
+++ b/client-react/src/ApiHelpers/AuthService.ts
@@ -1,4 +1,4 @@
-import { ACRManagedIdentityType, RoleAssignment } from '../pages/app/deployment-center/DeploymentCenter.types';
+import { ManagedIdentityType, RoleAssignment } from '../pages/app/deployment-center/DeploymentCenter.types';
 import { Guid } from '../utils/Guid';
 import { CommonConstants } from '../utils/CommonConstants';
 import MakeArmCall from './ArmHelper';
@@ -76,12 +76,12 @@ export default class AuthService {
   private static _getIdentity(identity?: MsiIdentity) {
     if (identity?.userAssignedIdentities) {
       return {
-        type: ACRManagedIdentityType.systemAssigned + ', ' + ACRManagedIdentityType.userAssigned,
+        type: ManagedIdentityType.systemAssigned + ', ' + ManagedIdentityType.userAssigned,
         userAssignedIdentities: identity.userAssignedIdentities,
       };
     } else {
       return {
-        type: ACRManagedIdentityType.systemAssigned,
+        type: ManagedIdentityType.systemAssigned,
       };
     }
   }

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -154,14 +154,9 @@ export enum ACRCredentialType {
   managedIdentity = 'managedIdentity',
 }
 
-export enum ACRManagedIdentityType {
+export enum ManagedIdentityType {
   systemAssigned = 'SystemAssigned',
   userAssigned = 'UserAssigned',
-}
-
-export enum ManagedIdentityInfo {
-  clientId = 'clientId',
-  principalId = 'principalId',
 }
 
 export interface AzureDevOpsUrl {
@@ -334,7 +329,7 @@ export interface AcrFormData {
   acrResourceId: string;
   acrLocation: string;
   acrCredentialType: string;
-  acrManagedIdentityClientId: string | null;
+  acrManagedIdentityClientId: string;
   acrManagedIdentityPrincipalId: string;
 }
 
@@ -757,6 +752,7 @@ export interface RoleAssignment {
   type: string;
   name: string;
 }
+
 export interface UserAssignedIdentity {
   clientId: string;
   principalId: string;

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
@@ -180,7 +180,7 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
           portalContext.log(getTelemetryInfo('info', 'listAcrCredentials', 'submit'));
           const credentialsResponse = await deploymentCenterData.listAcrCredentials(selectedRegistryIdentifier.resourceId);
 
-          if (credentialsResponse.metadata.success && credentialsResponse.data.passwords && credentialsResponse.data.passwords.length > 0) {
+          if (credentialsResponse.metadata.success && credentialsResponse.data.passwords.length > 0) {
             registryIdentifiers.current[serverUrl].credential = credentialsResponse.data;
           } else {
             const errorMessage = getErrorMessage(credentialsResponse.metadata.error);
@@ -380,10 +380,10 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
     // NOTE(yoonaoh): Have to call fetchSite instead of using siteStateContext to refresh the list of identities
     const siteResponse = await deploymentCenterData.fetchSite(deploymentCenterContext.resourceId);
     if (siteResponse.metadata.success && siteResponse.data.identity?.userAssignedIdentities) {
-      for (const [id, identity] of Object.entries(siteResponse.data.identity?.userAssignedIdentities)) {
+      for (const [id, identity] of Object.entries(siteResponse.data.identity.userAssignedIdentities)) {
         const clientId = identity.clientId;
         const principalId = identity.principalId;
-        const name = id.split(CommonConstants.singleForwardSlash).pop() || '';
+        const name = id.split(CommonConstants.singleForwardSlash).pop() || clientId;
         managedIdentityInfo.current[clientId] = { clientId, principalId, name };
         userAssignedIdentitiesOptions.push({ key: clientId, text: name });
       }

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrSettings.tsx
@@ -22,7 +22,7 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
     acrStatusMessage,
     acrStatusMessageType,
     formProps,
-    loadingRegistryOptions: loadingAcrRegistryOptions,
+    loadingRegistryOptions,
     loadingImageOptions,
     loadingTagOptions,
     acrSubscription,
@@ -140,7 +140,7 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
         />
       )}
       <Field
-        id="container-acr-repository"
+        id="container-acr-registry"
         label={t('containerACRRegistry')}
         name="acrLoginServer"
         selectedKey={formProps.values.acrLoginServer?.toLocaleLowerCase() ?? ''}
@@ -150,7 +150,7 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
         options={aCRRegistryOptions}
         setOptions={setACRRegistryOptions}
         displayInVerticalLayout={true}
-        isLoading={loadingAcrRegistryOptions}
+        isLoading={loadingRegistryOptions}
         required={true}
         placeholder={t('deploymentCenterAcrComboBoxPlaceholder')}
       />

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -11,7 +11,7 @@ import {
   WorkflowOption,
   ContainerDockerAccessTypes,
   ACRCredentialType,
-  ACRManagedIdentityType,
+  ManagedIdentityType,
 } from '../DeploymentCenter.types';
 import { commandBarSticky, pivotContent } from '../DeploymentCenter.styles';
 import DeploymentCenterContainerPivot from './DeploymentCenterContainerPivot';
@@ -364,7 +364,7 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
       const acrResourceId = values.acrResourceId;
       const siteIdentity = siteContext.site?.identity;
 
-      if (values.acrManagedIdentityClientId === ACRManagedIdentityType.systemAssigned) {
+      if (values.acrManagedIdentityClientId === ManagedIdentityType.systemAssigned) {
         portalContext.log(getTelemetryInfo('info', 'enableSystemAssignedIdentity', 'submit'));
         const response = await deploymentCenterData.enableSystemAssignedIdentity(deploymentCenterContext.resourceId, siteIdentity);
         if (response.metadata.success) {
@@ -409,7 +409,7 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
     if (setSiteConfigForACR) {
       siteConfig.acrUseManagedIdentityCreds = values.acrCredentialType === ACRCredentialType.managedIdentity;
       siteConfig.acrUserManagedIdentityID =
-        values.acrManagedIdentityClientId !== ACRManagedIdentityType.systemAssigned ? values.acrManagedIdentityClientId : '';
+        values.acrManagedIdentityClientId !== ManagedIdentityType.systemAssigned ? values.acrManagedIdentityClientId : '';
     }
 
     return {

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -11,6 +11,7 @@ import {
   DockerHubFormData,
   PrivateRegistryFormData,
   ACRCredentialType,
+  ManagedIdentityType,
 } from '../DeploymentCenter.types';
 import * as Yup from 'yup';
 import { DeploymentCenterFormBuilder } from '../DeploymentCenterFormBuilder';
@@ -359,7 +360,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
       acrCredentialType = this._siteConfig.properties.acrUseManagedIdentityCreds
         ? ACRCredentialType.managedIdentity
         : ACRCredentialType.adminCredentials;
-      acrManagedIdentityClientId = this._siteConfig.properties.acrUserManagedIdentityID || '';
+      acrManagedIdentityClientId = this._siteConfig.properties.acrUserManagedIdentityID || ManagedIdentityType.systemAssigned;
     }
 
     if (this._isAcrConfigured(serverUrl)) {


### PR DESCRIPTION
FixesAB#[15363412](https://msazure.visualstudio.com/Antares/_workitems/edit/15363412) and [15366215](https://msazure.visualstudio.com/Antares/_workitems/edit/15366215)

- Fixed so that fetchImage and fetchTag are only called when admin credentials are selected (acrUseManagedIdentity was not updating immediately from setState, so now using direct comparison in useEffect) 
- Should reduce number of calls to getTag and getRepositories if they fail