### PR TITLE
[FTPS Credentials][Deployment Center] Add warning on App Credentials for FTP credentials option

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
@@ -94,7 +94,7 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
               message={t('deploymentCenterFtpsPermissionWarning')}
               type={MessageBarType.warning}
               onDismiss={closeBlockedBanner}
-              learnMoreLink={Links.ftpDisabledByPolicyLink}
+              learnMoreLink={DeploymentCenterLinks.configureFTPSSettingsDeploy}
             />
           </div>
         )}

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
@@ -19,7 +19,7 @@ import TextFieldNoFormik from '../../../components/form-controls/TextFieldNoForm
 import CustomBanner from '../../../components/CustomBanner/CustomBanner';
 import { DeploymentCenterContext } from './DeploymentCenterContext';
 import CustomFocusTrapCallout from '../../../components/CustomCallout/CustomFocusTrapCallout';
-import { DeploymentCenterLinks, Links } from '../../../utils/FwLinks';
+import { DeploymentCenterLinks } from '../../../utils/FwLinks';
 import { DeploymentCenterPublishingContext } from './DeploymentCenterPublishingContext';
 import { ScmType } from '../../../models/site/config';
 import { getGitCloneUri, getTelemetryInfo } from './utility/DeploymentCenterUtility';
@@ -73,16 +73,16 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
     deploymentCenterPublishingContext.basicPublishingCredentialsPolicies.ftp &&
     !deploymentCenterPublishingContext.basicPublishingCredentialsPolicies.ftp.allow;
 
-  const getDisabledByFTPPolicyMessage = () => (
-    <div className={deploymentCenterContent}>
-      <CustomBanner
-        id="ftp-disabled-by-policy"
-        message={t('ftpDisabledByPolicy')}
-        type={MessageBarType.info}
-        learnMoreLink={Links.ftpDisabledByPolicyLink}
-      />
-    </div>
-  );
+  // const getDisabledByFTPPolicyMessage = () => (
+  //   <div className={deploymentCenterContent}>
+  //     <CustomBanner
+  //       id="ftp-disabled-by-policy"
+  //       message={t('ftpDisabledByPolicy')}
+  //       type={MessageBarType.info}
+  //       learnMoreLink={Links.ftpDisabledByPolicyLink}
+  //     />
+  //   </div>
+  // );
 
   const getCredentialsControls = () => {
     return (
@@ -106,6 +106,14 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
               type={MessageBarType.warning}
               onDismiss={closeBlockedBanner}
             />
+            <Link
+              id="deployment-center-settings-ftps-learnMore"
+              href={DeploymentCenterLinks.configureFTPSSettingsDeploy}
+              target="_blank"
+              className={learnMoreLinkStyle}
+              aria-labelledby="deployment-center-settings-ftps-message">
+              {` ${t('learnMore')}`}
+            </Link>
           </div>
         )}
 
@@ -199,8 +207,6 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
 
   if (isDataRefreshing) {
     return getProgressIndicator();
-  } else if (disableFtp()) {
-    return getDisabledByFTPPolicyMessage();
   } else {
     return getCredentialsControls();
   }

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
@@ -19,7 +19,7 @@ import TextFieldNoFormik from '../../../components/form-controls/TextFieldNoForm
 import CustomBanner from '../../../components/CustomBanner/CustomBanner';
 import { DeploymentCenterContext } from './DeploymentCenterContext';
 import CustomFocusTrapCallout from '../../../components/CustomCallout/CustomFocusTrapCallout';
-import { DeploymentCenterLinks, Links } from '../../../utils/FwLinks';
+import { DeploymentCenterLinks } from '../../../utils/FwLinks';
 import { DeploymentCenterPublishingContext } from './DeploymentCenterPublishingContext';
 import { ScmType } from '../../../models/site/config';
 import { getGitCloneUri, getTelemetryInfo } from './utility/DeploymentCenterUtility';

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
@@ -101,9 +101,9 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
         {deploymentCenterContext && disableFtp() && showBlockedBanner && (
           <div className={deploymentCenterInfoBannerDiv}>
             <CustomBanner
-              id="deployment-center-ftps-write-permissions-required"
-              message={t('deploymentCenterFtpsWritePermissionRequired')}
-              type={MessageBarType.blocked}
+              id="deployment-center-ftps-permission-warning"
+              message={t('deploymentCenterFtpsPermissionWarning')}
+              type={MessageBarType.warning}
               onDismiss={closeBlockedBanner}
             />
           </div>

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
@@ -19,7 +19,7 @@ import TextFieldNoFormik from '../../../components/form-controls/TextFieldNoForm
 import CustomBanner from '../../../components/CustomBanner/CustomBanner';
 import { DeploymentCenterContext } from './DeploymentCenterContext';
 import CustomFocusTrapCallout from '../../../components/CustomCallout/CustomFocusTrapCallout';
-import { DeploymentCenterLinks } from '../../../utils/FwLinks';
+import { DeploymentCenterLinks, Links } from '../../../utils/FwLinks';
 import { DeploymentCenterPublishingContext } from './DeploymentCenterPublishingContext';
 import { ScmType } from '../../../models/site/config';
 import { getGitCloneUri, getTelemetryInfo } from './utility/DeploymentCenterUtility';
@@ -73,17 +73,6 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
     deploymentCenterPublishingContext.basicPublishingCredentialsPolicies.ftp &&
     !deploymentCenterPublishingContext.basicPublishingCredentialsPolicies.ftp.allow;
 
-  // const getDisabledByFTPPolicyMessage = () => (
-  //   <div className={deploymentCenterContent}>
-  //     <CustomBanner
-  //       id="ftp-disabled-by-policy"
-  //       message={t('ftpDisabledByPolicy')}
-  //       type={MessageBarType.info}
-  //       learnMoreLink={Links.ftpDisabledByPolicyLink}
-  //     />
-  //   </div>
-  // );
-
   const getCredentialsControls = () => {
     return (
       <div className={deploymentCenterContent}>
@@ -105,15 +94,8 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
               message={t('deploymentCenterFtpsPermissionWarning')}
               type={MessageBarType.warning}
               onDismiss={closeBlockedBanner}
+              learnMoreLink={Links.ftpDisabledByPolicyLink}
             />
-            <Link
-              id="deployment-center-settings-ftps-learnMore"
-              href={DeploymentCenterLinks.configureFTPSSettingsDeploy}
-              target="_blank"
-              className={learnMoreLinkStyle}
-              aria-labelledby="deployment-center-settings-ftps-message">
-              {` ${t('learnMore')}`}
-            </Link>
           </div>
         )}
 

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
@@ -28,9 +28,8 @@ import { PortalContext } from '../../../PortalContext';
 import { learnMoreLinkStyle } from '../../../components/form-controls/formControl.override.styles';
 import { TextFieldType } from '../../../utils/CommonConstants';
 
-const DeploymentCenterFtps: React.FC<
-  DeploymentCenterFtpsProps & DeploymentCenterFieldProps<DeploymentCenterContainerFormData | DeploymentCenterCodeFormData>
-> = props => {
+const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
+  DeploymentCenterFieldProps<DeploymentCenterContainerFormData | DeploymentCenterCodeFormData>> = props => {
   const { t } = useTranslation();
   const deploymentCenterContext = useContext(DeploymentCenterContext);
   const deploymentCenterPublishingContext = useContext(DeploymentCenterPublishingContext);
@@ -92,6 +91,17 @@ const DeploymentCenterFtps: React.FC<
           <div className={deploymentCenterInfoBannerDiv}>
             <CustomBanner
               id="deployment-center-ftps-write-permission-required"
+              message={t('deploymentCenterFtpsWritePermissionRequired')}
+              type={MessageBarType.blocked}
+              onDismiss={closeBlockedBanner}
+            />
+          </div>
+        )}
+
+        {deploymentCenterContext && disableFtp() && showBlockedBanner && (
+          <div className={deploymentCenterInfoBannerDiv}>
+            <CustomBanner
+              id="deployment-center-ftps-write-permissions-required"
               message={t('deploymentCenterFtpsWritePermissionRequired')}
               type={MessageBarType.blocked}
               onDismiss={closeBlockedBanner}

--- a/client-react/src/utils/FwLinks.ts
+++ b/client-react/src/utils/FwLinks.ts
@@ -54,6 +54,7 @@ export const DeploymentCenterLinks = {
   appServiceDocumentation: 'https://go.microsoft.com/fwlink/?linkid=874656',
   configureDeployment: 'https://go.microsoft.com/fwlink/?linkid=2086046',
   containerContinuousDeploy: 'https://go.microsoft.com/fwlink/?linkid=2133570',
+  configureFTPSSettingsDeploy: 'https://go.microsoft.com/fwlink/?linkid=2205819',
   configureDeploymentSlots: 'https://go.microsoft.com/fwlink/?linkid=2142216',
   configureLocalGitDeployment: 'https://go.microsoft.com/fwlink/?linkid=2151801',
   vstsBuildGetStarted: 'https://go.microsoft.com/fwlink/?LinkId=2014579',

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2049,7 +2049,7 @@ export class PortalResources {
   public static deploymentCenterFtpsPasswordLabel = 'deploymentCenterFtpsPasswordLabel';
   public static deploymentCenterFtpsConfirmPasswordLabel = 'deploymentCenterFtpsConfirmPasswordLabel';
   public static deploymentCenterFtpsWritePermissionRequired = 'deploymentCenterFtpsWritePermissionRequired';
-  public static deploymentCenterFtpsPermissionWarning = 'deployment-center-ftps-permission-warning';
+  public static deploymentCenterFtpsPermissionWarning = 'deploymentCenterFtpsPermissionWarning';
   public static deploymentCenterPublishingUserLoadingMessage = 'deploymentCenterPublishingUserLoadingMessage';
   public static deploymentCenterPublishingUserLoadingAriaLabel = 'deploymentCenterPublishingUserLoadingAriaLabel';
   public static publishingUserFetchFailedMessage = 'publishingUserFetchFailedMessage';

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2049,6 +2049,7 @@ export class PortalResources {
   public static deploymentCenterFtpsPasswordLabel = 'deploymentCenterFtpsPasswordLabel';
   public static deploymentCenterFtpsConfirmPasswordLabel = 'deploymentCenterFtpsConfirmPasswordLabel';
   public static deploymentCenterFtpsWritePermissionRequired = 'deploymentCenterFtpsWritePermissionRequired';
+  public static deploymentCenterFtpsPermissionWarning = 'deployment-center-ftps-permission-warning';
   public static deploymentCenterPublishingUserLoadingMessage = 'deploymentCenterPublishingUserLoadingMessage';
   public static deploymentCenterPublishingUserLoadingAriaLabel = 'deploymentCenterPublishingUserLoadingAriaLabel';
   public static publishingUserFetchFailedMessage = 'publishingUserFetchFailedMessage';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -6318,6 +6318,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="deploymentCenterFtpsWritePermissionRequired" xml:space="preserve">
         <value>Write permission on the site or the slot is required to view credentials.</value>
     </data>
+    <data name="deploymentCenterFtpsPermissionWarning" xml:space="preserve">
+        <value>The "User Credentials" won't work on the site if basicPublishingCredentials/ftp is disabled, but the user credentials could be used for other sites.</value>
+    </data>
     <data name="deploymentCenterPublishingUserLoadingMessage" xml:space="preserve">
         <value>Loading user credentials</value>
     </data>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -6319,7 +6319,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>Write permission on the site or the slot is required to view credentials.</value>
     </data>
     <data name="deploymentCenterFtpsPermissionWarning" xml:space="preserve">
-        <value>The "User Credentials" won't work on the site if basicPublishingCredentials/ftp is disabled, but the user credentials could be used for other sites.</value>
+        <value>FTP authentication has been disabled for this web app, you will not be able to authenticate using these credentials.</value>
     </data>
     <data name="deploymentCenterPublishingUserLoadingMessage" xml:space="preserve">
         <value>Loading user credentials</value>


### PR DESCRIPTION
fixes [[DC] Add warning on App Credentials for FTP credentials option #12767703](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s196?workitem=12767703)

- Banner on the FTP credentials tab on the DC for when the user doesn't have FTPS access
- Both write and FTP Banners can be displayed together
- Text: FTP authentication has been disabled for this web app, you will not be able to authenticate using these credentials. Learn more.
- Learn more link: https://go.microsoft.com/fwlink/?linkid=2205819
- Render the text as a warning


<img width="895" alt="Screen Shot 2022-08-30 at 1 13 58 PM" src="https://user-images.githubusercontent.com/45466137/187512469-b0b6052b-a1b2-4b51-8e7b-a432a096c516.png">
