### PR TITLE
[DC] Set acrUseManagedIdentityCreds property to false for other registry sources

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -315,6 +315,9 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
           responseResult.success = false;
           responseResult.error = updateSiteConfigForACRResponse.error;
         }
+      } else {
+        siteConfigResponse.data.properties.acrUseManagedIdentityCreds = false;
+        siteConfigResponse.data.properties.acrUserManagedIdentityID = '';
       }
 
       if (values.scmType !== ScmType.GitHubAction) {


### PR DESCRIPTION
FixesAB#[15412681](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s196?workitem=15412681)
If registry source is not ACR, then reset acrUseManagedIdentityCreds and acrUserManagedIdentityId to false and ''.
