### PR TITLE
[CP] Hide http2.0 proxy for fxn apps

### DIFF
--- a/client-react/src/utils/scenario-checker/linux-site.environment.ts
+++ b/client-react/src/utils/scenario-checker/linux-site.environment.ts
@@ -1,6 +1,7 @@
 import { ScenarioIds } from './scenario-ids';
 import { ScenarioCheckInput, ScenarioResult, Environment } from './scenario.models';
 import { isLinuxApp } from '../arm-utils';
+import { NationalCloudEnvironment } from './national-cloud.environment';
 
 export class LinuxSiteEnvironment extends Environment {
   public name = 'LinuxSite';
@@ -117,7 +118,9 @@ export class LinuxSiteEnvironment extends Environment {
     this.scenarioChecks[ScenarioIds.http20ProxySupported] = {
       id: ScenarioIds.http20ProxySupported,
       runCheck: () => {
-        return { status: 'enabled' };
+        return {
+          status: NationalCloudEnvironment.isUSNat() || NationalCloudEnvironment.isUSSec() ? 'disabled' : 'enabled',
+        };
       },
     };
 

--- a/client-react/src/utils/scenario-checker/national-cloud.environment.ts
+++ b/client-react/src/utils/scenario-checker/national-cloud.environment.ts
@@ -142,15 +142,6 @@ export class NationalCloudEnvironment extends AzureEnvironment {
       runCheck: () => ({ status: 'disabled' }),
     };
 
-    this.scenarioChecks[ScenarioIds.http20ProxySupported] = {
-      id: ScenarioIds.http20ProxySupported,
-      runCheck: () => {
-        return {
-          status: NationalCloudEnvironment.isUSNat() || NationalCloudEnvironment.isUSSec() ? 'disabled' : 'enabled',
-        };
-      },
-    };
-
     this.scenarioChecks[ScenarioIds.showAppInsightsLogs] = {
       id: ScenarioIds.showAppInsightsLogs,
       runCheck: () => {

--- a/client-react/src/utils/scenario-checker/windows-code.environment.ts
+++ b/client-react/src/utils/scenario-checker/windows-code.environment.ts
@@ -27,15 +27,6 @@ export class WindowsCode extends Environment {
       },
     };
 
-    this.scenarioChecks[ScenarioIds.http20ProxySupported] = {
-      id: ScenarioIds.http20ProxySupported,
-      runCheck: () => {
-        return {
-          status: 'disabled',
-        };
-      },
-    };
-
     this.scenarioChecks[ScenarioIds.azureBlobMount] = {
       id: ScenarioIds.azureBlobMount,
       runCheck: () => {


### PR DESCRIPTION
* Only show http 20 proxy in linux fxn apps

* Aggregate show/hide http 2.0 logic into linux-site

* Add back kube-env check

Co-authored-by: REDMOND\tmauldin <tmauldin@microsoft.com>