### PR TITLE
Go 1.19 should be flagged as experimental

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Golang.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Golang.ts
@@ -11,7 +11,7 @@ const getGolangStack: (useIsoDateFormat: boolean) => WebAppStack = () => {
         value: 'go1',
         minorVersions: [
           {
-            displayText: 'Go 1.19',
+            displayText: 'Go 1.19 (Experimental)',
             value: 'go1.19',
             stackSettings: {
               linuxRuntimeSettings: {
@@ -24,6 +24,7 @@ const getGolangStack: (useIsoDateFormat: boolean) => WebAppStack = () => {
                   isSupported: true,
                 },
                 isHidden: true,
+                isEarlyAccess: false,
               },
             },
           },
@@ -41,7 +42,7 @@ const getGolangStack: (useIsoDateFormat: boolean) => WebAppStack = () => {
                   isSupported: false,
                 },
                 isHidden: true,
-                isEarlyAccess: true,
+                isEarlyAccess: false,
               },
             },
           },


### PR DESCRIPTION
Fixing 2 issues with go settings in Available stacks API:

1) Go 1.19 should be flagged as experimental
2) Go 1.18 has 2 flags (experimental) and (early access) we should only have 1 flag and in this case experimental takes precedence.

![image](https://user-images.githubusercontent.com/4119816/189735223-b9d516fe-d5b8-4466-bad3-e02c7edc50a0.png)
