### PR TITLE
Revert "Enable AI for .NET7"

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -27,7 +27,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 runtimeVersion: 'v7.0',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
-                  isSupported: true,
+                  isSupported: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -39,7 +39,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 runtimeVersion: 'DOTNETCORE|7.0',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
-                  isSupported: true,
+                  isSupported: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,


### PR DESCRIPTION
Reverts Azure/azure-functions-ux#6864


Need to revert this change as backend needs new .NET7 image for this.