### PR TITLE
Update EOL dates since the Date method is 0 based so we need to set it to one month earlier than what is expected (#6879)

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/DotnetCore.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/DotnetCore.ts
@@ -1,10 +1,10 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
 
-const dotnetCore3Point0EOL = new Date(2020, 3, 3).toString();
-const dotnetCore2Point2EOL = new Date(2019, 12, 23).toString();
-const dotnetCore2Point1EOL = new Date(2021, 7, 21).toString();
-const dotnetCore2Point0EOL = new Date(2018, 10, 1).toString();
-const dotnetCore1EOL = new Date(2019, 6, 27).toString();
+const dotnetCore3Point0EOL = new Date(2020, 2, 3).toString();
+const dotnetCore2Point2EOL = new Date(2019, 11, 23).toString();
+const dotnetCore2Point1EOL = new Date(2021, 6, 21).toString();
+const dotnetCore2Point0EOL = new Date(2018, 9, 1).toString();
+const dotnetCore1EOL = new Date(2019, 5, 27).toString();
 
 export const dotnetCoreStack: WebAppStack = {
   displayText: '.NET Core',

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Java.ts
@@ -1,10 +1,10 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
 
 // EOL source: https://docs.microsoft.com/en-us/java/azure/jdk/?view=azure-java-stable#supported-java-versions-and-update-schedule
-const java17EOL = new Date(2031, 9).toString();
-const java11EOL = new Date(2026, 9).toString();
-const java8EOL = new Date(2025, 3).toString();
-const java7EOL = new Date(2023, 7).toString();
+const java17EOL = new Date(2031, 8).toString();
+const java11EOL = new Date(2026, 8).toString();
+const java8EOL = new Date(2025, 2).toString();
+const java7EOL = new Date(2023, 6).toString();
 
 export const javaStack: WebAppStack = {
   displayText: 'Java',

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
@@ -1,14 +1,14 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
 
-const node16EOL = new Date(2024, 4, 30).toString();
-const node14EOL = new Date(2023, 4, 30).toString();
-const node12EOL = new Date(2022, 4, 1).toString();
-const node10EOL = new Date(2021, 4, 1).toString();
-const node9EOL = new Date(2019, 6, 30).toString();
-const node8EOL = new Date(2019, 12, 31).toString();
-const node7EOL = new Date(2017, 6, 30).toString();
-const node6EOL = new Date(2019, 4, 30).toString();
-const node4EOL = new Date(2018, 4, 30).toString();
+const node16EOL = new Date(2024, 3, 30).toString();
+const node14EOL = new Date(2023, 3, 30).toString();
+const node12EOL = new Date(2022, 3, 1).toString();
+const node10EOL = new Date(2021, 3, 1).toString();
+const node9EOL = new Date(2019, 5, 30).toString();
+const node8EOL = new Date(2019, 11, 31).toString();
+const node7EOL = new Date(2017, 5, 30).toString();
+const node6EOL = new Date(2019, 3, 30).toString();
+const node4EOL = new Date(2018, 3, 30).toString();
 
 export const nodeStack: WebAppStack = {
   displayText: 'Node',

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Php.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Php.ts
@@ -1,14 +1,14 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
 
-const php8Point2EOL = new Date(2025, 11, 30).toString();
-const php8Point1EOL = new Date(2024, 11, 30).toString();
-const php8Point0EOL = new Date(2023, 11, 30).toString();
-const php7Point4EOL = new Date(2022, 11, 30).toString();
-const php7Point3EOL = new Date(2021, 12, 6).toString();
-const php7Point2EOL = new Date(2020, 11, 30).toString();
-const php7Point1EOL = new Date(2020, 2, 1).toString();
-const php7Point0EOL = new Date(2020, 2, 1).toString();
-const php5Point6EOL = new Date(2021, 2, 1).toString();
+const php8Point2EOL = new Date(2025, 10, 30).toString();
+const php8Point1EOL = new Date(2024, 10, 30).toString();
+const php8Point0EOL = new Date(2023, 10, 30).toString();
+const php7Point4EOL = new Date(2022, 10, 30).toString();
+const php7Point3EOL = new Date(2021, 11, 6).toString();
+const php7Point2EOL = new Date(2020, 10, 30).toString();
+const php7Point1EOL = new Date(2020, 1, 1).toString();
+const php7Point0EOL = new Date(2020, 1, 1).toString();
+const php5Point6EOL = new Date(2021, 1, 1).toString();
 
 export const phpStack: WebAppStack = {
   displayText: 'PHP',

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Python.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Python.ts
@@ -1,6 +1,6 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
 
-const python2EOL = new Date(2020, 1, 1).toString();
+const python2EOL = new Date(2020, 0, 1).toString();
 
 export const pythonStack: WebAppStack = {
   displayText: 'Python',

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Ruby.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Ruby.ts
@@ -1,10 +1,10 @@
 import { WebAppStack } from '../../models/WebAppStackModel';
 
-const ruby2Point7EOL = new Date(2023, 3, 31).toString();
-const ruby2Point6EOL = new Date(2022, 3, 31).toString();
-const ruby2Point5EOL = new Date(2021, 3, 31).toString();
-const ruby2Point4EOL = new Date(2020, 4, 1).toString();
-const ruby2Point3EOL = new Date(2019, 3, 31).toString();
+const ruby2Point7EOL = new Date(2023, 2, 31).toString();
+const ruby2Point6EOL = new Date(2022, 2, 31).toString();
+const ruby2Point5EOL = new Date(2021, 2, 31).toString();
+const ruby2Point4EOL = new Date(2020, 3, 1).toString();
+const ruby2Point3EOL = new Date(2019, 2, 31).toString();
 
 export const rubyStack: WebAppStack = {
   displayText: 'Ruby',

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
@@ -2,8 +2,8 @@ import { FunctionAppStack } from '../../models/FunctionAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDateFormat: boolean) => {
-  const dotnet5EOL = getDateString(new Date(2022, 5, 8), useIsoDateFormat);
-  const dotnetCore3EOL = getDateString(new Date(2022, 12, 3), useIsoDateFormat);
+  const dotnet5EOL = getDateString(new Date(2022, 4, 8), useIsoDateFormat);
+  const dotnetCore3EOL = getDateString(new Date(2022, 11, 3), useIsoDateFormat);
 
   return {
     displayText: '.NET',

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Java.ts
@@ -3,9 +3,9 @@ import { getDateString } from '../date-utilities';
 
 const getJavaStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDateFormat: boolean) => {
   // EOL source: https://docs.microsoft.com/en-us/java/azure/jdk/?view=azure-java-stable#supported-java-versions-and-update-schedule
-  const java17EOL = getDateString(new Date(2031, 9), useIsoDateFormat);
-  const java11EOL = getDateString(new Date(2026, 9), useIsoDateFormat);
-  const java8EOL = getDateString(new Date(2025, 3), useIsoDateFormat);
+  const java17EOL = getDateString(new Date(2031, 8), useIsoDateFormat);
+  const java11EOL = getDateString(new Date(2026, 8), useIsoDateFormat);
+  const java8EOL = getDateString(new Date(2025, 2), useIsoDateFormat);
 
   return {
     displayText: 'Java',

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Node.ts
@@ -2,13 +2,13 @@ import { FunctionAppStack } from '../../models/FunctionAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getNodeStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDateFormat: boolean) => {
-  const node12EOL = getDateString(new Date(2022, 4, 30), useIsoDateFormat);
-  const node10EOL = getDateString(new Date(2021, 4, 30), useIsoDateFormat);
-  const node8EOL = getDateString(new Date(2019, 12, 31), useIsoDateFormat);
-  const node6EOL = getDateString(new Date(2019, 4, 30), useIsoDateFormat);
-  const node18EOL = getDateString(new Date(2025, 4, 30), useIsoDateFormat);
-  const node16EOL = getDateString(new Date(2023, 9, 11), useIsoDateFormat);
-  const node14EOL = getDateString(new Date(2023, 4, 30), useIsoDateFormat);
+  const node12EOL = getDateString(new Date(2022, 3, 30), useIsoDateFormat);
+  const node10EOL = getDateString(new Date(2021, 3, 30), useIsoDateFormat);
+  const node8EOL = getDateString(new Date(2019, 11, 31), useIsoDateFormat);
+  const node6EOL = getDateString(new Date(2019, 3, 30), useIsoDateFormat);
+  const node18EOL = getDateString(new Date(2025, 3, 30), useIsoDateFormat);
+  const node16EOL = getDateString(new Date(2023, 8, 11), useIsoDateFormat);
+  const node14EOL = getDateString(new Date(2023, 3, 30), useIsoDateFormat);
 
   return {
     displayText: 'Node.js',

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
@@ -2,7 +2,7 @@ import { FunctionAppStack } from '../../models/FunctionAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDateFormat: boolean) => {
-  const powershell6point2EOL = getDateString(new Date(2020, 9, 4), useIsoDateFormat);
+  const powershell6point2EOL = getDateString(new Date(2020, 8, 4), useIsoDateFormat);
 
   return {
     displayText: 'PowerShell Core',

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Python.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Python.ts
@@ -2,11 +2,11 @@ import { FunctionAppStack } from '../../models/FunctionAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getPythonStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDateFormat: boolean) => {
-  const python36EOL = getDateString(new Date(2021, 12, 23), useIsoDateFormat);
-  const python37EOL = getDateString(new Date(2023, 6, 30), useIsoDateFormat);
-  const python38EOL = getDateString(new Date(2024, 10, 31), useIsoDateFormat);
-  const python39EOL = getDateString(new Date(2025, 10, 31), useIsoDateFormat);
-  const python310EOL = getDateString(new Date(2026, 10, 31), useIsoDateFormat);
+  const python36EOL = getDateString(new Date(2021, 11, 23), useIsoDateFormat);
+  const python37EOL = getDateString(new Date(2023, 5, 30), useIsoDateFormat);
+  const python38EOL = getDateString(new Date(2024, 9, 31), useIsoDateFormat);
+  const python39EOL = getDateString(new Date(2025, 9, 31), useIsoDateFormat);
+  const python310EOL = getDateString(new Date(2026, 9, 31), useIsoDateFormat);
 
   return {
     displayText: 'Python',

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -2,13 +2,13 @@ import { WebAppStack } from '../../models/WebAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFormat: boolean) => {
-  const dotnet5EOL = getDateString(new Date(2022, 5, 8), useIsoDateFormat);
-  const dotnetCore3Point0EOL = getDateString(new Date(2020, 3, 3), useIsoDateFormat);
-  const dotnetCore3Point1EOL = getDateString(new Date(2022, 12, 3), useIsoDateFormat);
-  const dotnetCore2Point2EOL = getDateString(new Date(2019, 12, 23), useIsoDateFormat);
-  const dotnetCore2Point1EOL = getDateString(new Date(2021, 7, 21), useIsoDateFormat);
-  const dotnetCore2Point0EOL = getDateString(new Date(2018, 10, 1), useIsoDateFormat);
-  const dotnetCore1EOL = getDateString(new Date(2019, 6, 27), useIsoDateFormat);
+  const dotnet5EOL = getDateString(new Date(2022, 4, 8), useIsoDateFormat);
+  const dotnetCore3Point0EOL = getDateString(new Date(2020, 2, 3), useIsoDateFormat);
+  const dotnetCore3Point1EOL = getDateString(new Date(2022, 11, 3), useIsoDateFormat);
+  const dotnetCore2Point2EOL = getDateString(new Date(2019, 11, 23), useIsoDateFormat);
+  const dotnetCore2Point1EOL = getDateString(new Date(2021, 6, 21), useIsoDateFormat);
+  const dotnetCore2Point0EOL = getDateString(new Date(2018, 9, 1), useIsoDateFormat);
+  const dotnetCore1EOL = getDateString(new Date(2019, 5, 27), useIsoDateFormat);
 
   return {
     displayText: '.NET',

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
@@ -3,10 +3,10 @@ import { getDateString } from '../date-utilities';
 
 const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFormat: boolean) => {
   // EOL source: https://docs.microsoft.com/en-us/java/azure/jdk/?view=azure-java-stable#supported-java-versions-and-update-schedule
-  const java17EOL = getDateString(new Date(2031, 9), useIsoDateFormat);
-  const java11EOL = getDateString(new Date(2026, 9), useIsoDateFormat);
-  const java8EOL = getDateString(new Date(2025, 3), useIsoDateFormat);
-  const java7EOL = getDateString(new Date(2023, 7), useIsoDateFormat);
+  const java17EOL = getDateString(new Date(2031, 8), useIsoDateFormat);
+  const java11EOL = getDateString(new Date(2026, 8), useIsoDateFormat);
+  const java8EOL = getDateString(new Date(2025, 2), useIsoDateFormat);
+  const java7EOL = getDateString(new Date(2023, 6), useIsoDateFormat);
 
   return {
     displayText: 'Java',

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
@@ -2,15 +2,15 @@ import { WebAppStack } from '../../models/WebAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFormat: boolean) => {
-  const node16EOL = getDateString(new Date(2024, 4, 30), useIsoDateFormat);
-  const node14EOL = getDateString(new Date(2023, 4, 30), useIsoDateFormat);
-  const node12EOL = getDateString(new Date(2022, 4, 1), useIsoDateFormat);
-  const node10EOL = getDateString(new Date(2021, 4, 1), useIsoDateFormat);
-  const node9EOL = getDateString(new Date(2019, 6, 30), useIsoDateFormat);
-  const node8EOL = getDateString(new Date(2019, 12, 31), useIsoDateFormat);
-  const node7EOL = getDateString(new Date(2017, 6, 30), useIsoDateFormat);
-  const node6EOL = getDateString(new Date(2019, 4, 30), useIsoDateFormat);
-  const node4EOL = getDateString(new Date(2018, 4, 30), useIsoDateFormat);
+  const node16EOL = getDateString(new Date(2024, 3, 30), useIsoDateFormat);
+  const node14EOL = getDateString(new Date(2023, 3, 30), useIsoDateFormat);
+  const node12EOL = getDateString(new Date(2022, 3, 1), useIsoDateFormat);
+  const node10EOL = getDateString(new Date(2021, 3, 1), useIsoDateFormat);
+  const node9EOL = getDateString(new Date(2019, 5, 30), useIsoDateFormat);
+  const node8EOL = getDateString(new Date(2019, 11, 31), useIsoDateFormat);
+  const node7EOL = getDateString(new Date(2017, 5, 30), useIsoDateFormat);
+  const node6EOL = getDateString(new Date(2019, 3, 30), useIsoDateFormat);
+  const node4EOL = getDateString(new Date(2018, 3, 30), useIsoDateFormat);
 
   return {
     displayText: 'Node',

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Php.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Php.ts
@@ -2,15 +2,15 @@ import { WebAppStack } from '../../models/WebAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getPhpStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFormat: boolean) => {
-  const php8Point2EOL = getDateString(new Date(2025, 11, 30), useIsoDateFormat);
-  const php8Point1EOL = getDateString(new Date(2024, 11, 30), useIsoDateFormat);
-  const php8Point0EOL = getDateString(new Date(2023, 11, 30), useIsoDateFormat);
-  const php7Point4EOL = getDateString(new Date(2022, 11, 30), useIsoDateFormat);
-  const php7Point3EOL = getDateString(new Date(2021, 12, 6), useIsoDateFormat);
-  const php7Point2EOL = getDateString(new Date(2020, 11, 30), useIsoDateFormat);
-  const php7Point1EOL = getDateString(new Date(2020, 2, 1), useIsoDateFormat);
-  const php7Point0EOL = getDateString(new Date(2020, 2, 1), useIsoDateFormat);
-  const php5Point6EOL = getDateString(new Date(2021, 2, 1), useIsoDateFormat);
+  const php8Point2EOL = getDateString(new Date(2025, 10, 30), useIsoDateFormat);
+  const php8Point1EOL = getDateString(new Date(2024, 10, 30), useIsoDateFormat);
+  const php8Point0EOL = getDateString(new Date(2023, 10, 30), useIsoDateFormat);
+  const php7Point4EOL = getDateString(new Date(2022, 10, 30), useIsoDateFormat);
+  const php7Point3EOL = getDateString(new Date(2021, 11, 6), useIsoDateFormat);
+  const php7Point2EOL = getDateString(new Date(2020, 10, 30), useIsoDateFormat);
+  const php7Point1EOL = getDateString(new Date(2020, 1, 1), useIsoDateFormat);
+  const php7Point0EOL = getDateString(new Date(2020, 1, 1), useIsoDateFormat);
+  const php5Point6EOL = getDateString(new Date(2021, 1, 1), useIsoDateFormat);
 
   return {
     displayText: 'PHP',

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Ruby.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Ruby.ts
@@ -2,11 +2,11 @@ import { WebAppStack } from '../../models/WebAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getRubyStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFormat: boolean) => {
-  const ruby2Point7EOL = getDateString(new Date(2023, 3, 31), useIsoDateFormat);
-  const ruby2Point6EOL = getDateString(new Date(2022, 3, 31), useIsoDateFormat);
-  const ruby2Point5EOL = getDateString(new Date(2021, 3, 31), useIsoDateFormat);
-  const ruby2Point4EOL = getDateString(new Date(2020, 4, 1), useIsoDateFormat);
-  const ruby2Point3EOL = getDateString(new Date(2019, 3, 31), useIsoDateFormat);
+  const ruby2Point7EOL = getDateString(new Date(2023, 2, 31), useIsoDateFormat);
+  const ruby2Point6EOL = getDateString(new Date(2022, 2, 31), useIsoDateFormat);
+  const ruby2Point5EOL = getDateString(new Date(2021, 2, 31), useIsoDateFormat);
+  const ruby2Point4EOL = getDateString(new Date(2020, 3, 1), useIsoDateFormat);
+  const ruby2Point3EOL = getDateString(new Date(2019, 2, 31), useIsoDateFormat);
 
   return {
     displayText: 'Ruby',


### PR DESCRIPTION


* Update EOL dates since the Date method is 0 based so we need to set it to one month earlier than what is expected

* Update EOL for Java

* Update Node

* Update Powershell

* Update Python

* Update Dotnet webapp

* Update Java webapp

* Update Node webapps

* Update Php webapps

* Update Ruby webapps

* Update Dotnetcore

* Update Java

* Update node

* Update php

* Update python

* Update Ruby