### PR TITLE
AB#14920888 Allow for App Plan deletion after change

### DIFF
--- a/client-react/src/ApiHelpers/ServerFarmService.ts
+++ b/client-react/src/ApiHelpers/ServerFarmService.ts
@@ -54,21 +54,25 @@ export default class ServerFarmService {
     }
   };
 
-  public static updateServerFarm = (resourceId: string, serverFarm: ArmObj<ServerFarm>) => {
+  public static updateServerFarm = (
+    resourceId: string,
+    serverFarm: ArmObj<ServerFarm>,
+    apiVersion = CommonConstants.ApiVersions.antaresApiVersion20181101
+  ) => {
     return MakeArmCall<ArmObj<ServerFarm>>({
       resourceId,
       commandName: 'UpdateServerFarm',
-      apiVersion: CommonConstants.ApiVersions.antaresApiVersion20181101,
+      apiVersion: apiVersion,
       method: 'PUT',
       body: serverFarm,
     });
   };
 
-  public static deleteServerFarm = (resourceId: string) => {
+  public static deleteServerFarm = (resourceId: string, apiVersion = CommonConstants.ApiVersions.antaresApiVersion20181101) => {
     return MakeArmCall<ArmObj<ServerFarm>>({
       resourceId,
       commandName: 'DeleteAppServicePlan',
-      apiVersion: CommonConstants.ApiVersions.antaresApiVersion20181101,
+      apiVersion: apiVersion,
       method: 'DELETE',
     });
   };

--- a/client-react/src/ApiHelpers/ServerFarmService.ts
+++ b/client-react/src/ApiHelpers/ServerFarmService.ts
@@ -64,6 +64,15 @@ export default class ServerFarmService {
     });
   };
 
+  public static deleteServerFarm = (resourceId: string) => {
+    return MakeArmCall<ArmObj<ServerFarm>>({
+      resourceId,
+      commandName: 'DeleteAppServicePlan',
+      apiVersion: CommonConstants.ApiVersions.antaresApiVersion20181101,
+      method: 'DELETE',
+    });
+  };
+
   public static getTotalSitesIncludingSlotsInServerFarm = (subscriptionId: string, resourceId: string) => {
     const queryString =
       `where type == 'microsoft.web/sites' or type == 'microsoft.web/sites/slots'` +

--- a/client-react/src/pages/app/change-app-plan/ChangeAppPlan.styles.ts
+++ b/client-react/src/pages/app/change-app-plan/ChangeAppPlan.styles.ts
@@ -36,9 +36,11 @@ export const bannerStyle = style({
   maxWidth: '725px',
   marginBottom: '5px',
 });
+
 export const checkBoxStyle = style({
   paddingTop: '10px',
 });
+
 export const textboxStyle = style({
   maxWidth: '275px',
   paddingRight: '0px',

--- a/client-react/src/pages/app/change-app-plan/ChangeAppPlan.styles.ts
+++ b/client-react/src/pages/app/change-app-plan/ChangeAppPlan.styles.ts
@@ -36,7 +36,9 @@ export const bannerStyle = style({
   maxWidth: '725px',
   marginBottom: '5px',
 });
-
+export const checkBoxStyle = style({
+  paddingTop: '10px',
+});
 export const textboxStyle = style({
   maxWidth: '275px',
   paddingRight: '0px',

--- a/client-react/src/pages/app/change-app-plan/ChangeAppPlan.types.ts
+++ b/client-react/src/pages/app/change-app-plan/ChangeAppPlan.types.ts
@@ -21,6 +21,7 @@ export interface ChangeAppPlanFormValues {
   site: ArmObj<Site>;
   currentServerFarm: ArmObj<ServerFarm>;
   serverFarmInfo: CreateOrSelectPlanFormValues;
+  deletePreviousPlan: boolean;
 }
 
 export enum ChangeAppPlanTierTypes {

--- a/client-react/src/pages/app/change-app-plan/ChangeAppPlanDestinationPlanDetails.tsx
+++ b/client-react/src/pages/app/change-app-plan/ChangeAppPlanDestinationPlanDetails.tsx
@@ -38,7 +38,7 @@ export const DestinationPlanDetails: React.FC<DestinationPlanDetailsProps> = ({
   const changeSkuLinkElement = useRef<ILink | null>(null);
   const [skuTier, setSkuTier] = useState(formProps.values.currentServerFarm.sku?.tier);
 
-  const [deletePreviousPlanFlag, setDeletePreviousPlanFlag] = useState(false);
+  const [showDeletePlanOption, setshowDeletePlanOption] = useState(false);
   const { t } = useTranslation();
   const portalCommunicator = useContext(PortalContext);
 
@@ -200,7 +200,7 @@ export const DestinationPlanDetails: React.FC<DestinationPlanDetailsProps> = ({
   const onPlanChange = (planInfo: CreateOrSelectPlanFormValues) => {
     const appPlanSiteCount = formProps.values.currentServerFarm.properties.numberOfSites;
     if (appPlanSiteCount <= 1) {
-      setDeletePreviousPlanFlag(true);
+      setshowDeletePlanOption(true);
     }
 
     formProps.setFieldValue('serverFarmInfo', planInfo);
@@ -208,10 +208,6 @@ export const DestinationPlanDetails: React.FC<DestinationPlanDetailsProps> = ({
 
   const onPlanTierChange = (planTier: ChangeAppPlanTierTypes) => {
     setSkuTier(planTier);
-  };
-
-  const onChecked = checked => {
-    formProps.setFieldValue('deletePreviousPlan', checked);
   };
 
   const serverFarmOptions = useMemo(() => {
@@ -296,24 +292,31 @@ export const DestinationPlanDetails: React.FC<DestinationPlanDetailsProps> = ({
             formProps={formProps}
             isConsumptionToPremiumEnabled={isConsumptionToPremiumEnabled}
           />
-          {deletePreviousPlanFlag && (
-            <CustomBanner
-              undocked={true}
-              className={bannerStyle}
-              type={MessageBarType.info}
-              message={`After changing plans, ${currentServerFarm.name} will have no more apps. Would you like to delete ${currentServerFarm.name} to prevent unexpected charges?`}
-            />
-          )}
-          {deletePreviousPlanFlag && (
-            <Checkbox
-              className={checkBoxStyle}
-              boxSide="end"
-              label={`Delete ${currentServerFarm.name}:`}
-              id="delete-previous-plan-checkbox"
-              onChange={(e, isChecked) => {
-                onChecked(isChecked);
-              }}
-            />
+
+          {showDeletePlanOption && (
+            <>
+              <CustomBanner
+                undocked={true}
+                className={bannerStyle}
+                type={MessageBarType.info}
+                message={t('deletePreviousPlanMessage').format(
+                  currentServerFarm.name,
+                  formProps.values.serverFarmInfo.isNewPlan
+                    ? formProps.values.serverFarmInfo.newPlanInfo.name
+                    : formProps.values.serverFarmInfo.existingPlan?.name
+                )}
+              />
+
+              <Checkbox
+                className={checkBoxStyle}
+                boxSide="end"
+                label={t('deletePreviousPlanCheckBoxText').format(currentServerFarm.name)}
+                id="delete-previous-plan-checkbox"
+                onChange={(_, isChecked) => {
+                  formProps.setFieldValue('deletePreviousPlan', isChecked);
+                }}
+              />
+            </>
           )}
         </>
       </ReactiveFormControl>

--- a/client-react/src/pages/app/change-app-plan/ChangeAppPlanDestinationPlanDetails.tsx
+++ b/client-react/src/pages/app/change-app-plan/ChangeAppPlanDestinationPlanDetails.tsx
@@ -20,6 +20,7 @@ import {
 import { consumptionToPremiumEnabled } from './ChangeAppPlanDataLoader';
 import { CreateOrSelectPlan, NEW_PLAN } from './CreateOrSelectPlan';
 import { addNewRgOption } from './CreateOrSelectResourceGroup';
+import { Checkbox } from '@fluentui/react';
 
 interface SpecPickerOutput {
   skuCode: string; // Like "S1"
@@ -36,8 +37,8 @@ export const DestinationPlanDetails: React.FC<DestinationPlanDetailsProps> = ({
 }) => {
   const changeSkuLinkElement = useRef<ILink | null>(null);
   const [skuTier, setSkuTier] = useState(formProps.values.currentServerFarm.sku?.tier);
-  const [deletePreviousPlan, setDeletePreviousPlan] = useState(false);
 
+  const [deletePreviousPlanFlag, setDeletePreviousPlanFlag] = useState(false);
   const { t } = useTranslation();
   const portalCommunicator = useContext(PortalContext);
 
@@ -199,7 +200,7 @@ export const DestinationPlanDetails: React.FC<DestinationPlanDetailsProps> = ({
   const onPlanChange = (planInfo: CreateOrSelectPlanFormValues) => {
     const appPlanSiteCount = formProps.values.currentServerFarm.properties.numberOfSites;
     if (appPlanSiteCount <= 1) {
-      setDeletePreviousPlan(true);
+      setDeletePreviousPlanFlag(true);
     }
 
     formProps.setFieldValue('serverFarmInfo', planInfo);
@@ -207,6 +208,10 @@ export const DestinationPlanDetails: React.FC<DestinationPlanDetailsProps> = ({
 
   const onPlanTierChange = (planTier: ChangeAppPlanTierTypes) => {
     setSkuTier(planTier);
+  };
+
+  const onChecked = checked => {
+    formProps.setFieldValue('deletePreviousPlan', checked);
   };
 
   const serverFarmOptions = useMemo(() => {
@@ -275,54 +280,42 @@ export const DestinationPlanDetails: React.FC<DestinationPlanDetailsProps> = ({
       )}
 
       <ReactiveFormControl id="destinationAppServicePlan" label={t('appServicePlan')} required={true}>
-        <CreateOrSelectPlan
-          subscriptionId={subscriptionId}
-          isNewPlan={formProps.values.serverFarmInfo.isNewPlan}
-          newPlanInfo={formProps.values.serverFarmInfo.newPlanInfo}
-          existingPlan={formProps.values.serverFarmInfo.existingPlan}
-          options={serverFarmOptions}
-          resourceGroupOptions={rgOptions}
-          onPlanChange={onPlanChange}
-          serverFarmsInWebspace={serverFarms}
-          hostingEnvironment={hostingEnvironment}
-          skuTier={skuTier}
-          isUpdating={isUpdating}
-          formProps={formProps}
-          isConsumptionToPremiumEnabled={isConsumptionToPremiumEnabled}
-        />
+        <>
+          <CreateOrSelectPlan
+            subscriptionId={subscriptionId}
+            isNewPlan={formProps.values.serverFarmInfo.isNewPlan}
+            newPlanInfo={formProps.values.serverFarmInfo.newPlanInfo}
+            existingPlan={formProps.values.serverFarmInfo.existingPlan}
+            options={serverFarmOptions}
+            resourceGroupOptions={rgOptions}
+            onPlanChange={onPlanChange}
+            serverFarmsInWebspace={serverFarms}
+            hostingEnvironment={hostingEnvironment}
+            skuTier={skuTier}
+            isUpdating={isUpdating}
+            formProps={formProps}
+            isConsumptionToPremiumEnabled={isConsumptionToPremiumEnabled}
+          />
+          {deletePreviousPlanFlag && (
+            <CustomBanner
+              undocked={true}
+              className={bannerStyle}
+              type={MessageBarType.info}
+              message={`After changing plans, ${currentServerFarm.name} will have no more apps. Delete ${currentServerFarm.name} to prevent unexpected charges.`}
+            />
+          )}
+          {deletePreviousPlanFlag && (
+            <Checkbox
+              boxSide="end"
+              label={`Delete ${currentServerFarm.name}:`}
+              id="delete-previous-plan-checkbox"
+              onChange={(e, isChecked) => {
+                onChecked(isChecked);
+              }}
+            />
+          )}
+        </>
       </ReactiveFormControl>
-
-      {deletePreviousPlan && (
-        <CustomBanner
-          className={bannerStyle}
-          type={MessageBarType.warning}
-          message={`'${currentServerFarm.name}' will be unused if you change to '${
-            formProps.values.serverFarmInfo.isNewPlan
-              ? formProps.values.serverFarmInfo.newPlanInfo?.name
-              : formProps.values.serverFarmInfo.existingPlan?.name
-          }'. Would you like to delete '${currentServerFarm.name}'?`}
-        />
-      )}
-
-      {deletePreviousPlan && (
-        <RadioButtonNoFormik
-          id="deleteAppPlan"
-          aria-label={'deleteAppPlan'}
-          defaultSelectedKey={skuTier}
-          disabled={isUpdating}
-          options={[
-            { key: 'Delete', text: `Delete '${currentServerFarm.name}'` },
-            { key: 'Keep', text: `Keep '${currentServerFarm.name}'` },
-          ]}
-          onChange={(o, e) => {
-            if (e) {
-              e.key === 'Delete'
-                ? formProps.setFieldValue('deletePreviousPlan', true)
-                : formProps.setFieldValue('deletePreviousPlan', false);
-            }
-          }}
-        />
-      )}
 
       <ReactiveFormControl id="currentResourceGroup" label={t('resourceGroup')}>
         <div tabIndex={0} aria-label={`${t('resourceGroup')} ${getSelectedResourceGroupString()}`}>

--- a/client-react/src/pages/app/change-app-plan/ChangeAppPlanDestinationPlanDetails.tsx
+++ b/client-react/src/pages/app/change-app-plan/ChangeAppPlanDestinationPlanDetails.tsx
@@ -36,6 +36,7 @@ export const DestinationPlanDetails: React.FC<DestinationPlanDetailsProps> = ({
 }) => {
   const changeSkuLinkElement = useRef<ILink | null>(null);
   const [skuTier, setSkuTier] = useState(formProps.values.currentServerFarm.sku?.tier);
+  const [deletePreviousPlan, setDeletePreviousPlan] = useState(false);
 
   const { t } = useTranslation();
   const portalCommunicator = useContext(PortalContext);
@@ -196,6 +197,11 @@ export const DestinationPlanDetails: React.FC<DestinationPlanDetailsProps> = ({
   }, [currentServerFarm, forbiddenSkus, formProps.values.site]);
 
   const onPlanChange = (planInfo: CreateOrSelectPlanFormValues) => {
+    const appPlanSiteCount = formProps.values.currentServerFarm.properties.numberOfSites;
+    if (appPlanSiteCount <= 1) {
+      setDeletePreviousPlan(true);
+    }
+
     formProps.setFieldValue('serverFarmInfo', planInfo);
   };
 
@@ -285,6 +291,38 @@ export const DestinationPlanDetails: React.FC<DestinationPlanDetailsProps> = ({
           isConsumptionToPremiumEnabled={isConsumptionToPremiumEnabled}
         />
       </ReactiveFormControl>
+
+      {deletePreviousPlan && (
+        <CustomBanner
+          className={bannerStyle}
+          type={MessageBarType.warning}
+          message={`'${currentServerFarm.name}' will be unused if you change to '${
+            formProps.values.serverFarmInfo.isNewPlan
+              ? formProps.values.serverFarmInfo.newPlanInfo?.name
+              : formProps.values.serverFarmInfo.existingPlan?.name
+          }'. Would you like to delete '${currentServerFarm.name}'?`}
+        />
+      )}
+
+      {deletePreviousPlan && (
+        <RadioButtonNoFormik
+          id="deleteAppPlan"
+          aria-label={'deleteAppPlan'}
+          defaultSelectedKey={skuTier}
+          disabled={isUpdating}
+          options={[
+            { key: 'Delete', text: `Delete '${currentServerFarm.name}'` },
+            { key: 'Keep', text: `Keep '${currentServerFarm.name}'` },
+          ]}
+          onChange={(o, e) => {
+            if (e) {
+              e.key === 'Delete'
+                ? formProps.setFieldValue('deletePreviousPlan', true)
+                : formProps.setFieldValue('deletePreviousPlan', false);
+            }
+          }}
+        />
+      )}
 
       <ReactiveFormControl id="currentResourceGroup" label={t('resourceGroup')}>
         <div tabIndex={0} aria-label={`${t('resourceGroup')} ${getSelectedResourceGroupString()}`}>

--- a/client-react/src/pages/app/change-app-plan/ChangeAppPlanDestinationPlanDetails.tsx
+++ b/client-react/src/pages/app/change-app-plan/ChangeAppPlanDestinationPlanDetails.tsx
@@ -38,7 +38,7 @@ export const DestinationPlanDetails: React.FC<DestinationPlanDetailsProps> = ({
   const changeSkuLinkElement = useRef<ILink | null>(null);
   const [skuTier, setSkuTier] = useState(formProps.values.currentServerFarm.sku?.tier);
 
-  const [showDeletePlanOption, setshowDeletePlanOption] = useState(false);
+  const [showDeletePlanOption, setShowDeletePlanOption] = useState(false);
   const { t } = useTranslation();
   const portalCommunicator = useContext(PortalContext);
 
@@ -200,7 +200,7 @@ export const DestinationPlanDetails: React.FC<DestinationPlanDetailsProps> = ({
   const onPlanChange = (planInfo: CreateOrSelectPlanFormValues) => {
     const appPlanSiteCount = formProps.values.currentServerFarm.properties.numberOfSites;
     if (appPlanSiteCount <= 1) {
-      setshowDeletePlanOption(true);
+      setShowDeletePlanOption(true);
     }
 
     formProps.setFieldValue('serverFarmInfo', planInfo);

--- a/client-react/src/pages/app/change-app-plan/ChangeAppPlanDestinationPlanDetails.tsx
+++ b/client-react/src/pages/app/change-app-plan/ChangeAppPlanDestinationPlanDetails.tsx
@@ -10,7 +10,7 @@ import { ServerFarm } from '../../../models/serverFarm/serverfarm';
 import { PortalContext } from '../../../PortalContext';
 import { isFunctionApp, isLinuxApp } from '../../../utils/arm-utils';
 import { ArmPlanDescriptor } from '../../../utils/resourceDescriptors';
-import { bannerStyle, headerStyle, labelSectionStyle, planTypeStyle } from './ChangeAppPlan.styles';
+import { bannerStyle, checkBoxStyle, headerStyle, labelSectionStyle, planTypeStyle } from './ChangeAppPlan.styles';
 import {
   ChangeAppPlanDefaultSkuCodes,
   ChangeAppPlanTierTypes,
@@ -301,11 +301,12 @@ export const DestinationPlanDetails: React.FC<DestinationPlanDetailsProps> = ({
               undocked={true}
               className={bannerStyle}
               type={MessageBarType.info}
-              message={`After changing plans, ${currentServerFarm.name} will have no more apps. Delete ${currentServerFarm.name} to prevent unexpected charges.`}
+              message={`After changing plans, ${currentServerFarm.name} will have no more apps. Would you like to delete ${currentServerFarm.name} to prevent unexpected charges?`}
             />
           )}
           {deletePreviousPlanFlag && (
             <Checkbox
+              className={checkBoxStyle}
               boxSide="end"
               label={`Delete ${currentServerFarm.name}:`}
               id="delete-previous-plan-checkbox"

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -88,6 +88,8 @@ export class PortalResources {
   public static or = 'or';
   public static readOnlySourceControlled = 'readOnlySourceControlled';
   public static region = 'region';
+  public static deletePreviousPlanMessage = 'deletePreviousPlanMessage';
+  public static deletePreviousPlanCheckBoxText = 'deletePreviousPlanCheckBoxText';
   public static run = 'run';
   public static refresh = 'refresh';
   public static save = 'save';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -370,6 +370,12 @@
     <data name="region" xml:space="preserve">
         <value>Region</value>
     </data>
+    <data name="deletePreviousPlanMessage" xml:space="preserve">
+        <value>'{0}' will be unused if you change to '{1}'. Delete '{0}' to prevent unexpected charges.</value>
+    </data>
+    <data name="deletePreviousPlanCheckBoxText" xml:space="preserve">
+        <value>Delete '{0}':</value>
+    </data>
     <data name="run" xml:space="preserve">
         <value>Run</value>
     </data>
@@ -5814,7 +5820,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="hostConfigurationLabel" xml:space="preserve">
         <value>Host configuration</value>
     </data>
-     <data name="destinationPlanPlaceholder" xml:space="preserve">
+    <data name="destinationPlanPlaceholder" xml:space="preserve">
         <value>Select destination plan</value>
     </data>
     <data name="configureHostJson" xml:space="preserve">
@@ -7386,7 +7392,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="staticSite_generalSettingsUpdateWithSuccess" xml:space="preserve">
         <value>Successfully updated general settings.</value>
     </data>
-     <data name="staticSite_generalSettingsUpdateWithFailure" xml:space="preserve">
+    <data name="staticSite_generalSettingsUpdateWithFailure" xml:space="preserve">
         <value>Failed to update general settings with message: {0}</value>
     </data>
     <data name="staticSite_generalSettingsUpdateWithFailureNoMessage" xml:space="preserve">
@@ -7394,7 +7400,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     </data>
     <data name="staticSite_passwordProtectionSkuWarning" xml:space="preserve">
         <value>Password protection is only available on the Standard hosting plan. Please update your hosting plan to configure password protection.</value>
-    </data> 
+    </data>
     <data name="functionSupportedRuntimeVersionNotConfiguredMessage" xml:space="preserve">
         <value>Your app is pinned to an unsupported runtime version for '{0}'. For better performance, we recommend using one of our supported versions instead: {1}.</value>
     </data>


### PR DESCRIPTION
Solution for (AB#[14920888](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s198?workitem=14920888))
Adding a checkbox option to delete an unused app plan when on the change app plan service bl
![ChangeAppPlanGif](https://user-images.githubusercontent.com/34044735/192350776-91cace98-1a6d-4bbc-b1bd-8ea09a0c283d.gif)
ade. 