### PR TITLE
Update Node.ts end of support date

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Node.ts
@@ -2,7 +2,7 @@ import { FunctionAppStack } from '../../models/FunctionAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getNodeStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDateFormat: boolean) => {
-  const node12EOL = getDateString(new Date(2022, 3, 30), useIsoDateFormat);
+  const node12EOL = getDateString(new Date(2022, 11, 13), useIsoDateFormat);
   const node10EOL = getDateString(new Date(2021, 3, 30), useIsoDateFormat);
   const node8EOL = getDateString(new Date(2019, 11, 31), useIsoDateFormat);
   const node6EOL = getDateString(new Date(2019, 3, 30), useIsoDateFormat);

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
@@ -2,7 +2,7 @@ import { FunctionAppStack } from '../../models/FunctionAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDateFormat: boolean) => {
-  const powershell6point2EOL = getDateString(new Date(2020, 8, 4), useIsoDateFormat);
+  const powershell6point2EOL = getDateString(new Date(2022, 8, 30), useIsoDateFormat);
 
   return {
     displayText: 'PowerShell Core',

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Python.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Python.ts
@@ -2,7 +2,7 @@ import { FunctionAppStack } from '../../models/FunctionAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getPythonStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDateFormat: boolean) => {
-  const python36EOL = getDateString(new Date(2021, 11, 23), useIsoDateFormat);
+  const python36EOL = getDateString(new Date(2022, 8, 30), useIsoDateFormat);
   const python37EOL = getDateString(new Date(2023, 5, 30), useIsoDateFormat);
   const python38EOL = getDateString(new Date(2024, 9, 31), useIsoDateFormat);
   const python39EOL = getDateString(new Date(2025, 9, 31), useIsoDateFormat);


### PR DESCRIPTION
We're retiring Node 12 past the community EOL, so it's an exception. Correcting date to when we actually stop support.

cc @pragnagopa / @nzthiago