### PR TITLE
[DC] Clear values for ACR image and tag when switching registries, refresh on discard

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
@@ -165,10 +165,14 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
     setLoadingRegistryOptions(false);
   };
 
-  const fetchRepositories = async (loginServer: string) => {
+  const fetchRepositories = async (loginServer: string, clearValues?: boolean) => {
     setLoadingImageOptions(true);
-    setAcrImageOptions([]);
-    setAcrTagOptions([]);
+    if (clearValues) {
+      formProps.values.acrImage = '';
+      formProps.values.acrTag = '';
+      setAcrImageOptions([]);
+      setAcrTagOptions([]);
+    }
     clearStatusBanner();
     const serverUrl = loginServer?.toLocaleLowerCase() ?? '';
 
@@ -251,7 +255,7 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
             setAcrImageOptions(repositoryOptions);
 
             if (formProps.values.acrImage && !acrUseManagedIdentities) {
-              fetchTags(formProps.values.acrImage);
+              fetchTags(formProps.values.acrImage, clearValues);
             }
           }
         }
@@ -266,9 +270,12 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
     setLoadingImageOptions(false);
   };
 
-  const fetchTags = async (imageSelected: string) => {
+  const fetchTags = async (imageSelected: string, clearValues?: boolean) => {
     setLoadingTagOptions(true);
-    setAcrTagOptions([]);
+    if (clearValues) {
+      formProps.values.acrTag = '';
+      setAcrTagOptions([]);
+    }
     clearStatusBanner();
     const loginServer = formProps.values.acrLoginServer?.toLocaleLowerCase() ?? '';
     const selectedRegistryIdentifier = registryIdentifiers.current[loginServer];
@@ -476,7 +483,7 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
   useEffect(() => {
     if (registryIdentifiers.current[formProps.values.acrLoginServer]) {
       if (!acrUseManagedIdentities) {
-        fetchRepositories(formProps.values.acrLoginServer);
+        fetchRepositories(formProps.values.acrLoginServer, true);
       } else {
         setAcrResourceId(formProps.values.acrLoginServer);
       }
@@ -484,8 +491,8 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
   }, [formProps.values.acrLoginServer, acrUseManagedIdentities]);
 
   useEffect(() => {
-    if (formProps.values.acrImage && !acrUseManagedIdentities) {
-      fetchTags(formProps.values.acrImage);
+    if (registryIdentifiers.current[formProps.values.acrLoginServer] && formProps.values.acrImage && !acrUseManagedIdentities) {
+      fetchTags(formProps.values.acrImage, true);
     }
   }, [formProps.values.acrImage]);
 

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -795,6 +795,7 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
                 title: t('ok'),
                 onClick: () => {
                   formProps.resetForm();
+                  deploymentCenterContext.refresh();
                   hideDiscardConfirmDialog();
                 },
               }}


### PR DESCRIPTION
FixesAB#[15624693](https://msazure.visualstudio.com/Antares/_workitems/edit/15624693) and [14097225](https://msazure.visualstudio.com/Antares/_workitems/edit/14097225)

- Values for ACR image and tag were not being cleared when switching registries
- Added in a check for registryIdentifiers to preserve initial form values in useEffect
- Refreshing on 'Discard' because formProps.initialValues was being overwritten
- ^ This helps with the overall issue of form sometimes not repopulating on resetForm()

**Before:**
![get acr tag call before](https://user-images.githubusercontent.com/29874289/193341093-6bc54ba3-d1e5-43d7-bbbf-9236e22ed03f.gif)

**After:**
![get acr tag call after](https://user-images.githubusercontent.com/29874289/193341120-56c04ec2-0d17-4d55-ab62-4f67808302ac.gif)
