### PR TITLE
[Configuration] updated source configuration reference

### DIFF
--- a/client-react/src/pages/app/app-settings/ApplicationSettings/ApplicationSettings.tsx
+++ b/client-react/src/pages/app/app-settings/ApplicationSettings/ApplicationSettings.tsx
@@ -252,7 +252,7 @@ const ApplicationSettings: React.FC<AppSettingsFormikPropsCombined> = props => {
     }
     if (column.key === 'source') {
       if (values.references && values.references.appSettings) {
-        return <SettingSourceColumn name={item.name} references={values.references.appSettings} />;
+        return <SettingSourceColumn name={item.name} value={item.value} references={values.references.appSettings} />;
       }
     }
     return <div className={defaultCellStyle}>{item[column.fieldName!]}</div>;

--- a/client-react/src/pages/app/app-settings/ConnectionStrings/ConnectionStrings.tsx
+++ b/client-react/src/pages/app/app-settings/ConnectionStrings/ConnectionStrings.tsx
@@ -258,7 +258,7 @@ const ConnectionStrings: React.FC<AppSettingsFormikPropsCombined> = props => {
     }
     if (column.key === 'source') {
       if (values.references && values.references.connectionStrings) {
-        return <SettingSourceColumn name={item.name} references={values.references.connectionStrings} />;
+        return <SettingSourceColumn name={item.name} value={item.value} references={values.references.connectionStrings} />;
       }
     }
     return <div className={defaultCellStyle}>{item[column.fieldName!]}</div>;

--- a/client-react/src/pages/app/app-settings/SettingSourceColumn.tsx
+++ b/client-react/src/pages/app/app-settings/SettingSourceColumn.tsx
@@ -11,21 +11,30 @@ import {
   getKeyVaultReferenceStatusIconProps,
   getKeyVaultReferenceStatusIconColor,
 } from './AppSettingsFormData';
+import { azureAppConfigRefStart } from '../../../utils/CommonConstants';
 
 export interface SettingSourceColumnProps {
   name: string;
+  value?: string;
   references: KeyVaultReferenceSummary[];
 }
 
 const SettingSourceColumn: React.FC<SettingSourceColumnProps> = props => {
-  const { name, references } = props;
+  const { name, value, references } = props;
   const theme = useContext(ThemeContext);
   const { t } = useTranslation();
 
   const updatedName = name.toLowerCase();
+  const updatedValue = value?.toLowerCase();
   const filteredReference = references.filter(ref => ref.name.toLowerCase() === updatedName);
 
-  if (filteredReference.length > 0) {
+  if (updatedValue?.startsWith(azureAppConfigRefStart)) {
+    return (
+      <div className={defaultCellStyle} aria-label={t('azureAppConfigValue')}>
+        {t('azureAppConfigRefValue')}
+      </div>
+    );
+  } else if (filteredReference.length > 0) {
     return (
       <div
         className={defaultCellStyle}
@@ -47,8 +56,8 @@ const SettingSourceColumn: React.FC<SettingSourceColumnProps> = props => {
     );
   } else {
     return (
-      <div className={defaultCellStyle} aria-label={t('azureAppConfigValue')}>
-        {t('azureAppConfigValue')}
+      <div className={defaultCellStyle} aria-label={t('azureAppServiceValue')}>
+        {t('azureAppServiceValue')}
       </div>
     );
   }

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -358,3 +358,5 @@ export const ScmHosts = ['.scm.azurewebsites.net', '.scm.azurewebsites.us', '.sc
 export const KeyBoard = {
   shiftTab: '\x1B[Z',
 };
+
+export const azureAppConfigRefStart = '@microsoft.appconfiguration';

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1762,7 +1762,8 @@ export class PortalResources {
   public static functionKeyNamesUnique = 'functionKeyNamesUnique';
   public static gitHubActionBuildServerDesc = 'gitHubActionBuildServerDesc';
   public static azureKeyVault = 'azureKeyVault';
-  public static azureAppConfigValue = 'azureAppConfigValue';
+  public static azureAppServiceValue = 'azureAppServiceValue';
+  public static azureAppConfigRefValue = 'azureAppConfigRefValue';
   public static appSettingKeyvaultAPIError = 'appSettingKeyvaultAPIError';
   public static containerSettingsNotConfigured = 'containerSettingsNotConfigured';
   public static containerSettingsTitle = 'containerSettingsTitle';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -5457,8 +5457,11 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="azureKeyVault" xml:space="preserve">
         <value>Key vault Reference</value>
     </data>
-    <data name="azureAppConfigValue" xml:space="preserve">
-        <value>App Service Config</value>
+    <data name="azureAppServiceValue" xml:space="preserve">
+        <value>App Service</value>
+    </data>
+    <data name="azureAppConfigRefValue" xml:space="preserve">
+        <value>App Configuration Reference</value>
     </data>
     <data name="appSettingKeyvaultAPIError" xml:space="preserve">
         <value>Error: Could not access key vault reference metadata</value>


### PR DESCRIPTION
updates source column to indicate the Microsoft configuration reference  [#13504741 ](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/S199?workitem=13504741)

Before
<img width="1411" alt="Screen Shot 2022-10-03 at 10 42 16 AM" src="https://user-images.githubusercontent.com/45466137/193620202-6efd213f-05d6-4521-9fe1-a5fb87705d1c.png">
<img width="1411" alt="Screen Shot 2022-10-04 at 12 21 50 PM" src="https://user-images.githubusercontent.com/45466137/193935728-b19fd074-52bc-4978-b341-25d1e65c8d90.png">

After
<img width="1411" alt="Screen Shot 2022-10-03 at 10 44 19 AM" src="https://user-images.githubusercontent.com/45466137/193620266-c171f964-ca52-4399-aee1-1a017b2ece56.png">
<img width="1411" alt="Screen Shot 2022-10-04 at 4 37 26 PM" src="https://user-images.githubusercontent.com/45466137/193935672-bac4af3a-49c9-4b4b-a4ea-b7f30bcab917.png">