### PR TITLE
[DC] Enable save button only when form values are valid

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -432,6 +432,7 @@ export type DeploymentCenterCodePivotProps = DeploymentCenterCodeFormProps & Dep
 export interface DeploymentCenterCommandBarProps {
   isDataRefreshing: boolean;
   isDirty: boolean;
+  isValid: boolean;
   isVstsBuildProvider: boolean;
   saveFunction: () => void;
   discardFunction: () => void;

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
@@ -11,7 +11,16 @@ import { PortalContext } from '../../../PortalContext';
 import { getTelemetryInfo } from './utility/DeploymentCenterUtility';
 
 const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = props => {
-  const { saveFunction, discardFunction, showPublishProfilePanel, redeploy, isDataRefreshing, isDirty, isVstsBuildProvider } = props;
+  const {
+    saveFunction,
+    discardFunction,
+    showPublishProfilePanel,
+    redeploy,
+    isDataRefreshing,
+    isDirty,
+    isValid,
+    isVstsBuildProvider,
+  } = props;
   const { t } = useTranslation();
 
   const portalContext = useContext(PortalContext);
@@ -48,7 +57,7 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
   };
 
   const isSaveDisabled = () => {
-    return isDisabledOnReload() || !isDirty || isVstsBuildProvider || hasNoWritePermission;
+    return isDisabledOnReload() || !(isDirty && isValid) || isVstsBuildProvider || hasNoWritePermission;
   };
 
   const isDiscardDisabled = () => {

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildRuntimeAndVersion.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildRuntimeAndVersion.tsx
@@ -256,7 +256,7 @@ const DeploymentCenterCodeBuildRuntimeAndVersion: React.FC<DeploymentCenterField
       <h3 className={titleWithPaddingStyle}>{t('deploymentCenterSettingsBuildTitle')}</h3>
 
       {!defaultStack || !defaultVersion ? (
-        <ReactiveFormControl id="deployment-center-code-settings-runtime-stack" label={t('deploymentCenterSettingsRuntimeLabel')}>
+        <ReactiveFormControl id="deployment-center-code-settings-runtime-stack" label={t('deploymentCenterSettingsRuntimeLabel')} required>
           <div>
             {t('deploymentCenterConfigureRuntimeMessage')}
             <Link id="deployment-center-code-settings-configure-runtime-link" onClick={openConfigurationBlade}>

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
@@ -669,13 +669,13 @@ const DeploymentCenterCodeForm: React.FC<DeploymentCenterCodeFormProps> = props 
       onSubmit={onSubmit}
       enableReinitialize={true}
       validateOnBlur={false}
-      validateOnChange={false}
       validationSchema={props.formValidationSchema}>
       {(formProps: FormikProps<DeploymentCenterFormData<DeploymentCenterCodeFormData>>) => (
         <form onKeyDown={onKeyDown}>
           <div id="deployment-center-command-bar" className={commandBarSticky}>
             <DeploymentCenterCommandBar
               isDirty={formProps.dirty}
+              isValid={formProps.isValid}
               isDataRefreshing={props.isDataRefreshing}
               isVstsBuildProvider={formProps.values.buildProvider === BuildProvider.Vsts}
               saveFunction={formProps.submitForm}

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -786,6 +786,7 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
               showPublishProfilePanel={deploymentCenterPublishingContext.showPublishProfilePanel}
               isDataRefreshing={props.isDataRefreshing}
               isDirty={isSettingsDirty(formProps, deploymentCenterContext) || isFtpsDirty(formProps, deploymentCenterPublishingContext)}
+              isValid={formProps.isValid}
               isVstsBuildProvider={formProps.values.scmType === ScmType.Vsts}
             />
           </div>


### PR DESCRIPTION
FixesAB#[15679933 ](https://msazure.visualstudio.com/Antares/_workitems/edit/15679933)
- Save button is enabled with controls are dirty and form values are valid (for both Code and Container form)
- Making runtime stack required so that it is part of validation

**Before:**
![dc save button before](https://user-images.githubusercontent.com/29874289/194436699-88f47b24-9c3b-475d-9e1b-96412986f316.gif)

**After:**
![dc save button after](https://user-images.githubusercontent.com/29874289/194436671-d1b47e6c-545e-4cc7-9459-20c670ae5efe.gif)