### PR TITLE
AB#15777298 Disable Log for requesting scm host names that are not white listed

### DIFF
--- a/client-react/src/models/portal-models.ts
+++ b/client-react/src/models/portal-models.ts
@@ -40,6 +40,7 @@ export interface IStartupInfo<T> {
   userInfo: IUserInfo;
   theme: string;
   armEndpoint: string;
+  trustedDomains: string[];
   featureInfo: IFeatureInfo<T>;
   highContrastKey: HighContrastTheme;
 }

--- a/client-react/src/pages/app/functions/function/function-log/FunctionLogFileStreamDataLoader.tsx
+++ b/client-react/src/pages/app/functions/function/function-log/FunctionLogFileStreamDataLoader.tsx
@@ -10,6 +10,7 @@ import { Site } from '../../../../../models/site/site';
 import FunctionsService from '../../../../../ApiHelpers/FunctionsService';
 import { PortalContext } from '../../../../../PortalContext';
 import { getTelemetryInfo } from '../../../../../utils/TelemetryUtils';
+import { isScmHostNameInTrustedDomains } from '../../../log-stream/LogStreamDataLoader';
 
 interface FunctionLogFileStreamDataLoaderProps {
   site: ArmObj<Site>;
@@ -51,10 +52,7 @@ const FunctionLogFileStreamDataLoader: React.FC<FunctionLogFileStreamDataLoaderP
   const msInMin = 60000;
 
   const isScmHostNameWhiteListed = React.useMemo<boolean | undefined>(() => {
-    if (site) {
-      const scmHostName = Url.getScmUrl(site);
-      return Url.isScmHostNameWhitelisted(scmHostName, window.appsvc?.trustedDomains);
-    }
+    return isScmHostNameInTrustedDomains(site);
   }, [site]);
 
   const openStream = async () => {

--- a/client-react/src/pages/app/log-stream/LogStream.tsx
+++ b/client-react/src/pages/app/log-stream/LogStream.tsx
@@ -19,6 +19,7 @@ export interface LogStreamProps {
   connectionError: boolean;
   logType: LogType;
   logsEnabled: LogsEnabled;
+  isScmHostNameWhiteListed?: boolean;
 }
 
 const LogStream: React.SFC<LogStreamProps> = props => {
@@ -35,11 +36,14 @@ const LogStream: React.SFC<LogStreamProps> = props => {
     connectionError,
     logType,
     logsEnabled,
+    isScmHostNameWhiteListed,
   } = props;
   const portalCommunicator = useContext(PortalContext);
+
   useEffect(() => {
     portalCommunicator.loadComplete();
   }, [portalCommunicator]);
+
   return (
     <>
       <LogStreamCommandBar
@@ -51,6 +55,7 @@ const LogStream: React.SFC<LogStreamProps> = props => {
         logEntries={logEntries}
         logType={logType}
         logsEnabled={logsEnabled}
+        isScmHostNameWhiteListed={isScmHostNameWhiteListed}
       />
       <LogStreamLogContainer
         clearLogs={clearLogs}
@@ -60,6 +65,7 @@ const LogStream: React.SFC<LogStreamProps> = props => {
         connectionError={connectionError}
         logType={logType}
         logsEnabled={logsEnabled}
+        isScmHostNameWhiteListed={isScmHostNameWhiteListed}
       />
     </>
   );

--- a/client-react/src/pages/app/log-stream/LogStreamCommandBar.tsx
+++ b/client-react/src/pages/app/log-stream/LogStreamCommandBar.tsx
@@ -15,9 +15,10 @@ const getItems = (
   logEntries: LogEntry[],
   logType: LogType,
   logsEnabled: LogsEnabled,
-  t: (string) => string
+  t: (string) => string,
+  isScmHostNameWhiteListed?: boolean
 ): ICommandBarItemProps[] => {
-  const disableCommand = !logStreamEnabled(logType, logsEnabled);
+  const disableCommand = !logStreamEnabled(logType, logsEnabled, isScmHostNameWhiteListed);
   return [
     {
       key: 'reconnect',
@@ -70,6 +71,7 @@ interface LogStreamCommandBarProps {
   logEntries: LogEntry[];
   logType: LogType;
   logsEnabled: LogsEnabled;
+  isScmHostNameWhiteListed?: boolean;
 }
 
 type LogStreamCommandBarPropsCombined = LogStreamCommandBarProps;
@@ -77,7 +79,7 @@ type LogStreamCommandBarPropsCombined = LogStreamCommandBarProps;
 export const LogStreamCommandBar: React.FC<LogStreamCommandBarPropsCombined> = props => {
   const theme = useContext(ThemeContext);
   const { t } = useTranslation();
-  const { reconnect, pause, start, clear, isStreaming, logEntries, logType, logsEnabled } = props;
+  const { reconnect, pause, start, clear, isStreaming, logEntries, logType, logsEnabled, isScmHostNameWhiteListed } = props;
   const overflowButtonProps: IButtonProps = { ariaLabel: t('moreCommands') };
 
   const customButton = (buttonProps: IButtonProps) => {
@@ -101,7 +103,7 @@ export const LogStreamCommandBar: React.FC<LogStreamCommandBarPropsCombined> = p
 
   return (
     <CommandBar
-      items={getItems(reconnect, pause, start, clear, isStreaming, logEntries, logType, logsEnabled, t)}
+      items={getItems(reconnect, pause, start, clear, isStreaming, logEntries, logType, logsEnabled, t, isScmHostNameWhiteListed)}
       role="nav"
       buttonAs={customButton}
       overflowButtonProps={overflowButtonProps}

--- a/client-react/src/pages/app/log-stream/LogStreamData.ts
+++ b/client-react/src/pages/app/log-stream/LogStreamData.ts
@@ -91,8 +91,8 @@ export function processLogConfig(site: Site, logsConfig: SiteLogsConfig): LogsEn
   return { applicationLogs: appLogs, webServerLogs: webLogs };
 }
 
-export function logStreamEnabled(logType: LogType, logsEnabled: LogsEnabled): boolean {
-  return logType === LogType.Application ? logsEnabled.applicationLogs : logsEnabled.webServerLogs;
+export function logStreamEnabled(logType: LogType, logsEnabled: LogsEnabled, isScmHostNameWhitelisted?: boolean): boolean {
+  return (logType === LogType.Application ? logsEnabled.applicationLogs : logsEnabled.webServerLogs) && !!isScmHostNameWhitelisted;
 }
 
 export function copyLogEntries(logs: LogEntry[]) {

--- a/client-react/src/pages/app/log-stream/LogStreamDataLoader.tsx
+++ b/client-react/src/pages/app/log-stream/LogStreamDataLoader.tsx
@@ -30,6 +30,8 @@ export const isScmHostNameInTrustedDomains = (site: ArmObj<Site>): boolean | und
     const scmHostName = Url.getScmUrl(site);
     return Url.isScmHostNameWhitelisted(scmHostName, window.appsvc?.trustedDomains);
   }
+
+  return undefined;
 };
 
 class LogStreamDataLoader extends React.Component<LogStreamDataLoaderProps, LogStreamDataLoaderState> {

--- a/client-react/src/pages/app/log-stream/LogStreamDataLoader.tsx
+++ b/client-react/src/pages/app/log-stream/LogStreamDataLoader.tsx
@@ -25,6 +25,13 @@ export interface LogStreamDataLoaderState {
   isScmHostNameWhiteListed?: boolean;
 }
 
+export const isScmHostNameInTrustedDomains = (site: ArmObj<Site>): boolean | undefined => {
+  if (site) {
+    const scmHostName = Url.getScmUrl(site);
+    return Url.isScmHostNameWhitelisted(scmHostName, window.appsvc?.trustedDomains);
+  }
+};
+
 class LogStreamDataLoader extends React.Component<LogStreamDataLoaderProps, LogStreamDataLoaderState> {
   private _currentSiteId = '';
   private _xhReq: XMLHttpRequest;
@@ -59,7 +66,7 @@ class LogStreamDataLoader extends React.Component<LogStreamDataLoaderProps, LogS
           this.setState({
             site: siteCall.data,
             logsEnabled: processLogConfig(siteCall.data.properties, logsConfigCall.data.properties),
-            isScmHostNameWhiteListed: Url.isScmHostNameWhitelisted(Url.getScmUrl(siteCall.data), window.appsvc?.trustedDomains),
+            isScmHostNameWhiteListed: isScmHostNameInTrustedDomains(siteCall.data),
           });
         }
       })

--- a/client-react/src/pages/app/log-stream/LogStreamDataLoader.tsx
+++ b/client-react/src/pages/app/log-stream/LogStreamDataLoader.tsx
@@ -35,7 +35,6 @@ class LogStreamDataLoader extends React.Component<LogStreamDataLoaderProps, LogS
   constructor(props) {
     super(props);
     this.state = {
-      isScmHostNameWhiteListed: false,
       isStreaming: true,
       logEntries: [],
       clearLogs: false,

--- a/client-react/src/pages/app/log-stream/LogStreamLogContainer.tsx
+++ b/client-react/src/pages/app/log-stream/LogStreamLogContainer.tsx
@@ -70,6 +70,8 @@ const fieldStyle = style({
 
 export const DisableLogInfo = React.memo(() => {
   const { t } = useTranslation();
+  const githubLink = 'https://github.com/projectkudu/kudu/wiki/Diagnostic-Log-Stream';
+
   return (
     <div
       key={'logBlockingMessage'}
@@ -80,8 +82,8 @@ export const DisableLogInfo = React.memo(() => {
       }}>
       <p>
         <span id="disableLogInfoMessage">{t('disableLogInfoMessage')}</span>
-        <Link id="disableLogInfoLink" href={''} target="_blank" className={learnMoreLinkStyle}>
-          {`here`}
+        <Link id="disableLogInfoLink" href={githubLink} target="_blank" className={learnMoreLinkStyle}>
+          {t('disableLogInfoMessageLinkText')}
         </Link>
       </p>
     </div>

--- a/client-react/src/pages/app/log-stream/LogStreamLogContainer.tsx
+++ b/client-react/src/pages/app/log-stream/LogStreamLogContainer.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { style } from 'typestyle';
-import { LogEntry, LogType, LogsEnabled } from './LogStream.types';
-import { ChoiceGroup, IChoiceGroupOption } from '@fluentui/react';
+import { LogEntry, LogType, LogsEnabled, LogLevel } from './LogStream.types';
+import { ChoiceGroup, IChoiceGroupOption, Link } from '@fluentui/react';
 import { ScenarioService } from '../../../utils/scenario-checker/scenario.service';
 import { ScenarioIds } from '../../../utils/scenario-checker/scenario-ids';
 import { getLogTextColor } from './LogStreamData';
 import { ChoiceGroupStyles } from '../../../theme/CustomOfficeFabric/AzurePortal/ChoiceGroup.styles';
 import { ArmObj } from '../../../models/arm-obj';
 import { Site } from '../../../models/site/site';
+import { learnMoreLinkStyle } from '../../../components/form-controls/formControl.override.styles';
 
 interface LogStreamLogContainerProps {
   clearLogs: boolean;
@@ -18,6 +19,7 @@ interface LogStreamLogContainerProps {
   connectionError: boolean;
   logType: LogType;
   logsEnabled: LogsEnabled;
+  isScmHostNameWhiteListed?: boolean;
 }
 
 const containerDivStyle = style({
@@ -66,9 +68,31 @@ const fieldStyle = style({
   marginRight: '10px',
 });
 
+export const DisableLogInfo = React.memo(() => {
+  const { t } = useTranslation();
+  return (
+    <div
+      key={'logBlockingMessage'}
+      className={logEntryDivStyle}
+      style={{ color: getLogTextColor(LogLevel.Normal) }}
+      ref={el => {
+        el?.scrollIntoView({ behavior: 'smooth' });
+      }}>
+      <p>
+        <span id="disableLogInfoMessage">{t('disableLogInfoMessage')}</span>
+        <Link id="disableLogInfoLink" href={''} target="_blank" className={learnMoreLinkStyle}>
+          {`here`}
+        </Link>
+      </p>
+    </div>
+  );
+});
+
+DisableLogInfo.displayName = 'DisableLogInfo';
+
 type LogStreamLogContainerPropsCombined = LogStreamLogContainerProps;
 const LogStreamLogContainer: React.FC<LogStreamLogContainerPropsCombined> = props => {
-  const { clearLogs, logEntries, connectionError, site, logType, logsEnabled } = props;
+  const { clearLogs, logEntries, connectionError, site, logType, logsEnabled, isScmHostNameWhiteListed } = props;
   const { t } = useTranslation();
   const scenarioChecker = new ScenarioService(t);
   const showWebServerOption = !!site.id && scenarioChecker.checkScenario(ScenarioIds.addWebServerLogging, { site }).status !== 'disabled';
@@ -107,45 +131,54 @@ const LogStreamLogContainer: React.FC<LogStreamLogContainerPropsCombined> = prop
         </div>
       )}
 
-      <div className={bodyDivStyle} style={{ height: showWebServerOption ? 'calc(100% - 50px)' : 'calc(100% - 20px)' }}>
-        {/*Logs Disabled Message or Connecting*/}
-        {!!site.id &&
-          ((logType === LogType.Application && !logsEnabled.applicationLogs && (
-            <div className={connectionErrorDivStyle}>{t('logStreamingApplicationLogsDisabled')}</div>
-          )) ||
-            (logType === LogType.WebServer && !logsEnabled.webServerLogs && (
-              <div className={connectionErrorDivStyle}>{t('logStreamingWebServerLogsDisabled')}</div>
+      {isScmHostNameWhiteListed === undefined ? null : (
+        <div className={bodyDivStyle} style={{ height: showWebServerOption ? 'calc(100% - 50px)' : 'calc(100% - 20px)' }}>
+          {/*Logs Disabled Message or Connecting*/}
+          {isScmHostNameWhiteListed &&
+            !!site.id &&
+            ((logType === LogType.Application && !logsEnabled.applicationLogs && (
+              <div className={connectionErrorDivStyle}>{t('logStreamingApplicationLogsDisabled')}</div>
             )) ||
-            (!clearLogs && <div className={connectingDivStyle}>{t('feature_logStreamingConnecting')}</div>))}
+              (logType === LogType.WebServer && !logsEnabled.webServerLogs && (
+                <div className={connectionErrorDivStyle}>{t('logStreamingWebServerLogsDisabled')}</div>
+              )) ||
+              (!clearLogs && <div className={connectingDivStyle}>{t('feature_logStreamingConnecting')}</div>))}
 
-        {/*Connection Error*/}
-        {connectionError && !clearLogs && <div className={connectionErrorDivStyle}>{t('feature_logStreamingConnectionError')}</div>}
+          {/*Connection Error*/}
+          {isScmHostNameWhiteListed && connectionError && !clearLogs && (
+            <div className={connectionErrorDivStyle}>{t('feature_logStreamingConnectionError')}</div>
+          )}
 
-        {/*Log Entries*/}
-        {!!logEntries &&
-          logEntries.map((logEntry, logIndex) => {
-            if (logIndex + 1 !== totalNumberOfLogs) {
+          {/*Log Entries*/}
+          {isScmHostNameWhiteListed ? (
+            !!logEntries &&
+            logEntries.map((logEntry, logIndex) => {
+              if (logIndex + 1 !== totalNumberOfLogs) {
+                return (
+                  <div key={logEntry.message} className={logEntryDivStyle} style={{ color: getLogTextColor(logEntry.level) }}>
+                    {logEntry.message}
+                  </div>
+                );
+              }
+
+              /*Last Log Entry needs to be scrolled into focus*/
               return (
-                <div key={logEntry.message} className={logEntryDivStyle} style={{ color: getLogTextColor(logEntry.level) }}>
+                <div
+                  key={logEntry.message}
+                  className={logEntryDivStyle}
+                  style={{ color: getLogTextColor(logEntry.level) }}
+                  ref={el => {
+                    el?.scrollIntoView({ behavior: 'smooth' });
+                  }}>
                   {logEntry.message}
                 </div>
               );
-            }
-
-            /*Last Log Entry needs to be scrolled into focus*/
-            return (
-              <div
-                key={logEntry.message}
-                className={logEntryDivStyle}
-                style={{ color: getLogTextColor(logEntry.level) }}
-                ref={el => {
-                  el?.scrollIntoView({ behavior: 'smooth' });
-                }}>
-                {logEntry.message}
-              </div>
-            );
-          })}
-      </div>
+            })
+          ) : (
+            <DisableLogInfo />
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/client-react/src/pages/app/log-stream/LogStreamLogContainer.tsx
+++ b/client-react/src/pages/app/log-stream/LogStreamLogContainer.tsx
@@ -64,6 +64,10 @@ const logEntryDivStyle = style({
   paddingBottom: '5px',
 });
 
+const disableLogInfoMessageStyle = style({
+  paddingRight: '4px',
+});
+
 const fieldStyle = style({
   marginRight: '10px',
 });
@@ -81,9 +85,11 @@ export const DisableLogInfo = React.memo(() => {
         el?.scrollIntoView({ behavior: 'smooth' });
       }}>
       <p>
-        <span id="disableLogInfoMessage">{t('disableLogInfoMessage')}</span>
+        <span id="disableLogInfoMessage" className={disableLogInfoMessageStyle}>
+          {t('disableLogInfoMessage')}
+        </span>
         <Link id="disableLogInfoLink" href={githubLink} target="_blank" className={learnMoreLinkStyle}>
-          {t('disableLogInfoMessageLinkText')}
+          {t('learnMore')}
         </Link>
       </p>
     </div>

--- a/client-react/src/portal-communicator.ts
+++ b/client-react/src/portal-communicator.ts
@@ -574,6 +574,7 @@ export default class PortalCommunicator {
         window.appsvc.resourceId = startupInfo.resourceId;
         window.appsvc.feature = startupInfo.featureInfo && startupInfo.featureInfo.feature;
         window.appsvc.frameId = this.frameId;
+        window.appsvc.trustedDomains = startupInfo.trustedDomains;
       }
     } else if (methodName === Verbs.sendToken2) {
       this.setArmTokenInternal(data && data.token);

--- a/client-react/src/react-app-env.d.ts
+++ b/client-react/src/react-app-env.d.ts
@@ -22,6 +22,7 @@ interface AppSvc {
   env: Environment;
   version: string;
   sessionId: string;
+  trustedDomains?: string[];
   resourceId?: string;
   feature?: string;
   cdn?: string;

--- a/client-react/src/utils/url.ts
+++ b/client-react/src/utils/url.ts
@@ -106,6 +106,13 @@ export default class Url {
     return scmHost ? `https://${scmHost.name}` : this.getMainUrl(site);
   }
 
+  public static isScmHostNameWhitelisted(scmHostName: string, trustedDomains: string[] = []): boolean {
+    return trustedDomains.some(domain => {
+      const trustedDomain = domain.startsWith('*.') ? domain.substring(1) : domain;
+      return scmHostName.endsWith(trustedDomain);
+    });
+  }
+
   public static getSyncTriggerUrl(site: ArmObj<Site>) {
     return `${this.getScmUrl(site)}/api/functions/synctriggers`;
   }

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1621,6 +1621,7 @@ export class PortalResources {
   public static logStreamingApplicationLogsDisabled = 'logStreamingApplicationLogsDisabled';
   public static logStreamingWebServerLogsDisabled = 'logStreamingWebServerLogsDisabled';
   public static disableLogInfoMessage = 'disableLogInfoMessage';
+  public static disableLogInfoMessageLinkText = 'disableLogInfoMessageLinkText';
   public static remoteDebuggingNotAvailableForRuntimeStack = 'remoteDebuggingNotAvailableForRuntimeStack';
   public static appSettingsUpsellBannerMessage = 'appSettingsUpsellBannerMessage';
   public static appInsightsNotConfigured = 'appInsightsNotConfigured';

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1621,7 +1621,6 @@ export class PortalResources {
   public static logStreamingApplicationLogsDisabled = 'logStreamingApplicationLogsDisabled';
   public static logStreamingWebServerLogsDisabled = 'logStreamingWebServerLogsDisabled';
   public static disableLogInfoMessage = 'disableLogInfoMessage';
-  public static disableLogInfoMessageLinkText = 'disableLogInfoMessageLinkText';
   public static remoteDebuggingNotAvailableForRuntimeStack = 'remoteDebuggingNotAvailableForRuntimeStack';
   public static appSettingsUpsellBannerMessage = 'appSettingsUpsellBannerMessage';
   public static appInsightsNotConfigured = 'appInsightsNotConfigured';

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1620,6 +1620,7 @@ export class PortalResources {
   public static virtualDirectoryPathError = 'virtualDirectoryPathError';
   public static logStreamingApplicationLogsDisabled = 'logStreamingApplicationLogsDisabled';
   public static logStreamingWebServerLogsDisabled = 'logStreamingWebServerLogsDisabled';
+  public static disableLogInfoMessage = 'disableLogInfoMessage';
   public static remoteDebuggingNotAvailableForRuntimeStack = 'remoteDebuggingNotAvailableForRuntimeStack';
   public static appSettingsUpsellBannerMessage = 'appSettingsUpsellBannerMessage';
   public static appInsightsNotConfigured = 'appInsightsNotConfigured';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -5028,8 +5028,11 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>Web server logs are switched off. You can turn them on using the 'App Service logs' settings.</value>
     </data>
     <data name="disableLogInfoMessage" xml:space="preserve">
-        <value>We are unable to fetch logs for apps hosted on an App Service Environment with custom domains.  To learn how to view real-time logs, click </value>
+        <value>We are unable to fetch logs for apps hosted on an App Service Environment with custom domains. To learn how to view real-time logs, click </value>
         <comment>'here' will be a link text follwing the string</comment>
+    </data>
+    <data name="disableLogInfoMessageLinkText" xml:space="preserve">
+        <value>here</value>
     </data>
     <data name="remoteDebuggingNotAvailableForRuntimeStack" xml:space="preserve">
         <value>Your selected runtime stack does not currently support remote debugging.</value>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -5028,11 +5028,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>Web server logs are switched off. You can turn them on using the 'App Service logs' settings.</value>
     </data>
     <data name="disableLogInfoMessage" xml:space="preserve">
-        <value>We are unable to fetch logs for apps hosted on an App Service Environment with custom domains. To learn how to view real-time logs, click </value>
-        <comment>'here' will be a link text follwing the string</comment>
-    </data>
-    <data name="disableLogInfoMessageLinkText" xml:space="preserve">
-        <value>here</value>
+        <value>We are unable to fetch logs for apps hosted on an App Service Environment with custom domains.</value>
     </data>
     <data name="remoteDebuggingNotAvailableForRuntimeStack" xml:space="preserve">
         <value>Your selected runtime stack does not currently support remote debugging.</value>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -5027,6 +5027,10 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="logStreamingWebServerLogsDisabled" xml:space="preserve">
         <value>Web server logs are switched off. You can turn them on using the 'App Service logs' settings.</value>
     </data>
+    <data name="disableLogInfoMessage" xml:space="preserve">
+        <value>We are unable to fetch logs for apps hosted on an App Service Environment with custom domains.  To learn how to view real-time logs, click </value>
+        <comment>'here' will be a link text follwing the string</comment>
+    </data>
     <data name="remoteDebuggingNotAvailableForRuntimeStack" xml:space="preserve">
         <value>Your selected runtime stack does not currently support remote debugging.</value>
     </data>


### PR DESCRIPTION
Fixes [AB#15777298](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/S199?workitem=15777298)

Disable function app file system logs and web app web server logs and application logs if the scm host domains are not in the trust domain list

Function app log stream
 - File system logs (show disabled message)
![functionappLogStreamFileSystemLogs](https://user-images.githubusercontent.com/33185278/194729795-6c6ebcfc-83a1-404c-a770-b83697590b11.png)

- Application Insights logs (stay same)
![functionappLogStreamApplicationInsights](https://user-images.githubusercontent.com/33185278/194729827-21f04f48-95c6-4bb7-93df-ad944a160df7.png)

Function app functions code+test
 - File system logs (show disabled message)
![codePlusTestFileSystem](https://user-images.githubusercontent.com/33185278/194729847-e7d19652-f913-4b2c-9ace-e27008b5b62d.png)

- Application Insights logs (stay same)
![codeplustestapplicationinsights](https://user-images.githubusercontent.com/33185278/194729854-b3a70c2c-3983-48d3-83de-47b12864ed1c.png)

Function app functions monitor
 - File system logs (show disabled message)
![monitorFileSystem](https://user-images.githubusercontent.com/33185278/194729859-534d09db-9ac6-4213-b683-b3f44221f514.png)

- Application Insights logs (stay same)
![monitorApplicationInsights](https://user-images.githubusercontent.com/33185278/194729867-1865025a-af25-4906-93a5-5b10b3f058ab.png)

Web app
- Application logs (show disabled message)
![webappLogStreamApplocationLogs](https://user-images.githubusercontent.com/33185278/194729888-07c861f0-8a0a-4a8f-8138-cd13ca35f763.png)

- Web server logs (show disabled message)
![webAppLogStreamWebServerLogs](https://user-images.githubusercontent.com/33185278/194729893-f8b3582f-47e1-454f-a298-e15a9f68e912.png)
