### PR TITLE
Add PowerShell 7.0 and 7.2 EOL dates

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
@@ -3,7 +3,7 @@ import { getDateString } from '../date-utilities';
 
 const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDateFormat: boolean) => {
   // EOL source: https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle?view=powershell-7.2#powershell-end-of-support-dates
-  const powershell62EOL = getDateString(new Date(2022, 8, 30), useIsoDateFormat);
+  const powershell62EOL = getDateString(new Date(2022, 9, 30), useIsoDateFormat);
   const powershell70EOL = getDateString(new Date(2022, 12, 3), useIsoDateFormat);
   const powershell72EOL = getDateString(new Date(2024, 11, 8), useIsoDateFormat);
 

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
@@ -2,7 +2,10 @@ import { FunctionAppStack } from '../../models/FunctionAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDateFormat: boolean) => {
-  const powershell6point2EOL = getDateString(new Date(2022, 8, 30), useIsoDateFormat);
+  // EOL source: https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle?view=powershell-7.2#powershell-end-of-support-dates
+  const powershell62EOL = getDateString(new Date(2022, 8, 30), useIsoDateFormat);
+  const powershell70EOL = getDateString(new Date(2022, 12, 3), useIsoDateFormat);
+  const powershell72EOL = getDateString(new Date(2024, 11, 8), useIsoDateFormat);
 
   return {
     displayText: 'PowerShell Core',
@@ -38,6 +41,7 @@ const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (use
                   netFrameworkVersion: 'v6.0',
                 },
                 supportedFunctionsExtensionVersions: ['~4'],
+                endOfLifeDate: powershell72EOL
               },
               linuxRuntimeSettings: {
                 runtimeVersion: 'PowerShell|7.2',
@@ -59,6 +63,7 @@ const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (use
                   linuxFxVersion: 'PowerShell|7.2',
                 },
                 supportedFunctionsExtensionVersions: ['~4'],
+                endOfLifeDate: powershell72EOL
               },
             },
           },
@@ -84,6 +89,7 @@ const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (use
                   netFrameworkVersion: 'v6.0',
                 },
                 supportedFunctionsExtensionVersions: ['~4', '~3'],
+                endOfLifeDate: powershell70EOL
               },
               linuxRuntimeSettings: {
                 runtimeVersion: 'PowerShell|7',
@@ -104,6 +110,7 @@ const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (use
                   linuxFxVersion: 'PowerShell|7',
                 },
                 supportedFunctionsExtensionVersions: ['~4'],
+                endOfLifeDate: powershell70EOL
               },
             },
           },
@@ -135,7 +142,7 @@ const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (use
                 },
                 isDeprecated: true,
                 supportedFunctionsExtensionVersions: ['~2', '~3'],
-                endOfLifeDate: powershell6point2EOL,
+                endOfLifeDate: powershell62EOL
               },
             },
           },

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
@@ -3,9 +3,10 @@ import { getDateString } from '../date-utilities';
 
 const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDateFormat: boolean) => {
   // EOL source: https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle?view=powershell-7.2#powershell-end-of-support-dates
-  const powershell62EOL = getDateString(new Date(2022, 9, 30), useIsoDateFormat);
-  const powershell70EOL = getDateString(new Date(2022, 12, 3), useIsoDateFormat);
-  const powershell72EOL = getDateString(new Date(2024, 11, 8), useIsoDateFormat);
+  // Please note that the month uses based-zero index, as a result, 9/30/22 -> new Date(2022, 8, 30)
+  const powershell62EOL = getDateString(new Date(2022, 8, 30), useIsoDateFormat);
+  const powershell70EOL = getDateString(new Date(2022, 11, 3), useIsoDateFormat);
+  const powershell72EOL = getDateString(new Date(2024, 10, 8), useIsoDateFormat);
 
   return {
     displayText: 'PowerShell Core',


### PR DESCRIPTION
This PR contains the following changes:
* Adding `PowerShell 7.0` and `7.2` EOL dates as they are publish here: https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle?view=powershell-7.2#powershell-end-of-support-dates
*  Update EOL date for PowerShell 6.2 to `2022-9-30`