### PR TITLE
Yutlin adding App Insights isDefaultOff property

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/AspDotnet.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/AspDotnet.ts
@@ -18,6 +18,7 @@ export const aspDotnetStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -31,6 +32,7 @@ export const aspDotnetStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -97,6 +99,7 @@ export const aspDotnetStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -109,6 +112,7 @@ export const aspDotnetStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/AspDotnet.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/AspDotnet.ts
@@ -56,6 +56,7 @@ export const aspDotnetStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: false,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -69,6 +70,7 @@ export const aspDotnetStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: false,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -130,6 +132,7 @@ export const aspDotnetStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: false,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -153,6 +156,7 @@ export const aspDotnetStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: false,
               },
               gitHubActionSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/DotnetCore.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/DotnetCore.ts
@@ -24,6 +24,7 @@ export const dotnetCoreStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: false,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -35,6 +36,7 @@ export const dotnetCoreStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: false,
               },
               gitHubActionSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/DotnetCore.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/DotnetCore.ts
@@ -55,6 +55,7 @@ export const dotnetCoreStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -93,6 +94,7 @@ export const dotnetCoreStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -106,6 +108,7 @@ export const dotnetCoreStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -124,6 +127,7 @@ export const dotnetCoreStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -136,6 +140,7 @@ export const dotnetCoreStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -155,6 +160,7 @@ export const dotnetCoreStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -168,6 +174,7 @@ export const dotnetCoreStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -193,6 +200,7 @@ export const dotnetCoreStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -206,6 +214,7 @@ export const dotnetCoreStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -225,6 +234,7 @@ export const dotnetCoreStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -237,6 +247,7 @@ export const dotnetCoreStack: WebAppStack = {
               isDeprecated: true,
               remoteDebuggingSupported: false,
               appInsightsSettings: {
+                isDefaultOff: true,
                 isSupported: false,
               },
               gitHubActionSettings: {

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/DotnetCore.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/DotnetCore.ts
@@ -69,6 +69,7 @@ export const dotnetCoreStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
@@ -51,6 +51,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -63,6 +64,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -87,6 +89,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -99,6 +102,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
@@ -29,6 +29,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -128,6 +129,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -141,6 +143,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -159,6 +162,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: true,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -184,6 +188,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -203,6 +208,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -224,6 +230,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -243,6 +250,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -256,6 +264,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -275,6 +284,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -294,6 +304,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -307,6 +318,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -326,6 +338,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -339,6 +352,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -357,6 +371,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -382,6 +397,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -406,6 +422,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -424,6 +441,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -442,6 +460,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -454,6 +473,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: false,
@@ -472,6 +492,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: false,
@@ -490,6 +511,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -502,6 +524,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: false,
@@ -520,6 +543,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -538,6 +562,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: false,
@@ -556,6 +581,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: false,
@@ -574,6 +600,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -592,6 +619,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -604,6 +632,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -622,6 +651,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -646,6 +676,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: false,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: false,
@@ -670,6 +701,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -688,6 +720,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: false,
@@ -706,6 +739,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -724,6 +758,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -742,6 +777,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -754,6 +790,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -772,6 +809,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -790,6 +828,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: false,
@@ -808,6 +847,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -832,6 +872,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -844,6 +885,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: false,
@@ -862,6 +904,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -880,6 +923,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
+                isDefaultOff: true,
               },
               gitHubActionSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -28,6 +28,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -40,6 +41,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -101,6 +103,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -114,6 +117,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -139,6 +143,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 appInsightsSettings: {
                   isSupported: true,
                   isDefaultOff: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -152,6 +157,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 appInsightsSettings: {
                   isSupported: true,
                   isDefaultOff: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -171,6 +177,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -184,6 +191,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -209,6 +217,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -222,6 +231,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -241,6 +251,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 isDeprecated: true,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -254,6 +265,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 isDeprecated: true,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -273,6 +285,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -286,6 +299,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -311,6 +325,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -324,6 +339,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -343,6 +359,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -356,6 +373,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -143,7 +143,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 appInsightsSettings: {
                   isSupported: true,
                   isDefaultOff: false,
-                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -157,7 +156,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 appInsightsSettings: {
                   isSupported: true,
                   isDefaultOff: false,
-                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -64,6 +64,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -75,6 +76,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -136,6 +138,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -148,6 +151,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -399,6 +403,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -64,7 +64,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
-                  isDefaultOff: true,
+                  isDefaultOff: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -76,7 +76,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
-                  isDefaultOff: true,
+                  isDefaultOff: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -138,7 +138,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
-                  isDefaultOff: true,
+                  isDefaultOff: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -151,7 +151,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
-                  isDefaultOff: true,
+                  isDefaultOff: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -380,6 +380,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -403,7 +404,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
-                  isDefaultOff: true,
+                  isDefaultOff: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
@@ -53,6 +53,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -64,6 +65,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -87,6 +89,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -99,6 +102,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -123,6 +127,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -135,6 +140,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
@@ -181,6 +181,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
@@ -31,6 +31,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -166,6 +167,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -197,6 +199,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: true,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -222,6 +225,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -241,6 +245,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -262,6 +267,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -281,6 +287,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -294,6 +301,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -313,6 +321,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -332,6 +341,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -345,6 +355,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -364,6 +375,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -377,6 +389,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -395,6 +408,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -420,6 +434,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -444,6 +459,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -462,6 +478,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -480,6 +497,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -492,6 +510,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: false,
@@ -510,6 +529,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: false,
@@ -528,6 +548,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -540,6 +561,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: false,
@@ -558,6 +580,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -576,6 +599,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: false,
@@ -594,6 +618,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: false,
@@ -612,6 +637,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -630,6 +656,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -642,6 +669,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -660,6 +688,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -684,6 +713,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: false,
@@ -708,6 +738,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -726,6 +757,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: false,
@@ -744,6 +776,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -762,6 +795,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -780,6 +814,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -792,6 +827,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -810,6 +846,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -828,6 +865,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: false,
@@ -846,6 +884,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -870,6 +909,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -882,6 +922,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: false,
@@ -900,6 +941,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -918,6 +960,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,


### PR DESCRIPTION
Adding App Insights Property isDefaultOff to [2020-06-01] and [2020-10-01] for stacks that are not deprecated and that support App Insights

- .NET 6, .NET Core 3.1
- - OnBD for Windows and Linux

- ASP .NET 4.8, 3.5
- - OnBD for Windows

- Node 18, 16, 14
- - NOT OnBd for Windows and Linux