### PR TITLE
Removed hidden flag for .NET 6 Isolated, .NET 7 Isolated in Stacks API.

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
@@ -21,7 +21,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
               windowsRuntimeSettings: {
                 runtimeVersion: 'v7.0',
                 isPreview: true,
-                isHidden: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
@@ -42,7 +41,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
               linuxRuntimeSettings: {
                 runtimeVersion: 'DOTNET-ISOLATED|7.0',
                 isPreview: true,
-                isHidden: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
@@ -126,7 +124,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
             stackSettings: {
               windowsRuntimeSettings: {
                 runtimeVersion: 'v6.0',
-                isHidden: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -146,7 +143,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
               },
               linuxRuntimeSettings: {
                 runtimeVersion: 'DOTNET-ISOLATED|6.0',
-                isHidden: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,


### PR DESCRIPTION
Fixes Azure/azure-functions-dotnet-worker#1120