### PR TITLE
[DC] Set user assigned identity's principal id when info is updated

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
@@ -506,7 +506,7 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
 
   useEffect(() => {
     setManagedIdentityPrincipalId(formProps.values.acrManagedIdentityClientId);
-  }, [formProps.values.acrManagedIdentityClientId]);
+  }, [formProps.values.acrManagedIdentityClientId, managedIdentityInfo.current[formProps.values.acrManagedIdentityClientId]]);
 
   return (
     <DeploymentCenterContainerAcrSettings


### PR DESCRIPTION
When selected user assigned identity was not changed, the principalId was not getting set (needed for getting role assignments) because it only depended on a change in identity. PrincipalId is now set on managedIdentityInfo initialization and change. Fix in response to https://portal.microsofticm.com/imp/v3/incidents/details/341582946/home