### PR TITLE
[DC] Refresh siteStateContext after save for vnetImagePullEnabled

### DIFF
--- a/client-react/src/SiteState.ts
+++ b/client-react/src/SiteState.ts
@@ -12,6 +12,7 @@ export interface ISiteState {
   isKubeApp: boolean;
   resourceId?: string;
   site?: ArmObj<Site>;
+  refresh: () => Promise<void>;
 }
 
 export const SiteStateContext = React.createContext<ISiteState>({} as ISiteState);

--- a/client-react/src/pages/app/SiteRouter.tsx
+++ b/client-react/src/pages/app/SiteRouter.tsx
@@ -148,6 +148,7 @@ const SiteRouter: React.FC<RouteComponentProps<SiteRouterProps>> = () => {
                       isContainerApp: isContainerApplication,
                       isFunctionApp: isFunctionApplication,
                       isKubeApp: isKubeApplication,
+                      refresh: () => fetchDataAndSetState(resourceId),
                     }}>
                     <Router>
                       {/* NOTE(michinoy): The paths should be always all lowercase. */}

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -651,6 +651,9 @@ export interface DeploymentCenterContainerAcrSettingsProps extends DeploymentCen
   loadingManagedIdentities: boolean;
   learnMoreLink?: string;
   openIdentityBlade: () => void;
+  isVnetConfigured?: boolean;
+  legacyVnetAppSetting?: string;
+  defaultVnetImagePullSetting?: SettingOption;
 }
 
 export interface DeploymentCenterOneDriveProviderProps<T = DeploymentCenterContainerFormData | DeploymentCenterCodeFormData>

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ACRCredentialType, ContainerOptions, DeploymentCenterContainerAcrSettingsProps, SettingOption } from '../DeploymentCenter.types';
 import { Field } from 'formik';
 import { useTranslation } from 'react-i18next';
@@ -12,9 +12,6 @@ import { IDropdownOption, Link, MessageBar, MessageBarType } from '@fluentui/rea
 import ComboBoxNoFormik from '../../../../components/form-controls/ComboBoxnoFormik';
 import RadioButton from '../../../../components/form-controls/RadioButton';
 import { addIdentityLinkStyle, deploymentCenterAcrBannerDiv, deploymentCenterInfoBannerDiv } from '../DeploymentCenter.styles';
-import { DeploymentCenterContext } from '../DeploymentCenterContext';
-import { DeploymentCenterConstants } from '../DeploymentCenterConstants';
-import { SiteStateContext } from '../../../../SiteState';
 
 const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAcrSettingsProps> = props => {
   const {
@@ -35,11 +32,12 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
     learnMoreLink,
     fetchRegistriesInSub,
     openIdentityBlade,
+    isVnetConfigured,
+    legacyVnetAppSetting,
+    defaultVnetImagePullSetting,
   } = props;
   const { t } = useTranslation();
 
-  const deploymentCenterContext = useContext(DeploymentCenterContext);
-  const siteStateContext = useContext(SiteStateContext);
   const [isComposeOptionSelected, setIsComposeOptionSelected] = useState(false);
   const [isGitHubActionSelected, setIsGitHubActionSelected] = useState(false);
   const [aCRSubscriptionOptions, setACRSubscriptionOptions] = useState<IDropdownOption[]>(acrSubscriptionOptions);
@@ -54,23 +52,6 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
     { key: SettingOption.on, text: t('on') },
     { key: SettingOption.off, text: t('off') },
   ];
-  const isVnetConfigured = useMemo(() => siteStateContext.site?.properties.virtualNetworkSubnetId, [
-    siteStateContext.site?.properties.virtualNetworkSubnetId,
-  ]);
-  const legacyVnetAppSetting = useMemo(
-    () => deploymentCenterContext.applicationSettings?.properties[DeploymentCenterConstants.vnetImagePullSetting],
-    [deploymentCenterContext.applicationSettings?.properties[DeploymentCenterConstants.vnetImagePullSetting]]
-  );
-
-  const getDefaultVnetImagePullOption = () => {
-    if (isVnetConfigured) {
-      if (legacyVnetAppSetting) {
-        return legacyVnetAppSetting === 'true' ? SettingOption.on : SettingOption.off;
-      }
-      return siteStateContext.site?.properties.vnetImagePullEnabled ? SettingOption.on : SettingOption.off;
-    }
-    return undefined;
-  };
 
   useEffect(() => {
     setIsComposeOptionSelected(formProps.values.option === ContainerOptions.compose);
@@ -281,7 +262,7 @@ const DeploymentCenterContainerAcrSettings: React.FC<DeploymentCenterContainerAc
                 name="acrVnetImagePullSetting"
                 component={RadioButton}
                 options={acrVnetImagePullOptions}
-                defaultSelectedKey={getDefaultVnetImagePullOption()}
+                defaultSelectedKey={defaultVnetImagePullSetting}
               />
             </>
           )}

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -726,8 +726,8 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
     portalContext.log(getTelemetryInfo('info', 'onSubmitContainer', 'submit'));
 
     await Promise.all([updateDeploymentConfigurations(values), updatePublishingUser(values)]);
-    deploymentCenterContext.refresh();
     props.refresh();
+    siteContext.refresh();
   };
 
   const updateDeploymentConfigurations = async (values: DeploymentCenterFormData<DeploymentCenterContainerFormData>) => {

--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
@@ -24,7 +24,7 @@ import { IDeploymentCenterContext } from '../DeploymentCenterContext';
 import { CommonConstants } from '../../../../utils/CommonConstants';
 import { deploymentCenterDescriptionTextStyle } from '../DeploymentCenter.styles';
 import { learnMoreLinkStyle } from '../../../../components/form-controls/formControl.override.styles';
-import { Link } from '@fluentui/react';
+import { ISelectableOption, Link } from '@fluentui/react';
 import { DeploymentCenterConstants } from '../DeploymentCenterConstants';
 
 export const getRuntimeStackSetting = (
@@ -470,3 +470,5 @@ export const getDescriptionSection = (source: string, description: string, learn
     </p>
   );
 };
+
+export const optionsSortingFunction = (a: ISelectableOption, b: ISelectableOption) => a.text.localeCompare(b.text);


### PR DESCRIPTION
FixesAB#[15815579](https://msazure.visualstudio.com/Antares/_workitems/edit/15815579)
- Pull image over VNet value was not persisting after save because siteStateContext was not updating with the refresh