### PR TITLE
chore: Update prismjs to 1.27.0 in /client

### DIFF
--- a/client/.angular-cli.json
+++ b/client/.angular-cli.json
@@ -66,5 +66,8 @@
   "defaults": {
     "styleExt": "scss",
     "component": {}
+  },
+  "warnings": {
+    "typescriptMismatch": false
   }
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -391,9 +391,9 @@
       "dev": true
     },
     "@types/prismjs": {
-      "version": "1.9.0",
-      "resolved": "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.9.0.tgz",
-      "integrity": "sha1-OK+UkeLxBQeaRDcD7mdfsnNx7JQ="
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
+      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ=="
     },
     "@types/q": {
       "version": "0.0.32",
@@ -998,6 +998,15 @@
       "resolved": "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.12.0.tgz",
       "integrity": "sha1-wteA9T1Fu6gxeokC1M7q86Y4WxQ="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "blob": {
       "version": "0.0.4",
       "resolved": "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz",
@@ -1542,6 +1551,7 @@
       "requires": {
         "anymatch": "^1.3.0",
         "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
         "glob-parent": "^2.0.0",
         "inherits": "^2.0.1",
         "is-binary-path": "^1.0.0",
@@ -1667,17 +1677,6 @@
       "resolved": "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
-    },
-    "clipboard": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
-      "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
-      "optional": true,
-      "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
     },
     "cliui": {
       "version": "3.2.0",
@@ -2380,12 +2379,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -3419,6 +3412,12 @@
         "schema-utils": "^0.4.5"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -3625,6 +3624,16 @@
       "resolved": "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      }
+    },
     "fstream": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
@@ -3799,15 +3808,6 @@
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
-      }
-    },
-    "good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "optional": true,
-      "requires": {
-        "delegate": "^3.1.2"
       }
     },
     "got": {
@@ -6994,12 +6994,9 @@
       }
     },
     "prismjs": {
-      "version": "1.15.0",
-      "resolved": "https://registry.yarnpkg.com/prismjs/-/prismjs-1.15.0.tgz",
-      "integrity": "sha1-iAHTMuRyCRuo3vlJdsiHetYDmNk=",
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA=="
     },
     "process": {
       "version": "0.11.10",
@@ -8023,12 +8020,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.yarnpkg.com/secure-keys/-/secure-keys-1.0.0.tgz",
       "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
-    },
-    "select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "optional": true
     },
     "select-hose": {
       "version": "2.0.0",
@@ -9101,12 +9092,6 @@
         "setimmediate": "^1.0.4"
       }
     },
-    "tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "optional": true
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz",
@@ -9355,9 +9340,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.4.2",
-      "resolved": "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz",
-      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
       "dev": true
     },
     "uglify-js": {
@@ -9825,6 +9810,7 @@
           "requires": {
             "anymatch": "~3.1.2",
             "braces": "~3.0.2",
+            "fsevents": "~2.3.2",
             "glob-parent": "~5.1.2",
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
@@ -9840,6 +9826,12 @@
           "requires": {
             "to-regex-range": "^5.0.1"
           }
+        },
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "optional": true
         },
         "glob-parent": {
           "version": "5.1.2",
@@ -9945,6 +9937,7 @@
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
@@ -10406,6 +10399,7 @@
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -46,7 +46,7 @@
     "ngx-markdown": "^1.5.2",
     "ngx-uploader": "^4.2.4",
     "node-sass": "^4.13.1",
-    "prismjs": "^1.13.0",
+    "prismjs": "^1.27.0",
     "rxjs": "^5.5.2",
     "swagger-editor": "git+https://github.com/azure/swagger-editor.git#5c7736ff93ffe36569e1f21efd72a91c9c1f9f77",
     "ts-helpers": "^1.1.1",
@@ -60,7 +60,7 @@
     "@types/jsonschema": "^1.1.1",
     "@types/lodash-es": "^4.17.0",
     "@types/node": "~6.0.60",
-    "@types/prismjs": "^1.9.0",
+    "@types/prismjs": "^1.26.0",
     "codelyzer": "~2.0.0",
     "coveralls": "^3.0.0",
     "jasmine-core": "~2.5.2",
@@ -78,7 +78,7 @@
     "puppeteer": "^1.17.0",
     "ts-node": "~2.0.0",
     "tslint": "~4.5.0",
-    "typescript": "2.4.2",
+    "typescript": "^2.9.2",
     "webpack-bundle-analyzer": "^3.3.2"
   },
   "engines": {

--- a/client/src/app/controls/form-wizard/directives/wizard-step-title.directive.spec.ts
+++ b/client/src/app/controls/form-wizard/directives/wizard-step-title.directive.spec.ts
@@ -12,13 +12,13 @@ import { WizardModule } from '../wizard.module';
   selector: 'test-wizard',
   template: `
     <wizard>
-      <wizard-step title='Other not visible title'>
+      <wizard-step title="Other not visible title">
         <ng-template wizardStepTitle>
           Steptitle 1
         </ng-template>
         Step 1
       </wizard-step>
-      <wizard-completion-step title='Other not visible title'>
+      <wizard-completion-step title="Other not visible title">
         <ng-template wizardStepTitle>
           Steptitle 2
         </ng-template>
@@ -33,6 +33,7 @@ class WizardTestComponent {
 }
 
 describe('PreviousStepDirective', () => {
+  // @ts-ignore: error TS6133: 'wizardTest' is declared but its value is never read.
   let wizardTest: WizardTestComponent;
   let wizardTestFixture: ComponentFixture<WizardTestComponent>;
 

--- a/client/src/app/dev-guide/highlight.service.ts
+++ b/client/src/app/dev-guide/highlight.service.ts
@@ -10,11 +10,11 @@ export class HighlightService {
 
   highlightString(s: string, l: 'typescript' | 'scss' | 'html'): string {
     if (l === 'typescript') {
-      return Prism.highlight(s, Prism.languages.typescript);
+      return Prism.highlight(s, Prism.languages.typescript, 'ts');
     } else if (l === 'scss') {
-      return Prism.highlight(s, Prism.languages.scss);
+      return Prism.highlight(s, Prism.languages.scss, 'scss');
     } else {
-      return Prism.highlight(s, Prism.languages.html);
+      return Prism.highlight(s, Prism.languages.html, 'html');
     }
   }
 }

--- a/client/src/app/shared/components/function-app-context-component.ts
+++ b/client/src/app/shared/components/function-app-context-component.ts
@@ -33,6 +33,7 @@ export abstract class FunctionAppContextComponent extends ErrorableComponent imp
   private timeout: number;
 
   @Input('viewInfo')
+  // @ts-ignore: error TS6133: 'viewInfoComponent_viewInfo' is declared but its value is never read.
   private set viewInfoComponent_viewInfo(viewInfo: TreeViewInfo<any>) {
     this.viewInfoSubject.next(viewInfo);
   }

--- a/client/src/app/shared/services/broadcast.service.ts
+++ b/client/src/app/shared/services/broadcast.service.ts
@@ -47,6 +47,7 @@ export class BroadcastService implements IBroadcastService {
   private trialExpired: EventEmitter<void>;
   private resetKeySelection: EventEmitter<FunctionInfo>;
   private clearErrorEvent: EventEmitter<string>;
+  // @ts-ignore: error TS6133: 'refreshMonitorEvent' is declared but its value is never read.
   private refreshMonitorEvent: EventEmitter<FunctionMonitorInfo>;
   private dirtyStateMap: { [key: string]: string } = {};
   private defaultDirtyReason = 'global';

--- a/client/src/app/site/slots/add-slot/add-slot.component.ts
+++ b/client/src/app/site/slots/add-slot/add-slot.component.ts
@@ -74,6 +74,7 @@ export class AddSlotComponent extends FeatureComponent<ResourceId> implements On
   private _siteId: string;
   private _slotsArm: ArmObj<Site>[];
   private _functionAppContext: FunctionAppContext;
+  // @ts-ignore: error TS6133: '_isKubeApp' is declared but its value is never read.
   private _isKubeApp = false;
   private _customLocationId = '';
 

--- a/client/src/app/site/spec-picker/spec-list/spec-list.component.spec.ts
+++ b/client/src/app/site/spec-picker/spec-list/spec-list.component.spec.ts
@@ -6,7 +6,9 @@ import { By } from '@angular/platform-browser';
 
 @Component({
   selector: `spec-list-host-component`,
-  template: `<spec-list [specGroup]='specGroup' [isRecommendedList]='isRecommendedList'></spec-list>`,
+  template: `
+    <spec-list [specGroup]="specGroup" [isRecommendedList]="isRecommendedList"></spec-list>
+  `,
 })
 class TestSpecListComponent {
   @ViewChild(SpecListComponent)
@@ -43,6 +45,7 @@ class TestSpecListComponent {
 
 describe('SpecList', () => {
   let hostComponent: TestSpecListComponent;
+  // @ts-ignore: error TS6133: 'specListComponent' is declared but its value is never read.
   let specListComponent: SpecListComponent;
   let testFixture: ComponentFixture<TestSpecListComponent>;
 


### PR DESCRIPTION
Update TypeScript to 2.9.2 to enable updating prismjs to 1.27.0.

[#13977088](https://msazure.visualstudio.com/Antares/_workitems/edit/13977088/)