### PR TITLE
Adding .NET Framework 4.8 support in Stacks API

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
@@ -11,6 +11,37 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
     preferredOs: 'windows',
     majorVersions: [
       {
+        displayText: '.NET Framework 4.8',
+        value: 'dotnetframework48',
+        minorVersions: [
+          {
+            displayText: '.NET Framework 4.8',
+            value: '4.8',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: 'v4.8',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '4.8.x',
+                },
+                appSettingsDictionary: {
+                  FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated',
+                },
+                siteConfigPropertiesDictionary: {
+                  use32BitWorkerProcess: true,
+                  netFrameworkVersion: 'v4.8',
+                },
+                supportedFunctionsExtensionVersions: ['~4'],
+              },
+            },
+          },
+        ],
+      },
+      {
         displayText: '.NET 7 Isolated',
         value: 'dotnet7isolated',
         minorVersions: [

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
@@ -34,7 +34,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
                 },
                 siteConfigPropertiesDictionary: {
                   use32BitWorkerProcess: true,
-                  netFrameworkVersion: 'v4.8',
+                  netFrameworkVersion: 'v6.0',
                 },
                 supportedFunctionsExtensionVersions: ['~4'],
               },

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
@@ -19,7 +19,8 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
             value: '4.8',
             stackSettings: {
               windowsRuntimeSettings: {
-                runtimeVersion: 'v4.8',
+                runtimeVersion: 'v6.0',
+                isHidden: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,

--- a/server/src/tests/Stacks/2020-10-01/function-app/validations.ts
+++ b/server/src/tests/Stacks/2020-10-01/function-app/validations.ts
@@ -149,7 +149,7 @@ function validateDotnetStack(dotnetStack) {
   expect(dotnetStack.displayText).to.equal('.NET');
   expect(dotnetStack.value).to.equal('dotnet');
   expect(dotnetStack.preferredOs).to.equal('windows');
-  expect(dotnetStack.majorVersions.length).to.equal(7);
+  expect(dotnetStack.majorVersions.length).to.equal(8);
   expect(dotnetStack).to.deep.equal(hardCodedDotnetStack);
 }
 


### PR DESCRIPTION
Resolves Azure/azure-functions-dotnet-worker/issues/994