### PR TITLE
Yutlin Windows Node App Insights Enable OnBD

### DIFF
--- a/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-06-01/stacks/web-app-stacks/Node.ts
@@ -65,7 +65,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
-                isDefaultOff: true,
+                isDefaultOff: false,
               },
               gitHubActionSettings: {
                 isSupported: true,
@@ -103,7 +103,7 @@ export const nodeStack: WebAppStack = {
               remoteDebuggingSupported: false,
               appInsightsSettings: {
                 isSupported: true,
-                isDefaultOff: true,
+                isDefaultOff: false,
               },
               gitHubActionSettings: {
                 isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Node.ts
@@ -66,7 +66,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
-                  isDefaultOff: true,
+                  isDefaultOff: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -103,7 +103,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
-                  isDefaultOff: true,
+                  isDefaultOff: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -141,7 +141,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
-                  isDefaultOff: true,
+                  isDefaultOff: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,


### PR DESCRIPTION
Windows currently has Node as OnBD for App Insights, so updating "isDefaultOff" to keep the current prod behaviour.