### PR TITLE
AB#15709969  Make startup command resizable

### DIFF
--- a/client-react/src/pages/app/app-settings/GeneralSettings/LinuxStacks/LinuxStacks.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/LinuxStacks/LinuxStacks.tsx
@@ -192,6 +192,8 @@ const LinuxStacks: React.FC<PropsType> = props => {
           infoBubbleMessage={t('appCommandLineLabelHelpNoLink')}
           learnMoreLink={Links.linuxContainersLearnMore}
           style={{ marginLeft: '1px', marginTop: '1px' }} // Not sure why but left border disappears without margin and for small windows the top also disappears
+          multiline={true}
+          autoAdjustHeight={true}
         />
       )}
     </>


### PR DESCRIPTION
Fixes [AB#15709969](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s201?workitem=15709969)

Based on custoemr's feedback, we make startup command resizable in case the command is pretty large such as Java fatjar