### PR TITLE
15620874 Remove info banner inside orchestration/Entities tab for durable triggers

### DIFF
--- a/client-react/src/pages/app/functions/function/monitor/tabs/entities/FunctionEntities.tsx
+++ b/client-react/src/pages/app/functions/function/monitor/tabs/entities/FunctionEntities.tsx
@@ -1,16 +1,14 @@
 import React, { useContext, useState } from 'react';
 import { AppInsightsEntityTrace, AppInsightsEntityTraceDetail } from '../../../../../../../models/app-insights';
 import { tableStyle, tabStyle } from '../FunctionMonitorTab.styles';
-import CustomBanner from '../../../../../../../components/CustomBanner/CustomBanner';
 import { useTranslation } from 'react-i18next';
-import { MessageBarType, DetailsListLayoutMode, SelectionMode, ICommandBarItemProps, IColumn, Link, PanelType } from '@fluentui/react';
+import { DetailsListLayoutMode, SelectionMode, ICommandBarItemProps, IColumn, Link, PanelType } from '@fluentui/react';
 import DisplayTableWithCommandBar from '../../../../../../../components/DisplayTableWithCommandBar/DisplayTableWithCommandBar';
 import { openAppInsightsQueryEditor } from '../FunctionMonitorTab.data';
 import { PortalContext } from '../../../../../../../PortalContext';
 import { FunctionEntitiesContext } from './FunctionEntitiesDataLoader';
 import CustomPanel from '../../../../../../../components/CustomPanel/CustomPanel';
 import FunctionEntityDetails from './FunctionEntityDetails';
-import { Links } from '../../../../../../../utils/FwLinks';
 import { getSearchFilter } from '../../../../../../../components/form-controls/SearchBox';
 
 interface FunctionEntitiesProps {
@@ -105,15 +103,6 @@ const FunctionEntities: React.FC<FunctionEntitiesProps> = props => {
 
   return (
     <div id="entities-tab" className={tabStyle}>
-      {/**Durable Functions Extension Message Banner/ */}
-      {!!entityTraces && entityTraces.length === 0 && (
-        <CustomBanner
-          message={t('durableFunctionNoDataFound')}
-          type={MessageBarType.info}
-          learnMoreLink={Links.durableFunctionExtensionLearnMore}
-        />
-      )}
-
       {/*Orchestration Traces Table*/}
       <div>
         <h3>{t('entityTracesTableTitle')}</h3>

--- a/client-react/src/pages/app/functions/function/monitor/tabs/orchestrations/FunctionOrchestrations.tsx
+++ b/client-react/src/pages/app/functions/function/monitor/tabs/orchestrations/FunctionOrchestrations.tsx
@@ -1,16 +1,14 @@
 import React, { useState, useContext } from 'react';
 import { AppInsightsOrchestrationTrace, AppInsightsOrchestrationTraceDetail } from '../../../../../../../models/app-insights';
 import { tableStyle, tabStyle } from '../FunctionMonitorTab.styles';
-import CustomBanner from '../../../../../../../components/CustomBanner/CustomBanner';
 import { useTranslation } from 'react-i18next';
-import { MessageBarType, DetailsListLayoutMode, SelectionMode, ICommandBarItemProps, IColumn, Link, PanelType } from '@fluentui/react';
+import { DetailsListLayoutMode, SelectionMode, ICommandBarItemProps, IColumn, Link, PanelType } from '@fluentui/react';
 import DisplayTableWithCommandBar from '../../../../../../../components/DisplayTableWithCommandBar/DisplayTableWithCommandBar';
 import { openAppInsightsQueryEditor } from '../FunctionMonitorTab.data';
 import { PortalContext } from '../../../../../../../PortalContext';
 import { FunctionOrchestrationsContext } from './FunctionOrchestrationsDataLoader';
 import CustomPanel from '../../../../../../../components/CustomPanel/CustomPanel';
 import FunctionOrchestrationDetails from './FunctionOrchestrationDetails';
-import { Links } from '../../../../../../../utils/FwLinks';
 import { getSearchFilter } from '../../../../../../../components/form-controls/SearchBox';
 
 interface FunctionOrchestrationsProps {
@@ -118,15 +116,6 @@ const FunctionOrchestrations: React.FC<FunctionOrchestrationsProps> = props => {
 
   return (
     <div id="orchestrations-tab" className={tabStyle}>
-      {/**Durable Functions Extension Message Banner/ */}
-      {!!orchestrationTraces && orchestrationTraces.length === 0 && (
-        <CustomBanner
-          message={t('durableFunctionNoDataFound')}
-          type={MessageBarType.info}
-          learnMoreLink={Links.durableFunctionExtensionLearnMore}
-        />
-      )}
-
       {/*Orchestration Traces Table*/}
       <div>
         <h3>{t('orchestrationTracesTableTitle')}</h3>

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2243,7 +2243,6 @@ export class PortalResources {
   public static failedToFetchRepositories = 'failedToFetchRepositories';
   public static failedToFetchTags = 'failedToFetchTags';
   public static entityDetails = 'entityDetails';
-  public static durableFunctionNoDataFound = 'durableFunctionNoDataFound';
   public static pricing_pv2FlexStampCheckboxAriaLabel = 'pricing_pv2FlexStampCheckboxAriaLabel';
   public static pricing_pv2UpsellInfoMessageAriaLabel = 'pricing_pv2UpsellInfoMessageAriaLabel';
   public static pricing_appDensityWarningMessageAriaLabel = 'pricing_appDensityWarningMessageAriaLabel';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -6876,9 +6876,6 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="entityDetails" xml:space="preserve">
         <value>Entity Details</value>
     </data>
-    <data name="durableFunctionNoDataFound" xml:space="preserve">
-        <value>No data found. Please make sure you install the latest Durable Functions extension (.NET) or use V2 of extension bundles.</value>
-    </data>
     <data name="pricing_pv2FlexStampCheckboxAriaLabel" xml:space="preserve">
         <value>Learn more about flex stamps.</value>
     </data>


### PR DESCRIPTION
Remove info message from Orchestrations tab.
**Before:**
<img width="587" alt="image" src="https://user-images.githubusercontent.com/30202258/200088443-c56929c0-9332-4f9d-b324-b418ff9b6a0d.png">

**After:**
<img width="634" alt="image" src="https://user-images.githubusercontent.com/30202258/200088360-c5af1f8c-0d6b-416a-9c9e-603d837366d9.png">
