### PR TITLE
[DC] Show ACR settings only when ACR is selected as registry source

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettings.tsx
@@ -58,7 +58,7 @@ const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<Dep
 
   const isGitHubActionSelected = formProps.values.scmType === ScmType.GitHubAction;
   const isVstsSelected = formProps.values.scmType === ScmType.Vsts;
-  const isAcrConfigured = formProps.values.registrySource === ContainerRegistrySources.acr && !formProps.values.privateRegistryUsername;
+  const isAcrConfigured = formProps.values.registrySource === ContainerRegistrySources.acr;
   const isDockerHubConfigured = formProps.values.registrySource === ContainerRegistrySources.docker;
   const isPrivateRegistryConfigured = formProps.values.registrySource === ContainerRegistrySources.privateRegistry;
 


### PR DESCRIPTION
[FixesAB#16188501](https://msazure.visualstudio.com/Antares/_workitems/edit/16188501)
- Previously, !formProps.values.privateRegistryUsername was used for accessing cross-subscription registries
- But now, we have the subscriptions dropdown in ACR settings, so this condition is no longer needed

**Before:**
![dc acr settings hidden before](https://user-images.githubusercontent.com/29874289/200659772-ddcdb1bc-2680-46cd-8ab5-1d562da28c73.gif)

**After:**
![dc acr settings hidden after](https://user-images.githubusercontent.com/29874289/200659974-039bf7b1-474d-4308-85d4-b3f7f6dd5d07.gif)
