### PR TITLE
Revert "Unhide python 3.10 in stack"

### DIFF
--- a/server/src/stacks/2020-05-01/stacks/function-app-stacks/Python.ts
+++ b/server/src/stacks/2020-05-01/stacks/function-app-stacks/Python.ts
@@ -16,7 +16,7 @@ export const pythonStack: FunctionAppStack = {
           os: 'linux',
           isPreview: true,
           isDeprecated: false,
-          isHidden: false,
+          isHidden: true,
           applicationInsightsEnabled: true,
           runtimeVersion: 'Python|3.10',
           appSettingsDictionary: {

--- a/server/src/stacks/2020-06-01/stacks/function-app-stacks/Python.ts
+++ b/server/src/stacks/2020-06-01/stacks/function-app-stacks/Python.ts
@@ -18,7 +18,7 @@ export const pythonStack: FunctionAppStack = {
               remoteDebuggingSupported: false,
               isPreview: true,
               isDefault: false,
-              isHidden: false,
+              isHidden: true,
               appInsightsSettings: {
                 isSupported: true,
               },

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Python.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Python.ts
@@ -26,7 +26,7 @@ const getPythonStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
                 remoteDebuggingSupported: false,
                 isPreview: true,
                 isDefault: false,
-                isHidden: false,
+                isHidden: true,
                 appInsightsSettings: {
                   isSupported: true,
                 },


### PR DESCRIPTION
Reverts Azure/azure-functions-ux#6895

Reverting this as backend is expected to be ready by Nov end
