### PR TITLE
[DC] Show validation error for username and password onBlur

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenterPublishingUser.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterPublishingUser.tsx
@@ -140,7 +140,7 @@ const DeploymentCenterPublishingUser: React.FC<DeploymentCenterFtpsProps &
         <>
           <Field
             className={textboxStyle}
-            id="deployment-center-ftps-provider-username"
+            id="publishingUsername"
             name="publishingUsername"
             component={TextField}
             label={t('deploymentCenterFtpsUsernameLabel')}
@@ -150,7 +150,7 @@ const DeploymentCenterPublishingUser: React.FC<DeploymentCenterFtpsProps &
           <div className={ftpsPasswordTextboxStyle}>
             <Field
               className={textboxStyle}
-              id="deployment-center-ftps-provider-password"
+              id="publishingPassword"
               name="publishingPassword"
               component={TextField}
               label={t('deploymentCenterFtpsPasswordLabel')}
@@ -171,7 +171,7 @@ const DeploymentCenterPublishingUser: React.FC<DeploymentCenterFtpsProps &
 
             <Field
               className={textboxStyle}
-              id="deployment-center-ftps-provider-confirm-password"
+              id="publishingConfirmPassword"
               name="publishingConfirmPassword"
               component={TextField}
               label={t('deploymentCenterFtpsConfirmPasswordLabel')}

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
@@ -664,12 +664,7 @@ const DeploymentCenterCodeForm: React.FC<DeploymentCenterCodeFormProps> = props 
   };
 
   return (
-    <Formik
-      initialValues={props.formData}
-      onSubmit={onSubmit}
-      enableReinitialize={true}
-      validateOnBlur={false}
-      validationSchema={props.formValidationSchema}>
+    <Formik initialValues={props.formData} onSubmit={onSubmit} enableReinitialize={true} validationSchema={props.formValidationSchema}>
       {(formProps: FormikProps<DeploymentCenterFormData<DeploymentCenterCodeFormData>>) => (
         <form onKeyDown={onKeyDown}>
           <div id="deployment-center-command-bar" className={commandBarSticky}>

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerForm.tsx
@@ -806,7 +806,6 @@ const DeploymentCenterContainerForm: React.FC<DeploymentCenterContainerFormProps
       initialValues={props.formData}
       onSubmit={onSubmit}
       enableReinitialize={true}
-      validateOnBlur={false}
       validateOnChange={false}
       validationSchema={props.formValidationSchema}>
       {(formProps: FormikProps<DeploymentCenterFormData<DeploymentCenterContainerFormData>>) => (


### PR DESCRIPTION
FixesAB#[16065060](https://msazure.visualstudio.com/Antares/_workitems/edit/16065060)
- Changed so that validation happens onBlur
- Error message was not showing under Textfields because getErrorMessage() requires component id and name to be the same
    - May need to do this for other components in Deployment Center to show error messages and make invalid input more transparent

**Before:**
![dc user scope textfield validation before](https://user-images.githubusercontent.com/29874289/201193759-82ed5755-9958-4929-945c-623c0b00e91f.gif)

**After:**
![dc user scope textfield validation after](https://user-images.githubusercontent.com/29874289/201193767-7639698b-8d45-4c7b-95fd-d11248584625.gif)