### PR TITLE
[DC] Validate fields and show error messages onBlur

### DIFF
--- a/client-react/src/components/form-controls/ComboBox.tsx
+++ b/client-react/src/components/form-controls/ComboBox.tsx
@@ -3,6 +3,7 @@ import { FieldProps } from 'formik';
 import get from 'lodash-es/get';
 import { useContext, useEffect, useState } from 'react';
 import { comboBoxSpinnerStyle, loadingComboBoxStyle } from '../../pages/app/deployment-center/DeploymentCenter.styles';
+import { formikOnBlur } from '../../pages/app/deployment-center/utility/DeploymentCenterUtility';
 import { ComboBoxStyles } from '../../theme/CustomOfficeFabric/AzurePortal/ComboBox.styles';
 import { ThemeContext } from '../../ThemeContext';
 import ComboBoxNoFormik from './ComboBoxnoFormik';
@@ -67,11 +68,6 @@ const ComboBox = (props: FieldProps & IComboBoxProps & CustomComboBoxProps) => {
     form.setFieldValue(field.name, undefined);
   };
 
-  const onBlur = (e: any) => {
-    form.setFieldTouched(field.name);
-    field.onBlur(e);
-  };
-
   useEffect(() => {
     if (clearComboBox) {
       form.setFieldValue(field.name, undefined);
@@ -91,7 +87,7 @@ const ComboBox = (props: FieldProps & IComboBoxProps & CustomComboBoxProps) => {
         ariaLabel={props.label}
         options={options}
         onChange={onChange}
-        onBlur={onBlur}
+        onBlur={e => formikOnBlur(e, { field, form })}
         errorMessage={errorMessage}
         styles={ComboBoxStyles(theme)}
         allowFreeform={allowFreeform}

--- a/client-react/src/components/form-controls/ComboBox.tsx
+++ b/client-react/src/components/form-controls/ComboBox.tsx
@@ -67,6 +67,11 @@ const ComboBox = (props: FieldProps & IComboBoxProps & CustomComboBoxProps) => {
     form.setFieldValue(field.name, undefined);
   };
 
+  const onBlur = (e: any) => {
+    form.setFieldTouched(field.name);
+    field.onBlur(e);
+  };
+
   useEffect(() => {
     if (clearComboBox) {
       form.setFieldValue(field.name, undefined);
@@ -86,7 +91,7 @@ const ComboBox = (props: FieldProps & IComboBoxProps & CustomComboBoxProps) => {
         ariaLabel={props.label}
         options={options}
         onChange={onChange}
-        onBlur={field.onBlur}
+        onBlur={onBlur}
         errorMessage={errorMessage}
         styles={ComboBoxStyles(theme)}
         allowFreeform={allowFreeform}

--- a/client-react/src/components/form-controls/DropDown.tsx
+++ b/client-react/src/components/form-controls/DropDown.tsx
@@ -6,6 +6,7 @@ import { Layout } from './ReactiveFormControl';
 import { Spinner, SpinnerSize } from '@fluentui/react';
 import { style } from 'typestyle';
 import { useTranslation } from 'react-i18next';
+import { formikOnBlur } from '../../pages/app/deployment-center/utility/DeploymentCenterUtility';
 
 export interface CustomDropdownProps {
   id: string;
@@ -29,11 +30,6 @@ const Dropdown = (props: FieldProps & IDropdownProps & CustomDropdownProps) => {
   const { field, form, multiSelect, isLoading } = props;
 
   const { t } = useTranslation();
-
-  const onBlur = (e: any) => {
-    form.setFieldTouched(field.name);
-    field.onBlur(e);
-  };
 
   const modeSpecificProps = multiSelect
     ? {
@@ -75,7 +71,7 @@ const Dropdown = (props: FieldProps & IDropdownProps & CustomDropdownProps) => {
 
   return (
     <DropdownNoFormik
-      onBlur={onBlur}
+      onBlur={e => formikOnBlur(e, { field, form })}
       errorMessage={errorMessage}
       // Overriding default dropdown to panel transfer due to many of our dropdown existing in panels
       // https://github.com/OfficeDev/@fluentui/reactcommit/1aa8ab4e9e16ecc17d8e90c1374c0958eba77ee3#diff-406409baf14f369160f322b075e148d4

--- a/client-react/src/components/form-controls/DropDown.tsx
+++ b/client-react/src/components/form-controls/DropDown.tsx
@@ -30,6 +30,11 @@ const Dropdown = (props: FieldProps & IDropdownProps & CustomDropdownProps) => {
 
   const { t } = useTranslation();
 
+  const onBlur = (e: any) => {
+    form.setFieldTouched(field.name);
+    field.onBlur(e);
+  };
+
   const modeSpecificProps = multiSelect
     ? {
         selectedKeys: field.value,
@@ -70,7 +75,7 @@ const Dropdown = (props: FieldProps & IDropdownProps & CustomDropdownProps) => {
 
   return (
     <DropdownNoFormik
-      onBlur={field.onBlur}
+      onBlur={onBlur}
       errorMessage={errorMessage}
       // Overriding default dropdown to panel transfer due to many of our dropdown existing in panels
       // https://github.com/OfficeDev/@fluentui/reactcommit/1aa8ab4e9e16ecc17d8e90c1374c0958eba77ee3#diff-406409baf14f369160f322b075e148d4

--- a/client-react/src/components/form-controls/RadioButton.tsx
+++ b/client-react/src/components/form-controls/RadioButton.tsx
@@ -9,6 +9,7 @@ import { FieldProps } from 'formik';
 import { useCallback } from 'react';
 import { ChoiceGroupStyles, ChoiceGroupVerticalStyles } from '../../theme/CustomOfficeFabric/AzurePortal/ChoiceGroup.styles';
 import RadioButtonNoFormik from './RadioButtonNoFormik';
+import { formikOnBlur } from '../../pages/app/deployment-center/utility/DeploymentCenterUtility';
 
 interface RadioButtonProps {
   id: string;
@@ -36,15 +37,10 @@ const RadioButton: React.FC<IChoiceGroupProps & FieldProps & RadioButtonProps> =
     [field.name, form]
   );
 
-  const onBlur = (e: any) => {
-    form.setFieldTouched(field.name);
-    field.onBlur(e);
-  };
-
   return (
     <RadioButtonNoFormik
       ariaLabelledBy={`${props.id}-label`}
-      onBlur={onBlur}
+      onBlur={e => formikOnBlur(e, { field, form })}
       onChange={onChange}
       options={options}
       selectedKey={field.value}

--- a/client-react/src/components/form-controls/RadioButton.tsx
+++ b/client-react/src/components/form-controls/RadioButton.tsx
@@ -36,9 +36,15 @@ const RadioButton: React.FC<IChoiceGroupProps & FieldProps & RadioButtonProps> =
     [field.name, form]
   );
 
+  const onBlur = (e: any) => {
+    form.setFieldTouched(field.name);
+    field.onBlur(e);
+  };
+
   return (
     <RadioButtonNoFormik
       ariaLabelledBy={`${props.id}-label`}
+      onBlur={onBlur}
       onChange={onChange}
       options={options}
       selectedKey={field.value}

--- a/client-react/src/components/form-controls/TextField.tsx
+++ b/client-react/src/components/form-controls/TextField.tsx
@@ -6,6 +6,7 @@ import TextFieldNoFormik from './TextFieldNoFormik';
 import { Links } from '../../utils/FwLinks';
 import { Layout } from './ReactiveFormControl';
 import { useTranslation } from 'react-i18next';
+import { formikOnBlur } from '../../pages/app/deployment-center/utility/DeploymentCenterUtility';
 
 export interface CustomTextFieldProps {
   id: string;
@@ -32,11 +33,6 @@ const TextField: React.FC<FieldProps & Omit<ITextFieldProps, 'form'> & CustomTex
     field.onChange(e);
   };
 
-  const onBlur = (e: any) => {
-    form.setFieldTouched(field.name);
-    field.onBlur(e);
-  };
-
   const getErrorMessage = () => {
     return get(form.touched, field.name, false) ? cronErrorMessage(get(form.errors, field.name, '') as string) : undefined;
   };
@@ -50,7 +46,15 @@ const TextField: React.FC<FieldProps & Omit<ITextFieldProps, 'form'> & CustomTex
     return errorMessage;
   };
 
-  return <TextFieldNoFormik value={field.value} onBlur={onBlur} errorMessage={getErrorMessage()} onChange={onChange} {...rest} />;
+  return (
+    <TextFieldNoFormik
+      value={field.value}
+      onBlur={e => formikOnBlur(e, { field, form })}
+      errorMessage={getErrorMessage()}
+      onChange={onChange}
+      {...rest}
+    />
+  );
 };
 
 export default TextField;

--- a/client-react/src/components/form-controls/TextField.tsx
+++ b/client-react/src/components/form-controls/TextField.tsx
@@ -32,6 +32,11 @@ const TextField: React.FC<FieldProps & Omit<ITextFieldProps, 'form'> & CustomTex
     field.onChange(e);
   };
 
+  const onBlur = (e: any) => {
+    form.setFieldTouched(field.name);
+    field.onBlur(e);
+  };
+
   const getErrorMessage = () => {
     return get(form.touched, field.name, false) ? cronErrorMessage(get(form.errors, field.name, '') as string) : undefined;
   };
@@ -45,7 +50,7 @@ const TextField: React.FC<FieldProps & Omit<ITextFieldProps, 'form'> & CustomTex
     return errorMessage;
   };
 
-  return <TextFieldNoFormik value={field.value} onBlur={field.onBlur} errorMessage={getErrorMessage()} onChange={onChange} {...rest} />;
+  return <TextFieldNoFormik value={field.value} onBlur={onBlur} errorMessage={getErrorMessage()} onChange={onChange} {...rest} />;
 };
 
 export default TextField;

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterPublishingUser.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterPublishingUser.tsx
@@ -140,7 +140,7 @@ const DeploymentCenterPublishingUser: React.FC<DeploymentCenterFtpsProps &
         <>
           <Field
             className={textboxStyle}
-            id="publishingUsername"
+            id="deployment-center-ftps-provider-username"
             name="publishingUsername"
             component={TextField}
             label={t('deploymentCenterFtpsUsernameLabel')}
@@ -150,7 +150,7 @@ const DeploymentCenterPublishingUser: React.FC<DeploymentCenterFtpsProps &
           <div className={ftpsPasswordTextboxStyle}>
             <Field
               className={textboxStyle}
-              id="publishingPassword"
+              id="deployment-center-ftps-provider-password"
               name="publishingPassword"
               component={TextField}
               label={t('deploymentCenterFtpsPasswordLabel')}
@@ -171,7 +171,7 @@ const DeploymentCenterPublishingUser: React.FC<DeploymentCenterFtpsProps &
 
             <Field
               className={textboxStyle}
-              id="publishingConfirmPassword"
+              id="deployment-center-ftps-provider-confirm-password"
               name="publishingConfirmPassword"
               component={TextField}
               label={t('deploymentCenterFtpsConfirmPasswordLabel')}

--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
@@ -19,7 +19,7 @@ import { ArmSiteDescriptor } from '../../../../utils/resourceDescriptors';
 import { PublishingCredentials } from '../../../../models/site/publish';
 import { LogLevel, TelemetryInfo } from '../../../../models/telemetry';
 import { LogCategories } from '../../../../utils/LogCategories';
-import { FormikProps } from 'formik';
+import { FieldProps, FormikProps } from 'formik';
 import { IDeploymentCenterContext } from '../DeploymentCenterContext';
 import { CommonConstants } from '../../../../utils/CommonConstants';
 import { deploymentCenterDescriptionTextStyle } from '../DeploymentCenter.styles';
@@ -478,3 +478,9 @@ export const getDescriptionSection = (source: string, description: string, learn
 };
 
 export const optionsSortingFunction = (a: ISelectableOption, b: ISelectableOption) => a.text.localeCompare(b.text);
+
+export function formikOnBlur<T>(e: React.FocusEvent<T>, props: FieldProps) {
+  const { field, form } = props;
+  form.setFieldTouched(field.name);
+  field.onBlur(e);
+}


### PR DESCRIPTION
Task#[16260609](https://msazure.visualstudio.com/Antares/_workitems/edit/16260609)

**Notes:**
Currently, Formik seems to store form.touched() using the component's id as keys instead of its field name. This is because the field name is not being passed into the native Fluent UI components (some of which don't have a "name" attribute). This causes the getErrorMessage on these Formik components to not find the right form.errors() and display the error message. This could be mitigated by upgrading from Formik 1 to Formik 2 (however this will need to be discussed). For now, passing in a custom onBlur function to manually set the field as touched.

**Code Form GHA: ComboBox**
![dc formik validation gha](https://user-images.githubusercontent.com/29874289/203175858-1660c813-e029-4073-b11c-8ac3af7d04ae.gif)

**Code Form External Git: TextField**
![dc formik validation external git](https://user-images.githubusercontent.com/29874289/203175863-88201ce6-96de-4225-aec4-3176578f03f0.gif)

**Container Form ACR: TextField**
![dc formik validation container](https://user-images.githubusercontent.com/29874289/203175881-57254271-e924-4d1e-bacf-87e409587c95.gif)

**Container Function App: TextField**
![image](https://user-images.githubusercontent.com/29874289/203175497-0f315754-823d-43ab-bbc7-0af951d715bf.png)
