### PR TITLE
15492872Show Orchestration/Entity tab as the first tab and track AI query edit visit on Orchestrations tab

### DIFF
--- a/client-react/src/pages/app/functions/function/monitor/FunctionMonitor.tsx
+++ b/client-react/src/pages/app/functions/function/monitor/FunctionMonitor.tsx
@@ -45,7 +45,7 @@ const FunctionMonitor: React.FC<FunctionMonitorProps> = props => {
   const portalContext = useContext(PortalContext);
   const theme = useContext(ThemeContext);
 
-  const [pivotStateKey, setPivotStateKey] = useState<PivotState>(PivotState.invocations);
+  const [pivotStateKey, setPivotStateKey] = useState<PivotState>();
 
   const armFunctionDescriptor = new ArmFunctionDescriptor(resourceId);
 
@@ -136,14 +136,6 @@ const FunctionMonitor: React.FC<FunctionMonitorProps> = props => {
   return (
     <div style={paddingStyle}>
       <Pivot getTabId={getPivotTabId} selectedKey={pivotStateKey} onLinkClick={onPivotItemClicked}>
-        <PivotItem itemKey={PivotState.invocations} headerText={t('functionMonitor_invocations')}>
-          <FunctionInvocationsDataLoader
-            resourceId={resourceId}
-            appInsightsAppId={appInsightsComponent.properties.AppId}
-            appInsightsResourceId={appInsightsComponent.id}
-            appInsightsToken={appInsightsToken}
-          />
-        </PivotItem>
         {isOrchestrationTrigger() && (
           <PivotItem itemKey={PivotState.orchestration} headerText={t('functionMonitor_orchestrations')}>
             <FunctionOrchestrationsDataLoader
@@ -164,6 +156,14 @@ const FunctionMonitor: React.FC<FunctionMonitorProps> = props => {
             />
           </PivotItem>
         )}
+        <PivotItem itemKey={PivotState.invocations} headerText={t('functionMonitor_invocations')}>
+          <FunctionInvocationsDataLoader
+            resourceId={resourceId}
+            appInsightsAppId={appInsightsComponent.properties.AppId}
+            appInsightsResourceId={appInsightsComponent.id}
+            appInsightsToken={appInsightsToken}
+          />
+        </PivotItem>
         <PivotItem itemKey={PivotState.logs} headerText={t('functionMonitor_logs')}>
           <FunctionLogsDataLoader resourceId={resourceId} />
         </PivotItem>

--- a/client-react/src/pages/app/functions/function/monitor/tabs/orchestrations/FunctionOrchestrations.tsx
+++ b/client-react/src/pages/app/functions/function/monitor/tabs/orchestrations/FunctionOrchestrations.tsx
@@ -10,6 +10,7 @@ import { FunctionOrchestrationsContext } from './FunctionOrchestrationsDataLoade
 import CustomPanel from '../../../../../../../components/CustomPanel/CustomPanel';
 import FunctionOrchestrationDetails from './FunctionOrchestrationDetails';
 import { getSearchFilter } from '../../../../../../../components/form-controls/SearchBox';
+import { getTelemetryInfo } from '../../../../../../../utils/TelemetryUtils';
 
 interface FunctionOrchestrationsProps {
   functionResourceId: string;
@@ -42,12 +43,19 @@ const FunctionOrchestrations: React.FC<FunctionOrchestrationsProps> = props => {
     return [
       {
         key: 'orchestrations-run-query',
-        onClick: () =>
+        onClick: () => {
+          portalContext.log(
+            getTelemetryInfo('info', 'openMonitorBlade', 'clickAiQueryEditorOnOrchestrationsTab', {
+              resourceId: functionResourceId,
+              message: 'Opening App Insights Query editor from Orchestrations tab.',
+            })
+          );
           openAppInsightsQueryEditor(
             portalContext,
             appInsightsResourceId,
             orchestrationsContext.formOrchestrationTracesQuery(functionResourceId)
-          ),
+          );
+        },
         iconProps: { iconName: 'LineChart' },
         name: t('runQueryInApplicationInsights'),
         ariaLabel: t('runQueryInApplicationInsights'),


### PR DESCRIPTION
If it is Orchestrator or Entity function, we would like to display "Orchestrations/Entity" tabs as the first tab all the time.

Also, I added a log to keep track how many people clicked AI query editor on Orchestrations tab.

![image](https://user-images.githubusercontent.com/30202258/203184708-768a8c5f-b7f9-4321-b924-dfc396d99994.png)
