### PR TITLE
16474792 Remove '\' that implies a directory structure inside a Function

### DIFF
--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditorFileSelectorBar.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditorFileSelectorBar.tsx
@@ -7,6 +7,7 @@ import { ArmObj } from '../../../../../models/arm-obj';
 import { FunctionInfo } from '../../../../../models/functions/function-info';
 import StringUtils from '../../../../../utils/string';
 import { fileSelectorStackStyle, fileSelectorDropdownStyle } from './FunctionEditor.styles';
+import { isNewProgrammingModel } from './useFunctionEditorQueries';
 
 export interface FunctionEditorFileSelectorBarProps {
   fileDropdownOptions: IDropdownOption[];
@@ -25,17 +26,22 @@ const FunctionEditorFileSelectorBar: React.FC<FunctionEditorFileSelectorBarProps
   const { functionAppNameLabel, fileDropdownOptions, fileDropdownSelectedKey, onChangeDropdown, functionInfo, disabled } = props;
   const { t } = useTranslation();
   const theme = useContext(ThemeContext);
+  const isNewProgramming = isNewProgrammingModel(functionInfo);
 
   return (
     <>
       <Stack horizontal className={fileSelectorStackStyle(theme)}>
-        {!!functionAppNameLabel && (
-          <>
-            <Label>{functionAppNameLabel}</Label>
-            <Label className={fileSeparatorStyle}>{StringUtils.fileSeparator}</Label>
-          </>
+        {isNewProgramming ? (
+          <Label className={fileSeparatorStyle}>{functionAppNameLabel}</Label>
+        ) : (
+          !!functionAppNameLabel && (
+            <>
+              <Label>{functionAppNameLabel}</Label>
+              <Label className={fileSeparatorStyle}>{StringUtils.fileSeparator}</Label>
+            </>
+          )
         )}
-        {!!functionInfo && (
+        {!isNewProgramming && !!functionInfo && (
           <>
             <Label>{functionInfo.properties.name}</Label>
             <Label className={fileSeparatorStyle}>{StringUtils.fileSeparator}</Label>

--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditorFileSelectorBar.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditorFileSelectorBar.tsx
@@ -31,25 +31,15 @@ const FunctionEditorFileSelectorBar: React.FC<FunctionEditorFileSelectorBarProps
   return (
     <>
       <Stack horizontal className={fileSelectorStackStyle(theme)}>
-        {functionAppNameLabel ? (
-          isNewProgramming ? (
-            <Label className={fileSeparatorStyle}>{functionAppNameLabel}</Label>
-          ) : (
-            <>
-              <Label>{functionAppNameLabel}</Label>
-              <Label className={fileSeparatorStyle}>{StringUtils.fileSeparator}</Label>
-            </>
-          )
+        {isNewProgramming ? (
+          <Label className={fileSeparatorStyle}>{functionAppNameLabel}</Label>
         ) : (
-          <></>
-        )}
-        {!isNewProgramming && !!functionInfo ? (
           <>
-            <Label>{functionInfo.properties.name}</Label>
+            <Label>{functionAppNameLabel}</Label>
+            <Label className={fileSeparatorStyle}>{StringUtils.fileSeparator}</Label>
+            <Label>{functionInfo?.properties.name}</Label>
             <Label className={fileSeparatorStyle}>{StringUtils.fileSeparator}</Label>
           </>
-        ) : (
-          <></>
         )}
         <OfficeDropdown
           id="fucntion-editor-file-selector"

--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditorFileSelectorBar.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditorFileSelectorBar.tsx
@@ -41,11 +41,13 @@ const FunctionEditorFileSelectorBar: React.FC<FunctionEditorFileSelectorBarProps
             </>
           )
         )}
-        {!isNewProgramming && !!functionInfo && (
+        {!isNewProgramming && !!functionInfo ? (
           <>
             <Label>{functionInfo.properties.name}</Label>
             <Label className={fileSeparatorStyle}>{StringUtils.fileSeparator}</Label>
           </>
+        ) : (
+          <></>
         )}
         <OfficeDropdown
           id="fucntion-editor-file-selector"

--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditorFileSelectorBar.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditorFileSelectorBar.tsx
@@ -31,15 +31,17 @@ const FunctionEditorFileSelectorBar: React.FC<FunctionEditorFileSelectorBarProps
   return (
     <>
       <Stack horizontal className={fileSelectorStackStyle(theme)}>
-        {isNewProgramming ? (
-          <Label className={fileSeparatorStyle}>{functionAppNameLabel}</Label>
-        ) : (
-          !!functionAppNameLabel && (
+        {functionAppNameLabel ? (
+          isNewProgramming ? (
+            <Label className={fileSeparatorStyle}>{functionAppNameLabel}</Label>
+          ) : (
             <>
               <Label>{functionAppNameLabel}</Label>
               <Label className={fileSeparatorStyle}>{StringUtils.fileSeparator}</Label>
             </>
           )
+        ) : (
+          <></>
         )}
         {!isNewProgramming && !!functionInfo ? (
           <>


### PR DESCRIPTION
For new Programming mode, we are removing '\' since it should not implies a directory structure.

**New Programming model:**
![image](https://user-images.githubusercontent.com/30202258/208729120-78ca033b-3f6a-450d-a726-247de8db148f.png)
