### PR TITLE
[DC] Add Go support in runtime stack options and remove GHA support

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -77,6 +77,7 @@ export enum RuntimeStackOptions {
   AspDotNet = 'asp.net',
   Dotnet = 'dotnet',
   DotnetIsolated = 'dotnet-isolated',
+  Go = 'go',
 }
 
 export enum RuntimeStackDisplayNames {
@@ -91,6 +92,7 @@ export enum RuntimeStackDisplayNames {
   AspDotNet = 'ASP.NET',
   Dotnet = '.NET',
   DotnetIsolated = '.Net Isolated',
+  Go = 'Go',
 }
 
 export enum RuntimeVersionOptions {

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildCallout.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeBuildCallout.tsx
@@ -28,6 +28,7 @@ const DeploymentCenterCodeBuildCallout: React.FC<DeploymentCenterCodeBuildCallou
   const isGitHubActionEnabled =
     runtimeStack.toLocaleLowerCase() !== RuntimeStackOptions.Ruby &&
     !(runtimeStack.toLocaleLowerCase() == RuntimeStackOptions.PHP && !siteStateContext.isLinuxApp && !runtimeVersion) &&
+    runtimeStack.toLocaleLowerCase() !== RuntimeStackOptions.Go &&
     !deploymentCenterContext.isIlbASE;
 
   const isKuduDisabled = () => {

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSourceAndBuild.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSourceAndBuild.tsx
@@ -149,13 +149,13 @@ const DeploymentCenterCodeSourceAndBuild: React.FC<DeploymentCenterFieldProps<De
 
   const setSourceBuildProvider = () => {
     if (formProps.values.sourceProvider === ScmType.GitHub) {
-      //Note (stpelleg): Need to disable GitHub Actions for Ruby, PHP (Windows), and ILB ASE as we do not support it
+      //Note (stpelleg): Need to disable GitHub Actions for Ruby, PHP (Windows), Go, and ILB ASE as we do not support it
       if (
-        (!!defaultStackAndVersion && defaultStackAndVersion.runtimeStack.toLocaleLowerCase() === RuntimeStackOptions.Ruby) ||
-        (!!defaultStackAndVersion &&
-          defaultStackAndVersion.runtimeStack.toLocaleLowerCase() === RuntimeStackOptions.PHP &&
+        defaultStackAndVersion?.runtimeStack.toLocaleLowerCase() === RuntimeStackOptions.Ruby ||
+        (defaultStackAndVersion?.runtimeStack.toLocaleLowerCase() === RuntimeStackOptions.PHP &&
           !defaultStackAndVersion.runtimeVersion &&
           !siteStateContext.isLinuxApp) ||
+        defaultStackAndVersion?.runtimeStack.toLocaleLowerCase() === RuntimeStackOptions.Go ||
         deploymentCenterContext.isIlbASE
       ) {
         setSelectedBuild(BuildProvider.AppServiceBuildService);

--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
@@ -440,6 +440,8 @@ export const getRuntimeStackDisplayName = (stack: string) => {
       return RuntimeStackDisplayNames.Dotnet;
     case RuntimeStackOptions.DotnetIsolated:
       return RuntimeStackDisplayNames.DotnetIsolated;
+    case RuntimeStackOptions.Go:
+      return RuntimeStackDisplayNames.Go;
     default:
       return '';
   }


### PR DESCRIPTION
FixesAB#[16946068](https://msazure.visualstudio.com/Antares/_workitems/edit/16946068)

**Before:**
![image](https://user-images.githubusercontent.com/29874289/216414446-f0e658f0-f779-4d4f-b9f3-c32bdf499f07.png)

**After:**
Populating runtime information 
![image](https://user-images.githubusercontent.com/29874289/216414638-8b2f0370-8234-4f27-9d70-a0c0030142c0.png)

But for now, removing GHA support for Go runtimes until we have a workflow file
![image](https://user-images.githubusercontent.com/29874289/216415095-49efedf3-4041-4c5b-a6ef-dc467463750c.png)
