### PR TITLE
Update Node.ts

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Node.ts
@@ -186,6 +186,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDat
             stackSettings: {
               windowsRuntimeSettings: {
                 runtimeVersion: '~12',
+                isDeprecated: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -206,6 +207,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDat
               },
               linuxRuntimeSettings: {
                 runtimeVersion: 'Node|12',
+                isDeprecated: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,


### PR DESCRIPTION
adding `isDeprecated: true` to Node 12, which reached EOL last year.

