### PR TITLE
[Custom Error Pages] Fixes Dirty Error Pages

### DIFF
--- a/client-react/src/pages/app/app-settings/ErrorPages/ErrorPageGrid.tsx
+++ b/client-react/src/pages/app/app-settings/ErrorPages/ErrorPageGrid.tsx
@@ -44,11 +44,11 @@ const ErrorPageGrid: React.FC<FormikProps<AppSettingsFormValues>> = props => {
   const addEditItem = React.useCallback(
     (item: FormErrorPage, file: string, key: number) => {
       const errorPages: FormErrorPage[] = [...values.errorPages];
+      item.content = file;
       const index = errorPages.findIndex(x => x.key == key);
       if (index > -1) {
         errorPages[index] = item;
       } else {
-        item.content = file;
         item.status = t('errorPage_columnStatus_configured');
         errorPages.push(item);
       }


### PR DESCRIPTION
The bug was if you uploaded a file and error Page was already configured, it the save button would still be disabled. 

<img width="1037" alt="Screenshot 2023-03-15 at 1 15 44 PM" src="https://user-images.githubusercontent.com/45466137/225404918-90de441b-f36a-4d41-9165-c873251408e1.png">
<img width="1034" alt="Screenshot 2023-03-15 at 1 15 53 PM" src="https://user-images.githubusercontent.com/45466137/225404964-39e56c7a-88de-4ccc-a1db-467b65181b93.png">
