### PR TITLE
[DC] Fix aria label for sync command and add show password aria labels for FTPS and User Scope credentials

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
@@ -188,11 +188,11 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
   const getRedeployButton = (): ICommandBarItemProps => {
     return {
       key: 'redeploy',
-      name: t('deploymentCenterRedeploy'),
+      name: t('deploymentCenterSync'),
       iconProps: {
         iconName: 'Redeploy',
       },
-      ariaLabel: t('deploymentCenterRedeployAriaLabel'),
+      ariaLabel: t('deploymentCenterSyncCommandAriaLabel'),
       disabled: isRedeployDisabled(),
       onClick: onRedeployClick,
     };

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFtps.tsx
@@ -157,6 +157,8 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
             copyButton={true}
             readOnly={true}
             type={TextFieldType.password}
+            canRevealPassword
+            revealPasswordAriaLabel={t('showApplicationPasswordAriaLabel')}
             additionalControls={[
               <ActionButton
                 id="deployment-center-ftps-application-password-reset"

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterPublishingUser.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterPublishingUser.tsx
@@ -178,6 +178,8 @@ const DeploymentCenterPublishingUser: React.FC<DeploymentCenterFtpsProps &
               component={TextField}
               label={t('deploymentCenterFtpsConfirmPasswordLabel')}
               type={TextFieldType.password}
+              canRevealPassword
+              revealPasswordAriaLabel={t('showProviderConfirmPasswordAriaLabel')}
               widthOverride={'100%'}
             />
           </div>

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterPublishingUser.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterPublishingUser.tsx
@@ -155,6 +155,8 @@ const DeploymentCenterPublishingUser: React.FC<DeploymentCenterFtpsProps &
               component={TextField}
               label={t('deploymentCenterFtpsPasswordLabel')}
               type={TextFieldType.password}
+              canRevealPassword
+              revealPasswordAriaLabel={t('showProviderPasswordAriaLabel')}
               widthOverride={'100%'}
               additionalControls={[
                 <ActionButton

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2004,8 +2004,7 @@ export class PortalResources {
   public static deploymentCenterPublishProfileCommandAriaLabel = 'deploymentCenterPublishProfileCommandAriaLabel';
   public static deploymentCenterRefreshCommandAriaLabel = 'deploymentCenterRefreshCommandAriaLabel';
   public static deploymentCenterSyncCommandAriaLabel = 'deploymentCenterSyncCommandAriaLabel';
-  public static deploymentCenterRedeployAriaLabel = 'deploymentCenterRedeployAriaLabel';
-  public static deploymentCenterRedeploy = 'deploymentCenterRedeploy';
+  public static deploymentCenterSync = 'deploymentCenterSync';
   public static deploymentCenterErrorFetchingInfo = 'deploymentCenterErrorFetchingInfo';
   public static deploymentCenterSettingsConfiguredViewUserNotAuthorized = 'deploymentCenterSettingsConfiguredViewUserNotAuthorized';
   public static deploymentCenterVstsInfoMessage = 'deploymentCenterVstsInfoMessage';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -6183,10 +6183,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="deploymentCenterSyncCommandAriaLabel" xml:space="preserve">
         <value>Deployment center sync command</value>
     </data>
-    <data name="deploymentCenterRedeployAriaLabel" xml:space="preserve">
-        <value>Deployment center redeploy command</value>
-    </data>
-    <data name="deploymentCenterRedeploy" xml:space="preserve">
+    <data name="deploymentCenterSync" xml:space="preserve">
         <value>Sync</value>
     </data>
     <data name="deploymentCenterErrorFetchingInfo" xml:space="preserve">


### PR DESCRIPTION
FixesAB#[17455444 ](https://msazure.visualstudio.com/Antares/_workitems/edit/17455444) and [17436506](https://msazure.visualstudio.com/Antares/_workitems/edit/17436506)

- Aria label was calling Sync command Redeploy command
- Added canRevealPassword and revealPasswordAriaLabel to password textfields 
- NOTE: Fluent does not have a method for adding hidePasswordAriaLabel
