### PR TITLE
chore: Update ESLint configuration for PR builds

### DIFF
--- a/client-react/.eslintrc.js
+++ b/client-react/.eslintrc.js
@@ -17,14 +17,9 @@ module.exports = {
   rules: {
     '@typescript-eslint/no-explicit-any': ['warn', { ignoreRestArgs: true }],
     '@typescript-eslint/no-inferrable-types': ['error', { ignoreParameters: true }],
+    '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
     'react/jsx-uses-react': 'off',
     'react/react-in-jsx-scope': 'off',
     'no-bitwise': 'warn',
-
-    /** @todo Fix lint errors */
-    '@typescript-eslint/ban-types': 'warn',
-    '@typescript-eslint/no-empty-function': 'warn',
-    '@typescript-eslint/no-unused-vars': ['warn', { ignoreRestSiblings: true }],
-    'react-hooks/rules-of-hooks': 'warn',
   },
 };

--- a/client-react/package.json
+++ b/client-react/package.json
@@ -41,7 +41,7 @@
     "test:ci": "react-app-rewired test --coverage --reporters default --reporters=jest-junit",
     "test:debug": "react-app-rewired --inspect-brk test --no-cache --verbose=false --runInBand",
     "analyze": "react-app-rewired build --stats && webpack-bundle-analyzer build/bundle-stats.json -m static -r build/bundle-stats.html -O",
-    "lint": "eslint --ext .tsx,.ts src --format visualstudio"
+    "lint": "eslint --ext .tsx,.ts src --format visualstudio --quiet"
   },
   "devDependencies": {
     "@types/applicationinsights-js": "^1.0.9",

--- a/client-react/src/ApiHelpers/ACRService.ts
+++ b/client-react/src/ApiHelpers/ACRService.ts
@@ -108,7 +108,7 @@ export default class ACRService {
     do {
       nextLink = '';
       const requestUrl = `${url}${pageableRequest}`;
-      const pageResponse = await this._sendSpecificACRRequest<T>(portalContext, data, requestUrl, method, headers);
+      const pageResponse = await this._sendSpecificACRRequest(portalContext, data, requestUrl, method, headers);
       if (isPortalCommunicationStatusSuccess(pageResponse.status)) {
         acrObjectList.push(pageResponse.result.content);
         const headers: string[] = pageResponse.result?.headers?.split(CommonConstants.newlineRegex) ?? [];
@@ -129,7 +129,7 @@ export default class ACRService {
     return acrObjectList;
   }
 
-  private static _sendSpecificACRRequest = async <T>(
+  private static _sendSpecificACRRequest = async (
     portalContext: PortalCommunicator,
     data: any,
     url: string,

--- a/client-react/src/ApiHelpers/AppKeysService.ts
+++ b/client-react/src/ApiHelpers/AppKeysService.ts
@@ -30,7 +30,7 @@ export default class AppKeyService {
 
   public static deleteKey = (resourceId: string, keyName: string, keyType: AppKeysTypes) => {
     const id = `${resourceId}/host/default/${keyType}/${keyName}`;
-    return MakeArmCall<{}>({
+    return MakeArmCall<void>({
       resourceId: id,
       commandName: 'deleteAppKey',
       method: 'DELETE',

--- a/client-react/src/ApiHelpers/KeyVaultService.ts
+++ b/client-react/src/ApiHelpers/KeyVaultService.ts
@@ -9,6 +9,6 @@ export default class KeyVaultService {
       subscriptions: [subscriptionId],
       query: queryString,
     };
-    return MakeAzureResourceGraphCall<ArmObj<{}>>(request, 'fetchKeyVaultReference');
+    return MakeAzureResourceGraphCall<ArmObj<Record<string, any>>>(request, 'fetchKeyVaultReference');
   };
 }

--- a/client-react/src/ApiHelpers/SiteService.ts
+++ b/client-react/src/ApiHelpers/SiteService.ts
@@ -174,7 +174,7 @@ export default class SiteService {
       ? `${resourceId}/sourcecontrols/web`
       : `${resourceId}/sourcecontrols/web/?additionalFlags=ScmGitHubActionSkipWorkflowDelete`;
 
-    return MakeArmCall<{}>({
+    return MakeArmCall<void>({
       resourceId: id,
       commandName: 'deleteSourceControl',
       method: 'DELETE',

--- a/client-react/src/ApiHelpers/static-site/EnvironmentService.ts
+++ b/client-react/src/ApiHelpers/static-site/EnvironmentService.ts
@@ -1,7 +1,7 @@
 import MakeArmCall from '../ArmHelper';
 import { CommonConstants } from '../../utils/CommonConstants';
 import { Environment } from '../../models/static-site/environment';
-import { Function } from '../../models/static-site/function';
+import { Function as StaticSiteFunction } from '../../models/static-site/function';
 import { ArmObj, ArmArray } from '../../models/arm-obj';
 import { KeyValue } from '../../models/portal-models';
 
@@ -35,7 +35,7 @@ export default class EnvironmentService {
   };
 
   public static fetchFunctions = (resourceId: string) => {
-    return MakeArmCall<ArmArray<Function>>({
+    return MakeArmCall<ArmArray<StaticSiteFunction>>({
       resourceId: `${resourceId}/functions`,
       commandName: 'fetchFunctions',
       method: 'GET',

--- a/client-react/src/components/CustomPanel/CustomPanel.tsx
+++ b/client-react/src/components/CustomPanel/CustomPanel.tsx
@@ -8,7 +8,7 @@ import { closeButtonStyle, closeButtonSvgStyle, panelBodyStyle, panelHeaderStyle
 type IPanelPropsReduced = Pick<IPanelProps, Exclude<keyof IPanelProps, 'styles' | 'closeButtonAriaLabel' | 'onRenderNavigationContent'>>;
 
 interface CustomPanelProps {
-  customStyle?: {};
+  customStyle?: any;
   headerContent?: JSX.Element;
   overlay?: boolean;
 }
@@ -18,11 +18,7 @@ const CustomPanel: React.SFC<CustomPanelProps & IPanelPropsReduced> = props => {
   const theme = useContext(ThemeContext);
   const { t } = useTranslation();
 
-  let allPanelStyle = panelStyle;
-
-  if (customStyle) {
-    allPanelStyle = Object.assign(panelStyle, customStyle);
-  }
+  const allPanelStyle = { ...panelStyle, ...customStyle };
 
   const onRenderNavigationContent = panelProps => {
     const onClick = panelProps.onDismiss && (() => panelProps.onDismiss());

--- a/client-react/src/components/CustomPanel/CustomPanel.tsx
+++ b/client-react/src/components/CustomPanel/CustomPanel.tsx
@@ -1,4 +1,4 @@
-import { IPanelProps, Overlay, Panel, PanelType } from '@fluentui/react';
+import { IPanelProps, IPanelStyles, Overlay, Panel, PanelType } from '@fluentui/react';
 import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as CloseSvg } from '../../images/Common/close.svg';
@@ -8,7 +8,7 @@ import { closeButtonStyle, closeButtonSvgStyle, panelBodyStyle, panelHeaderStyle
 type IPanelPropsReduced = Pick<IPanelProps, Exclude<keyof IPanelProps, 'styles' | 'closeButtonAriaLabel' | 'onRenderNavigationContent'>>;
 
 interface CustomPanelProps {
-  customStyle?: any;
+  customStyle?: Partial<IPanelStyles>;
   headerContent?: JSX.Element;
   overlay?: boolean;
 }
@@ -18,7 +18,11 @@ const CustomPanel: React.SFC<CustomPanelProps & IPanelPropsReduced> = props => {
   const theme = useContext(ThemeContext);
   const { t } = useTranslation();
 
-  const allPanelStyle = { ...panelStyle, ...customStyle };
+  let allPanelStyle = panelStyle;
+
+  if (customStyle) {
+    allPanelStyle = Object.assign(panelStyle, customStyle);
+  }
 
   const onRenderNavigationContent = panelProps => {
     const onClick = panelProps.onDismiss && (() => panelProps.onDismiss());

--- a/client-react/src/components/ErrorLogger.tsx
+++ b/client-react/src/components/ErrorLogger.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PortalCommunicator from '../portal-communicator';
 import { PortalContext } from '../PortalContext';
 
-export default class ErrorLogger extends React.Component<{}, {}> {
+export default class ErrorLogger extends React.Component<{ children?: React.ReactNode }> {
   public static contextType = PortalContext;
   public context!: PortalCommunicator;
 

--- a/client-react/src/components/MarkdownComponents/MarkdownComponents.tsx
+++ b/client-react/src/components/MarkdownComponents/MarkdownComponents.tsx
@@ -5,7 +5,7 @@ import IconButton from '../IconButton/IconButton';
 import { TextUtilitiesService } from '../../utils/textUtilities';
 import { WorkerRuntimeLanguages } from '../../utils/CommonConstants';
 
-export const MarkdownHighlighter: React.FC<{}> = props => {
+export const MarkdownHighlighter: React.FC = props => {
   const theme = useContext(ThemeContext);
   const copyToClipboard = () => {
     TextUtilitiesService.copyContentToClipboard((props.children as string) || '');

--- a/client-react/src/components/form-controls/SearchBox.tsx
+++ b/client-react/src/components/form-controls/SearchBox.tsx
@@ -23,7 +23,9 @@ export const getSearchFilter = (
       styles={filterTextFieldStyle}
       disabled={disabled}
       autoFocus={autoFocus}
-      onSearch={() => {}}
+      onSearch={() => {
+        /** @note (joechung): Ignore Enter key press. */
+      }}
     />
   );
 };

--- a/client-react/src/pages/app/app-settings/AppSettings.types.ts
+++ b/client-react/src/pages/app/app-settings/AppSettings.types.ts
@@ -30,7 +30,7 @@ export interface FormAzureStorageMounts extends AzureStorageMount {
 }
 
 export interface FormErrorPage {
-  key: number;
+  key: string;
   errorCode: string;
   status: string;
   content?: string;

--- a/client-react/src/pages/app/app-settings/AppSettings.types.ts
+++ b/client-react/src/pages/app/app-settings/AppSettings.types.ts
@@ -30,7 +30,7 @@ export interface FormAzureStorageMounts extends AzureStorageMount {
 }
 
 export interface FormErrorPage {
-  key: string;
+  key: number;
   errorCode: string;
   status: string;
   content?: string;

--- a/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
+++ b/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
@@ -261,7 +261,7 @@ export function getFormErrorPages(errorPage: ArmArray<ErrorPage> | null) {
     errorPage.value.map(value => ({
       status: 'Configured',
       key: Number(value.properties.statusCode),
-      errorCode: value.properties.statusCode,
+      errorCode: String(value.properties.statusCode),
     }))
   );
 }

--- a/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
+++ b/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
@@ -258,9 +258,9 @@ export function getFormErrorPages(errorPage: ArmArray<ErrorPage> | null) {
   }
 
   return sortBy(
-    Object.values(errorPage.value).map(value => ({
+    errorPage.value.map(value => ({
       status: 'Configured',
-      key: value.properties.statusCode,
+      key: Number(value.properties.statusCode),
       errorCode: value.properties.statusCode,
     }))
   );

--- a/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
+++ b/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
@@ -258,10 +258,10 @@ export function getFormErrorPages(errorPage: ArmArray<ErrorPage> | null) {
   }
 
   return sortBy(
-    Object.entries(errorPage.value).map(([key, value]) => ({
+    Object.values(errorPage.value).map(value => ({
       status: 'Configured',
-      key: errorPage.value[key].properties.statusCode,
-      errorCode: String(errorPage.value[key].properties.statusCode),
+      key: value.properties.statusCode,
+      errorCode: value.properties.statusCode,
     }))
   );
 }

--- a/client-react/src/pages/app/app-settings/ErrorPages/ErrorPageFileUpload.tsx
+++ b/client-react/src/pages/app/app-settings/ErrorPages/ErrorPageFileUpload.tsx
@@ -35,7 +35,7 @@ const ErrorPageFileUploader: React.FC<ErrorPageFileUploaderProps> = props => {
     }
   };
 
-  const onGetErrorMessage = (value: string) => {
+  const onGetErrorMessage = () => {
     if (!fileUploadSuccess) {
       return errorMsg;
     }

--- a/client-react/src/pages/app/app-settings/GeneralSettings/Platform.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/Platform.tsx
@@ -109,7 +109,9 @@ const Platform: React.FC<FormikProps<AppSettingsFormValues>> = props => {
       {scenarioChecker.checkScenario(ScenarioIds.ftpStateSupported, { site }).status !== 'disabled' &&
         (disableFtp() ? (
           <DropdownNoFormik
-            onChange={() => {}}
+            onChange={() => {
+              /** @note (joechung): Ignore selection change since there is only a single option. */
+            }}
             infoBubbleMessage={t('ftpDisabledByPolicy')}
             learnMoreLink={Links.ftpDisabledByPolicyLink}
             label={t('ftpState')}

--- a/client-react/src/pages/app/app-settings/GeneralSettings/stacks/function-app/FunctionAppStackSettings.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/stacks/function-app/FunctionAppStackSettings.tsx
@@ -134,7 +134,9 @@ const FunctionAppStackSettings: React.FC<StackProps> = props => {
           id="function-app-stack"
           selectedKey={runtimeStack}
           disabled={true}
-          onChange={() => {}}
+          onChange={() => {
+            /** @note (joechung): Ignore selection change since there is only a single option. */
+          }}
           options={[{ key: runtimeStack ?? '', text: currentStackData?.displayText ?? '' }]}
           label={t('stack')}
         />

--- a/client-react/src/pages/app/change-app-plan/ChangeAppPlanHeader.tsx
+++ b/client-react/src/pages/app/change-app-plan/ChangeAppPlanHeader.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import FeatureDescriptionCard from '../../../components/feature-description-card/FeatureDescriptionCard';
 import { ReactComponent as AppServicePlanSvg } from '../../../images/AppService/app-service-plan.svg';
 
-export const ChangeAppPlanHeader: React.FC<{}> = () => {
+export const ChangeAppPlanHeader: React.FC = () => {
   const { t } = useTranslation();
 
   return (

--- a/client-react/src/pages/app/deployment-center/bitbucket-provider/DeploymentCenterBitbucketConfiguredView.tsx
+++ b/client-react/src/pages/app/deployment-center/bitbucket-provider/DeploymentCenterBitbucketConfiguredView.tsx
@@ -93,7 +93,7 @@ const DeploymentCenterBitbucketConfiguredView: React.FC<DeploymentCenterFieldPro
   };
 
   const authorizeBitbucketAccount = () => {
-    authorizeWithProvider(BitbucketService.authorizeUrl, () => {}, completingAuthCallback);
+    authorizeWithProvider(BitbucketService.authorizeUrl, /* startingAuth */ undefined, completingAuthCallback);
   };
 
   const completingAuthCallback = (authorizationResult: AuthorizationResult) => {

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPivot.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPivot.tsx
@@ -81,7 +81,12 @@ const DeploymentCenterContainerPivot: React.FC<DeploymentCenterContainerPivotPro
             itemKey="githublogs"
             headerText={t('deploymentCenterPivotItemBuildLogsHeaderText')}
             ariaLabel={t('deploymentCenterPivotItemBuildLogsAriaLabel')}>
-            <DeploymentCenterGitHubActionsCodeLogs isLogsDataRefreshing={isLogsDataRefreshing} refreshLogs={() => {}} />
+            <DeploymentCenterGitHubActionsCodeLogs
+              isLogsDataRefreshing={isLogsDataRefreshing}
+              refreshLogs={() => {
+                /** @note (joechung): Do nothing when refreshing logs. */
+              }}
+            />
           </PivotItem>
         )}
 

--- a/client-react/src/pages/app/deployment-center/dropbox-provider/DeploymentCenterDropboxConfiguredView.tsx
+++ b/client-react/src/pages/app/deployment-center/dropbox-provider/DeploymentCenterDropboxConfiguredView.tsx
@@ -84,7 +84,7 @@ const DeploymentCenterDropboxConfiguredView: React.FC<DeploymentCenterFieldProps
   };
 
   const authorizeDropboxAccount = () => {
-    authorizeWithProvider(DropboxService.authorizeUrl, () => {}, completingAuthCallback);
+    authorizeWithProvider(DropboxService.authorizeUrl, /* startingAuth */ undefined, completingAuthCallback);
   };
 
   const completingAuthCallback = async (authorizationResult: AuthorizationResult) => {

--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubConfiguredView.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubConfiguredView.tsx
@@ -119,7 +119,7 @@ const DeploymentCenterGitHubConfiguredView: React.FC<DeploymentCenterFieldProps<
   };
 
   const authorizeGitHubAccount = () => {
-    authorizeWithProvider(GitHubService.authorizeUrl, () => {}, completingAuthCallBack);
+    authorizeWithProvider(GitHubService.authorizeUrl, /* startingAuth */ undefined, completingAuthCallBack);
   };
 
   const completingAuthCallBack = (authorizationResult: AuthorizationResult) => {

--- a/client-react/src/pages/app/deployment-center/onedrive-provider/DeploymentCenterOneDriveConfiguredView.tsx
+++ b/client-react/src/pages/app/deployment-center/onedrive-provider/DeploymentCenterOneDriveConfiguredView.tsx
@@ -83,7 +83,7 @@ const DeploymentCenterOneDriveConfiguredView: React.FC<DeploymentCenterFieldProp
   };
 
   const authorizeOneDriveAccount = () => {
-    authorizeWithProvider(OneDriveService.authorizeUrl, () => {}, completingAuthCallback);
+    authorizeWithProvider(OneDriveService.authorizeUrl, /* startingAuth */ undefined, completingAuthCallback);
   };
 
   const completingAuthCallback = async (authorizationResult: AuthorizationResult) => {

--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
@@ -225,7 +225,9 @@ export const getWorkflowFilePath = (branch: string, siteName: string, slotName?:
 
 export const authorizeWithProvider = (
   providerAuthUrl: string,
-  startingAuth: () => void,
+  startingAuth: () => void = () => {
+    /** @note (joechung): Do nothing before starting authorization. */
+  },
   completingAuthCallback: (authResult: AuthorizationResult) => void
 ) => {
   const oauthWindow = window.open(providerAuthUrl, 'appservice-deploymentcenter-provider-auth', 'width=800, height=600');

--- a/client-react/src/pages/app/functions/common/callout/storageAccountPivot/StorageAccountPivot.tsx
+++ b/client-react/src/pages/app/functions/common/callout/storageAccountPivot/StorageAccountPivot.tsx
@@ -81,8 +81,7 @@ const StorageAccountPivot: React.SFC<NewConnectionCalloutProps & CustomDropdownP
           appSettingKeys,
           props.setNewAppSetting,
           props.setSelectedItem,
-          props.setIsDialogVisible,
-          setKeyList
+          props.setIsDialogVisible
         )
       }>
       {(formProps: FormikProps<StorageAccountPivotFormValues>) => {
@@ -130,8 +129,7 @@ const setStorageAccountConnection = (
   appSettingKeys: string[],
   setNewAppSetting: React.Dispatch<React.SetStateAction<{ key: string; value: string }>>,
   setSelectedItem: React.Dispatch<React.SetStateAction<IDropdownOption | undefined>>,
-  setIsDialogVisible: React.Dispatch<React.SetStateAction<boolean>>,
-  setKeyList: React.Dispatch<React.SetStateAction<StorageAccountKeys | undefined>>
+  setIsDialogVisible: React.Dispatch<React.SetStateAction<boolean>>
 ) => {
   if (formValues.storageAccount && keyList) {
     let appSettingName = generateAppSettingName(appSettingKeys, `${formValues.storageAccount.name}_STORAGE`);

--- a/client-react/src/pages/container-app/console/ConsoleDataLoader.tsx
+++ b/client-react/src/pages/container-app/console/ConsoleDataLoader.tsx
@@ -192,7 +192,7 @@ const ConsoleDataLoader: React.FC<ConsoleDataLoaderProps> = props => {
           resizeHandler(width, height);
         };
 
-        ws.current.onerror = (ev: Event) => {
+        ws.current.onerror = () => {
           updateConsoleText(t('containerApp_console_failedToConnect'));
         };
 

--- a/client-react/src/pages/container-app/log-stream/LogStreamDataLoader.tsx
+++ b/client-react/src/pages/container-app/log-stream/LogStreamDataLoader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import LogStream, { LogStreamProps } from './LogStream';
 import LogService from '../../../utils/LogService';
 
-class LogStreamDataLoader extends React.Component<LogStreamProps, {}> {
+class LogStreamDataLoader extends React.Component<LogStreamProps> {
   constructor(props) {
     super(props);
     this.state = {};

--- a/client-react/src/pages/static-app/configuration/ConfigurationSnippets.tsx
+++ b/client-react/src/pages/static-app/configuration/ConfigurationSnippets.tsx
@@ -48,15 +48,15 @@ const ConfigurationSnippets: React.FC<ConfigurationSnippetsProps> = ({
   const { values } = formProps;
   const [isOpen, { setTrue: openAddEditPanel, setFalse: dismissAddEditPanel }] = useBoolean(false);
   const [filter, setFilter] = useState('');
-  const [selectedSnippet, setSelectedSnippet] = useState();
+  const [selectedSnippet, setSelectedSnippet] = useState<Snippet>();
   const [isDeleteConfirmDialogVisible, { setTrue: showDiscardConfirmDialog, setFalse: hideDeleteConfirmDialog }] = useBoolean(false);
 
-  const setSnippetAndOpenPanel = (currentSnippet: any) => {
+  const setSnippetAndOpenPanel = (currentSnippet: Snippet) => {
     setSelectedSnippet(currentSnippet);
     openAddEditPanel();
   };
 
-  const setSnippetAndDismissPanel = (_ev?: React.SyntheticEvent<HTMLElement, Event> | KeyboardEvent | undefined) => {
+  const setSnippetAndDismissPanel = () => {
     setSelectedSnippet(undefined);
     dismissAddEditPanel();
   };
@@ -428,7 +428,7 @@ const ConfigurationSnippets: React.FC<ConfigurationSnippetsProps> = ({
               formProps={formProps}
               isLoading={isLoading}
               disabled={disabled}
-              dismissPanel={ev => setSnippetAndDismissPanel(ev)}
+              dismissPanel={() => setSnippetAndDismissPanel()}
               selectedSnippet={selectedSnippet}
             />
           </CustomPanel>

--- a/client-react/src/pages/static-app/skupicker/StaticSiteSkuPicker.tsx
+++ b/client-react/src/pages/static-app/skupicker/StaticSiteSkuPicker.tsx
@@ -127,6 +127,14 @@ const StaticSiteSkuPicker: React.FC<StaticSiteSkuPickerProps> = ({
     [portalContext]
   );
 
+  const monthlyCost = useSWACostString(billingInformation, StaticSiteBillingType.SWAMonthly);
+  const incrementalCost = useSWACostString(billingInformation, StaticSiteBillingType.SWAIncremental);
+  const azureFrontDoorCost = useSWACostString(billingInformation, StaticSiteBillingType.SWAAzureFrontDoor);
+  const staticSiteStandardPlanAriaLabel = useMemo(
+    () => t('staticSiteStandardPlanAriaLabel').format(monthlyCost, incrementalCost, azureFrontDoorCost),
+    [azureFrontDoorCost, incrementalCost, monthlyCost, t]
+  );
+
   useEffect(() => {
     if (!isBillingInformationLoading) {
       setSkuCost(<SkuCost billingInformation={billingInformation} />);
@@ -170,11 +178,7 @@ const StaticSiteSkuPicker: React.FC<StaticSiteSkuPickerProps> = ({
                     onChange={handleChange}
                   />
                   <PlanPickerTitleSection
-                    buttonAriaLabel={t('staticSiteStandardPlanAriaLabel').format(
-                      getSWACostString(billingInformation, StaticSiteBillingType.SWAMonthly),
-                      getSWACostString(billingInformation, StaticSiteBillingType.SWAIncremental),
-                      getSWACostString(billingInformation, StaticSiteBillingType.SWAAzureFrontDoor)
-                    )}
+                    buttonAriaLabel={staticSiteStandardPlanAriaLabel}
                     className={selectedSku === StaticSiteSku.Standard ? selectedTitleStyleClassName : unselectedTitleStyleClassName}
                     description={t('staticSiteStandardDescription')}
                     id="static-site-sku-standard"
@@ -342,7 +346,7 @@ const SkuCost: React.FC<SkuCostProps> = ({ billingInformation = [] }) => {
   return <PricingCalculatorLink />;
 };
 
-const getSWACostString = (billingInformation: CostEstimate[] = [], id: StaticSiteBillingType) => {
+const useSWACostString = (billingInformation: CostEstimate[] = [], id: StaticSiteBillingType) => {
   const { t } = useTranslation();
 
   if (billingInformation.length > 0) {

--- a/client-react/src/polyfills.ts
+++ b/client-react/src/polyfills.ts
@@ -27,5 +27,6 @@ import 'core-js/es7/reflect';
 import './polyfills/string';
 
 if (typeof console == 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   (console as any) = { log: function() {}, error: function() {}, warn: function() {}, debug: function() {} };
 }


### PR DESCRIPTION
[#17890321](https://dev.azure.com/msazure/Antares/_workitems/edit/17890321/)

Change the `npm run lint` command to show only errors with `--quiet`.

Fix these lint errors before turning the rules back on:
- `@typescript-eslint/ban-types`
- `@typescript-eslint/no-empty-function`
- `@typescript-eslint/no-unused-vars`
- `react-hooks/rules-of-hooks`