### PR TITLE
[DC] Hide Docker Compose option for container function apps

### DIFF
--- a/client-react/src/utils/scenario-checker/function-app.environment.ts
+++ b/client-react/src/utils/scenario-checker/function-app.environment.ts
@@ -133,6 +133,13 @@ export class FunctionAppEnvironment extends Environment {
       id: ScenarioIds.clientAffinitySupported,
       runCheck: () => ({ status: 'disabled' }),
     };
+
+    this.scenarioChecks[ScenarioIds.dockerCompose] = {
+      id: ScenarioIds.dockerCompose,
+      runCheck: () => {
+        return { status: 'disabled' };
+      },
+    };
   }
 
   public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {


### PR DESCRIPTION
FixesAB#[17870704](https://msazure.visualstudio.com/Antares/_workitems/edit/17870704)

- Removing Docker Compose option for container function apps since functionality is not supported

**Before**
![image](https://user-images.githubusercontent.com/29874289/231797528-ab058a02-c9bb-4f9b-940a-3d6fa60fc667.png)

**After**
![image](https://user-images.githubusercontent.com/29874289/231797548-f992281f-2c6d-40a7-a659-6d574cdf405d.png)
