### PR TITLE
AB#17534566 and AB#17534609: Adding screen reading and aria labels to the console blade

### DIFF
--- a/client-react/package-lock.json
+++ b/client-react/package-lock.json
@@ -698,7 +698,7 @@
     },
     "@babel/helper-replace-supers": {
       "version": "7.14.5",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.14.5",

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2602,4 +2602,5 @@ export class PortalResources {
   public static resetUserScopeCredentialsConfirmationDescription = 'resetUserScopeCredentialsConfirmationDescription';
   public static connectionStringInfoMessage = 'connectionStringInfoMessage';
   public static ibizafication_readOnlyDotnetIsolated = 'ibizafication_readOnlyDotnetIsolated';
+  public static consoleContainerTextAreaAriaLabel = 'consoleContainerTextAreaAriaLabel';
 }

--- a/client/src/app/site/console/shared/components/abstract.console.component.ts
+++ b/client/src/app/site/console/shared/components/abstract.console.component.ts
@@ -20,6 +20,7 @@ import { PromptComponent } from './prompt.component';
 import { Headers } from '@angular/http';
 import { PortalService } from '../../../../shared/services/portal.service';
 import { Subject } from 'rxjs/Subject';
+import { PortalResources } from 'app/shared/models/portal-resources';
 
 export abstract class AbstractConsoleComponent implements OnInit, OnDestroy {
   public resourceId: string;
@@ -33,7 +34,7 @@ export abstract class AbstractConsoleComponent implements OnInit, OnDestroy {
   protected site: ArmObj<Site>;
   protected siteSubscription: Subscription;
   protected publishingCredSubscription: Subscription;
-
+  public Resources = PortalResources;
   /*** Variables for Tab-key ***/
   protected listOfDir: string[] = [];
   protected dirIndex = -1;

--- a/client/src/app/site/console/shared/components/abstract.windows.component.ts
+++ b/client/src/app/site/console/shared/components/abstract.windows.component.ts
@@ -9,7 +9,7 @@ import { PortalService } from '../../../../shared/services/portal.service';
 
 export abstract class AbstractWindowsComponent extends AbstractConsoleComponent {
   private _defaultDirectory = 'D:\\home\\site\\wwwroot';
-
+  public Resources = PortalResources;
   constructor(
     componentFactoryResolver: ComponentFactoryResolver,
     public consoleService: ConsoleService,

--- a/client/src/app/site/console/shared/components/abstract.windows.component.ts
+++ b/client/src/app/site/console/shared/components/abstract.windows.component.ts
@@ -9,7 +9,6 @@ import { PortalService } from '../../../../shared/services/portal.service';
 
 export abstract class AbstractWindowsComponent extends AbstractConsoleComponent {
   private _defaultDirectory = 'D:\\home\\site\\wwwroot';
-  public Resources = PortalResources;
   constructor(
     componentFactoryResolver: ComponentFactoryResolver,
     public consoleService: ConsoleService,

--- a/client/src/app/site/console/shared/components/error.component.ts
+++ b/client/src/app/site/console/shared/components/error.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input } from '@angular/core';
 @Component({
-  template: `<div class="console-message-error">{{message}}</div>`,
+  template: `
+    <div aria-live="polite" class="console-message-error">{{ message }}</div>
+  `,
   styleUrls: ['./../../console.component.scss'],
 })
 export class ErrorComponent {

--- a/client/src/app/site/console/shared/components/message.component.ts
+++ b/client/src/app/site/console/shared/components/message.component.ts
@@ -1,6 +1,9 @@
 import { Component, Input } from '@angular/core';
 @Component({
-  template: `<div [class]="className">{{message}}</div><i *ngIf="loading" class="fa fa-spinner fa-spin fa-fw"></i>`,
+  template: `
+    <div aria-live="polite" [class]="className">{{ message }}</div>
+    <i *ngIf="loading" class="fa fa-spinner fa-spin fa-fw"></i>
+  `,
   styleUrls: ['./../../console.component.scss'],
 })
 export class MessageComponent {

--- a/client/src/app/site/console/shared/templates/abstract.console.component.html
+++ b/client/src/app/site/console/shared/templates/abstract.console.component.html
@@ -1,4 +1,4 @@
-<div aria-label="Console text area container" id="console-container" (clickOutside)="unFocusConsole()" (click)="focusConsole()" tabindex="{{isFocused ? 1 : 0}}" (contextmenu)="handleRightMouseClick($event)">
+<div   [attr.aria-label]="Resources.consoleContainerTextAreaAriaLabel | translate" id="console-container" (clickOutside)="unFocusConsole()" (click)="focusConsole()" tabindex="{{isFocused ? 1 : 0}}" (contextmenu)="handleRightMouseClick($event)">
   <div class="console">
     <div id="console-body" class="console-inner">
       <textarea #consoleText class="console-typer" (copy)="handleCopy($event)"

--- a/client/src/app/site/console/shared/templates/abstract.console.component.html
+++ b/client/src/app/site/console/shared/templates/abstract.console.component.html
@@ -1,15 +1,15 @@
-<div id="console-container" (clickOutside)="unFocusConsole()" (click)="focusConsole()" tabindex="{{isFocused ? 1 : 0}}" (contextmenu)="handleRightMouseClick($event)">
+<div aria-label="Console text area container" id="console-container" (clickOutside)="unFocusConsole()" (click)="focusConsole()" tabindex="{{isFocused ? 1 : 0}}" (contextmenu)="handleRightMouseClick($event)">
   <div class="console">
     <div id="console-body" class="console-inner">
       <textarea #consoleText class="console-typer" (copy)="handleCopy($event)"
         (onfocus)="focusConsoleOnTabPress()" (paste)="handlePaste($event)" (keydown)="keyEvent($event)" ng-blur="unFocusConsole()"></textarea>
       <div *ngIf="!cleared" class="console-message-header" aria-live="polite">
         <span>              _    _____   _ ___ ___
-             /_\  |_  / | | | _ \ __| 
-       _ ___/ _ \__/ /| |_| |   / _|___ _ _ 
-     (___  /_/ \_\/___|\___/|_|_\___| _____) 
-        (_______ _ _)         _ ______ _)_ _ 
-               (______________ _ )   (___ _ _) 
+             /_\  |_  / | | | _ \ __|
+       _ ___/ _ \__/ /| |_| |   / _|___ _ _
+     (___  /_/ \_\/___|\___/|_|_\___| _____)
+        (_______ _ _)         _ ______ _)_ _
+               (______________ _ )   (___ _ _)
 
 {{ 'feature_consoleMsg' | translate}}
         </span>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7949,5 +7949,8 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     </data>
     <data name="ibizafication_readOnlyDotnetIsolated" xml:space="preserve">
         <value>Editing .NET Isolated Function Apps is not supported in the Azure portal. Use your local development environment to edit this function.</value>
+    </data>    
+    <data name="consoleContainerTextAreaAriaLabel" xml:space="preserve">
+        <value>Console text area container</value>
     </data>
 </root>


### PR DESCRIPTION
Solution for (AB#[17534566](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s212?workitem=17534566)) and (AB#[17534609](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s212?workitem=17534609))

 Adding an aria label for the console container text area and aria-live to the users typed commands/feedback . Allows user input and console responses to be read out loud by screen readers