### PR TITLE
[Functions][Python] Ensure new v2 programming model dropdown shows...

### DIFF
--- a/client-react/src/pages/app/functions/function/function-editor/useFunctionEditorQueries.ts
+++ b/client-react/src/pages/app/functions/function/function-editor/useFunctionEditorQueries.ts
@@ -20,19 +20,17 @@ import FunctionEditorData from './FunctionEditor.data';
 export type Status = 'idle' | 'loading' | 'success' | 'error' | 'unauthorized';
 
 export const isNewProgrammingModel = (functionInfo?: ArmObj<FunctionInfo>): boolean => {
-  const properties = functionInfo?.properties;
-  const configLanguage = properties?.config.language;
-
-  return (
-    properties?.config_href === null &&
-    (configLanguage === WorkerRuntimeLanguages.python || configLanguage === WorkerRuntimeLanguages.nodejs)
-  );
+  return isNewNodeProgrammingModel(functionInfo) || isNewPythonProgrammingModel(functionInfo);
 };
 
 export const isNewNodeProgrammingModel = (functionInfo?: ArmObj<FunctionInfo>): boolean => {
   const properties = functionInfo?.properties;
-
   return properties?.config_href === null && properties?.config.language === WorkerRuntimeLanguages.nodejs;
+};
+
+export const isNewPythonProgrammingModel = (functionInfo?: ArmObj<FunctionInfo>): boolean => {
+  const properties = functionInfo?.properties;
+  return properties?.config_href === null && properties?.config.language === WorkerRuntimeLanguages.python;
 };
 
 // Currently, Node is the only new programming model which supports storing files in any folders.

--- a/client-react/src/pages/app/functions/function/hooks/useFunctionsQuery.ts
+++ b/client-react/src/pages/app/functions/function/hooks/useFunctionsQuery.ts
@@ -34,7 +34,6 @@ export function useFunctionsQuery(resourceId: string) {
             getTelemetryInfo('error', 'getFunctions', 'failed', {
               error: response.metadata.error,
               message: 'Failed to fetch functions',
-
             })
           );
         }

--- a/client-react/src/pages/app/functions/function/hooks/useFunctionsQuery.ts
+++ b/client-react/src/pages/app/functions/function/hooks/useFunctionsQuery.ts
@@ -33,7 +33,8 @@ export function useFunctionsQuery(resourceId: string) {
           portalContext.log(
             getTelemetryInfo('error', 'getFunctions', 'failed', {
               error: response.metadata.error,
-              message: 'Failed to fetch site-config',
+              message: 'Failed to fetch functions',
+
             })
           );
         }

--- a/client-react/src/pages/app/functions/function/hooks/useFunctionsQuery.ts
+++ b/client-react/src/pages/app/functions/function/hooks/useFunctionsQuery.ts
@@ -1,0 +1,53 @@
+import { useContext, useEffect, useMemo, useState } from 'react';
+import FunctionsService from '../../../../../ApiHelpers/FunctionsService';
+import { PortalContext } from '../../../../../PortalContext';
+import { FunctionInfo } from '../../../../../models/functions/function-info';
+import { getTelemetryInfo } from '../../../../../utils/TelemetryUtils';
+import { isNewPythonProgrammingModel } from '../function-editor/useFunctionEditorQueries';
+import { ArmObj } from '../../../../../models/arm-obj';
+
+export function useFunctionsQuery(resourceId: string) {
+  const portalContext = useContext(PortalContext);
+
+  const [functions, setFunctions] = useState<ArmObj<FunctionInfo>[]>();
+
+  /** @note Currently Python only. Change `isNewPythonProgrammingModel` when the v2 programming model becomes GA for other runtimes, e.g., Node.js. */
+  const programmingModel = useMemo(() => {
+    if (!functions) {
+      return undefined;
+    } else if (functions.length === 0) {
+      return null;
+    } else {
+      return functions.some(isNewPythonProgrammingModel) ? 2 : 1;
+    }
+  }, [functions]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    FunctionsService.getFunctions(resourceId).then(response => {
+      if (isMounted) {
+        if (response.metadata.success) {
+          setFunctions(response.data.value);
+        } else {
+          portalContext.log(
+            getTelemetryInfo('error', 'getFunctions', 'failed', {
+              error: response.metadata.error,
+              message: 'Failed to fetch site-config',
+            })
+          );
+        }
+      }
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [portalContext, resourceId]);
+
+  return {
+    functions,
+    /** @prop `undefined` if not loaded, `null` if loaded but indeterminate, `1` if old (v1), `2` if new (v2) */
+    programmingModel,
+  };
+}

--- a/client-react/src/pages/app/functions/function/hooks/useSiteConfigQuery.ts
+++ b/client-react/src/pages/app/functions/function/hooks/useSiteConfigQuery.ts
@@ -1,0 +1,52 @@
+import { useContext, useEffect, useMemo, useState } from 'react';
+import SiteService from '../../../../../ApiHelpers/SiteService';
+import { PortalContext } from '../../../../../PortalContext';
+import { ArmObj } from '../../../../../models/arm-obj';
+import { SiteConfig } from '../../../../../models/site/config';
+import { getTelemetryInfo } from '../../../../../utils/TelemetryUtils';
+
+/**
+ * @note Python is available only on Linux. If this changes, find another way to detect Python on Windows.
+ */
+export function useSiteConfigQuery(resourceId: string) {
+  const portalContext = useContext(PortalContext);
+
+  const [siteConfig, setSiteConfig] = useState<ArmObj<SiteConfig>>();
+
+  const [language, version] = useMemo(() => siteConfig?.properties.linuxFxVersion?.split('|') ?? [], [
+    siteConfig?.properties.linuxFxVersion,
+  ]);
+
+  const isPythonLanguage = useMemo(() => (!siteConfig ? undefined : /^python$/i.test(language)), [language, siteConfig]);
+
+  const pythonVersion = isPythonLanguage ? version : undefined;
+
+  useEffect(() => {
+    let isMounted = true;
+
+    SiteService.fetchWebConfig(resourceId).then(response => {
+      if (isMounted) {
+        if (response.metadata.success) {
+          setSiteConfig(response.data);
+        } else {
+          portalContext.log(
+            getTelemetryInfo('error', 'fetchWebConfig', 'failed', {
+              error: response.metadata.error,
+              message: 'Failed to fetch site config',
+            })
+          );
+        }
+      }
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [portalContext, resourceId]);
+
+  return {
+    isPythonLanguage,
+    pythonVersion,
+    siteConfig,
+  };
+}

--- a/client-react/src/pages/app/functions/new-create-preview/FunctionCreateDataLoader.tsx
+++ b/client-react/src/pages/app/functions/new-create-preview/FunctionCreateDataLoader.tsx
@@ -52,8 +52,6 @@ export interface FunctionCreateDataLoaderProps {
   resourceId: string;
 }
 
-const enableNewProgrammingModel = Url.getFeatureValue(CommonConstants.FeatureFlags.enableNewProgrammingModel);
-
 const FunctionCreateDataLoader: React.FC<FunctionCreateDataLoaderProps> = ({ resourceId }: FunctionCreateDataLoaderProps) => {
   const siteStateContext = useContext(SiteStateContext);
   const site = useMemo(() => siteStateContext.site, [siteStateContext]);
@@ -76,7 +74,8 @@ const FunctionCreateDataLoader: React.FC<FunctionCreateDataLoaderProps> = ({ res
     programmingModelDisabled,
     programmingModelDropdownStyles,
     programmingModelOptions,
-  } = useProgrammingModel();
+    programmingModelVisible,
+  } = useProgrammingModel(resourceId);
 
   const { appSettings } = useAppSettingsQuery(resourceId);
 
@@ -258,7 +257,7 @@ const FunctionCreateDataLoader: React.FC<FunctionCreateDataLoaderProps> = ({ res
             selectedKey={selectedDropdownKey}
             disabled={creatingFunction}
           />
-          {enableNewProgrammingModel && (
+          {programmingModelVisible && (
             <Dropdown
               id="function-create-programming-model"
               aria-labelledby="programming-model-label"
@@ -294,6 +293,7 @@ const FunctionCreateDataLoader: React.FC<FunctionCreateDataLoaderProps> = ({ res
                     setHostStatus={setHostStatus}
                     armResources={armResources}
                     setArmResources={setArmResources}
+                    useNewProgrammingModel={programmingModel === 2}
                   />
                 </div>
                 <ActionBar

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create/TemplateList.tsx
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create/TemplateList.tsx
@@ -45,6 +45,7 @@ export interface TemplateListProps {
   selectedTemplate?: FunctionTemplate;
   setArmResources?: TSetArmResourceTemplates;
   templates?: FunctionTemplate[] | null;
+  useNewProgrammingModel?: boolean;
 }
 
 const TemplateList: React.FC<TemplateListProps> = ({
@@ -83,7 +84,8 @@ const TemplateList: React.FC<TemplateListProps> = ({
     [setSelectedTemplate]
   );
 
-  const columns = useTemplateListColumns(hostStatus);
+  /** @todo Do not show the "View Template" column until we get design feedback for this feature. */
+  const columns = useTemplateListColumns(hostStatus, /* useNewProgrammingModel */ false);
 
   const items = useMemo(() => {
     return (

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create/useTemplateListColumns.tsx
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create/useTemplateListColumns.tsx
@@ -51,8 +51,11 @@ export function useTemplateListColumns(hostStatus?: ArmObj<HostStatus>, useNewPr
           return (
             <IconButton
               ariaLabel={t('viewTemplateFormat').format(getTemplateDisplayName(item))}
-              href={'https://aka.ms/todo' /** @todo (joechung) */}
               iconProps={iconProps}
+              onClick={() => {
+                /** @todo Do not show the "View Template" column until we get design feedback for this feature. */
+                console.log('View Template clicked');
+              }}
               styles={iconButtonStyles}
               target="_blank"
             />
@@ -90,7 +93,6 @@ export function useTemplateListColumns(hostStatus?: ArmObj<HostStatus>, useNewPr
             {
               key: 'view-template',
               name: t('viewTemplate'),
-              fieldName: 'view-template' /** @todo (joechung) */,
               minWidth: 100,
               onRender,
             },

--- a/client-react/src/pages/app/functions/new-create-preview/useProgrammingModel.tsx
+++ b/client-react/src/pages/app/functions/new-create-preview/useProgrammingModel.tsx
@@ -1,7 +1,11 @@
-import { IDropdownStyles, ILinkStyles, Icon, Link } from '@fluentui/react';
-import { useCallback, useMemo, useState } from 'react';
+import { IDropdownOption, IDropdownProps, IDropdownStyles, ILinkStyles, IRenderFunction, Icon, Link } from '@fluentui/react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { CommonConstants } from '../../../../utils/CommonConstants';
 import { Links } from '../../../../utils/FwLinks';
+import Url from '../../../../utils/url';
+import { useFunctionsQuery } from '../function/hooks/useFunctionsQuery';
+import { useSiteConfigQuery } from '../function/hooks/useSiteConfigQuery';
 
 const programmingModelDropdownStyles: Partial<IDropdownStyles> = {
   dropdown: {
@@ -26,7 +30,7 @@ const programmingModelDropdownStyles: Partial<IDropdownStyles> = {
   },
 };
 
-const programmingModelLinkStles: ILinkStyles = {
+const programmingModelLinkStyles: ILinkStyles = {
   root: {
     flex: '0 0 192px',
     fontSize: '13px',
@@ -34,24 +38,34 @@ const programmingModelLinkStles: ILinkStyles = {
   },
 };
 
-export function useProgrammingModel(initialDisabled = false, initialSelectedKey: number | string | null = null) {
-  const { t } = useTranslation();
-  const [programmingModelDisabled] = useState(initialDisabled);
-  const [programmingModel, setProgrammingModel] = useState<number | string | null>(initialSelectedKey);
+const enableNewProgrammingModel = !!Url.getFeatureValue(CommonConstants.FeatureFlags.enableNewProgrammingModel);
 
-  const onProgrammingModelChange = useCallback((_, option?) => {
+export function useProgrammingModel(resourceId: string) {
+  const { t } = useTranslation();
+
+  const { functions, programmingModel: selectedProgrammingModel } = useFunctionsQuery(resourceId);
+  const { isPythonLanguage, pythonVersion } = useSiteConfigQuery(resourceId);
+
+  /** @todo Check what versions of Python support the v2 programming model. */
+  const isSupported = isPythonLanguage === undefined ? undefined : isPythonLanguage && pythonVersion === '3.10';
+
+  const [programmingModelDisabled, setProgrammingModelDisabled] = useState(false);
+
+  const [programmingModel, setProgrammingModel] = useState<number | string | null>(null);
+
+  const onProgrammingModelChange = useCallback<NonNullable<IDropdownProps['onChange']>>((_, option?) => {
     if (option?.key) {
       setProgrammingModel(option.key);
     }
   }, []);
 
-  const onProgrammingModelRenderLabel = useCallback(
+  const onProgrammingModelRenderLabel = useCallback<IRenderFunction<IDropdownProps>>(
     () => (
       <Link
         id="programming-model-label"
         href={Links.functionCreateProgrammingModelLearnMore}
         target="_blank"
-        styles={programmingModelLinkStles}>
+        styles={programmingModelLinkStyles}>
         {`${t('programmingModel')} `}
         <Icon iconName="NavigateExternalInline" />
       </Link>
@@ -59,13 +73,26 @@ export function useProgrammingModel(initialDisabled = false, initialSelectedKey:
     [t]
   );
 
-  const programmingModelOptions = useMemo(
+  const programmingModelOptions = useMemo<IDropdownOption<unknown>[]>(
     () => [
       { key: 1, text: t('v1ProgrammingModel') },
       { key: 2, text: t('v2ProgrammingModel') },
     ],
     [t]
   );
+
+  const programmingModelVisible = enableNewProgrammingModel && isSupported;
+
+  /** @note Do not disable or initialize the dropdown until all APIs have completed. */
+  useEffect(() => {
+    if (selectedProgrammingModel !== undefined && functions !== undefined && isSupported !== undefined) {
+      /** @note Disable the dropdown if there is already a selected programming model. */
+      setProgrammingModelDisabled(selectedProgrammingModel !== null);
+
+      /** @note Initialize the dropdown to the selected programming model. Otherwise default to the new programming model is enabled and supported. Otherwise default to the old programming model. */
+      setProgrammingModel(selectedProgrammingModel ?? (enableNewProgrammingModel && isSupported ? 2 : 1));
+    }
+  }, [selectedProgrammingModel, functions, isSupported]);
 
   return {
     onProgrammingModelChange,
@@ -74,5 +101,6 @@ export function useProgrammingModel(initialDisabled = false, initialSelectedKey:
     programmingModelDisabled,
     programmingModelDropdownStyles,
     programmingModelOptions,
+    programmingModelVisible,
   };
 }


### PR DESCRIPTION
[Functions][Python] Ensure new v2 programming model dropdown shows only for Python

[AB#18600483](https://dev.azure.com/msazure/Antares/_workitems/edit/18600483/)

Enable the dropdown only if enabled via feature flag and the framework is supported (Python only).

Default the dropdown depending on circumstances:
- The current programming model if a function already exists (v1 or v2).
- v2 if enabled via feature flag and the framework is supported.
- v1 otherwise.

Hide the "View Template" column for the v2 programming model until design complete.

# Screenshot
![image](https://user-images.githubusercontent.com/26208574/234305835-bf94a6a4-20c9-42ac-837a-d8dbee9f72de.png)
