### PR TITLE
[Functions][Python] Ensure Code+Test works in v2 programming model

### DIFF
--- a/client-react/src/models/portal-models.ts
+++ b/client-react/src/models/portal-models.ts
@@ -336,6 +336,7 @@ export enum FunctionAppEditMode {
   ReadOnlyArc,
   ReadOnlyAzureFiles,
   ReadOnlyNewNodePreview,
+  ReadOnlyPythonV2,
 }
 
 export enum PortalTheme {

--- a/client-react/src/pages/app/functions/function/function-editor/useFunctionEditorQueries.ts
+++ b/client-react/src/pages/app/functions/function/function-editor/useFunctionEditorQueries.ts
@@ -2,17 +2,17 @@ import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import AppKeyService from '../../../../../ApiHelpers/AppKeysService';
 import FunctionsService from '../../../../../ApiHelpers/FunctionsService';
 import SiteService from '../../../../../ApiHelpers/SiteService';
+import { PortalContext } from '../../../../../PortalContext';
 import { ArmObj } from '../../../../../models/arm-obj';
 import { FunctionInfo } from '../../../../../models/functions/function-info';
 import { Host } from '../../../../../models/functions/host';
 import { VfsObject } from '../../../../../models/functions/vfs';
 import { SiteConfig } from '../../../../../models/site/config';
 import { Site } from '../../../../../models/site/site';
-import { PortalContext } from '../../../../../PortalContext';
 import { CommonConstants, ExperimentationConstants, WorkerRuntimeLanguages } from '../../../../../utils/CommonConstants';
+import { getTelemetryInfo } from '../../../../../utils/TelemetryUtils';
 import { ArmSiteDescriptor } from '../../../../../utils/resourceDescriptors';
 import StringUtils from '../../../../../utils/string';
-import { getTelemetryInfo } from '../../../../../utils/TelemetryUtils';
 import { SiteRouterContext } from '../../../SiteRouter';
 import { AppKeysInfo } from '../../app-keys/AppKeys.types';
 import FunctionEditorData from './FunctionEditor.data';
@@ -128,7 +128,7 @@ const useAppKeysQuery = (updated: number, siteResourceId: string) => {
   const [hostKeys, setHostKeys] = useState<AppKeysInfo>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalContext = useContext(PortalContext);
+  const portalCommunicator = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -139,7 +139,7 @@ const useAppKeysQuery = (updated: number, siteResourceId: string) => {
         setHostKeys(response.data);
       } else {
         setStatus('error');
-        portalContext.log(
+        portalCommunicator.log(
           getTelemetryInfo('error', 'fetchAppKeys', 'failed', {
             error: response.metadata.error,
             message: 'Failed to fetch app keys',
@@ -147,7 +147,7 @@ const useAppKeysQuery = (updated: number, siteResourceId: string) => {
         );
       }
     });
-  }, [siteResourceId, updated]);
+  }, [portalCommunicator, siteResourceId, updated]);
 
   return {
     hostKeys,
@@ -159,7 +159,7 @@ const useAppSettingsQuery = (updated: number, siteResourceId: string) => {
   const [status, setStatus] = useState<Status>('idle');
   const [workerRuntime, setWorkerRuntime] = useState<string>();
 
-  const portalContext = useContext(PortalContext);
+  const portalCommunicator = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -170,7 +170,7 @@ const useAppSettingsQuery = (updated: number, siteResourceId: string) => {
         setWorkerRuntime(response.data.properties[CommonConstants.AppSettingNames.functionsWorkerRuntime]?.toLowerCase());
       } else {
         setStatus('error');
-        portalContext.log(
+        portalCommunicator.log(
           getTelemetryInfo('error', 'fetchAppSettings', 'failed', {
             error: response.metadata.error,
             message: 'Failed to fetch app settings',
@@ -178,7 +178,7 @@ const useAppSettingsQuery = (updated: number, siteResourceId: string) => {
         );
       }
     });
-  }, [siteResourceId, updated]);
+  }, [portalCommunicator, siteResourceId, updated]);
 
   return {
     status,
@@ -199,7 +199,7 @@ const useFileListQuery = (updated: number, siteResourceId: string, functionInfo?
   const [fileList, setFileList] = useState<VfsObject[]>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalContext = useContext(PortalContext);
+  const portalCommunicator = useContext(PortalContext);
 
   useEffect(() => {
     if (functionName !== undefined && runtimeVersion) {
@@ -222,7 +222,7 @@ const useFileListQuery = (updated: number, siteResourceId: string, functionInfo?
           } else {
             setStatus('error');
           }
-          portalContext.log(
+          portalCommunicator.log(
             getTelemetryInfo('error', 'getFileContent', 'failed', {
               error: response.metadata.error,
               message: 'Failed to get file content',
@@ -233,7 +233,7 @@ const useFileListQuery = (updated: number, siteResourceId: string, functionInfo?
     } else {
       setStatus('idle');
     }
-  }, [functionName, newProgrammingModelFolderName, runtimeVersion, siteResourceId, updated]);
+  }, [functionName, newProgrammingModelFolderName, portalCommunicator, runtimeVersion, siteResourceId, updated]);
 
   return {
     fileList,
@@ -246,7 +246,7 @@ const useFunctionInfoQuery = (updated: number, resourceId: string, functionEdito
   const [functionInfo, setFunctionInfo] = useState<ArmObj<FunctionInfo>>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalContext = useContext(PortalContext);
+  const portalCommunicator = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -257,7 +257,7 @@ const useFunctionInfoQuery = (updated: number, resourceId: string, functionEdito
         setFunctionInfo(response.data);
       } else {
         setStatus('error');
-        portalContext.log(
+        portalCommunicator.log(
           getTelemetryInfo('error', 'getFunction', 'failed', {
             error: response.metadata.error,
             message: 'Failed to get function info',
@@ -265,7 +265,7 @@ const useFunctionInfoQuery = (updated: number, resourceId: string, functionEdito
         );
       }
     });
-  }, [functionEditorData, resourceId, updated]);
+  }, [functionEditorData, portalCommunicator, resourceId, updated]);
 
   return {
     functionInfo,
@@ -278,7 +278,7 @@ const useFunctionKeysQuery = (updated: number, resourceId: string) => {
   const [functionKeys, setFunctionKeys] = useState<Record<string, string>>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalContext = useContext(PortalContext);
+  const portalCommunicator = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -289,7 +289,7 @@ const useFunctionKeysQuery = (updated: number, resourceId: string) => {
         setFunctionKeys(response.data);
       } else {
         setStatus('error');
-        portalContext.log(
+        portalCommunicator.log(
           getTelemetryInfo('error', 'fetchFunctionKeys', 'failed', {
             error: response.metadata.error,
             message: 'Failed to fetch function keys',
@@ -297,7 +297,7 @@ const useFunctionKeysQuery = (updated: number, resourceId: string) => {
         );
       }
     });
-  }, [resourceId, updated]);
+  }, [portalCommunicator, resourceId, updated]);
 
   return {
     functionKeys,
@@ -309,7 +309,7 @@ const useHostJsonQuery = (updated: number, siteResourceId: string, runtimeVersio
   const [hostJsonContent, setHostJsonContent] = useState<Host>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalContext = useContext(PortalContext);
+  const portalCommunicator = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -325,7 +325,7 @@ const useHostJsonQuery = (updated: number, siteResourceId: string, runtimeVersio
           } else {
             setStatus('error');
           }
-          portalContext.log(
+          portalCommunicator.log(
             getTelemetryInfo('error', 'getHostJson', 'failed', {
               error: response.metadata.error,
               message: 'Failed to get host json file',
@@ -336,7 +336,7 @@ const useHostJsonQuery = (updated: number, siteResourceId: string, runtimeVersio
     } else {
       setStatus('idle');
     }
-  }, [runtimeVersion, siteResourceId, updated]);
+  }, [portalCommunicator, runtimeVersion, siteResourceId, updated]);
 
   return {
     hostJsonContent,
@@ -348,7 +348,7 @@ const useHostStatusQuery = (updated: number, siteResourceId: string) => {
   const [runtimeVersion, setRuntimeVersion] = useState<string>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalContext = useContext(PortalContext);
+  const portalCommunicator = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -361,7 +361,7 @@ const useHostStatusQuery = (updated: number, siteResourceId: string) => {
         setRuntimeVersion(currentRuntimeVersion);
       } else {
         setStatus('error');
-        portalContext.log(
+        portalCommunicator.log(
           getTelemetryInfo('error', 'fetchFunctionHostStatus', 'failed', {
             error: response.metadata.error,
             message: 'Failed to fetch host status',
@@ -369,7 +369,7 @@ const useHostStatusQuery = (updated: number, siteResourceId: string) => {
         );
       }
     });
-  }, [siteResourceId, updated]);
+  }, [portalCommunicator, siteResourceId, updated]);
 
   return {
     runtimeVersion,
@@ -407,7 +407,7 @@ const useSiteQuery = (updated: number, siteResourceId: string) => {
   const [site, setSite] = useState<ArmObj<Site>>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalContext = useContext(PortalContext);
+  const portalCommunicator = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -418,7 +418,7 @@ const useSiteQuery = (updated: number, siteResourceId: string) => {
         setSite(response.data);
       } else {
         setStatus('error');
-        portalContext.log(
+        portalCommunicator.log(
           getTelemetryInfo('error', 'fetchSite', 'failed', {
             error: response.metadata.error,
             message: 'Failed to fetch site',
@@ -426,7 +426,7 @@ const useSiteQuery = (updated: number, siteResourceId: string) => {
         );
       }
     });
-  }, [context, siteResourceId, updated]);
+  }, [context, portalCommunicator, siteResourceId, updated]);
 
   return {
     site,
@@ -438,7 +438,7 @@ const useSiteConfigQuery = (updated: number, siteResourceId: string, functionEdi
   const [siteConfig, setSiteConfig] = useState<ArmObj<SiteConfig>>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalContext = useContext(PortalContext);
+  const portalCommunicator = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -455,7 +455,7 @@ const useSiteConfigQuery = (updated: number, siteResourceId: string, functionEdi
         };
       } else {
         setStatus('error');
-        portalContext.log(
+        portalCommunicator.log(
           getTelemetryInfo('error', 'fetchSiteConfig', 'failed', {
             error: response.metadata.error,
             message: 'Failed to fetch site-config',
@@ -463,7 +463,7 @@ const useSiteConfigQuery = (updated: number, siteResourceId: string, functionEdi
         );
       }
     });
-  }, [functionEditorData, siteResourceId, updated]);
+  }, [functionEditorData, portalCommunicator, siteResourceId, updated]);
 
   return {
     siteConfig,

--- a/client-react/src/utils/FwLinks.ts
+++ b/client-react/src/utils/FwLinks.ts
@@ -9,6 +9,7 @@ export const Links = {
   runtimeScaleMonitoringLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2104710',
   remoteDebuggingLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2116583',
   readOnlyPythonAppLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2074230',
+  readOnlyPythonAppV2LearnMore: 'https://go.microsoft.com/fwlink/?linkid=2234387',
   readOnlyVSGeneratedFunctionLearnMore: 'https://go.microsoft.com/fwlink/?linkid=856288',
   staticSiteEnvironmentVariablesLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2128074',
   // TODO (krmitta): Update the learn more link with the correct fwlink

--- a/client-react/src/utils/SiteHelper.ts
+++ b/client-react/src/utils/SiteHelper.ts
@@ -1,10 +1,10 @@
-import { FunctionAppEditMode } from '../models/portal-models';
-import i18n from './i18n';
 import { ArmObj } from '../models/arm-obj';
-import { Site } from '../models/site/site';
+import { FunctionAppEditMode } from '../models/portal-models';
 import { SiteConfig } from '../models/site/config';
-import { isPremiumV2 } from './arm-utils';
+import { Site } from '../models/site/site';
 import { Links } from './FwLinks';
+import { isPremiumV2 } from './arm-utils';
+import i18n from './i18n';
 
 export default class SiteHelper {
   public static isFunctionAppReadOnly(editMode: FunctionAppEditMode): boolean {
@@ -26,7 +26,8 @@ export default class SiteHelper {
       editMode === FunctionAppEditMode.ReadOnlyDotnetIsolated ||
       editMode === FunctionAppEditMode.ReadOnlyArc ||
       editMode === FunctionAppEditMode.ReadOnlyAzureFiles ||
-      editMode === FunctionAppEditMode.ReadOnlyNewNodePreview
+      editMode === FunctionAppEditMode.ReadOnlyNewNodePreview ||
+      editMode === FunctionAppEditMode.ReadOnlyPythonV2
     );
   }
 
@@ -53,7 +54,8 @@ export default class SiteHelper {
       case FunctionAppEditMode.ReadOnlyBYOC: {
         return t('readOnlyBYOC');
       }
-      case FunctionAppEditMode.ReadOnlyPython: {
+      case FunctionAppEditMode.ReadOnlyPython:
+      case FunctionAppEditMode.ReadOnlyPythonV2: {
         return t('ibizafication_readOnlyPython');
       }
       case FunctionAppEditMode.ReadOnlyJava: {
@@ -91,6 +93,9 @@ export default class SiteHelper {
     switch (mode) {
       case FunctionAppEditMode.ReadOnlyPython: {
         return Links.readOnlyPythonAppLearnMore;
+      }
+      case FunctionAppEditMode.ReadOnlyPythonV2: {
+        return Links.readOnlyPythonAppV2LearnMore;
       }
       case FunctionAppEditMode.ReadOnlyVSGenerated: {
         return Links.readOnlyVSGeneratedFunctionLearnMore;

--- a/client-react/src/utils/app-state-utils.tsx
+++ b/client-react/src/utils/app-state-utils.tsx
@@ -3,18 +3,21 @@ import FunctionsService from '../ApiHelpers/FunctionsService';
 import SiteService from '../ApiHelpers/SiteService';
 import { AppSettings } from '../models/app-setting';
 import { ArmArray, ArmObj } from '../models/arm-obj';
-import { HostStatus, FunctionAppContentEditingState } from '../models/functions/host-status';
+import { FunctionAppContentEditingState, HostStatus } from '../models/functions/host-status';
 import { FunctionAppEditMode, SiteReadWriteState } from '../models/portal-models';
 import { SiteConfig } from '../models/site/config';
 import { Site } from '../models/site/site';
+import {
+  isNewNodeProgrammingModel,
+  isNewPythonProgrammingModel,
+} from '../pages/app/functions/function/function-editor/useFunctionEditorQueries';
 import PortalCommunicator from '../portal-communicator';
-import { isContainerApp, isElastic, isFunctionApp, isKubeApp, isLinuxApp, isLinuxDynamic } from './arm-utils';
 import { CommonConstants } from './CommonConstants';
 import FunctionAppService from './FunctionAppService';
+import SiteHelper from './SiteHelper';
+import { isContainerApp, isElastic, isFunctionApp, isKubeApp, isLinuxApp, isLinuxDynamic } from './arm-utils';
 import RbacConstants from './rbac-constants';
 import { ArmSiteDescriptor } from './resourceDescriptors';
-import SiteHelper from './SiteHelper';
-import { isNewNodeProgrammingModel } from '../pages/app/functions/function/function-editor/useFunctionEditorQueries';
 import Url from './url';
 
 export async function resolveState(
@@ -50,10 +53,11 @@ async function resolveStateForFunctionApp(
   functionResourceId?: string
 ) {
   // During new Node Preview, we will make it 'Read only' if it is new Node programming model.
+  // The editor will be read-only for the new v2 programming model for Python.
   if (functionResourceId) {
-    const isNewNodePreviewState = await fetchAndResolveNewNodePreviewState(functionResourceId, portalContext);
-    if (isNewNodePreviewState) {
-      return isNewNodePreviewState;
+    const state = await fetchAndResolveNewProgrammingModelState(functionResourceId, portalContext);
+    if (state) {
+      return state;
     }
   }
 
@@ -91,15 +95,22 @@ async function resolveStateForFunctionApp(
   return FunctionAppEditMode.ReadWrite;
 }
 
-// When we GA new Node programming model, we will remove 'read only' check and will support read/write.
-async function fetchAndResolveNewNodePreviewState(
+async function fetchAndResolveNewProgrammingModelState(
   functionResourceId: string,
   portalContext: PortalCommunicator
 ): Promise<FunctionAppEditMode | undefined> {
   const functionResponse = await FunctionsService.getFunction(functionResourceId);
 
   if (functionResponse.metadata.success) {
-    if (isNewNodeProgrammingModel(functionResponse.data) && !Url.getFeatureValue(CommonConstants.FeatureFlags.enableNewNodeEditMode)) {
+    const functionInfo = functionResponse.data;
+
+    // The v2 programming model for Python will remain 'read only' for the foreseeable future.
+    if (isNewPythonProgrammingModel(functionInfo)) {
+      return FunctionAppEditMode.ReadOnlyPythonV2;
+    }
+
+    // When we GA new Node programming model, we will remove 'read only' check and will support read/write.
+    if (isNewNodeProgrammingModel(functionInfo) && !Url.getFeatureValue(CommonConstants.FeatureFlags.enableNewNodeEditMode)) {
       return FunctionAppEditMode.ReadOnlyNewNodePreview;
     }
   } else {


### PR DESCRIPTION
[AB#18154547](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/18154547), [AB#18154619](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/18154619)

Make the editors (Code+Test and Integration) read-only for v2 programming model Python functions.

Fix React hook dependencies in `useFunctionEditorQueries` hooks.

![image](https://user-images.githubusercontent.com/26208574/234991430-d6b42f55-73f8-42c6-bf27-94a9649a9cdb.png)
