### PR TITLE
[Functions][Python] Re-enable Portal editing for v2 Python functions

### DIFF
--- a/client-react/src/models/portal-models.ts
+++ b/client-react/src/models/portal-models.ts
@@ -336,7 +336,6 @@ export enum FunctionAppEditMode {
   ReadOnlyArc,
   ReadOnlyAzureFiles,
   ReadOnlyNewNodePreview,
-  ReadOnlyPythonV2,
 }
 
 export enum PortalTheme {

--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditorDataLoader.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditorDataLoader.tsx
@@ -7,6 +7,9 @@ import FunctionsService, {
 } from '../../../../../ApiHelpers/FunctionsService';
 import { getJsonHeaders } from '../../../../../ApiHelpers/HttpClient';
 import SiteService from '../../../../../ApiHelpers/SiteService';
+import { PortalContext } from '../../../../../PortalContext';
+import { SiteStateContext } from '../../../../../SiteState';
+import { StartupInfoContext } from '../../../../../StartupInfoContext';
 import CustomBanner from '../../../../../components/CustomBanner/CustomBanner';
 import LoadingComponent from '../../../../../components/Loading/LoadingComponent';
 import { NetAjaxSettings } from '../../../../../models/ajax-request-model';
@@ -15,22 +18,19 @@ import { FunctionInfo } from '../../../../../models/functions/function-info';
 import { RuntimeExtensionCustomVersions, RuntimeExtensionMajorVersions } from '../../../../../models/functions/runtime-extension';
 import { VfsObject } from '../../../../../models/functions/vfs';
 import { KeyValue } from '../../../../../models/portal-models';
-import { PortalContext } from '../../../../../PortalContext';
-import { SiteStateContext } from '../../../../../SiteState';
-import { StartupInfoContext } from '../../../../../StartupInfoContext';
 import { BindingManager } from '../../../../../utils/BindingManager';
 import { Guid } from '../../../../../utils/Guid';
 import { LogCategories } from '../../../../../utils/LogCategories';
+import SiteHelper from '../../../../../utils/SiteHelper';
+import { getTelemetryInfo } from '../../../../../utils/TelemetryUtils';
 import { getJQXHR, isPortalCommunicationStatusSuccess } from '../../../../../utils/portal-utils';
 import { ArmSiteDescriptor } from '../../../../../utils/resourceDescriptors';
-import SiteHelper from '../../../../../utils/SiteHelper';
 import StringUtils from '../../../../../utils/string';
-import { getTelemetryInfo } from '../../../../../utils/TelemetryUtils';
 import Url from '../../../../../utils/url';
 import { FunctionEditor } from './FunctionEditor';
 import FunctionEditorData from './FunctionEditor.data';
 import { shrinkEditorStyle } from './FunctionEditor.styles';
-import { NameValuePair, ResponseContent, UrlObj, urlParameterRegExp, UrlType } from './FunctionEditor.types';
+import { NameValuePair, ResponseContent, UrlObj, UrlType, urlParameterRegExp } from './FunctionEditor.types';
 import { isNewNodeProgrammingModel, useFunctionEditorQueries } from './useFunctionEditorQueries';
 
 interface FunctionEditorDataLoaderProps {
@@ -245,7 +245,7 @@ const FunctionEditorDataLoader: React.FC<FunctionEditorDataLoaderProps> = ({ res
 
       const headers = getHeaders(testDataObject.headers, xFunctionKey);
 
-      let body: any = testDataObject.body;
+      let body: unknown = testDataObject.body;
       if (!body && isNewNodeProgrammingModel(newFunctionInfo)) {
         body = undefined;
       }
@@ -615,7 +615,7 @@ const FunctionEditorDataLoader: React.FC<FunctionEditorDataLoaderProps> = ({ res
         }
       });
     }
-  }, [refreshQueries, site]);
+  }, [portalContext, refreshQueries, site]);
 
   const getDefaultXFunctionKey = (): string => {
     return hostKeys && hostKeys.masterKey ? `master - Host` : '';
@@ -744,6 +744,17 @@ const FunctionEditorDataLoader: React.FC<FunctionEditorDataLoaderProps> = ({ res
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [site, functionInfo, hostKeys, functionKeys]);
 
+  const onCustomBannerClick = useCallback(() => {
+    portalContext.openBlade({
+      detailBlade: 'FunctionDownloadContentTemplateBlade',
+      detailBladeInputs: {
+        id: site?.id,
+      },
+      extension: 'WebsitesExtension',
+      openAsContextBlade: true,
+    });
+  }, [portalContext, site?.id]);
+
   // TODO (krmitta): Show a loading error message site or functionInfo call fails
   if (initialLoading || !site) {
     return <LoadingComponent />;
@@ -783,6 +794,8 @@ const FunctionEditorDataLoader: React.FC<FunctionEditorDataLoaderProps> = ({ res
             status={status}
           />
         </div>
+      ) : site?.id ? (
+        <CustomBanner message={t('functionInfoUnavailableError')} type={MessageBarType.error} onClick={onCustomBannerClick} />
       ) : (
         <CustomBanner message={t('functionInfoFetchError')} type={MessageBarType.error} />
       )}

--- a/client-react/src/pages/app/functions/function/function-editor/useFunctionEditorQueries.ts
+++ b/client-react/src/pages/app/functions/function/function-editor/useFunctionEditorQueries.ts
@@ -2,17 +2,17 @@ import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import AppKeyService from '../../../../../ApiHelpers/AppKeysService';
 import FunctionsService from '../../../../../ApiHelpers/FunctionsService';
 import SiteService from '../../../../../ApiHelpers/SiteService';
-import { PortalContext } from '../../../../../PortalContext';
 import { ArmObj } from '../../../../../models/arm-obj';
 import { FunctionInfo } from '../../../../../models/functions/function-info';
 import { Host } from '../../../../../models/functions/host';
 import { VfsObject } from '../../../../../models/functions/vfs';
 import { SiteConfig } from '../../../../../models/site/config';
 import { Site } from '../../../../../models/site/site';
+import { PortalContext } from '../../../../../PortalContext';
 import { CommonConstants, ExperimentationConstants, WorkerRuntimeLanguages } from '../../../../../utils/CommonConstants';
-import { getTelemetryInfo } from '../../../../../utils/TelemetryUtils';
 import { ArmSiteDescriptor } from '../../../../../utils/resourceDescriptors';
 import StringUtils from '../../../../../utils/string';
+import { getTelemetryInfo } from '../../../../../utils/TelemetryUtils';
 import { SiteRouterContext } from '../../../SiteRouter';
 import { AppKeysInfo } from '../../app-keys/AppKeys.types';
 import FunctionEditorData from './FunctionEditor.data';
@@ -128,7 +128,7 @@ const useAppKeysQuery = (updated: number, siteResourceId: string) => {
   const [hostKeys, setHostKeys] = useState<AppKeysInfo>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalCommunicator = useContext(PortalContext);
+  const portalContext = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -139,7 +139,7 @@ const useAppKeysQuery = (updated: number, siteResourceId: string) => {
         setHostKeys(response.data);
       } else {
         setStatus('error');
-        portalCommunicator.log(
+        portalContext.log(
           getTelemetryInfo('error', 'fetchAppKeys', 'failed', {
             error: response.metadata.error,
             message: 'Failed to fetch app keys',
@@ -147,7 +147,7 @@ const useAppKeysQuery = (updated: number, siteResourceId: string) => {
         );
       }
     });
-  }, [portalCommunicator, siteResourceId, updated]);
+  }, [siteResourceId, updated]);
 
   return {
     hostKeys,
@@ -159,7 +159,7 @@ const useAppSettingsQuery = (updated: number, siteResourceId: string) => {
   const [status, setStatus] = useState<Status>('idle');
   const [workerRuntime, setWorkerRuntime] = useState<string>();
 
-  const portalCommunicator = useContext(PortalContext);
+  const portalContext = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -170,7 +170,7 @@ const useAppSettingsQuery = (updated: number, siteResourceId: string) => {
         setWorkerRuntime(response.data.properties[CommonConstants.AppSettingNames.functionsWorkerRuntime]?.toLowerCase());
       } else {
         setStatus('error');
-        portalCommunicator.log(
+        portalContext.log(
           getTelemetryInfo('error', 'fetchAppSettings', 'failed', {
             error: response.metadata.error,
             message: 'Failed to fetch app settings',
@@ -178,7 +178,7 @@ const useAppSettingsQuery = (updated: number, siteResourceId: string) => {
         );
       }
     });
-  }, [portalCommunicator, siteResourceId, updated]);
+  }, [siteResourceId, updated]);
 
   return {
     status,
@@ -199,7 +199,7 @@ const useFileListQuery = (updated: number, siteResourceId: string, functionInfo?
   const [fileList, setFileList] = useState<VfsObject[]>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalCommunicator = useContext(PortalContext);
+  const portalContext = useContext(PortalContext);
 
   useEffect(() => {
     if (functionName !== undefined && runtimeVersion) {
@@ -222,7 +222,7 @@ const useFileListQuery = (updated: number, siteResourceId: string, functionInfo?
           } else {
             setStatus('error');
           }
-          portalCommunicator.log(
+          portalContext.log(
             getTelemetryInfo('error', 'getFileContent', 'failed', {
               error: response.metadata.error,
               message: 'Failed to get file content',
@@ -233,7 +233,7 @@ const useFileListQuery = (updated: number, siteResourceId: string, functionInfo?
     } else {
       setStatus('idle');
     }
-  }, [functionName, newProgrammingModelFolderName, portalCommunicator, runtimeVersion, siteResourceId, updated]);
+  }, [functionName, newProgrammingModelFolderName, runtimeVersion, siteResourceId, updated]);
 
   return {
     fileList,
@@ -246,7 +246,7 @@ const useFunctionInfoQuery = (updated: number, resourceId: string, functionEdito
   const [functionInfo, setFunctionInfo] = useState<ArmObj<FunctionInfo>>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalCommunicator = useContext(PortalContext);
+  const portalContext = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -257,7 +257,7 @@ const useFunctionInfoQuery = (updated: number, resourceId: string, functionEdito
         setFunctionInfo(response.data);
       } else {
         setStatus('error');
-        portalCommunicator.log(
+        portalContext.log(
           getTelemetryInfo('error', 'getFunction', 'failed', {
             error: response.metadata.error,
             message: 'Failed to get function info',
@@ -265,7 +265,7 @@ const useFunctionInfoQuery = (updated: number, resourceId: string, functionEdito
         );
       }
     });
-  }, [functionEditorData, portalCommunicator, resourceId, updated]);
+  }, [functionEditorData, resourceId, updated]);
 
   return {
     functionInfo,
@@ -278,7 +278,7 @@ const useFunctionKeysQuery = (updated: number, resourceId: string) => {
   const [functionKeys, setFunctionKeys] = useState<Record<string, string>>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalCommunicator = useContext(PortalContext);
+  const portalContext = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -289,7 +289,7 @@ const useFunctionKeysQuery = (updated: number, resourceId: string) => {
         setFunctionKeys(response.data);
       } else {
         setStatus('error');
-        portalCommunicator.log(
+        portalContext.log(
           getTelemetryInfo('error', 'fetchFunctionKeys', 'failed', {
             error: response.metadata.error,
             message: 'Failed to fetch function keys',
@@ -297,7 +297,7 @@ const useFunctionKeysQuery = (updated: number, resourceId: string) => {
         );
       }
     });
-  }, [portalCommunicator, resourceId, updated]);
+  }, [resourceId, updated]);
 
   return {
     functionKeys,
@@ -309,7 +309,7 @@ const useHostJsonQuery = (updated: number, siteResourceId: string, runtimeVersio
   const [hostJsonContent, setHostJsonContent] = useState<Host>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalCommunicator = useContext(PortalContext);
+  const portalContext = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -325,7 +325,7 @@ const useHostJsonQuery = (updated: number, siteResourceId: string, runtimeVersio
           } else {
             setStatus('error');
           }
-          portalCommunicator.log(
+          portalContext.log(
             getTelemetryInfo('error', 'getHostJson', 'failed', {
               error: response.metadata.error,
               message: 'Failed to get host json file',
@@ -336,7 +336,7 @@ const useHostJsonQuery = (updated: number, siteResourceId: string, runtimeVersio
     } else {
       setStatus('idle');
     }
-  }, [portalCommunicator, runtimeVersion, siteResourceId, updated]);
+  }, [runtimeVersion, siteResourceId, updated]);
 
   return {
     hostJsonContent,
@@ -348,7 +348,7 @@ const useHostStatusQuery = (updated: number, siteResourceId: string) => {
   const [runtimeVersion, setRuntimeVersion] = useState<string>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalCommunicator = useContext(PortalContext);
+  const portalContext = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -361,7 +361,7 @@ const useHostStatusQuery = (updated: number, siteResourceId: string) => {
         setRuntimeVersion(currentRuntimeVersion);
       } else {
         setStatus('error');
-        portalCommunicator.log(
+        portalContext.log(
           getTelemetryInfo('error', 'fetchFunctionHostStatus', 'failed', {
             error: response.metadata.error,
             message: 'Failed to fetch host status',
@@ -369,7 +369,7 @@ const useHostStatusQuery = (updated: number, siteResourceId: string) => {
         );
       }
     });
-  }, [portalCommunicator, siteResourceId, updated]);
+  }, [siteResourceId, updated]);
 
   return {
     runtimeVersion,
@@ -407,7 +407,7 @@ const useSiteQuery = (updated: number, siteResourceId: string) => {
   const [site, setSite] = useState<ArmObj<Site>>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalCommunicator = useContext(PortalContext);
+  const portalContext = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -418,7 +418,7 @@ const useSiteQuery = (updated: number, siteResourceId: string) => {
         setSite(response.data);
       } else {
         setStatus('error');
-        portalCommunicator.log(
+        portalContext.log(
           getTelemetryInfo('error', 'fetchSite', 'failed', {
             error: response.metadata.error,
             message: 'Failed to fetch site',
@@ -426,7 +426,7 @@ const useSiteQuery = (updated: number, siteResourceId: string) => {
         );
       }
     });
-  }, [context, portalCommunicator, siteResourceId, updated]);
+  }, [context, siteResourceId, updated]);
 
   return {
     site,
@@ -438,7 +438,7 @@ const useSiteConfigQuery = (updated: number, siteResourceId: string, functionEdi
   const [siteConfig, setSiteConfig] = useState<ArmObj<SiteConfig>>();
   const [status, setStatus] = useState<Status>('idle');
 
-  const portalCommunicator = useContext(PortalContext);
+  const portalContext = useContext(PortalContext);
 
   useEffect(() => {
     setStatus('loading');
@@ -455,7 +455,7 @@ const useSiteConfigQuery = (updated: number, siteResourceId: string, functionEdi
         };
       } else {
         setStatus('error');
-        portalCommunicator.log(
+        portalContext.log(
           getTelemetryInfo('error', 'fetchSiteConfig', 'failed', {
             error: response.metadata.error,
             message: 'Failed to fetch site-config',
@@ -463,7 +463,7 @@ const useSiteConfigQuery = (updated: number, siteResourceId: string, functionEdi
         );
       }
     });
-  }, [functionEditorData, portalCommunicator, siteResourceId, updated]);
+  }, [functionEditorData, siteResourceId, updated]);
 
   return {
     siteConfig,

--- a/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.tsx
+++ b/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.tsx
@@ -1,9 +1,12 @@
 import { IStackTokens, MessageBarType, Stack } from '@fluentui/react';
-import React, { useContext, useRef, useState } from 'react';
+import React, { useCallback, useContext, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useWindowSize } from 'react-use';
 import { Observable, Subject } from 'rxjs';
 import { classes } from 'typestyle';
+import { PortalContext } from '../../../../../PortalContext';
+import { SiteStateContext } from '../../../../../SiteState';
+import { ThemeContext } from '../../../../../ThemeContext';
 import CustomBanner from '../../../../../components/CustomBanner/CustomBanner';
 import EditModeBanner from '../../../../../components/EditModeBanner/EditModeBanner';
 import LoadingComponent from '../../../../../components/Loading/LoadingComponent';
@@ -14,15 +17,9 @@ import { Binding, BindingDirection } from '../../../../../models/functions/bindi
 import { BindingInfo } from '../../../../../models/functions/function-binding';
 import { FunctionInfo } from '../../../../../models/functions/function-info';
 import { HostStatus } from '../../../../../models/functions/host-status';
-import { SiteStateContext } from '../../../../../SiteState';
-import { ThemeContext } from '../../../../../ThemeContext';
+import { Links } from '../../../../../utils/FwLinks';
 import SiteHelper from '../../../../../utils/SiteHelper';
 import StringUtils from '../../../../../utils/string';
-import FunctionNameBindingCard from './binding-card/FunctionNameBindingCard';
-import InputBindingCard from './binding-card/InputBindingCard';
-import OutputBindingCard from './binding-card/OutputBindingCard';
-import TriggerBindingCard from './binding-card/TriggerBindingCard';
-import UnknownDirectionBindingCard from './binding-card/UnknownDirectionBindingCard';
 import { ClosedReason } from './BindingPanel/BindingEditor';
 import BindingPanel from './BindingPanel/BindingPanel';
 import {
@@ -36,11 +33,15 @@ import {
 } from './FunctionIntegrate.style';
 import FunctionIntegrateCommandBar from './FunctionIntegrateCommandBar';
 import { FunctionIntegrateConstants } from './FunctionIntegrateConstants';
-import { Links } from '../../../../../utils/FwLinks';
+import FunctionNameBindingCard from './binding-card/FunctionNameBindingCard';
+import InputBindingCard from './binding-card/InputBindingCard';
+import OutputBindingCard from './binding-card/OutputBindingCard';
+import TriggerBindingCard from './binding-card/TriggerBindingCard';
+import UnknownDirectionBindingCard from './binding-card/UnknownDirectionBindingCard';
 
 export interface FunctionIntegrateProps {
   functionAppId: string;
-  functionInfo: ArmObj<FunctionInfo>;
+  functionInfo: ArmObj<FunctionInfo> | null;
   bindings: Binding[];
   bindingsError: boolean;
   hostStatus: HostStatus;
@@ -77,6 +78,7 @@ export const FunctionIntegrate: React.FunctionComponent<FunctionIntegrateProps> 
     loadBindingSettings,
   } = props;
   const { t } = useTranslation();
+  const portalCommunicator = useContext(PortalContext);
   const siteStateContext = useContext(SiteStateContext);
   const theme = useContext(ThemeContext);
   const { width } = useWindowSize();
@@ -85,7 +87,7 @@ export const FunctionIntegrate: React.FunctionComponent<FunctionIntegrateProps> 
   const bindingUpdate$ = useRef(new Subject<BindingUpdateInfo>());
   const [bindingToUpdate, setBindingToUpdate] = useState<BindingInfo | undefined>(undefined);
   const [bindingDirection, setBindingDirection] = useState<BindingDirection>(BindingDirection.in);
-  const [functionInfo, setFunctionInfo] = useState<ArmObj<FunctionInfo>>(initialFunctionInfo);
+  const [functionInfo, setFunctionInfo] = useState<ArmObj<FunctionInfo> | null>(initialFunctionInfo);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isUpdating, setIsUpdating] = useState<boolean>(false);
 
@@ -141,7 +143,7 @@ export const FunctionIntegrate: React.FunctionComponent<FunctionIntegrateProps> 
     childrenGap: 0,
   };
 
-  const fullPageContent: JSX.Element = (
+  const fullPageContent: JSX.Element | null = functionInfo ? (
     <Stack className={diagramWrapperStyle} horizontal horizontalAlign={'center'} tokens={tokens}>
       <Stack.Item grow>
         <Stack gap={40}>
@@ -181,9 +183,9 @@ export const FunctionIntegrate: React.FunctionComponent<FunctionIntegrateProps> 
         </Stack>
       </Stack.Item>
     </Stack>
-  );
+  ) : null;
 
-  const smallPageContent: JSX.Element = (
+  const smallPageContent: JSX.Element | null = functionInfo ? (
     <Stack className={smallPageStyle} gap={40} horizontalAlign={'start'}>
       <TriggerBindingCard functionInfo={functionInfo} bindings={bindings} readOnly={readOnly} loadBindingSettings={loadBindingSettings} />
       <InputBindingCard functionInfo={functionInfo} bindings={bindings} readOnly={readOnly} loadBindingSettings={loadBindingSettings} />
@@ -191,26 +193,41 @@ export const FunctionIntegrate: React.FunctionComponent<FunctionIntegrateProps> 
       <OutputBindingCard functionInfo={functionInfo} bindings={bindings} readOnly={readOnly} loadBindingSettings={loadBindingSettings} />
       <UnknownDirectionBindingCard functionInfo={functionInfo} bindings={bindings} />
     </Stack>
-  );
+  ) : null;
 
-  const functionConfig = functionInfo.properties.config;
-  const isCompiledFunction = StringUtils.equalsIgnoreCase(
-    functionConfig.configurationSource,
-    FunctionIntegrateConstants.compiledFunctionConfigurationSource
-  );
+  const functionConfig = functionInfo?.properties.config;
 
-  const bindingsMissingDirection = functionConfig.bindings.filter(
+  const isCompiledFunction =
+    functionConfig === undefined
+      ? undefined
+      : StringUtils.equalsIgnoreCase(functionConfig.configurationSource, FunctionIntegrateConstants.compiledFunctionConfigurationSource);
+
+  const bindingsMissingDirection = functionConfig?.bindings.filter(
     binding => !binding.direction && !StringUtils.endsWithIgnoreCase(binding.type.toString(), 'Trigger')
   );
+
+  const onFunctionInfoErrorClick = useCallback(() => {
+    portalCommunicator.openBlade({
+      detailBlade: 'FunctionDownloadContentTemplateBlade',
+      detailBladeInputs: {
+        id: functionAppId,
+      },
+      extension: 'WebsitesExtension',
+      openAsContextBlade: true,
+    });
+  }, [functionAppId, portalCommunicator]);
 
   let banner: JSX.Element | undefined;
   if (bindingsError) {
     // Issue loading bindings or binding settings
     banner = <CustomBanner message={t('integrate_bindingsFailedLoading')} type={MessageBarType.error} />;
-  } else if (isCompiledFunction && bindingsMissingDirection.length === 0) {
+  } else if (!functionInfo) {
+    // Issue loading function info
+    banner = <CustomBanner message={t('functionInfoUnavailableError')} type={MessageBarType.error} onClick={onFunctionInfoErrorClick} />;
+  } else if (isCompiledFunction && bindingsMissingDirection && bindingsMissingDirection.length === 0) {
     // It's a C# compiled function, and older versions of the SDK don't show input/out bindings.
     banner = <CustomBanner message={t('integrate_compiledDoNotShowInputOutput')} type={MessageBarType.info} />;
-  } else if (bindingsMissingDirection.length > 0) {
+  } else if (bindingsMissingDirection && bindingsMissingDirection.length > 0) {
     // Bindings are missing the direction property, we'll likely put them in the wrong spot
     banner = (
       <CustomBanner
@@ -234,20 +251,24 @@ export const FunctionIntegrate: React.FunctionComponent<FunctionIntegrateProps> 
           <h3>{t('integratePageTitle')}</h3>
           <div>{t('integratePageDescription')}</div>
         </div>
-        <BindingPanel
-          functionAppId={functionAppId}
-          functionInfo={functionInfo}
-          bindings={bindings}
-          bindingInfo={bindingToUpdate}
-          bindingDirection={bindingDirection}
-          isOpen={isOpen}
-          readOnly={readOnly}
-          onlyBuiltInBindings={onlyBuiltInBindings}
-          onPanelClose={onCancel}
-          onSubmit={onSubmit}
-          onDelete={onDelete}
-        />
-        {width > fullPageWidth ? fullPageContent : smallPageContent}
+        {functionInfo ? (
+          <>
+            <BindingPanel
+              functionAppId={functionAppId}
+              functionInfo={functionInfo}
+              bindings={bindings}
+              bindingInfo={bindingToUpdate}
+              bindingDirection={bindingDirection}
+              isOpen={isOpen}
+              readOnly={readOnly}
+              onlyBuiltInBindings={onlyBuiltInBindings}
+              onPanelClose={onCancel}
+              onSubmit={onSubmit}
+              onDelete={onDelete}
+            />
+            {width > fullPageWidth ? fullPageContent : smallPageContent}
+          </>
+        ) : null}
       </BindingEditorContext.Provider>
     </>
   );

--- a/client-react/src/utils/FwLinks.ts
+++ b/client-react/src/utils/FwLinks.ts
@@ -9,7 +9,6 @@ export const Links = {
   runtimeScaleMonitoringLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2104710',
   remoteDebuggingLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2116583',
   readOnlyPythonAppLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2074230',
-  readOnlyPythonAppV2LearnMore: 'https://go.microsoft.com/fwlink/?linkid=2234387',
   readOnlyVSGeneratedFunctionLearnMore: 'https://go.microsoft.com/fwlink/?linkid=856288',
   staticSiteEnvironmentVariablesLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2128074',
   // TODO (krmitta): Update the learn more link with the correct fwlink

--- a/client-react/src/utils/SiteHelper.ts
+++ b/client-react/src/utils/SiteHelper.ts
@@ -1,10 +1,10 @@
-import { ArmObj } from '../models/arm-obj';
 import { FunctionAppEditMode } from '../models/portal-models';
-import { SiteConfig } from '../models/site/config';
-import { Site } from '../models/site/site';
-import { Links } from './FwLinks';
-import { isPremiumV2 } from './arm-utils';
 import i18n from './i18n';
+import { ArmObj } from '../models/arm-obj';
+import { Site } from '../models/site/site';
+import { SiteConfig } from '../models/site/config';
+import { isPremiumV2 } from './arm-utils';
+import { Links } from './FwLinks';
 
 export default class SiteHelper {
   public static isFunctionAppReadOnly(editMode: FunctionAppEditMode): boolean {
@@ -26,8 +26,7 @@ export default class SiteHelper {
       editMode === FunctionAppEditMode.ReadOnlyDotnetIsolated ||
       editMode === FunctionAppEditMode.ReadOnlyArc ||
       editMode === FunctionAppEditMode.ReadOnlyAzureFiles ||
-      editMode === FunctionAppEditMode.ReadOnlyNewNodePreview ||
-      editMode === FunctionAppEditMode.ReadOnlyPythonV2
+      editMode === FunctionAppEditMode.ReadOnlyNewNodePreview
     );
   }
 
@@ -54,8 +53,7 @@ export default class SiteHelper {
       case FunctionAppEditMode.ReadOnlyBYOC: {
         return t('readOnlyBYOC');
       }
-      case FunctionAppEditMode.ReadOnlyPython:
-      case FunctionAppEditMode.ReadOnlyPythonV2: {
+      case FunctionAppEditMode.ReadOnlyPython: {
         return t('ibizafication_readOnlyPython');
       }
       case FunctionAppEditMode.ReadOnlyJava: {
@@ -93,9 +91,6 @@ export default class SiteHelper {
     switch (mode) {
       case FunctionAppEditMode.ReadOnlyPython: {
         return Links.readOnlyPythonAppLearnMore;
-      }
-      case FunctionAppEditMode.ReadOnlyPythonV2: {
-        return Links.readOnlyPythonAppV2LearnMore;
       }
       case FunctionAppEditMode.ReadOnlyVSGenerated: {
         return Links.readOnlyVSGeneratedFunctionLearnMore;

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2321,6 +2321,7 @@ export class PortalResources {
   public static pricing_ACU_Pv3 = 'pricing_ACU_Pv3';
   public static pricing_vCores = 'pricing_vCores';
   public static functionInfoFetchError = 'functionInfoFetchError';
+  public static functionInfoUnavailableError = 'functionInfoUnavailableError';
   public static createHostKeyNotification = 'createHostKeyNotification';
   public static createSystemKeyNotification = 'createSystemKeyNotification';
   public static createFunctionKeyNotification = 'createFunctionKeyNotification';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7110,6 +7110,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="functionInfoFetchError" xml:space="preserve">
         <value>Unable to fetch your function</value>
     </data>
+    <data name="functionInfoUnavailableError" xml:space="preserve">
+        <value>The function is unavailable for editing in the portal. Click to download app content and use a local development environment to fix the function.</value>
+    </data>
     <data name="createHostKeyNotification" xml:space="preserve">
         <value>Creating host key</value>
     </data>


### PR DESCRIPTION
Show error banner which, when clicked, opens the Download app content blade if either Code + Test or Integrate is unable to fetch function info due to 404 errors.

This could happen if the user made mistakes while creating or editing v2 programming model Python functions.

Revert "[Functions][Python] Ensure Code+Test works in v2 programming model (#7176)" (commit hash `cb6f31da9`)