### PR TITLE
AB#16368791 Updating Client certificate mode when using HTTP 2.0

### DIFF
--- a/client-react/package-lock.json
+++ b/client-react/package-lock.json
@@ -698,7 +698,7 @@
     },
     "@babel/helper-replace-supers": {
       "version": "7.14.5",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.14.5",

--- a/client-react/src/pages/app/app-settings/AppSettings.types.ts
+++ b/client-react/src/pages/app/app-settings/AppSettings.types.ts
@@ -47,6 +47,7 @@ export interface AppSettingsFormValues {
   currentlySelectedStack: string;
   basicPublishingCredentialsPolicies: ArmObj<PublishingCredentialPolicies> | null;
   references?: KeyVaultReferences;
+  httpTwo?: boolean;
 }
 
 export interface FormState {

--- a/client-react/src/pages/app/app-settings/GeneralSettings/ClientCert/ClientCert.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/ClientCert/ClientCert.tsx
@@ -104,7 +104,7 @@ const ClientCert: React.FC<FormikProps<AppSettingsFormValues>> = props => {
           label={t('clientCertificateMode')}
           id="incoming-client-certificate-mode"
           ariaLabelledBy={`incoming-client-certificate-mode-label`}
-          disabled={disableAllControls || clientCertEnabled.status === 'disabled'}
+          disabled={disableAllControls || clientCertEnabled.status === 'disabled' || values.httpTwo}
           upsellMessage={clientCertEnabled.status === 'disabled' ? clientCertEnabled.data : ''}
           selectedKey={getCompositeClientCertMode(values.site)}
           infoBubbleMessage={getClientCertInfoBubbleMessage(values.site)}

--- a/client-react/src/pages/app/app-settings/GeneralSettings/Platform.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/Platform.tsx
@@ -57,9 +57,12 @@ const Platform: React.FC<FormikProps<AppSettingsFormValues>> = props => {
     // Set HTTP 2.0 Proxy to 'Off' if http 2.0 is not enabled.
     if (!option.key) {
       props.setFieldValue('config.properties.http20ProxyFlag', 0);
+      values.httpTwo = false;
     } else {
       // Enable gPRC only mode for HTTP 2.0
       props.setFieldValue('config.properties.http20ProxyFlag', 2);
+      values.httpTwo = true;
+      props.setFieldValue('site.properties.clientCertEnabled', false);
     }
 
     props.setFieldValue('config.properties.http20Enabled', option.key);
@@ -211,6 +214,7 @@ const Platform: React.FC<FormikProps<AppSettingsFormValues>> = props => {
             name="config.properties.http20Enabled"
             dirty={values.config.properties.http20Enabled !== initialValues.config.properties.http20Enabled}
             component={Dropdown}
+            infoBubbleMessage={t('httpCertWarningInfoBubbleMessage')}
             fullpage
             label={t('httpVersion')}
             id="app-settings-http-enabled"

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -495,6 +495,7 @@ export class PortalResources {
   public static httpsOnlyInfoBubbleMessage = 'httpsOnlyInfoBubbleMessage';
   public static https20ProxyInfoBubbleMessage = 'https20ProxyInfoBubbleMessage';
   public static basicAuthPublishingCredInfoBubbleMessage = 'basicAuthPublishingCredInfoBubbleMessage';
+  public static httpCertWarningInfoBubbleMessage = 'httpCertWarningInfoBubbleMessage';
   public static minTlsVersionLabel = 'minTlsVersionLabel';
   public static minTlsVersionInfoBubbleMessage = 'minTlsVersionInfoBubbleMessage';
   public static minTlsCipherSuiteLabel = 'minTlsCipherSuiteLabel';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -1597,6 +1597,9 @@
     <data name="basicAuthPublishingCredInfoBubbleMessage" xml:space="preserve">
         <value>Disable basic authentication for FTP and SCM access.</value>
     </data>
+    <data name="httpCertWarningInfoBubbleMessage" xml:space="preserve">
+        <value>When selecting HTTP version 2.0, incoming client certificates must be ignored.</value>
+    </data>
     <data name="minTlsVersionLabel" xml:space="preserve">
         <value>Minimum TLS Version</value>
     </data>


### PR DESCRIPTION
Solution for AB#[16368791](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s214?workitem=16368791)

-Adding an information line under the HTTP version selector to explain that incoming client certificates must be ignored when HTTP version is 2.0
-Setting the Client certificate mode to Ignore and greying out the Incoming client certificates section when HTTP version 2.0 is selected
![httpCert](https://user-images.githubusercontent.com/34044735/236281052-69ee94c0-7023-4014-8709-43c24c777fe0.gif)

