### PR TITLE
[Functions][Python] Add support for blueprints

### DIFF
--- a/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/ExistingFileDropdown.tsx
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/ExistingFileDropdown.tsx
@@ -1,0 +1,109 @@
+import { IDropdownOption } from '@fluentui/react';
+import { Field } from 'formik';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Dropdown from '../../../../../components/form-controls/DropDown';
+import { Layout } from '../../../../../components/form-controls/ReactiveFormControl';
+import { VfsObject } from '../../../../../models/functions/vfs';
+import { horizontalLabelStyle } from '../../common/BindingFormBuilder.styles';
+import { useFiles } from './useFiles';
+
+interface ExistingFileDropdownProps {
+  id: string;
+  label: string;
+  required: boolean;
+  resourceId: string;
+  help?: string;
+}
+
+const ExistingFileDropdown: React.FC<ExistingFileDropdownProps> = ({
+  id,
+  help,
+  label,
+  required,
+  resourceId,
+}: ExistingFileDropdownProps) => {
+  const { isLoading, options, validate } = useExistingFileDropdown(resourceId, required);
+
+  return (
+    <Field
+      id={id}
+      component={Dropdown}
+      customLabelClassName={horizontalLabelStyle}
+      customLabelStackClassName={horizontalLabelStyle}
+      dirty={false}
+      isLoading={isLoading}
+      label={label}
+      layout={Layout.Horizontal}
+      mouseOverToolTip={help}
+      name={id}
+      onPanel
+      options={options}
+      required={required}
+      resourceId={resourceId}
+      validate={validate}
+    />
+  );
+};
+
+function useExistingFileDropdown(resourceId: string, required: boolean) {
+  const { t } = useTranslation();
+
+  const { getFileContent } = useFiles(resourceId);
+
+  const [files, setFiles] = useState<VfsObject[]>();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const options = useMemo<IDropdownOption<unknown>[] | undefined>(
+    () =>
+      files?.map(file => ({
+        key: file.name,
+        text: file.name,
+      })),
+    [files]
+  );
+
+  const validate = useCallback(
+    (value?: string): string | undefined => {
+      if (!value) {
+        if (required) {
+          return t('fieldRequired');
+        }
+      }
+    },
+    [required, t]
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (resourceId) {
+      setIsLoading(true);
+      getFileContent('')
+        .then(objects => {
+          if (isMounted) {
+            if (Array.isArray(objects)) {
+              setFiles(objects);
+            }
+          }
+        })
+        .finally(() => {
+          if (isMounted) {
+            setIsLoading(false);
+          }
+        });
+    }
+
+    return () => {
+      isMounted = false;
+    };
+  }, [getFileContent, resourceId]);
+
+  return {
+    isLoading,
+    options,
+    validate,
+  };
+}
+
+export default ExistingFileDropdown;

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/Helpers.ts
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/Helpers.ts
@@ -1,13 +1,52 @@
-import { FunctionTemplateV2 } from '../../../../../models/functions/function-template-v2';
+import { FunctionTemplateV2, JobInput } from '../../../../../models/functions/function-template-v2';
+import { BindingEditorFormValues } from '../../common/BindingFormBuilder';
+import { JobType } from './JobType';
 
-export function getAppendToFileInputs(selectedTemplate: FunctionTemplateV2) {
-  return getJobInputs(selectedTemplate, 'AppendToFile');
-}
-
-export function getCreateNewAppInputs(selectedTemplate: FunctionTemplateV2) {
-  return getJobInputs(selectedTemplate, 'CreateNewApp');
-}
-
-function getJobInputs(selectedTemplate: FunctionTemplateV2, jobType: string) {
+export function getJobInputs(selectedTemplate: FunctionTemplateV2, jobType: string) {
   return selectedTemplate.jobs.find(({ type }) => type === jobType)?.inputs;
+}
+
+export function getPaths(
+  selectedTemplate: FunctionTemplateV2,
+  jobType: string,
+  substitutions: Record<string, string>
+): string[] | undefined {
+  switch (jobType) {
+    case JobType.CreateNewApp: {
+      const path1 = selectedTemplate.actions.find(({ name }) => name === 'readFileContent_FunctionApp')?.filePath;
+      return path1 ? applySubstitutionsToPaths([path1], substitutions) : undefined;
+    }
+    case JobType.AppendToFile: {
+      const path1 = selectedTemplate.actions.find(({ name }) => name === 'readFileContent_FunctionBody')?.filePath;
+      return path1 ? applySubstitutionsToPaths([path1], substitutions) : undefined;
+    }
+    case JobType.CreateNewBlueprint: {
+      const path1 = selectedTemplate.actions.find(({ name }) => name === 'readFileContent_BlueprintFile')?.filePath;
+      const path2 = selectedTemplate.actions.find(({ name }) => name === 'readFileContent_BlueprintBody')?.filePath;
+      return path1 && path2 ? applySubstitutionsToPaths([path1, path2], substitutions) : undefined;
+    }
+    case JobType.AppendToBlueprint: {
+      const path1 = selectedTemplate.actions.find(({ name }) => name === 'readFileContent_BlueprintBody')?.filePath;
+      return path1 ? applySubstitutionsToPaths([path1], substitutions) : undefined;
+    }
+    default:
+      return undefined;
+  }
+}
+
+export function getSubstitutions(selectedTemplate: FunctionTemplateV2, jobType: string, values: BindingEditorFormValues) {
+  // Modify the file with form values via string interpolation.
+  const toSubstitution = (previous: Record<string, string>, current: JobInput): Record<string, string> => {
+    return { ...previous, [current.assignTo]: values[current.paramId] };
+  };
+
+  return getJobInputs(selectedTemplate, jobType)?.reduce(toSubstitution, {});
+}
+
+function applySubstitutionsToPaths(paths: string[], substitutions: Record<string, string>): string[] {
+  return paths.map(path => {
+    return Object.entries(substitutions).reduce((previous, [key, value]) => {
+      return previous.replaceAll(key, value);
+    }, path);
+  });
 }

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/NewFileTextField.tsx
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/NewFileTextField.tsx
@@ -1,0 +1,62 @@
+import { Field } from 'formik';
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import TextField from '../../../../../components/form-controls/TextField';
+import { horizontalLabelStyle } from '../../common/BindingFormBuilder.styles';
+import { useFiles } from './useFiles';
+import { Layout } from '../../../../../components/form-controls/ReactiveFormControl';
+
+interface NewFileTextFieldProps {
+  id: string;
+  label: string;
+  required: boolean;
+  resourceId: string;
+  help?: string;
+}
+
+const NewFileTextField: React.FC<NewFileTextFieldProps> = ({ id, help, label, required, resourceId }: NewFileTextFieldProps) => {
+  const validate = useNewFileValidator(required, resourceId);
+
+  return (
+    <Field
+      id={id}
+      component={TextField}
+      customLabelClassName={horizontalLabelStyle}
+      customLabelStackClassName={horizontalLabelStyle}
+      dirty={false}
+      label={label}
+      layout={Layout.Horizontal}
+      mouseOverToolTip={help}
+      name={id}
+      onPanel
+      required={required}
+      resourceId={resourceId}
+      validate={validate}
+    />
+  );
+};
+
+function useNewFileValidator(required: boolean, resourceId: string) {
+  const { t } = useTranslation();
+
+  const { existsFile } = useFiles(resourceId);
+
+  const validate = useCallback(
+    async (value?: string): Promise<string | undefined> => {
+      if (!value) {
+        if (required) {
+          return t('fieldRequired');
+        }
+      } else {
+        if (await existsFile(value)) {
+          return t('functionNew_fileExists').format(value);
+        }
+      }
+    },
+    [existsFile, required, t]
+  );
+
+  return validate;
+}
+
+export default NewFileTextField;

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/TemplateDetail.tsx
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/TemplateDetail.tsx
@@ -1,8 +1,11 @@
 import { Link } from '@fluentui/react';
 import { Field, FormikProps } from 'formik';
 import { useTranslation } from 'react-i18next';
+import Dropdown from '../../../../../components/form-controls/DropDown';
+import { Layout } from '../../../../../components/form-controls/ReactiveFormControl';
 import { FunctionTemplateV2 } from '../../../../../models/functions/function-template-v2';
 import { Links } from '../../../../../utils/FwLinks';
+import { horizontalLabelStyle } from '../../common/BindingFormBuilder.styles';
 import { detailContainerStyle } from '../FunctionCreate.styles';
 import { useTemplateDetail } from './useTemplateDetail';
 
@@ -15,7 +18,7 @@ interface TemplateDetailProps {
 const TemplateDetail: React.FC<TemplateDetailProps> = ({ formProps, resourceId, selectedTemplate }: TemplateDetailProps) => {
   const { t } = useTranslation();
 
-  const fields = useTemplateDetail(resourceId, selectedTemplate);
+  const { fields, jobTypeOptions, makeTextValidator } = useTemplateDetail(formProps, resourceId, selectedTemplate);
 
   return (
     <div className={detailContainerStyle}>
@@ -27,6 +30,20 @@ const TemplateDetail: React.FC<TemplateDetailProps> = ({ formProps, resourceId, 
         </Link>
       </p>
       <>
+        <Field
+          id="jobType"
+          component={Dropdown}
+          customLabelClassName={horizontalLabelStyle}
+          customLabelStackClassName={horizontalLabelStyle}
+          dirty={false}
+          label={t('functionNew_functionKind')}
+          layout={Layout.Horizontal}
+          name="jobType"
+          onPanel
+          options={jobTypeOptions}
+          required
+          validate={makeTextValidator(/* required */ true)}
+        />
         {fields?.map(field => (
           <Field key={field.id} {...formProps} {...field} />
         ))}

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFields.ts
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFields.ts
@@ -1,5 +1,5 @@
 import { IDropdownOption } from '@fluentui/react';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import Dropdown from '../../../../../components/form-controls/DropDown';
 import { Layout } from '../../../../../components/form-controls/ReactiveFormControl';
@@ -10,33 +10,29 @@ import { UserPrompt } from '../../../../../models/functions/user-prompt';
 import { horizontalLabelStyle } from '../../common/BindingFormBuilder.styles';
 import ResourceDropdown from '../../common/ResourceDropdown';
 import { useFunctionsQuery } from '../../function/hooks/useFunctionsQuery';
+import ExistingFileDropdown from './ExistingFileDropdown';
 import { FieldProps } from './FieldProps';
-import { getAppendToFileInputs, getCreateNewAppInputs } from './Helpers';
+import { getJobInputs } from './Helpers';
+import NewFileTextField from './NewFileTextField';
 
-export function useFields(
-  functionAppExists: boolean | undefined = undefined,
-  resourceId: string,
-  selectedTemplate?: FunctionTemplateV2,
-  userPrompts?: UserPrompt[]
-) {
+export function useFields(resourceId: string, jobType?: string, selectedTemplate?: FunctionTemplateV2, userPrompts?: UserPrompt[]) {
   const { t } = useTranslation();
 
   const { functions } = useFunctionsQuery(resourceId);
 
-  const fields = useMemo(() => {
-    if (functionAppExists === undefined || !selectedTemplate || !userPrompts) {
-      return [];
-    }
-
-    const makeBooleanValidator = (required: boolean) => {
+  const makeBooleanValidator = useCallback(
+    (required: boolean) => {
       return (value?: boolean): string | undefined => {
         if (required && value === undefined) {
           return t('fieldRequired');
         }
       };
-    };
+    },
+    [t]
+  );
 
-    const makeFunctionNameValidator = (required: boolean, validators: UserPrompt['validators']) => {
+  const makeFunctionNameValidator = useCallback(
+    (required: boolean, validators: UserPrompt['validators'] = []) => {
       return (value?: string): string | undefined => {
         if (!value) {
           if (required) {
@@ -54,9 +50,12 @@ export function useFields(
           }
         }
       };
-    };
+    },
+    [functions, t]
+  );
 
-    const makeTextValidator = (required: boolean, validators: UserPrompt['validators']) => {
+  const makeTextValidator = useCallback(
+    (required: boolean, validators: UserPrompt['validators'] = []) => {
       return (value?: string): string | undefined => {
         if (!value) {
           if (required) {
@@ -70,7 +69,14 @@ export function useFields(
           }
         }
       };
-    };
+    },
+    [t]
+  );
+
+  const fields = useMemo(() => {
+    if (jobType === undefined || !selectedTemplate || !userPrompts) {
+      return [];
+    }
 
     const deriveFieldFromUserPrompts = (
       paramId: string,
@@ -83,10 +89,10 @@ export function useFields(
         return undefined;
       }
 
-      /** @note A field is required if either the action input or user prompt indicates that it should be required. */
+      // A field is required if either the action input or user prompt indicates that it should be required.
       required = required || setting.required;
 
-      /** @note Prefer `paramId` over `setting.name` to keep `initialValues` keys and `field` IDs in sync. */
+      // Prefer `paramId` over `setting.name` to keep `initialValues` keys and `field` IDs in sync.
       const { value } = setting;
 
       if (value && /boolean/i.test(value)) {
@@ -150,24 +156,44 @@ export function useFields(
           validate: makeTextValidator(required, setting.validators),
         };
       } else if (setting.resource) {
-        return {
-          id: paramId,
-          component: ResourceDropdown,
-          customLabelClassName: horizontalLabelStyle,
-          customLabelStackClassName: horizontalLabelStyle,
-          dirty: false,
-          label: setting.label,
-          layout: Layout.Horizontal,
-          mouseOverToolTip: setting.help,
-          name: paramId,
-          onPanel: true,
-          required,
-          resourceId,
-          setting,
-          validate: makeTextValidator(required, setting.validators),
-        };
+        if (setting.resource === 'Newfile') {
+          return {
+            id: paramId,
+            component: NewFileTextField,
+            help: setting.help,
+            label: setting.label,
+            required,
+            resourceId,
+          };
+        } else if (setting.resource === 'Existingfile') {
+          return {
+            id: paramId,
+            component: ExistingFileDropdown,
+            help: setting.help,
+            label: setting.label,
+            required,
+            resourceId,
+          };
+        } else {
+          return {
+            id: paramId,
+            component: ResourceDropdown,
+            customLabelClassName: horizontalLabelStyle,
+            customLabelStackClassName: horizontalLabelStyle,
+            dirty: false,
+            label: setting.label,
+            layout: Layout.Horizontal,
+            mouseOverToolTip: setting.help,
+            name: paramId,
+            onPanel: true,
+            required,
+            resourceId,
+            setting,
+            validate: makeTextValidator(required, setting.validators),
+          };
+        }
       } else {
-        /** @note Unrecognized fields (like `null`) are treated as if they were `string` fields. */
+        // Unrecognized fields (like `null`) are treated as if they were `string` fields.
         return {
           id: paramId,
           component: TextField,
@@ -196,10 +222,8 @@ export function useFields(
       };
     };
 
-    /** @todo (joechung): AB#19990968, AB#19991047 */
-    const inputs = functionAppExists
-      ? getAppendToFileInputs(selectedTemplate)?.reduce(toInputs, {}) ?? {}
-      : getCreateNewAppInputs(selectedTemplate)?.reduce(toInputs, {}) ?? {};
+    // The blueprint filename input can be used for both the blueprint filename and the function name.
+    const inputs = getJobInputs(selectedTemplate, jobType)?.reduce(toInputs, {}) ?? {};
 
     /** @todo (joechung): AB#20749256 */
     const inputsWithoutFilenameInputs = Object.values(inputs).filter(
@@ -207,7 +231,10 @@ export function useFields(
     );
 
     return inputsWithoutFilenameInputs;
-  }, [functionAppExists, functions, resourceId, selectedTemplate, t, userPrompts]);
+  }, [jobType, makeBooleanValidator, makeFunctionNameValidator, makeTextValidator, resourceId, selectedTemplate, t, userPrompts]);
 
-  return fields;
+  return {
+    fields,
+    makeTextValidator,
+  };
 }

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFileMutator.ts
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFileMutator.ts
@@ -10,7 +10,7 @@ export function useFileMutator(resourceId: string) {
 
   const appendToFile = useCallback(
     async (path: string, contentToAppend: string) => {
-      /** @note Get the existing file to append to. */
+      // Get the existing file to append to.
       const getFileContentResponse = await FunctionsService.getFileContent(resourceId, path);
 
       if (!getFileContentResponse.metadata.success) {
@@ -24,10 +24,10 @@ export function useFileMutator(resourceId: string) {
         throw new Error(getErrorMessage(getFileContentResponse.metadata.error));
       }
 
-      /** @note Append `contentToAppend` to the existing file's content. */
+      // Append `contentToAppend` to the existing file's content.
       const content = `${getFileContentResponse.data}\r\n\r\n${contentToAppend}`;
 
-      /** @note Overwrite the existing file with the new content. */
+      // Overwrite the existing file with the new content.
       const saveFileContentResponse = await FunctionsService.saveFileContent(
         resourceId,
         path,

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFunctionAppFileDetector.ts
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFunctionAppFileDetector.ts
@@ -1,20 +1,28 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useFiles } from './useFiles';
 
 export function useFunctionAppFileDetector(resourceId: string) {
-  const { existsFile } = useFiles(resourceId);
+  const { existsFile, filter } = useFiles(resourceId);
 
+  const [blueprintsExist, setBlueprintsExist] = useState<boolean>();
   const [functionAppExists, setFunctionAppExists] = useState<boolean>();
   const [isInitialized, setIsInitialized] = useState(false);
 
+  const checkForBlueprints = useCallback(async () => {
+    const blueprints = await filter('', file => !!file['path']?.endsWith('.py') && !file['path']?.endsWith('/function_app.py'));
+    return blueprints.length > 0;
+  }, [filter]);
+
   // Check if there is a file named 'function_app.py' in the root folder.
+  // Check if there are any files whose extension is '.py' in the root folder.
   useEffect(() => {
     let isMounted = true;
 
     if (!isInitialized) {
-      existsFile('function_app.py').then(exists => {
+      Promise.all([existsFile('function_app.py'), checkForBlueprints()]).then(([exists, exist]) => {
         if (isMounted) {
           setFunctionAppExists(exists);
+          setBlueprintsExist(exist);
           setIsInitialized(true);
         }
       });
@@ -23,7 +31,10 @@ export function useFunctionAppFileDetector(resourceId: string) {
     return () => {
       isMounted = false;
     };
-  }, [existsFile, isInitialized]);
+  }, [checkForBlueprints, existsFile, isInitialized]);
 
-  return functionAppExists;
+  return {
+    blueprintsExist,
+    functionAppExists,
+  };
 }

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFunctionCreator.ts
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFunctionCreator.ts
@@ -11,7 +11,7 @@ import { getTelemetryInfo } from '../../../../../utils/TelemetryUtils';
 import { BindingEditorFormValues } from '../../common/BindingFormBuilder';
 import { useAppSettingsQuery } from '../../common/useAppSettingsQuery';
 import { usePermissions } from '../../common/usePermissions';
-import { applySubstitutionsToPaths, getPaths, getSubstitutions } from './Helpers';
+import { getPaths, getSubstitutions } from './Helpers';
 import { JobType } from './JobType';
 import { useAppSettingsMutator } from './useAppSettingsMutator';
 import { useFileMutator } from './useFileMutator';

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useTemplateDetail.ts
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useTemplateDetail.ts
@@ -1,14 +1,44 @@
+import { IDropdownOption } from '@fluentui/react';
+import { FormikProps } from 'formik';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { FunctionTemplateV2 } from '../../../../../models/functions/function-template-v2';
 import { useUserPromptQuery } from '../../function/hooks/useUserPromptQuery';
+import { JobType } from './JobType';
 import { useFields } from './useFields';
 import { useFunctionAppFileDetector } from './useFunctionAppFileDetector';
 
-export function useTemplateDetail(resourceId: string, selectedTemplate: FunctionTemplateV2) {
+export function useTemplateDetail(
+  formProps: FormikProps<Record<string, unknown>>,
+  resourceId: string,
+  selectedTemplate: FunctionTemplateV2
+) {
+  const { t } = useTranslation();
+
   const { userPrompts } = useUserPromptQuery(resourceId);
 
-  const functionAppExists = useFunctionAppFileDetector(resourceId);
+  const { blueprintsExist, functionAppExists } = useFunctionAppFileDetector(resourceId);
 
-  const fields = useFields(functionAppExists, resourceId, selectedTemplate, userPrompts);
+  const jobType = useMemo<string | undefined>(() => {
+    return typeof formProps.values.jobType === 'string' ? formProps.values.jobType : undefined;
+  }, [formProps.values.jobType]);
 
-  return fields;
+  const { fields, makeTextValidator } = useFields(resourceId, jobType, selectedTemplate, userPrompts);
+
+  const jobTypeOptions = useMemo<IDropdownOption<unknown>[]>(
+    () => [
+      ...(functionAppExists
+        ? [{ key: JobType.AppendToFile, text: t('jobType_appendToFile') }]
+        : [{ key: JobType.CreateNewApp, text: t('jobType_createNewApp') }]),
+      ...(blueprintsExist ? [{ key: JobType.AppendToBlueprint, text: t('jobType_appendToBlueprint') }] : []),
+      { key: JobType.CreateNewBlueprint, text: t('jobType_createNewBlueprint') },
+    ],
+    [blueprintsExist, functionAppExists, t]
+  );
+
+  return {
+    fields,
+    jobTypeOptions,
+    makeTextValidator,
+  };
 }

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -35,6 +35,7 @@ export class PortalResources {
   public static subNew_friendlySubNameName = 'subNew_friendlySubNameName';
   public static subNew_invitationCode = 'subNew_invitationCode';
   public static functionNew_experimentalTemplate = 'functionNew_experimentalTemplate';
+  public static functionNew_functionKind = 'functionNew_functionKind';
   public static functionNew_functionName = 'functionNew_functionName';
   public static functionNew_functionNameRequired = 'functionNew_functionNameRequired';
   public static functionNew_nameYourFunction = 'functionNew_nameYourFunction';
@@ -264,7 +265,12 @@ export class PortalResources {
   public static seeRecommendedOptions = 'seeRecommendedOptions';
   public static storageLockNote = 'storageLockNote';
   public static fileExplorer_fileAlreadyExists = 'fileExplorer_fileAlreadyExists';
+  public static functionNew_fileExists = 'functionNew_fileExists';
   public static functionNew_functionExists = 'functionNew_functionExists';
+  public static jobType_appendToBlueprint = 'jobType_appendToBlueprint';
+  public static jobType_appendToFile = 'jobType_appendToFile';
+  public static jobType_createNewApp = 'jobType_createNewApp';
+  public static jobType_createNewBlueprint = 'jobType_createNewBlueprint';
   public static binding_storageAccountKey = 'binding_storageAccountKey';
   public static binding_storageAccountName = 'binding_storageAccountName';
   public static binding_storageInfoFooter = 'binding_storageInfoFooter';
@@ -2596,8 +2602,11 @@ export class PortalResources {
   public static createFunction_filePathError = 'createFunction_filePathError';
   public static createFunction_functionAppExistsError = 'createFunction_functionAppExistsError';
   public static createFunction_functionNameError = 'createFunction_functionNameError';
+  public static createFunction_functionKindError = 'createFunction_functionKindError';
   public static createFunction_noAppSettingsPermissionsError = 'createFunction_noAppSettingsPermissionsError';
+  public static createFunction_noBlueprintFilenameError = 'createFunction_noBlueprintFilenameError';
   public static createFunction_noResourceIdError = 'createFunction_noResourceIdError';
+  public static createFunction_noSubstitutionsError = 'createFunction_noSubstitutionsError';
   public static createFunction_selectedTemplateError = 'createFunction_selectedTemplateError';
   public static createFunctionDeploymentNotification = 'createFunctionDeploymentNotification';
   public static createFunctionDeploymentNotificationDetails = 'createFunctionDeploymentNotificationDetails';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -210,6 +210,9 @@
     <data name="functionNew_experimentalTemplate" xml:space="preserve">
         <value>This language is experimental and does not yet have full support. If you run into issues, please file a bug on our &lt;a href="https://github.com/Azure/azure-webjobs-sdk-templates/issues" target="_blank"&gt;GitHub repository.&lt;/a&gt;</value>
     </data>
+    <data name="functionNew_functionKind" xml:space="preserve">
+        <value>Job type</value>
+    </data>
     <data name="functionNew_functionName" xml:space="preserve">
         <value>Function name</value>
     </data>
@@ -898,8 +901,23 @@
     <data name="fileExplorer_fileAlreadyExists" xml:space="preserve">
         <value>A File with the name {{fileName}} already exists.</value>
     </data>
+    <data name="functionNew_fileExists" xml:space="preserve">
+        <value>A file with the name '{0}' already exists.</value>
+    </data>
     <data name="functionNew_functionExists" xml:space="preserve">
         <value>Function with name '{{name}}' already exists.</value>
+    </data>
+    <data name="jobType_appendToBlueprint" xml:space="preserve">
+        <value>Append to blueprint</value>
+    </data>
+    <data name="jobType_appendToFile" xml:space="preserve">
+        <value>Append to app</value>
+    </data>
+    <data name="jobType_createNewApp" xml:space="preserve">
+        <value>Create new app</value>
+    </data>
+    <data name="jobType_createNewBlueprint" xml:space="preserve">
+        <value>Create new blueprint</value>
     </data>
     <data name="binding_storageAccountKey" xml:space="preserve">
         <value>Account Key:</value>
@@ -7932,11 +7950,20 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="createFunction_functionNameError" xml:space="preserve">
         <value>Cannot determine the function name.</value>
     </data>
+    <data name="createFunction_functionKindError" xml:space="preserve">
+        <value>Cannot determine the function kind.</value>
+    </data>
     <data name="createFunction_noAppSettingsPermissionsError" xml:space="preserve">
         <value>You do not have sufficient permissions to update app settings.</value>
     </data>
+    <data name="createFunction_noBlueprintFilenameError" xml:space="preserve">
+        <value>Cannot determine the blueprint filename.</value>
+    </data>
     <data name="createFunction_noResourceIdError" xml:space="preserve">
         <value>No resource ID</value>
+    </data>
+    <data name="createFunction_noSubstitutionsError" xml:space="preserve">
+        <value>Cannot determine the job inputs with which to perform substitutions.</value>
     </data>
     <data name="createFunction_selectedTemplateError" xml:space="preserve">
         <value>Cannot determine the selected template.</value>


### PR DESCRIPTION
[AB#19990968](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/19990968), [AB#19991047](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/19991047)

- Add "job type" dropdown input for selecting how to create the new function.
  - Append new function to existing app
  - Append new function to existing blueprint
  - Create app with new function
  - Create blueprint with new function
- Add "new file" text field input for entering new blueprint filenames.
- Add "existing file" dropdown input for selecting an existing blueprint.

# Screenshots
Append to existing blueprint
![image](https://github.com/Azure/azure-functions-ux/assets/26208574/13a40488-8194-480d-bd20-85b2c73f7b5d)

Create new blueprint
![image](https://github.com/Azure/azure-functions-ux/assets/26208574/0a7f5386-ed4f-4119-977f-df1a8bb87a81)
