### PR TITLE
Change recommended VS Code extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,4 @@
 {
-	"recommendations": [
-		"github.vscode-pull-request-github",
-		"eg2.tslint",
-		"esbenp.prettier-vscode"
-	],
-	"unwantedRecommendations": [
-		
-	]
+  "recommendations": ["github.vscode-pull-request-github", "esbenp.prettier-vscode", "dbaeumer.vscode-eslint"],
+  "unwantedRecommendations": []
 }


### PR DESCRIPTION
Recommend the ESLint VS Code extension instead of the TSLint one.