### PR TITLE
[Functions] Make Integration read-only for v2 Python functions

### DIFF
--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1980,6 +1980,7 @@ export class PortalResources {
   public static resourceDropdown_missingAppSetting = 'resourceDropdown_missingAppSetting';
   public static resourceDropdown_noAppSettingsFound = 'resourceDropdown_noAppSettingsFound';
   public static integrate_bindingsMissingDirection = 'integrate_bindingsMissingDirection';
+  public static integrate_readOnlyPythonV2 = 'integrate_readOnlyPythonV2';
   public static functionMonitor_invocations = 'functionMonitor_invocations';
   public static functionMonitor_logs = 'functionMonitor_logs';
   public static logStreaming_openInLiveMetrics = 'logStreaming_openInLiveMetrics';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -6114,6 +6114,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="integrate_bindingsMissingDirection" xml:space="preserve">
         <value>The following bindings are missing the required direction property and may have been placed incorrectly: {0}. Please update the bindings in your functions.json file.</value>
     </data>
+    <data name="integrate_readOnlyPythonV2" xml:space="preserve">
+        <value>Use the code editor to update v2 programming model Python function bindings.</value>
+    </data>
     <data name="functionMonitor_invocations" xml:space="preserve">
         <value>Invocations</value>
     </data>


### PR DESCRIPTION
[AB#22618416](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/22618416)

Enable making the Integration tab read-only for v2 programming model Python functions.

Do not rely on `readOnly` since v2 programming model Python functions are editable elsewhere.

# Screenshot
![image](https://github.com/Azure/azure-functions-ux/assets/26208574/47d2d234-3d1c-47b1-a924-333055e91998)
