### PR TITLE
[Functions] v2 functions created in portal have 'config_href'...

### DIFF
--- a/client-react/src/pages/app/functions/function/function-editor/useFunctionEditorQueries.ts
+++ b/client-react/src/pages/app/functions/function/function-editor/useFunctionEditorQueries.ts
@@ -28,9 +28,16 @@ export const isNewNodeProgrammingModel = (functionInfo?: ArmObj<FunctionInfo>): 
   return properties?.config_href === null && properties?.config.language === WorkerRuntimeLanguages.nodejs;
 };
 
+/**
+ * @todo (joechung): The `properties?.config.scriptFile` check is a temporary workaround for a runtime bug where
+ * `properties?.config_href` is being populated for v2 functions created in the portal.
+ */
 export const isNewPythonProgrammingModel = (functionInfo?: ArmObj<FunctionInfo>): boolean => {
   const properties = functionInfo?.properties;
-  return properties?.config_href === null && properties?.config.language === WorkerRuntimeLanguages.python;
+  return (
+    (properties?.config_href === null || properties?.config.scriptFile === 'function_app.py') &&
+    properties?.config.language === WorkerRuntimeLanguages.python
+  );
 };
 
 // Currently, Node is the only new programming model which supports storing files in any folders.


### PR DESCRIPTION
[AB#22618854](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/22618854)

[Functions] v2 functions created in portal have 'config_href' property set unexpectedly

Work around the unexpected `config_href` property by checking that `properties?.config.scriptFile` is set to `function_app.py`.

This is temporary and should be removed once the root cause for the unexpected `config_href` property is determined and fixed.