### PR TITLE
[Functions] Do not save test data in Test/Run for v2 Python functions

### DIFF
--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
@@ -395,7 +395,7 @@ export const FunctionEditor: React.FC<FunctionEditorProps> = (props: FunctionEdi
   };
 
   const isTestDisabled = () => {
-    return !isRuntimeReachable() || isNewPythonProgrammingModel(functionInfo);
+    return !isRuntimeReachable();
   };
 
   const isEditorDisabled = () => {

--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditorDataLoader.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditorDataLoader.tsx
@@ -31,7 +31,7 @@ import { FunctionEditor } from './FunctionEditor';
 import FunctionEditorData from './FunctionEditor.data';
 import { shrinkEditorStyle } from './FunctionEditor.styles';
 import { NameValuePair, ResponseContent, UrlObj, UrlType, urlParameterRegExp } from './FunctionEditor.types';
-import { isNewNodeProgrammingModel, useFunctionEditorQueries } from './useFunctionEditorQueries';
+import { isNewNodeProgrammingModel, isNewPythonProgrammingModel, useFunctionEditorQueries } from './useFunctionEditorQueries';
 
 interface FunctionEditorDataLoaderProps {
   resourceId: string;
@@ -303,7 +303,8 @@ const FunctionEditorDataLoader: React.FC<FunctionEditorDataLoaderProps> = ({ res
   const run = async (newFunctionInfo: ArmObj<FunctionInfo>, xFunctionKey?: string, liveLogsSessionId?: string) => {
     setFunctionRunning(true);
 
-    if (!SiteHelper.isFunctionAppReadOnly(siteStateContext.siteAppEditState)) {
+    // Do not update v2 Python functions here since its metadata is derived from code, not from function.json.
+    if (!SiteHelper.isFunctionAppReadOnly(siteStateContext.siteAppEditState) && !isNewPythonProgrammingModel(functionInfo)) {
       const updatedFunctionInfo = await functionEditorData.updateFunctionInfo(resourceId, newFunctionInfo);
       if (updatedFunctionInfo.metadata.success) {
         setFunctionInfo(updatedFunctionInfo.data);


### PR DESCRIPTION
AB#22862169

Re-enable Test/Run for v2 Python functions.
- Revert "[Functions] Disable Test/Run for v2 Python functions (#7207)"
- This reverts commit 18278babf84d5e0bd849c3dba30a89e00e1f37e6.