### PR TITLE
Fix shimmers (take 2)

### DIFF
--- a/client-react/src/components/DisplayTableWithEmptyMessage/DisplayTableWithEmptyMessage.tsx
+++ b/client-react/src/components/DisplayTableWithEmptyMessage/DisplayTableWithEmptyMessage.tsx
@@ -1,9 +1,10 @@
-import { DetailsList, IDetailsListProps, ShimmeredDetailsList } from '@fluentui/react';
+import { DetailsList, IDetailsListProps, ShimmeredDetailsList, ThemeProvider } from '@fluentui/react';
 import React, { useContext } from 'react';
 import { style } from 'typestyle';
-import { ThemeExtended } from '../../theme/SemanticColorsExtended';
 import { ThemeContext } from '../../ThemeContext';
+import { ThemeExtended } from '../../theme/SemanticColorsExtended';
 import { detailListHeaderStyle } from '../form-controls/formControl.override.styles';
+import { shimmerTheme } from '../shimmer/Shimmer.styles';
 
 export interface ShimmerProps {
   lines: number;
@@ -46,15 +47,17 @@ const DisplayTableWithEmptyMessage: React.SFC<Props> = props => {
   return (
     <>
       {shimmer ? (
-        <ShimmeredDetailsList
-          enableShimmer={shimmer.show}
-          shimmerLines={shimmer.lines}
-          className={initialShimmerTableStyle(shimmer.show)}
-          removeFadingOverlay={true}
-          columns={updatedColumns}
-          detailsListStyles={rest.styles}
-          {...rest}
-        />
+        <ThemeProvider theme={shimmerTheme}>
+          <ShimmeredDetailsList
+            enableShimmer={shimmer.show}
+            shimmerLines={shimmer.lines}
+            className={initialShimmerTableStyle(shimmer.show)}
+            removeFadingOverlay={true}
+            columns={updatedColumns}
+            detailsListStyles={rest.styles}
+            {...rest}
+          />
+        </ThemeProvider>
       ) : (
         <DetailsList columns={updatedColumns} {...rest} />
       )}

--- a/client-react/src/components/shimmer/BasicShimmerLines.tsx
+++ b/client-react/src/components/shimmer/BasicShimmerLines.tsx
@@ -1,6 +1,7 @@
+import { Shimmer, ThemeProvider } from '@fluentui/react';
 import React from 'react';
-import { wrapperClass, shimmerStyle } from './Shimmer.styles';
-import { Shimmer, Fabric } from '@fluentui/react';
+import { shimmerStyle, shimmerTheme, wrapperClass } from './Shimmer.styles';
+
 interface BasicShimmerLinesProps {
   repeatShimmer?: number;
 }
@@ -25,7 +26,11 @@ const BasicShimmerLines: React.FC<BasicShimmerLinesProps> = ({ repeatShimmer = 1
     return elements;
   };
 
-  return <Fabric className={wrapperClass}>{getLines()}</Fabric>;
+  return (
+    <ThemeProvider className={wrapperClass} theme={shimmerTheme}>
+      {getLines()}
+    </ThemeProvider>
+  );
 };
 
 export default BasicShimmerLines;

--- a/client-react/src/components/shimmer/CustomElementsShimmer.tsx
+++ b/client-react/src/components/shimmer/CustomElementsShimmer.tsx
@@ -1,23 +1,19 @@
+import { Shimmer, ThemeProvider } from '@fluentui/react';
 import React from 'react';
-import { Fabric, Shimmer } from '@fluentui/react';
-import { wrapperClass } from './Shimmer.styles';
-import { getLineGapShimmerGroup, getLineCircleShimmerGroup, getLineGapCircleShimmerGroup } from './Shimmer.types';
+import { shimmerTheme, wrapperClass } from './Shimmer.styles';
+import { LineCircleShimmerGroup, LineGapCircleShimmerGroup, LineGapShimmerGroup } from './Shimmer.types';
 
-interface CustomElementsShimmerProps {
-  className?: string;
-}
-
-const CustomElementsShimmer: React.FC<CustomElementsShimmerProps> = () => {
+const CustomElementsShimmer: React.FC = () => {
   return (
-    <Fabric className={wrapperClass}>
-      <Shimmer customElementsGroup={getLineGapShimmerGroup()} width="350" />
-      <Shimmer customElementsGroup={getLineCircleShimmerGroup()} width="550" />
-      <Shimmer customElementsGroup={getLineGapCircleShimmerGroup()} width="90%" />
+    <ThemeProvider className={wrapperClass} theme={shimmerTheme}>
+      <Shimmer customElementsGroup={<LineGapShimmerGroup />} width="350" />
+      <Shimmer customElementsGroup={<LineCircleShimmerGroup />} width="550" />
+      <Shimmer customElementsGroup={<LineGapCircleShimmerGroup />} width="90%" />
       <br />
-      <Shimmer customElementsGroup={getLineGapShimmerGroup()} width="350" />
-      <Shimmer customElementsGroup={getLineCircleShimmerGroup()} width="550" />
-      <Shimmer customElementsGroup={getLineGapCircleShimmerGroup()} width="90%" />
-    </Fabric>
+      <Shimmer customElementsGroup={<LineGapShimmerGroup />} width="350" />
+      <Shimmer customElementsGroup={<LineCircleShimmerGroup />} width="550" />
+      <Shimmer customElementsGroup={<LineGapCircleShimmerGroup />} width="90%" />
+    </ThemeProvider>
   );
 };
 

--- a/client-react/src/components/shimmer/Shimmer.styles.ts
+++ b/client-react/src/components/shimmer/Shimmer.styles.ts
@@ -1,4 +1,4 @@
-import { mergeStyles } from '@fluentui/react';
+import { PartialTheme, mergeStyles } from '@fluentui/react';
 import { style } from 'typestyle';
 
 export const wrapperClass = mergeStyles({
@@ -14,3 +14,15 @@ export const wrapperStyle = { display: 'flex' };
 export const shimmerStyle = style({
   marginTop: '10px',
 });
+
+/**
+ * @note
+ * Theme override to fix shimmers. `semanticColors.disabledBackground` is an empty string due to having previously been an invalid color
+ * value since 2018. We cannot fix this because other colors (e.g., disabled buttons and combo boxes) have come to rely on this style
+ * doing nothing.
+ */
+export const shimmerTheme: PartialTheme = {
+  semanticColors: {
+    disabledBackground: 'rgba(128, 128, 128, 0.1)',
+  },
+};

--- a/client-react/src/components/shimmer/Shimmer.types.tsx
+++ b/client-react/src/components/shimmer/Shimmer.types.tsx
@@ -1,7 +1,8 @@
 import { ShimmerElementsGroup, ShimmerElementType } from '@fluentui/react';
+import React from 'react';
 import { wrapperStyle } from './Shimmer.styles';
 
-export const getLineGapShimmerGroup = (): JSX.Element => {
+export const LineGapShimmerGroup: React.FC = () => {
   return (
     <div style={wrapperStyle}>
       <ShimmerElementsGroup
@@ -22,7 +23,7 @@ export const getLineGapShimmerGroup = (): JSX.Element => {
   );
 };
 
-export const getLineCircleShimmerGroup = (): JSX.Element => {
+export const LineCircleShimmerGroup: React.FC = () => {
   return (
     <div style={wrapperStyle}>
       <ShimmerElementsGroup
@@ -43,7 +44,7 @@ export const getLineCircleShimmerGroup = (): JSX.Element => {
   );
 };
 
-export const getLineGapCircleShimmerGroup = (): JSX.Element => {
+export const LineGapCircleShimmerGroup: React.FC = () => {
   return (
     <div style={wrapperStyle}>
       <ShimmerElementsGroup


### PR DESCRIPTION
To fix shimmers without breaking other controls that have come to depend on styles not working as intended, scope the shimmer theme override to just the components requiring shimmer.