### PR TITLE
[Functions] .NET Isolated changes

### DIFF
--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditor.tsx
@@ -1,5 +1,5 @@
 import { IDropdownOption, MessageBarType, PanelType } from '@fluentui/react';
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import FunctionsService from '../../../../../ApiHelpers/FunctionsService';
 import { PortalContext } from '../../../../../PortalContext';
@@ -307,7 +307,7 @@ export const FunctionEditor: React.FC<FunctionEditorProps> = (props: FunctionEdi
     if (isNewNodeProgrammingModel(functionInfo)) {
       filename = functionInfo.properties.config.scriptFile || '';
     } else if (isDotNetIsolatedFunction(functionInfo)) {
-      filename = 'functions.metadata';
+      filename = 'host.json';
     } else {
       const scriptHref = functionInfo.properties.script_href;
       filename = ((scriptHref && scriptHref.split('/').pop()) || '').toLocaleLowerCase();
@@ -515,6 +515,8 @@ export const FunctionEditor: React.FC<FunctionEditorProps> = (props: FunctionEdi
     }
   };
 
+  const uploadDisabled = useMemo(() => isDotNetIsolatedFunction(functionInfo), [functionInfo]);
+
   useEffect(() => {
     setLogPanelHeight(logPanelExpanded ? minimumLogPanelHeight : 0);
   }, [logPanelExpanded]);
@@ -564,6 +566,7 @@ export const FunctionEditor: React.FC<FunctionEditorProps> = (props: FunctionEdi
           functionInfo={functionInfo}
           runtimeVersion={runtimeVersion}
           upload={uploadFile}
+          uploadDisabled={uploadDisabled}
           setShowInvalidFileSelectedWarning={setShowInvalidFileSelectedWarning}
           setSelectedFileName={setSelectedFileName}
           resetInvalidFileSelectedWarningAndFileName={resetInvalidFileSelectedWarningAndFileName}

--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditorCommandBar.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditorCommandBar.tsx
@@ -30,6 +30,7 @@ interface FunctionEditorCommandBarProps {
   testDisabled: boolean;
   testFunction: () => void;
   upload: (file) => void;
+  uploadDisabled: boolean;
   urlObjs: UrlObj[];
   runtimeVersion?: string;
 }
@@ -48,6 +49,7 @@ const FunctionEditorCommandBar: React.FC<FunctionEditorCommandBarProps> = ({
   testDisabled,
   testFunction,
   upload,
+  uploadDisabled,
   urlObjs,
   runtimeVersion,
 }: FunctionEditorCommandBarProps) => {
@@ -154,7 +156,7 @@ const FunctionEditorCommandBar: React.FC<FunctionEditorCommandBarProps> = ({
         iconProps: {
           iconName: 'Upload',
         },
-        disabled: disabled || testDisabled,
+        disabled: disabled || testDisabled || uploadDisabled,
         ariaLabel: t('fileExplorer_upload'),
         onClick: onUploadButtonClick,
       },


### PR DESCRIPTION
Change default file from `functions.metadata` to `host.json` in Code/Test for .NET Isolated apps.
- Unlike `host.json`, `functions.metadata` is not always available for .NET Isolated apps.

Disable Upload button for .NET Isolated apps.

**Screenshot**

![image](https://github.com/Azure/azure-functions-ux/assets/26208574/6c29647e-d5d6-4533-a964-559d5aad2353)
