### PR TITLE
AB#16820690 Add key vault reference for byos

### DIFF
--- a/client-react/src/components/InfoTooltip/InfoTooltip.tsx
+++ b/client-react/src/components/InfoTooltip/InfoTooltip.tsx
@@ -7,7 +7,7 @@ import { ThemeContext } from '../../ThemeContext';
 
 export interface InfoTooltipProps {
   id: string;
-  content: string;
+  content: string | JSX.Element | JSX.Element[];
   iconClassName?: string;
 }
 

--- a/client-react/src/pages/app/app-settings/AppSettings.styles.ts
+++ b/client-react/src/pages/app/app-settings/AppSettings.styles.ts
@@ -95,3 +95,10 @@ export const messageBannerStyle = (theme: ThemeExtended, type: MessageBarType) =
 export const pivotWrapper = style({
   paddingLeft: '8px',
 });
+
+export const azureStorageTypeLabelStyle = style({
+  display: 'flex',
+  flexDirection: 'row',
+  gap: '2px',
+  marginRight: '8px',
+});

--- a/client-react/src/pages/app/app-settings/AppSettings.types.ts
+++ b/client-react/src/pages/app/app-settings/AppSettings.types.ts
@@ -26,6 +26,9 @@ export interface FormConnectionString {
 
 export interface FormAzureStorageMounts extends AzureStorageMount {
   name: string;
+  configurationOption: ConfigurationOption;
+  storageAccess: number;
+  appSettings?: string;
   sticky?: boolean;
 }
 
@@ -166,4 +169,19 @@ export enum AppSettingsTabs {
   defaultDocuments = 'defaultDocuments',
   pathMappings = 'pathMappings',
   customErrorPage = 'customErrorPage',
+}
+
+export enum StorageAccess {
+  AccessKey,
+  KeyVaultReference,
+}
+
+export enum ConfigurationOption {
+  Basic = 'basic',
+  Advanced = 'advanced',
+}
+
+export class AppSettingReference {
+  public static readonly prefix = '@AppSettingRef(';
+  public static readonly suffix = ')';
 }

--- a/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
@@ -155,7 +155,6 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
     if (!isKube) {
       azureStorageMounts = await SiteService.fetchAzureStorageMounts(resourceId);
       loadingFailed = loadingFailed || armCallFailed(azureStorageMounts, true);
-      console.log(azureStorageMounts);
     }
 
     // Get stacks response
@@ -233,7 +232,6 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
       if (site.data.properties.targetSwapSlot) {
         setEditable(false);
       }
-
       setInitialValues({
         ...convertStateToForm({
           site: site.data,

--- a/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
@@ -155,6 +155,7 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
     if (!isKube) {
       azureStorageMounts = await SiteService.fetchAzureStorageMounts(resourceId);
       loadingFailed = loadingFailed || armCallFailed(azureStorageMounts, true);
+      console.log(azureStorageMounts);
     }
 
     // Get stacks response

--- a/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
+++ b/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
@@ -213,7 +213,9 @@ export const isStorageMountsModified = (initialValues: AppSettingsFormValues | n
 
 export const isStorageAccessAppSetting = (configurationOption: ConfigurationOption, type: StorageType, storageAccess: StorageAccess) => {
   return (
-    configurationOption === ConfigurationOption.Advanced && type === StorageType.azureFiles && storageAccess === StorageAccess.AccessKey
+    configurationOption === ConfigurationOption.Advanced &&
+    type === StorageType.azureFiles &&
+    storageAccess === StorageAccess.KeyVaultReference
   );
 };
 

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMounts.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMounts.tsx
@@ -1,7 +1,7 @@
 import { FormikProps } from 'formik';
 import React, { useContext, useState } from 'react';
 import { defaultCellStyle } from '../../../../components/DisplayTableWithEmptyMessage/DisplayTableWithEmptyMessage';
-import { AppSettingsFormValues, FormAzureStorageMounts } from '../AppSettings.types';
+import { AppSettingsFormValues, ConfigurationOption, FormAzureStorageMounts, StorageAccess } from '../AppSettings.types';
 import IconButton from '../../../../components/IconButton/IconButton';
 import AzureStorageMountsAddEdit from './AzureStorageMountsAddEdit';
 import {
@@ -58,9 +58,11 @@ const AzureStorageMounts: React.FC<FormikProps<AppSettingsFormValues>> = props =
   const createNewAzureStorageMount = () => {
     const blankAzureStorageMount: FormAzureStorageMounts = {
       name: '',
+      configurationOption: ConfigurationOption.Basic,
       type: StorageType.azureBlob,
       accountName: '',
       shareName: '',
+      storageAccess: StorageAccess.AccessKey,
       accessKey: '',
       mountPath: '',
     };
@@ -300,6 +302,7 @@ const AzureStorageMounts: React.FC<FormikProps<AppSettingsFormValues>> = props =
           onDismiss={onCancel}
           headerText={createNewItem ? t('newAzureStorageMount') : t('editAzureStorageMount')}>
           <AzureStorageMountsAddEdit
+            appSettings={values.appSettings}
             azureStorageMount={currentAzureStorageMount!}
             otherAzureStorageMounts={values.azureStorageMounts}
             updateAzureStorageMount={item => onClosePanel(item)}

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEdit.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useContext, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import ActionBar from '../../../../components/ActionBar';
 import { ConfigurationOption, FormAppSetting, FormAzureStorageMounts, StorageAccess } from '../AppSettings.types';
-import { Checkbox } from '@fluentui/react';
+import { Checkbox, IChoiceGroupOption, Link } from '@fluentui/react';
 import AzureStorageMountsAddEditBasic from './AzureStorageMountsAddEditBasic';
 import AzureStorageMountsAddEditAdvanced from './AzureStorageMountsAddEditAdvanced';
 import { Formik, FormikProps, Field, Form } from 'formik';
@@ -16,8 +16,10 @@ import { CommonConstants } from '../../../../utils/CommonConstants';
 import { style } from 'typestyle';
 import { SiteStateContext } from '../../../../SiteState';
 import { StorageType } from '../../../../models/site/config';
-import { formElementStyle } from '../AppSettings.styles';
+import { azureStorageTypeLabelStyle, formElementStyle } from '../AppSettings.styles';
 import { isStorageAccessAppSetting } from '../AppSettingsFormData';
+import { Links } from '../../../../utils/FwLinks';
+import { InfoTooltip } from '../../../../components/InfoTooltip/InfoTooltip';
 
 const MountPathValidationRegex = ValidationRegex.StorageMountPath;
 const MountPathExamples = CommonConstants.MountPathValidationExamples;
@@ -305,6 +307,37 @@ const AzureStorageMountsAddEditSubForm: React.FC<AzureStorageMountsAddEdtSubForm
   const [fileShareInfoBubbleMessage, setFileShareInfoBubbleMessage] = useState<string>();
   const { t } = useTranslation();
 
+  const storageTypeOptions = React.useMemo<IChoiceGroupOption[]>(() => {
+    return [
+      {
+        key: StorageType.azureBlob,
+        text: t('azureBlob'),
+        onRenderLabel: (props, defaultRender) => {
+          return (
+            <div className={azureStorageTypeLabelStyle}>
+              {defaultRender?.(props)}
+              <InfoTooltip
+                id={'azure-blob-tooltip'}
+                content={
+                  <span>
+                    {t('readonlyBlobStorageWarning')}{' '}
+                    <Link href={Links.byosBlobReadonlyLearnMore} target="_blank" aria-label={t('learnMore')}>
+                      {t('learnMore')}
+                    </Link>
+                  </span>
+                }
+              />
+            </div>
+          );
+        },
+      },
+      {
+        key: StorageType.azureFiles,
+        text: t('azureFiles'),
+      },
+    ] as IChoiceGroupOption[];
+  }, []);
+
   React.useEffect(() => {
     setFileShareInfoBubbleMessage(props.values.type === StorageType.azureFiles ? t('shareNameInfoBubbleMessage') : undefined);
 
@@ -314,10 +347,18 @@ const AzureStorageMountsAddEditSubForm: React.FC<AzureStorageMountsAddEdtSubForm
   return (
     <>
       {props.values.configurationOption === ConfigurationOption.Basic && (
-        <AzureStorageMountsAddEditBasic {...props} fileShareInfoBubbleMessage={fileShareInfoBubbleMessage} />
+        <AzureStorageMountsAddEditBasic
+          {...props}
+          storageTypeOptions={storageTypeOptions}
+          fileShareInfoBubbleMessage={fileShareInfoBubbleMessage}
+        />
       )}
       {props.values.configurationOption === ConfigurationOption.Advanced && (
-        <AzureStorageMountsAddEditAdvanced {...props} fileShareInfoBubbleMessage={fileShareInfoBubbleMessage} />
+        <AzureStorageMountsAddEditAdvanced
+          {...props}
+          storageTypeOptions={storageTypeOptions}
+          fileShareInfoBubbleMessage={fileShareInfoBubbleMessage}
+        />
       )}
     </>
   );

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditAdvanced.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditAdvanced.tsx
@@ -6,9 +6,8 @@ import TextField from '../../../../components/form-controls/TextField';
 import RadioButton from '../../../../components/form-controls/RadioButton';
 import { useTranslation } from 'react-i18next';
 import { StorageType } from '../../../../models/site/config';
-import { MessageBarType } from '@fluentui/react';
+import { IChoiceGroupOption, MessageBarType } from '@fluentui/react';
 import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
-import { Links } from '../../../../utils/FwLinks';
 import { SiteContext } from '../Contexts';
 import { ScenarioService } from '../../../../utils/scenario-checker/scenario.service';
 import { ScenarioIds } from '../../../../utils/scenario-checker/scenario-ids';
@@ -19,9 +18,10 @@ import { IDropdownOption } from '@fluentui/react';
 
 const AzureStorageMountsAddEditAdvanced: React.FC<FormikProps<FormAzureStorageMounts> &
   AzureStorageMountsAddEditPropsCombined & {
+    storageTypeOptions: IChoiceGroupOption[];
     fileShareInfoBubbleMessage?: string;
   }> = props => {
-  const { values, fileShareInfoBubbleMessage, setFieldValue, validateField, appSettings } = props;
+  const { values, fileShareInfoBubbleMessage, setFieldValue, validateField, appSettings, storageTypeOptions } = props;
   const { t } = useTranslation();
   const site = useContext(SiteContext);
   const scenarioService = new ScenarioService(t);
@@ -62,31 +62,7 @@ const AzureStorageMountsAddEditAdvanced: React.FC<FormikProps<FormAzureStorageMo
     <>
       <Field component={TextField} name="accountName" label={t('storageAccounts')} id="azure-storage-mounts-account-name" required={true} />
       {supportsBlobStorage && (
-        <Field
-          component={RadioButton}
-          name="type"
-          id="azure-storage-mounts-name"
-          label={t('storageType')}
-          options={[
-            {
-              key: StorageType.azureBlob,
-              text: t('azureBlob'),
-            },
-            {
-              key: StorageType.azureFiles,
-              text: t('azureFiles'),
-            },
-          ]}
-        />
-      )}
-      {values.type === StorageType.azureBlob && supportsBlobStorage && (
-        <CustomBanner
-          id="azure-storage-mount-blob-warning"
-          message={t('readonlyBlobStorageWarning')}
-          learnMoreLink={Links.byosBlobReadonlyLearnMore}
-          type={MessageBarType.info}
-          undocked={true}
-        />
+        <Field component={RadioButton} name="type" id="azure-storage-mounts-name" label={t('storageType')} options={storageTypeOptions} />
       )}
       <Field
         component={TextField}

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditAdvanced.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditAdvanced.tsx
@@ -73,7 +73,7 @@ const AzureStorageMountsAddEditAdvanced: React.FC<FormikProps<FormAzureStorageMo
         required={true}
         validate={validateShareName}
       />
-      {values.type === StorageType.azureFiles && Url.getFeatureValue(CommonConstants.FeatureFlags.showBYOSStorageAccess) && (
+      {values.type === StorageType.azureFiles && Url.getFeatureValue(CommonConstants.FeatureFlags.showBYOSStorageAccess) === 'true' && (
         <Field
           id="storageAccess"
           name={'storageAccess'}

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditAdvanced.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditAdvanced.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect } from 'react';
 import { AzureStorageMountsAddEditPropsCombined } from './AzureStorageMountsAddEdit';
 import { FormikProps, Field } from 'formik';
-import { FormAzureStorageMounts } from '../AppSettings.types';
+import { FormAzureStorageMounts, StorageAccess } from '../AppSettings.types';
 import TextField from '../../../../components/form-controls/TextField';
 import RadioButton from '../../../../components/form-controls/RadioButton';
 import { useTranslation } from 'react-i18next';
@@ -12,12 +12,16 @@ import { Links } from '../../../../utils/FwLinks';
 import { SiteContext } from '../Contexts';
 import { ScenarioService } from '../../../../utils/scenario-checker/scenario.service';
 import { ScenarioIds } from '../../../../utils/scenario-checker/scenario-ids';
+import Url from '../../../../utils/url';
+import { CommonConstants } from '../../../../utils/CommonConstants';
+import Dropdown from '../../../../components/form-controls/DropDown';
+import { IDropdownOption } from '@fluentui/react';
 
 const AzureStorageMountsAddEditAdvanced: React.FC<FormikProps<FormAzureStorageMounts> &
   AzureStorageMountsAddEditPropsCombined & {
     fileShareInfoBubbleMessage?: string;
   }> = props => {
-  const { errors, values, fileShareInfoBubbleMessage, setFieldValue, validateField } = props;
+  const { values, fileShareInfoBubbleMessage, setFieldValue, validateField, appSettings } = props;
   const { t } = useTranslation();
   const site = useContext(SiteContext);
   const scenarioService = new ScenarioService(t);
@@ -27,6 +31,23 @@ const AzureStorageMountsAddEditAdvanced: React.FC<FormikProps<FormAzureStorageMo
   };
 
   const supportsBlobStorage = scenarioService.checkScenario(ScenarioIds.azureBlobMount, { site }).status !== 'disabled';
+
+  const appSettingDropdownOptions = React.useMemo<IDropdownOption[]>(() => {
+    return appSettings.map(appSetting => {
+      return {
+        key: appSetting.name,
+        text: appSetting.name,
+        data: appSetting,
+      };
+    });
+  }, [appSettings]);
+
+  const showDeploymentSettingsWarning = React.useMemo(() => {
+    const appSettingName = values.appSettings;
+    const isSelectedAppSettingSticky =
+      !appSettingName || appSettings.find(appSetting => appSetting.name === appSettingName && appSetting.sticky);
+    return values.sticky && !isSelectedAppSettingSticky;
+  }, [values.appSettings, values.sticky, appSettings]);
 
   useEffect(() => {
     if (!supportsBlobStorage) {
@@ -39,14 +60,7 @@ const AzureStorageMountsAddEditAdvanced: React.FC<FormikProps<FormAzureStorageMo
 
   return (
     <>
-      <Field
-        component={TextField}
-        name="accountName"
-        label={t('storageAccounts')}
-        id="azure-storage-mounts-account-name"
-        errorMessage={errors.accountName}
-        required={true}
-      />
+      <Field component={TextField} name="accountName" label={t('storageAccounts')} id="azure-storage-mounts-account-name" required={true} />
       {supportsBlobStorage && (
         <Field
           component={RadioButton}
@@ -79,21 +93,60 @@ const AzureStorageMountsAddEditAdvanced: React.FC<FormikProps<FormAzureStorageMo
         name="shareName"
         label={t('shareName')}
         id="azure-storage-mounts-share-name"
-        errorMessage={errors.shareName}
         infoBubbleMessage={fileShareInfoBubbleMessage}
         required={true}
         validate={validateShareName}
       />
-      <Field
-        component={TextField}
-        name="accessKey"
-        label={t('accessKey')}
-        id="azure-storage-mounts-access-key"
-        multiline
-        rows={4}
-        errorMessage={errors.accessKey}
-        required={true}
-      />
+      {values.type === StorageType.azureFiles && Url.getFeatureValue(CommonConstants.FeatureFlags.showBYOSStorageAccess) && (
+        <Field
+          id="storageAccess"
+          name={'storageAccess'}
+          label={t('storageAccessLabel')}
+          component={RadioButton}
+          options={[
+            {
+              key: StorageAccess.AccessKey,
+              text: t('manualInput'),
+            },
+            {
+              key: StorageAccess.KeyVaultReference,
+              text: t('keyVaultReference'),
+            },
+          ]}
+        />
+      )}
+      {(values.type === StorageType.azureBlob || values.storageAccess === StorageAccess.AccessKey) && (
+        <Field
+          component={TextField}
+          name="accessKey"
+          label={t('accessKey')}
+          id="azure-storage-mounts-access-key"
+          multiline
+          rows={4}
+          required={true}
+        />
+      )}
+      {values.type === StorageType.azureFiles && values.storageAccess === StorageAccess.KeyVaultReference && (
+        <Field
+          component={Dropdown}
+          name="appSettings"
+          label={t('applicationSettings')}
+          id="azure-storage-mounts-access-key"
+          options={appSettingDropdownOptions}
+          required={true}
+          onPanel={true}
+        />
+      )}
+      {values.type === StorageType.azureFiles &&
+        values.storageAccess === StorageAccess.KeyVaultReference &&
+        showDeploymentSettingsWarning && (
+          <CustomBanner
+            id="azure-storage-mount-keyvault-warning"
+            message={t('BYOSDeploymentSettingsWarning')}
+            type={MessageBarType.warning}
+            undocked={true}
+          />
+        )}
     </>
   );
 };

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
@@ -45,7 +45,7 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
   AzureStorageMountsAddEditPropsCombined & {
     fileShareInfoBubbleMessage?: string;
   }> = props => {
-  const { errors, values, initialValues, fileShareInfoBubbleMessage, setValues, setFieldValue, validateForm } = props;
+  const { values, initialValues, fileShareInfoBubbleMessage, setValues, setFieldValue, validateForm } = props;
   const [accountSharesFiles, setAccountSharesFiles] = useState([]);
   const [accountSharesBlob, setAccountSharesBlob] = useState([]);
   const [sharesLoading, setSharesLoading] = useState(false);
@@ -244,7 +244,6 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
         styles={{
           root: formElementStyle,
         }}
-        errorMessage={errors.accountName}
         infoBubbleMessage={t('byos_storageAccountInfoMessage')}
         learnMoreLink={Links.byosStorageAccountLearnMore}
         required={true}
@@ -291,7 +290,6 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
           return validateStorageContainer(value);
         }}
         infoBubbleMessage={fileShareInfoBubbleMessage}
-        errorMessage={errors.shareName}
         required={true}
       />
     </>

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
@@ -10,8 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { StorageAccountsContext } from '../Contexts';
 import { ScenarioService } from '../../../../utils/scenario-checker/scenario.service';
 import { ScenarioIds } from '../../../../utils/scenario-checker/scenario-ids';
-import { IChoiceGroupOption, MessageBarType } from '@fluentui/react';
-import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
+import { IChoiceGroupOption } from '@fluentui/react';
 import { Links } from '../../../../utils/FwLinks';
 import { StorageType } from '../../../../models/site/config';
 import StorageService from '../../../../ApiHelpers/StorageService';
@@ -251,15 +250,6 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
       />
       {showStorageTypeOption && (
         <Field component={RadioButton} name="type" id="azure-storage-mounts-name" label={t('storageType')} options={storageTypeOptions} />
-      )}
-      {values.type === StorageType.azureBlob && supportsBlobStorage && (
-        <CustomBanner
-          id="azure-storage-mount-blob-warning"
-          message={t('readonlyBlobStorageWarning')}
-          learnMoreLink={Links.byosBlobReadonlyLearnMore}
-          type={MessageBarType.info}
-          undocked={true}
-        />
       )}
       <Field
         component={ComboBox}

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { StorageAccountsContext } from '../Contexts';
 import { ScenarioService } from '../../../../utils/scenario-checker/scenario.service';
 import { ScenarioIds } from '../../../../utils/scenario-checker/scenario-ids';
-import { MessageBarType } from '@fluentui/react';
+import { IChoiceGroupOption, MessageBarType } from '@fluentui/react';
 import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
 import { Links } from '../../../../utils/FwLinks';
 import { StorageType } from '../../../../models/site/config';
@@ -43,9 +43,10 @@ const initializeStorageContainerErrorSchemaValue = (): StorageContainerErrorSche
 
 const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMounts> &
   AzureStorageMountsAddEditPropsCombined & {
+    storageTypeOptions: IChoiceGroupOption[];
     fileShareInfoBubbleMessage?: string;
   }> = props => {
-  const { values, initialValues, fileShareInfoBubbleMessage, setValues, setFieldValue, validateForm } = props;
+  const { values, initialValues, fileShareInfoBubbleMessage, setValues, setFieldValue, validateForm, storageTypeOptions } = props;
   const [accountSharesFiles, setAccountSharesFiles] = useState([]);
   const [accountSharesBlob, setAccountSharesBlob] = useState([]);
   const [sharesLoading, setSharesLoading] = useState(false);
@@ -249,22 +250,7 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
         required={true}
       />
       {showStorageTypeOption && (
-        <Field
-          component={RadioButton}
-          name="type"
-          id="azure-storage-mounts-name"
-          label={t('storageType')}
-          options={[
-            {
-              key: StorageType.azureBlob,
-              text: t('azureBlob'),
-            },
-            {
-              key: StorageType.azureFiles,
-              text: t('azureFiles'),
-            },
-          ]}
-        />
+        <Field component={RadioButton} name="type" id="azure-storage-mounts-name" label={t('storageType')} options={storageTypeOptions} />
       )}
       {values.type === StorageType.azureBlob && supportsBlobStorage && (
         <CustomBanner

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -77,6 +77,7 @@ export class CommonConstants {
     customErrorPage: 'customErrorPage',
     enableNewProgrammingModel: 'enableNewProgrammingModel',
     enableSnippets: 'enableSnippets',
+    showBYOSStorageAccess: 'showBYOSStorageAccess',
   };
 
   public static readonly AppDensityLimit = 8;

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1623,6 +1623,9 @@ export class PortalResources {
   public static emptyAzureStorageMount = 'emptyAzureStorageMount';
   public static azureStorageMountMustBeUnique = 'azureStorageMountMustBeUnique';
   public static virtualPathUnique = 'virtualPathUnique';
+  public static storageAccessLabel = 'storageAccessLabel';
+  public static manualInput = 'manualInput';
+  public static keyVaultReference = 'keyVaultReference';
   public static configurationOptions = 'configurationOptions';
   public static storageAccountNameMustBeLowerCase = 'storageAccountNameMustBeLowerCase';
   public static noBlobsOrFilesShares = 'noBlobsOrFilesShares';
@@ -1881,6 +1884,7 @@ export class PortalResources {
   public static createFunctionNotificationFailedDetails = 'createFunctionNotificationFailedDetails';
   public static createFunctionNotificationSuccess = 'createFunctionNotificationSuccess';
   public static readonlyBlobStorageWarning = 'readonlyBlobStorageWarning';
+  public static BYOSDeploymentSettingsWarning = 'BYOSDeploymentSettingsWarning';
   public static quickstartHeader = 'quickstartHeader';
   public static quickstartDesc = 'quickstartDesc';
   public static viewDocumentation = 'viewDocumentation';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -5013,7 +5013,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>Account Name</value>
     </data>
     <data name="azureBlob" xml:space="preserve">
-        <value>Azure Blob</value>
+        <value>Azure Blob (Read-only)</value>
     </data>
     <data name="azureFiles" xml:space="preserve">
         <value>Azure Files</value>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -5033,6 +5033,15 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="virtualPathUnique" xml:space="preserve">
         <value>Virtual paths must be unique</value>
     </data>
+    <data name="storageAccessLabel" xml:space="preserve">
+        <value>Storage access</value>
+    </data>
+    <data name="manualInput" xml:space="preserve">
+        <value>Manual input</value>
+    </data>
+    <data name="keyVaultReference" xml:space="preserve">
+        <value>Key vault reference</value>
+    </data>
     <data name="configurationOptions" xml:space="preserve">
         <value>Configuration options</value>
     </data>
@@ -5816,6 +5825,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     </data>
     <data name="readonlyBlobStorageWarning" xml:space="preserve">
         <value>Mounted Blob containers are read only.</value>
+    </data>
+    <data name="BYOSDeploymentSettingsWarning" xml:space="preserve">
+        <value>Selected App Setting is not marked as deployment slot setting. This may cause inconsistencies during the slot swap operation.</value>
     </data>
     <data name="quickstartHeader" xml:space="preserve">
         <value>Learn how to develop Azure Functions locally</value>


### PR DESCRIPTION
Fixes [AB#16820690](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s217?workitem=16820690)
1. Add app setting dropdown if the configuration is in advanced, the storage type is azure file shares.
2.  Show banner message is deployment setting is true but the selected app setting is not sticky.
3.  Remove unnecessary error message field input as formik control already handles the error message display.


![byosKeyVault](https://github.com/Azure/azure-functions-ux/assets/33185278/74060ea8-1181-4fb0-ac25-6527dc98c7b2)
