### PR TITLE
[Functions] Fix `runUsingPortal` to set `contentType` in NetAjaxSettings…

### DIFF
--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditorDataLoader.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditorDataLoader.tsx
@@ -396,7 +396,7 @@ const FunctionEditorDataLoader: React.FC<FunctionEditorDataLoaderProps> = ({ res
       let errorCount = 0;
       let functionSuccess = false;
       for (errorCount = 0; errorCount < 5 && !functionSuccess; ++errorCount) {
-        runFunctionResponse = await portalContext.makeHttpRequestsViaPortal(settings);
+        runFunctionResponse = await portalContext.makeHttpRequestsViaPortal(settings, /* setContentType */ true);
         const jqXHR = getJQXHR(runFunctionResponse, LogCategories.FunctionEdit, 'makeHttpRequestForRunFunction');
         if (jqXHR && jqXHR.status && jqXHR.status !== 200) {
           functionSuccess = true;
@@ -404,7 +404,7 @@ const FunctionEditorDataLoader: React.FC<FunctionEditorDataLoaderProps> = ({ res
       }
       setRetryFunctionTest(false);
     } else {
-      runFunctionResponse = await portalContext.makeHttpRequestsViaPortal(settings);
+      runFunctionResponse = await portalContext.makeHttpRequestsViaPortal(settings, /* setContentType */ true);
     }
 
     const runFunctionResponseResult = runFunctionResponse.result;


### PR DESCRIPTION
… when `Content-Type` header set.

[AB#24417824](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/24417824)

`runUsingPortal`, when passed a `Content-Type` header, was not setting the `NetAjaxSettings` `contentType` property.

`runUsingPortal` always stringified the JSON data, causing it to be parsed as stringified JSON, rather than a JSON payload.