### PR TITLE
[Functions] Disable updating `test_data` for Node.js functions...

### DIFF
--- a/client-react/src/pages/app/functions/function/function-editor/FunctionEditorDataLoader.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/FunctionEditorDataLoader.tsx
@@ -31,7 +31,12 @@ import { FunctionEditor } from './FunctionEditor';
 import FunctionEditorData from './FunctionEditor.data';
 import { shrinkEditorStyle } from './FunctionEditor.styles';
 import { NameValuePair, ResponseContent, UrlObj, UrlType, urlParameterRegExp } from './FunctionEditor.types';
-import { isNewNodeProgrammingModel, isNewPythonProgrammingModel, useFunctionEditorQueries } from './useFunctionEditorQueries';
+import {
+  isNewNodeProgrammingModel,
+  isNewPythonProgrammingModel,
+  isNodeFunction,
+  useFunctionEditorQueries,
+} from './useFunctionEditorQueries';
 
 interface FunctionEditorDataLoaderProps {
   resourceId: string;
@@ -302,8 +307,13 @@ const FunctionEditorDataLoader: React.FC<FunctionEditorDataLoaderProps> = ({ res
   const run = async (newFunctionInfo: ArmObj<FunctionInfo>, xFunctionKey?: string, liveLogsSessionId?: string) => {
     setFunctionRunning(true);
 
+    // Do not update Node.js functions here because of a runtime bug when worker indexing is enabled.
     // Do not update v2 Python functions here since its metadata is derived from code, not from function.json.
-    if (!SiteHelper.isFunctionAppReadOnly(siteStateContext.siteAppEditState) && !isNewPythonProgrammingModel(functionInfo)) {
+    if (
+      !SiteHelper.isFunctionAppReadOnly(siteStateContext.siteAppEditState) &&
+      !isNewPythonProgrammingModel(functionInfo) &&
+      !isNodeFunction(functionInfo)
+    ) {
       const updatedFunctionInfo = await functionEditorData.updateFunctionInfo(resourceId, newFunctionInfo);
       if (updatedFunctionInfo.metadata.success) {
         setFunctionInfo(updatedFunctionInfo.data);

--- a/client-react/src/pages/app/functions/function/function-editor/useFunctionEditorQueries.ts
+++ b/client-react/src/pages/app/functions/function/function-editor/useFunctionEditorQueries.ts
@@ -23,6 +23,10 @@ export const isDotNetIsolatedFunction = (functionInfo?: ArmObj<FunctionInfo>): b
   return functionInfo?.properties.config.language === WorkerRuntimeLanguages.dotnetIsolated;
 };
 
+export const isNodeFunction = (functionInfo?: ArmObj<FunctionInfo>): boolean => {
+  return functionInfo?.properties.language === WorkerRuntimeLanguages.nodejs;
+};
+
 export const isNewProgrammingModel = (functionInfo?: ArmObj<FunctionInfo>): boolean => {
   return isNewNodeProgrammingModel(functionInfo) || isNewPythonProgrammingModel(functionInfo);
 };


### PR DESCRIPTION
[Functions] Disable updating `test_data` for Node.js functions when using Test/Run

[AB#24418676](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/24418676)

After enabling worker indexing, the Functions runtime crashes after trying to update a Node.js function's test data with a PUT request. To mitigate this, temporarily disable updating `test_data` for Node.js functions during Test/Run.