### PR TITLE
Fix error when running Generic C# Webhook Trigger in v1 runtime.

### DIFF
--- a/client-react/src/pages/app/functions/function/function-editor/function-test/FunctionTest.tsx
+++ b/client-react/src/pages/app/functions/function/function-editor/function-test/FunctionTest.tsx
@@ -166,7 +166,18 @@ const FunctionTest: React.FC<FunctionTestProps> = props => {
           }
           delete localTestData.headers;
         }
-        setReqBody(localTestData.body ?? localTestData);
+
+        // test_data.body is stringified when saved to the function object.
+        // This is because the body in the Monaco editor is not parsed with `JSON.parse` before being saved.
+        if (localTestData.body) {
+          setReqBody(localTestData.body);
+        } // When loaded for the first time, it is JSON as was originally intended. Stringify it.
+        else if (typeof localTestData !== 'string') {
+          setReqBody(JSON.stringify(localTestData));
+        } // It is possible though unlikely that `localTestData` is a JSON string. Leave it alone.
+        else {
+          setReqBody(localTestData);
+        }
       } else {
         setReqBody(localTestData);
       }


### PR DESCRIPTION
[AB#24516433](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/24516433)

This fixes the issue reported in MPAC for PowerShell 7.2 in the v4 runtime too. See the email thread "MPAC bug - WebsitesExtension - When using default HttpTrigger (PowerShell 7.2) generated by Azure Portal, and run it on Azure Portal (Code + Test -> Test/Run), the value of $name is not passed at the first time." for details.