### PR TITLE
[v4 Node] Breakdown: Make v4 programming model Node.js apps editable

### DIFF
--- a/client-react/src/pages/app/functions/function/hooks/useFunctionsQuery.ts
+++ b/client-react/src/pages/app/functions/function/hooks/useFunctionsQuery.ts
@@ -4,7 +4,7 @@ import { ArmArray } from '../../../../../models/arm-obj';
 import { FunctionInfo } from '../../../../../models/functions/function-info';
 import { getTelemetryInfo } from '../../../../../utils/TelemetryUtils';
 import { useHttpResponseObjectQuery } from '../../../../../utils/useHttpResponseObjectQuery';
-import { isNewPythonProgrammingModel } from '../function-editor/useFunctionEditorQueries';
+import { isNewNodeProgrammingModel, isNewPythonProgrammingModel } from '../function-editor/useFunctionEditorQueries';
 
 export function useFunctionsQuery(resourceId: string) {
   const promise = useMemo(() => FunctionsService.getFunctions(resourceId), [resourceId]);
@@ -22,14 +22,14 @@ export function useFunctionsQuery(resourceId: string) {
 
   const { data: functions } = useHttpResponseObjectQuery(promise, onSuccess, onError);
 
-  /** @note Currently Python only. Change `isNewPythonProgrammingModel` when the v2 programming model becomes GA for other runtimes, e.g., Node.js. */
   const programmingModel = useMemo(() => {
     if (!functions) {
       return undefined;
     } else if (functions.length === 0) {
       return null;
     } else {
-      return functions.some(isNewPythonProgrammingModel) ? 2 : 1;
+      /** @todo Update this check when new frameworks and languages start supporting the v2 templates API. */
+      return functions.some(fn => isNewNodeProgrammingModel(fn) || isNewPythonProgrammingModel(fn)) ? 2 : 1;
     }
   }, [functions]);
 

--- a/client-react/src/pages/app/functions/function/hooks/useSiteConfigQuery.ts
+++ b/client-react/src/pages/app/functions/function/hooks/useSiteConfigQuery.ts
@@ -24,12 +24,16 @@ export function useSiteConfigQuery(resourceId: string) {
 
   const { data: siteConfig } = useHttpResponseObjectQuery(promise, onSuccess, onError);
 
-  const [language] = useMemo(() => siteConfig?.properties.linuxFxVersion?.split('|') ?? [], [siteConfig?.properties.linuxFxVersion]);
+  const [language, version] = useMemo(() => siteConfig?.properties.linuxFxVersion?.split('|') ?? [], [
+    siteConfig?.properties.linuxFxVersion,
+  ]);
 
   const isPythonLanguage = useMemo(() => (!siteConfig ? undefined : /^python$/i.test(language)), [language, siteConfig]);
 
   return {
     isPythonLanguage,
+    language: language as string | undefined,
     siteConfig,
+    version: version as string | undefined,
   };
 }

--- a/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.tsx
+++ b/client-react/src/pages/app/functions/function/integrate/FunctionIntegrate.tsx
@@ -20,7 +20,7 @@ import { HostStatus } from '../../../../../models/functions/host-status';
 import { Links } from '../../../../../utils/FwLinks';
 import SiteHelper from '../../../../../utils/SiteHelper';
 import StringUtils from '../../../../../utils/string';
-import { isNewPythonProgrammingModel } from '../function-editor/useFunctionEditorQueries';
+import { isNewNodeProgrammingModel, isNewPythonProgrammingModel } from '../function-editor/useFunctionEditorQueries';
 import { ClosedReason } from './BindingPanel/BindingEditor';
 import BindingPanel from './BindingPanel/BindingPanel';
 import {
@@ -93,7 +93,10 @@ export const FunctionIntegrate: React.FunctionComponent<FunctionIntegrateProps> 
   const [isUpdating, setIsUpdating] = useState<boolean>(false);
 
   const onlyBuiltInBindings = !hostStatus.version.startsWith('1') && !hostStatus.extensionBundle;
-  const bindingsReadOnly = useMemo(() => !!functionInfo && isNewPythonProgrammingModel(functionInfo), [functionInfo]);
+  const bindingsReadOnly = useMemo(
+    () => !!functionInfo && (isNewNodeProgrammingModel(functionInfo) || isNewPythonProgrammingModel(functionInfo)),
+    [functionInfo]
+  );
   const functionAppReadOnly = useMemo(() => SiteHelper.isFunctionAppReadOnly(siteStateContext.siteAppEditState), [
     siteStateContext.siteAppEditState,
   ]);
@@ -242,8 +245,8 @@ export const FunctionIntegrate: React.FunctionComponent<FunctionIntegrateProps> 
       />
     );
   } else if (bindingsReadOnly && !functionAppReadOnly) {
-    // Bindings are read-only for v2 Python progrmaming model functions, which are otherwise read-write.
-    banner = <CustomBanner message={t('integrate_readOnlyPythonV2')} type={MessageBarType.info} />;
+    // Bindings are read-only for v2 Python and v4 Node.js progrmaming model functions, which are otherwise read-write.
+    banner = <CustomBanner message={t('integrate_readOnlyNewProgrammingModel')} type={MessageBarType.info} />;
   } else if (readOnly) {
     // All readonly situations
     banner = <EditModeBanner />;

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFields.ts
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFields.ts
@@ -225,7 +225,6 @@ export function useFields(resourceId: string, jobType?: string, selectedTemplate
     // The blueprint filename input can be used for both the blueprint filename and the function name.
     const inputs = getJobInputs(selectedTemplate, jobType)?.reduce(toInputs, {}) ?? {};
 
-    /** @todo (joechung): AB#20749256 */
     const inputsWithoutFilenameInputs = Object.values(inputs).filter(
       ({ id }) => !/^app-fileName$/i.test(id) && !/^app-selectedFileName$/i.test(id)
     );

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFormContainer.ts
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFormContainer.ts
@@ -38,7 +38,7 @@ export function useFormContainer(resourceId: string) {
       ...getJobInputs(selectedTemplate, JobType.AppendToBlueprint)?.reduce(toInitialValues, {}),
     };
 
-    /** @todo (joechung): AB#20749256 */
+    /** @todo Check with Eric (`erijiz`) if v4 Node supports something like v2 Python's `function_app.py`. */
     return {
       ...initialValues,
       jobType: functionAppExists ? 'AppendToFile' : 'CreateNewApp',

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFunctionAppFileDetector.ts
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFunctionAppFileDetector.ts
@@ -8,13 +8,16 @@ export function useFunctionAppFileDetector(resourceId: string) {
   const [functionAppExists, setFunctionAppExists] = useState<boolean>();
   const [isInitialized, setIsInitialized] = useState(false);
 
+  /** @todo Check with Eric (`erijiz`) if v4 Node supports something like v2 Python's `function_app.py`. */
+  // v2 Python programming model expects a `function_app.py` file that registers blueprints for functions in other `.py` files.
   const checkForBlueprints = useCallback(async () => {
     const blueprints = await filter('', file => !!file['path']?.endsWith('.py') && !file['path']?.endsWith('/function_app.py'));
     return blueprints.length > 0;
   }, [filter]);
 
-  // Check if there is a file named 'function_app.py' in the root folder.
-  // Check if there are any files whose extension is '.py' in the root folder.
+  /** @todo Check with Eric (`erijiz`) if v4 Node supports something like v2 Python's blueprints. */
+  // For v2 Python programming model, check if there is a file named 'function_app.py' in the root folder.
+  // For v2 Python programming model, check if there are any files whose extension is '.py' in the root folder.
   useEffect(() => {
     let isMounted = true;
 

--- a/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFunctionCreator.ts
+++ b/client-react/src/pages/app/functions/new-create-preview/portal-create-v2/useFunctionCreator.ts
@@ -114,15 +114,13 @@ export function useFunctionCreator(resourceId: string, functionAppExists?: boole
         try {
           switch (jobType) {
             case JobType.CreateNewApp: {
-              /** @todo (joechung): AB#20749256 */
-              const appFileName = values['app-fileName'] ?? 'function_app.py';
+              const appFileName = values['app-fileName'];
               await createFile(appFileName, files[paths[0]]);
               break;
             }
 
             case JobType.AppendToFile: {
-              /** @todo (joechung): AB#20749256 */
-              const appSelectedFileName = values['app-selectedFileName'] ?? 'function_app.py';
+              const appSelectedFileName = values['app-selectedFileName'];
               await appendToFile(appSelectedFileName, files[paths[0]]);
               break;
             }

--- a/client-react/src/pages/app/functions/new-create-preview/useProgrammingModel.tsx
+++ b/client-react/src/pages/app/functions/new-create-preview/useProgrammingModel.tsx
@@ -12,9 +12,12 @@ import {
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ThemeExtended } from '../../../../theme/SemanticColorsExtended';
+import { CommonConstants, WorkerRuntimeLanguages } from '../../../../utils/CommonConstants';
 import { Links } from '../../../../utils/FwLinks';
+import { useAppSettingsQuery } from '../common/useAppSettingsQuery';
 import { useFunctionsQuery } from '../function/hooks/useFunctionsQuery';
 import { useSiteConfigQuery } from '../function/hooks/useSiteConfigQuery';
+import Url from '../../../../utils/url';
 
 const programmingModelDropdownStyles: IStyleFunctionOrObject<IDropdownStyleProps, IDropdownStyles> = ({ disabled, theme }) => {
   return {
@@ -57,14 +60,32 @@ const programmingModelLinkStyles: ILinkStyles = {
   },
 };
 
+const enableNewNodeEditMode = !!Url.getFeatureValue(CommonConstants.FeatureFlags.enableNewNodeEditMode);
+
 export function useProgrammingModel(resourceId: string) {
   const { t } = useTranslation();
 
   const { functions, programmingModel: selectedProgrammingModel } = useFunctionsQuery(resourceId);
-  const { isPythonLanguage } = useSiteConfigQuery(resourceId);
 
-  /** @todo Add more checks when they go GA, e.g., Node.js, .NET. */
-  const isSupported = isPythonLanguage;
+  /** @note The v2 Python programming model is supported for all versions of Python supported on the ~4 runtime. */
+  const { isPythonLanguage, language, siteConfig, version } = useSiteConfigQuery(resourceId);
+
+  /** @note The v4 Node.js programming model is supported only for Node.js 18 on the ~4 runtime. */
+  // Ignore `isNode18` when `linuxFxVersion` is not set.
+  const isNode18 = !language || !version ? undefined : /^node$/i.test(language) && version === '18';
+
+  // Ignore `isSupportedNodeVersion` when `FUNCTIONS_WORKER_RUNTIME` or `WEBSITE_NODE_DEFAULT_VERSION` app settings are missing.
+  const { appSettings } = useAppSettingsQuery(resourceId);
+  const workerRuntime = appSettings?.properties[CommonConstants.AppSettingNames.functionsWorkerRuntime];
+  const websiteNodeDefaultVersion = appSettings?.properties[CommonConstants.AppSettingNames.websiteNodeDefaultVersion];
+  const isSupportedNodeVersion =
+    !workerRuntime || !websiteNodeDefaultVersion
+      ? undefined
+      : workerRuntime === WorkerRuntimeLanguages.nodejs && websiteNodeDefaultVersion === '~18';
+
+  const isNode = isNode18 || isSupportedNodeVersion;
+
+  const isSupported = isPythonLanguage === undefined ? undefined : isPythonLanguage || (enableNewNodeEditMode && isNode);
 
   const [programmingModelDisabled, setProgrammingModelDisabled] = useState(false);
   const [programmingModel, setProgrammingModel] = useState<number | string | null>(null);
@@ -101,13 +122,13 @@ export function useProgrammingModel(resourceId: string) {
 
   /** @note Do not disable or initialize the dropdown until all APIs have completed. */
   useEffect(() => {
-    if (selectedProgrammingModel !== undefined && functions !== undefined && isSupported !== undefined) {
+    if (selectedProgrammingModel !== undefined && functions !== undefined && appSettings !== undefined && siteConfig !== undefined) {
       /** @note Disable the dropdown if there is already a selected programming model. */
       setProgrammingModelDisabled(selectedProgrammingModel !== null);
 
       /**
        * @note Initialize the dropdown to the selected programming model, if functions already exist.
-       * Otherwise default to the v2 programming model, if supported (Python only).
+       * Otherwise default to the v2 programming model, if supported (v4 Node.js or v2 Python).
        * Otherwise default to the v1 programming model.
        */
       if (selectedProgrammingModel) {
@@ -116,7 +137,7 @@ export function useProgrammingModel(resourceId: string) {
         setProgrammingModel(isSupported ? 2 : 1);
       }
     }
-  }, [selectedProgrammingModel, functions, isSupported]);
+  }, [appSettings, functions, isSupported, selectedProgrammingModel, siteConfig]);
 
   return {
     onProgrammingModelChange,

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -75,7 +75,6 @@ export class CommonConstants {
     enableACRManagedIdentities: 'enableACRManagedIdentities',
     enableNewNodeEditMode: 'enableNewNodeEditMode',
     customErrorPage: 'customErrorPage',
-    enableNewProgrammingModel: 'enableNewProgrammingModel',
     enableSnippets: 'enableSnippets',
     showBYOSStorageAccess: 'showBYOSStorageAccess',
     showJBossClustering: 'showJBossClustering',

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1984,7 +1984,7 @@ export class PortalResources {
   public static resourceDropdown_missingAppSetting = 'resourceDropdown_missingAppSetting';
   public static resourceDropdown_noAppSettingsFound = 'resourceDropdown_noAppSettingsFound';
   public static integrate_bindingsMissingDirection = 'integrate_bindingsMissingDirection';
-  public static integrate_readOnlyPythonV2 = 'integrate_readOnlyPythonV2';
+  public static integrate_readOnlyNewProgrammingModel = 'integrate_readOnlyNewProgrammingModel';
   public static functionMonitor_invocations = 'functionMonitor_invocations';
   public static functionMonitor_logs = 'functionMonitor_logs';
   public static logStreaming_openInLiveMetrics = 'logStreaming_openInLiveMetrics';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -6126,8 +6126,8 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="integrate_bindingsMissingDirection" xml:space="preserve">
         <value>The following bindings are missing the required direction property and may have been placed incorrectly: {0}. Please update the bindings in your functions.json file.</value>
     </data>
-    <data name="integrate_readOnlyPythonV2" xml:space="preserve">
-        <value>Use the code editor to update v2 programming model Python function bindings.</value>
+    <data name="integrate_readOnlyNewProgrammingModel" xml:space="preserve">
+        <value>Use the code editor to update new programming model function bindings.</value>
     </data>
     <data name="functionMonitor_invocations" xml:space="preserve">
         <value>Invocations</value>


### PR DESCRIPTION
[AB#24523087](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/24523087)

Use `enableNewNodeEditMode` feature flag to hide these features:
- Enable Code+Test editing of v4 Node.js functions.
- Make Integration read-only for v4 Node.js function bindings.
- Use v2 Template APIs to create v4 Node.js functions.