### PR TITLE
[DC] Show cross-sub ACR with no read access as private registry

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
@@ -13,7 +13,7 @@ import { IComboBoxOption, IDropdownOption, MessageBarType, SelectableOptionMenuI
 import DeploymentCenterData from '../DeploymentCenter.data';
 import { getErrorMessage } from '../../../../ApiHelpers/ArmHelper';
 import { ACRCredential } from '../../../../models/acr';
-import { getTelemetryInfo, optionsSortingFunction } from '../utility/DeploymentCenterUtility';
+import { getAcrNameFromLoginServer, getTelemetryInfo, optionsSortingFunction } from '../utility/DeploymentCenterUtility';
 import { PortalContext } from '../../../../PortalContext';
 import { useTranslation } from 'react-i18next';
 import { DeploymentCenterConstants } from '../DeploymentCenterConstants';
@@ -440,11 +440,6 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
     ];
     setManagedIdentityOptions(identities);
     setLoadingManagedIdentities(false);
-  };
-
-  const getAcrNameFromLoginServer = (loginServer: string): string => {
-    const loginServerParts = loginServer?.split('.') ?? [];
-    return loginServerParts.length > 0 ? loginServerParts[0] : '';
   };
 
   const parseHiddenTag = (tagValue: string) => {

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettings.tsx
@@ -18,7 +18,7 @@ import DeploymentCenterGitHubWorkflowConfigSelector from '../github-provider/Dep
 import DeploymentCenterGitHubWorkflowConfigPreview from '../github-provider/DeploymentCenterGitHubWorkflowConfigPreview';
 import { DeploymentCenterContext } from '../DeploymentCenterContext';
 import { useTranslation } from 'react-i18next';
-import { getTelemetryInfo, getWorkflowFileName } from '../utility/DeploymentCenterUtility';
+import { getAcrNameFromLoginServer, getTelemetryInfo, getWorkflowFileName } from '../utility/DeploymentCenterUtility';
 import { Guid } from '../../../../utils/Guid';
 import DeploymentCenterContainerContinuousDeploymentSettings from './DeploymentCenterContainerContinuousDeploymentSettings';
 import { DeploymentCenterConstants } from '../DeploymentCenterConstants';
@@ -31,6 +31,7 @@ import { AppOs } from '../../../../models/site/site';
 import DeploymentCenterData from '../DeploymentCenter.data';
 import { PortalContext } from '../../../../PortalContext';
 import { CommonConstants } from '../../../../utils/CommonConstants';
+import { AcrDependency } from '../../../../utils/dependency/Dependency';
 
 const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<DeploymentCenterContainerFormData>> = props => {
   const { formProps, isDataRefreshing } = props;
@@ -58,9 +59,52 @@ const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<Dep
 
   const isGitHubActionSelected = formProps.values.scmType === ScmType.GitHubAction;
   const isVstsSelected = formProps.values.scmType === ScmType.Vsts;
-  const isAcrConfigured = formProps.values.registrySource === ContainerRegistrySources.acr;
+  const [isAcrConfigured, setIsAcrConfigured] = useState<boolean>(formProps.values.registrySource === ContainerRegistrySources.acr);
   const isDockerHubConfigured = formProps.values.registrySource === ContainerRegistrySources.docker;
   const isPrivateRegistryConfigured = formProps.values.registrySource === ContainerRegistrySources.privateRegistry;
+
+  const [isDataLoading, setIsDataLoading] = useState<boolean>(false);
+
+  const hasAcrReadAccess = React.useCallback(() => {
+    // NOTE(yoonaoh): Checking to see if the user has read access to the ACR itself
+    // If not, we turn this into a private registry instead
+    if (formProps.values.registrySource === ContainerRegistrySources.acr) {
+      setIsDataLoading(true);
+      const acrTagInstance = new AcrDependency();
+      const acrName = getAcrNameFromLoginServer(formProps.values.acrLoginServer);
+      acrTagInstance.discoverResourceId(portalContext, acrName).then(response => {
+        const isValidAcr = !!response?.subscriptionId;
+        setIsAcrConfigured(isValidAcr);
+        if (!isValidAcr) {
+          const formattedAcrLoginServer = CommonConstants.DeploymentCenterConstants.https + formProps.values.acrLoginServer;
+          // Change initial values to not affect the dirty state checks
+          formProps.initialValues.registrySource = ContainerRegistrySources.privateRegistry;
+          formProps.initialValues.privateRegistryServerUrl = formattedAcrLoginServer;
+          formProps.initialValues.privateRegistryImageAndTag = `${formProps.values.acrImage}:${formProps.values.acrTag}`;
+          formProps.initialValues.privateRegistryComposeYml = formProps.values.acrComposeYml;
+          formProps.initialValues.privateRegistryUsername = formProps.values.acrUsername;
+          formProps.initialValues.privateRegistryPassword = formProps.values.acrPassword;
+
+          // Switch to private registry
+          formProps.setFieldValue('registrySource', ContainerRegistrySources.privateRegistry);
+          formProps.setFieldValue('privateRegistryServerUrl', formattedAcrLoginServer);
+          formProps.setFieldValue('privateRegistryImageAndTag', `${formProps.values.acrImage}:${formProps.values.acrTag}`);
+          formProps.setFieldValue('privateRegistryComposeYml', formProps.values.acrComposeYml);
+          formProps.setFieldValue('privateRegistryUsername', formProps.values.acrUsername);
+          formProps.setFieldValue('privateRegistryPassword', formProps.values.acrPassword);
+
+          // Reset the values of the initial acr fields
+          formProps.initialValues.acrLoginServer = '';
+          formProps.initialValues.acrImage = '';
+          formProps.initialValues.acrTag = '';
+          formProps.initialValues.acrComposeYml = '';
+          formProps.initialValues.acrUsername = '';
+          formProps.initialValues.acrPassword = '';
+        }
+        setIsDataLoading(false);
+      });
+    }
+  }, [formProps.values.registrySource, formProps.values.acrLoginServer]);
 
   const getWorkflowFileVariables = () => {
     const slotName = deploymentCenterContext.siteDescriptor?.slot ?? '';
@@ -275,6 +319,8 @@ const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<Dep
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [siteStateContext.isLinuxApp]);
 
+  useEffect(() => hasAcrReadAccess(), [hasAcrReadAccess]);
+
   const renderSetupView = () => {
     return (
       <>
@@ -333,7 +379,7 @@ const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<Dep
     <ProgressIndicator description={t('deploymentCenterSettingsLoading')} ariaValueText={t('deploymentCenterSettingsLoadingAriaValue')} />
   );
 
-  return isDataRefreshing ? getProgressIndicator() : getSettingsControls();
+  return isDataLoading || isDataRefreshing ? getProgressIndicator() : getSettingsControls();
 };
 
 export default DeploymentCenterContainerSettings;

--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
@@ -550,3 +550,8 @@ export const deleteDeploymentCenterLogs = async (
     portalContext.stopNotification(notificationId, true, t('deploymentCenterDeleteLogsSuccessNotificationDescription'));
   }
 };
+
+export const getAcrNameFromLoginServer = (loginServer: string): string => {
+  const loginServerParts = loginServer?.split('.') ?? [];
+  return loginServerParts.length > 0 ? loginServerParts[0] : '';
+};


### PR DESCRIPTION
FixesAB#[10409912](https://msazure.visualstudio.com/Antares/_workitems/edit/10409912)
- For a user who chooses to enter a cross-subscription ACR (that they don't have RBAC permissions for but have the credentials for) as a Private Registry in Creates, we want to show their configuration in Deployment Center as a Private Registry


**Before**
![image](https://github.com/Azure/azure-functions-ux/assets/29874289/3f4a592c-6677-497c-884d-d89a10035211)


**After**
![image](https://github.com/Azure/azure-functions-ux/assets/29874289/e8b08a25-4b3d-44c6-a6a7-6f3a18d8ec89)
