### PR TITLE
ANT100 Java stack updates

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
@@ -53,6 +53,38 @@ const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
             },
           },
           {
+            displayText: 'Java 17.0.4',
+            value: '17.0.4',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (jafreebe): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '17',
+                },
+                endOfLifeDate: java17EOL,
+              },
+              windowsRuntimeSettings: {
+                runtimeVersion: '17.0.4',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '17',
+                },
+                endOfLifeDate: java17EOL,
+              },
+            },
+          }, {
             displayText: 'Java 17.0.3',
             value: '17.0.3',
             stackSettings: {
@@ -179,6 +211,39 @@ const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
               windowsRuntimeSettings: {
                 runtimeVersion: '11',
                 isAutoUpdate: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 11.0.16',
+            value: '11.0.16',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (jafreebe): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
+              },
+              windowsRuntimeSettings: {
+                runtimeVersion: '11.0.16',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -576,6 +641,25 @@ const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
               windowsRuntimeSettings: {
                 runtimeVersion: '1.8',
                 isAutoUpdate: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_345',
+            value: '8.0.345',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '1.8.0_345',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -27,6 +27,15 @@ export const javaContainersStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Java SE 17.0.4',
+          value: '17.0.4',
+          stackSettings: {
+            linuxContainerSettings: {
+              java17Runtime: 'JAVA|17.0.4',
+            },
+          },
+        },
+        {
           displayText: 'Java SE 17.0.3',
           value: '17.0.3',
           stackSettings: {
@@ -53,6 +62,15 @@ export const javaContainersStack: WebAppStack = {
             linuxContainerSettings: {
               // Note (jafreebe): This doesn't have suffix of -java11 since setting to 11.0.8 prevents auto-updates
               java17Runtime: 'JAVA|17.0.1',
+            },
+          },
+        },
+        {
+          displayText: 'Java SE 11.0.16',
+          value: '11.0.16',
+          stackSettings: {
+            linuxContainerSettings: {
+              java11Runtime: 'JAVA|11.0.16',
             },
           },
         },
@@ -143,6 +161,15 @@ export const javaContainersStack: WebAppStack = {
             linuxContainerSettings: {
               // Note (jafreebe): This doesn't have suffix of -java11 since setting to 11.0.5 prevents auto-updates
               java11Runtime: 'JAVA|11.0.5',
+            },
+          },
+        },
+        {
+          displayText: 'Java SE 8u345',
+          value: '1.8.345',
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: 'JAVA|8u345',
             },
           },
         },
@@ -249,9 +276,21 @@ export const javaContainersStack: WebAppStack = {
             linuxContainerSettings: {
               java8Runtime: 'JBOSSEAP|7-java8',
               java11Runtime: 'JBOSSEAP|7-java11',
+              java17Runtime: 'JBOSSEAP|7-java17',
               isAutoUpdate: true,
             },
           },
+        },
+        {
+          displayText: 'Red Hat JBoss EAP 7.4.7',
+          value: '7.4.7',
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: 'JBOSSEAP|7.4.7-java8',
+              java11Runtime: 'JBOSSEAP|7.4.7-java11',
+              java17Runtime: 'JBOSSEAP|7.4.7-java17'
+            }
+          }
         },
         {
           displayText: 'Red Hat JBoss EAP 7.4.5',
@@ -259,7 +298,8 @@ export const javaContainersStack: WebAppStack = {
           stackSettings: {
             linuxContainerSettings: {
               java8Runtime: 'JBOSSEAP|7.4.5-java8',
-              java11Runtime: 'JBOSSEAP|7.4.5-java11'
+              java11Runtime: 'JBOSSEAP|7.4.5-java11',
+              java17Runtime: 'JBOSSEAP|7.4.5-java17'
             }
           }
         },
@@ -371,6 +411,21 @@ export const javaContainersStack: WebAppStack = {
           },
         },
         {
+          displayText: 'Apache Tomcat 10.0.23',
+          value: '10.0.23',
+          stackSettings: {
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '10.0.23',
+            },
+            linuxContainerSettings: {
+              java8Runtime: 'TOMCAT|10.0.23-java8',
+              java11Runtime: 'TOMCAT|10.0.23-java11',
+              java17Runtime: 'TOMCAT|10.0.23-java17'
+            },
+          },
+        },
+        {
           displayText: 'Apache Tomcat 10.0.21',
           value: '10.0.21',
           stackSettings: {
@@ -435,6 +490,21 @@ export const javaContainersStack: WebAppStack = {
               java11Runtime: 'TOMCAT|9.0-java11',
               java8Runtime: 'TOMCAT|9.0-jre8',
               isAutoUpdate: true,
+            },
+          },
+        },
+        {
+          displayText: 'Apache Tomcat 9.0.65',
+          value: '9.0.65',
+          stackSettings: {
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '9.0.65',
+            },
+            linuxContainerSettings: {
+              java8Runtime: 'TOMCAT|9.0.65-java8',
+              java11Runtime: 'TOMCAT|9.0.65-java11',
+              java17Runtime: 'TOMCAT|9.0.65-java17'
             },
           },
         },
@@ -654,6 +724,20 @@ export const javaContainersStack: WebAppStack = {
               java11Runtime: 'TOMCAT|8.5-java11',
               java8Runtime: 'TOMCAT|8.5-jre8',
               isAutoUpdate: true,
+            },
+          },
+        },
+        {
+          displayText: 'Apache Tomcat 8.5.82',
+          value: '8.5.82',
+          stackSettings: {
+            linuxContainerSettings: {
+              java8Runtime: 'TOMCAT|8.5.82-java8',
+              java11Runtime: 'TOMCAT|8.5.82-java11',
+            },
+            windowsContainerSettings: {
+              javaContainer: 'TOMCAT',
+              javaContainerVersion: '8.5.82',
             },
           },
         },


### PR DESCRIPTION
Adds the following versions to the Java stacks and Java containers:

Java
• Adoptium Temurin 8u345-b01
• MSFT OpenJDK 11.0.16.1
• MSFT OpenJDK 17.0.4.1

Tomcat
• 8.5.82 with Java 8 and Java 11
• 9.0.65 with Java 8, Java 11 and Java 17
• 10.0.23 with Java 8, Java 11 and Java 17

JBoss EAP
• 7.4.5 with Java 17
• 7.4.7 with Java 8, Java 11 and Java 17