### PR TITLE
Adding .NET 8 preview as hidden for Web Apps

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -16,6 +16,44 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
     preferredOs: 'windows',
     majorVersions: [
       {
+        displayText: '.NET 8 (Preview)',
+        value: 'dotnet8',
+        minorVersions: [
+          {
+            displayText: '.NET 8 (Preview)',
+            value: '8',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: 'v8.0',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8.x',
+                },
+                isHidden: true,
+                isPreview: true,
+              },
+              linuxRuntimeSettings: {
+                runtimeVersion: 'DOTNETCORE|8.0',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8.x',
+                },
+                isHidden: true,
+                isPreview: true,
+              },
+            },
+          },
+        ],
+      },
+      {
         displayText: '.NET 7 (STS)',
         value: 'dotnet7',
         minorVersions: [

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -16,11 +16,11 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
     preferredOs: 'windows',
     majorVersions: [
       {
-        displayText: '.NET 8 (Preview)',
+        displayText: '.NET 8 (LTS)',
         value: 'dotnet8',
         minorVersions: [
           {
-            displayText: '.NET 8 (Preview)',
+            displayText: '.NET 8 (LTS)',
             value: '8',
             stackSettings: {
               windowsRuntimeSettings: {

--- a/server/src/tests/Stacks/2020-10-01/web-app/validations.ts
+++ b/server/src/tests/Stacks/2020-10-01/web-app/validations.ts
@@ -167,7 +167,7 @@ function validateDotnetStack(dotnetStack) {
   expect(dotnetStack.displayText).to.equal('.NET');
   expect(dotnetStack.value).to.equal('dotnet');
   expect(dotnetStack.preferredOs).to.equal('windows');
-  expect(dotnetStack.majorVersions.length).to.equal(8);
+  expect(dotnetStack.majorVersions.length).to.equal(9);
   expect(dotnetStack).to.deep.equal(hardCodedDotnetStack);
 }
 


### PR DESCRIPTION
Added .Net 8 preview as a major version with linux and windows settings for web apps