### PR TITLE
AB#17484539 Path mapping - Set command bar focus when closing the panel

### DIFF
--- a/client-react/src/components/DisplayTableWithCommandBar/DisplayTableWithCommandBar.tsx
+++ b/client-react/src/components/DisplayTableWithCommandBar/DisplayTableWithCommandBar.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { ICommandBarItemProps, CommandBar, IDetailsListProps, IButtonProps } from '@fluentui/react';
+import { ICommandBarItemProps, CommandBar, IDetailsListProps, IButtonProps, ICommandBar } from '@fluentui/react';
 import { ThemeContext } from '../../ThemeContext';
 import { commandBarStyles, DetailListStyles } from './DisplayTableWithCommandBar.style';
 import DisplayTableCommandBarButton from './DisplayTableCommandBarButton';
@@ -9,12 +9,13 @@ import DisplayTableWithEmptyMessage, {
 import { useTranslation } from 'react-i18next';
 
 interface DisplayTableWithCommandBarProps {
+  commandBarRef?: React.MutableRefObject<ICommandBar | null>;
   commandBarItems?: ICommandBarItemProps[];
 }
 
 type Props = DisplayTableWithEmptyMessageProps & DisplayTableWithCommandBarProps & IDetailsListProps;
 const DisplayTableWithCommandBar: React.SFC<Props> = props => {
-  const { commandBarItems, styles, ...rest } = props;
+  const { commandBarItems, styles, commandBarRef, ...rest } = props;
   const { t } = useTranslation();
 
   const theme = useContext(ThemeContext);
@@ -30,6 +31,11 @@ const DisplayTableWithCommandBar: React.SFC<Props> = props => {
     <>
       {!!commandBarItems && commandBarItems.length > 0 && (
         <CommandBar
+          componentRef={ref => {
+            if (commandBarRef) {
+              commandBarRef.current = ref;
+            }
+          }}
           items={commandBarItems}
           styles={commandBarStyles(theme)}
           buttonAs={DisplayTableCommandBarButton}

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMounts.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMounts.tsx
@@ -1,5 +1,5 @@
 import { FormikProps } from 'formik';
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useRef } from 'react';
 import { defaultCellStyle } from '../../../../components/DisplayTableWithEmptyMessage/DisplayTableWithEmptyMessage';
 import {
   AppSettingsFormValues,
@@ -21,6 +21,7 @@ import {
   IDetailsRowStyles,
   DetailsRow,
   IDetailsListProps,
+  ICommandBar,
 } from '@fluentui/react';
 import { PermissionsContext } from '../Contexts';
 import { sortBy } from 'lodash-es';
@@ -44,6 +45,7 @@ const AzureStorageMounts: React.FC<FormikProps<AppSettingsFormValues>> = props =
   const [currentAzureStorageMount, setCurrentAzureStorageMount] = useState<FormAzureStorageMounts | null>(null);
   const [currentItemIndex, setCurrentItemIndex] = useState<number | undefined>(undefined);
   const [createNewItem, setCreateNewItem] = useState(false);
+  const commandBarRef = useRef<ICommandBar | null>(null);
 
   const { values } = props;
   const { t } = useTranslation();
@@ -95,11 +97,13 @@ const AzureStorageMounts: React.FC<FormikProps<AppSettingsFormValues>> = props =
 
     setCreateNewItem(false);
     setShowPanel(false);
+    commandBarRef.current?.focus();
   };
 
   const onCancel = (): void => {
     setCreateNewItem(false);
     setShowPanel(false);
+    commandBarRef.current?.focus();
   };
 
   const onShowPanel = (item: FormAzureStorageMounts, index: number): void => {
@@ -292,6 +296,7 @@ const AzureStorageMounts: React.FC<FormikProps<AppSettingsFormValues>> = props =
     return (
       <>
         <DisplayTableWithCommandBar
+          commandBarRef={commandBarRef}
           onRenderRow={onRenderRow}
           commandBarItems={getCommandBarItems()}
           items={values.azureStorageMounts || []}

--- a/client-react/src/pages/app/app-settings/HandlerMappings/HandlerMappings.tsx
+++ b/client-react/src/pages/app/app-settings/HandlerMappings/HandlerMappings.tsx
@@ -1,6 +1,6 @@
 import { FormikProps } from 'formik';
 import { DetailsListLayoutMode, IColumn, SelectionMode } from '@fluentui/react';
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useRef } from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import { defaultCellStyle } from '../../../../components/DisplayTableWithEmptyMessage/DisplayTableWithEmptyMessage';
 import IconButton from '../../../../components/IconButton/IconButton';
@@ -8,7 +8,15 @@ import { AppSettingsFormValues } from '../AppSettings.types';
 import HandlerMappingsAddEdit from './HandlerMappingsAddEdit';
 import { PermissionsContext } from '../Contexts';
 import { HandlerMapping } from '../../../../models/site/config';
-import { TooltipHost, ICommandBarItemProps, PanelType, IDetailsRowStyles, DetailsRow, IDetailsListProps } from '@fluentui/react';
+import {
+  TooltipHost,
+  ICommandBarItemProps,
+  PanelType,
+  IDetailsRowStyles,
+  DetailsRow,
+  IDetailsListProps,
+  ICommandBar,
+} from '@fluentui/react';
 import CustomPanel from '../../../../components/CustomPanel/CustomPanel';
 import DisplayTableWithCommandBar from '../../../../components/DisplayTableWithCommandBar/DisplayTableWithCommandBar';
 import { ThemeContext } from '../../../../ThemeContext';
@@ -23,6 +31,7 @@ const HandlerMappings: React.FC<FormikProps<AppSettingsFormValues> & WithTransla
   const [currentHandlerMapping, setCurrentHandlerMapping] = useState<HandlerMapping | null>(null);
   const [currentItemIndex, setCurrentItemIndex] = useState<number | null>(null);
   const [createNewItem, setCreateNewItem] = useState(false);
+  const commandBarRef = useRef<ICommandBar | null>(null);
 
   const { t, values } = props;
 
@@ -82,11 +91,13 @@ const HandlerMappings: React.FC<FormikProps<AppSettingsFormValues> & WithTransla
     }
     setCreateNewItem(false);
     setShowPanel(false);
+    commandBarRef.current?.focus();
   };
 
   const onCancel = (): void => {
     setCreateNewItem(false);
     setShowPanel(false);
+    commandBarRef.current?.focus();
   };
 
   const onShowPanel = (item: HandlerMapping, index: number): void => {
@@ -251,6 +262,7 @@ const HandlerMappings: React.FC<FormikProps<AppSettingsFormValues> & WithTransla
   return (
     <>
       <DisplayTableWithCommandBar
+        commandBarRef={commandBarRef}
         onRenderRow={onRenderRow}
         commandBarItems={getCommandBarItems()}
         items={values.config.properties.handlerMappings || []}

--- a/client-react/src/pages/app/app-settings/VirtualApplications/VirtualApplications.tsx
+++ b/client-react/src/pages/app/app-settings/VirtualApplications/VirtualApplications.tsx
@@ -1,5 +1,5 @@
 import { FormikProps } from 'formik';
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useRef } from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { defaultCellStyle } from '../../../../components/DisplayTableWithEmptyMessage/DisplayTableWithEmptyMessage';
 import IconButton from '../../../../components/IconButton/IconButton';
@@ -17,6 +17,7 @@ import {
   IDetailsRowStyles,
   DetailsRow,
   IDetailsListProps,
+  ICommandBar,
 } from '@fluentui/react';
 import CustomPanel from '../../../../components/CustomPanel/CustomPanel';
 import DisplayTableWithCommandBar from '../../../../components/DisplayTableWithCommandBar/DisplayTableWithCommandBar';
@@ -38,6 +39,7 @@ const VirtualApplications: React.FC<FormikProps<AppSettingsFormValues> & WithTra
   const [currentVirtualApplication, setCurrentVirtualApplication] = useState<VirtualApplication | null>(null);
   const [currentItemIndex, setCurrentItemIndex] = useState<number | null>(null);
   const [createNewItem, setCreateNewItem] = useState(false);
+  const commandBarRef = useRef<ICommandBar | null>(null);
 
   const { t, values } = props;
 
@@ -72,6 +74,7 @@ const VirtualApplications: React.FC<FormikProps<AppSettingsFormValues> & WithTra
   const onCancelPanel = () => {
     setShowPanel(false);
     setCreateNewItem(false);
+    commandBarRef.current?.focus();
   };
 
   const onClosePanel = (item: VirtualApplication) => {
@@ -87,6 +90,7 @@ const VirtualApplications: React.FC<FormikProps<AppSettingsFormValues> & WithTra
     });
     setCreateNewItem(false);
     setShowPanel(false);
+    commandBarRef.current?.focus();
   };
 
   const onShowPanel = (item: VirtualApplication, index: number): void => {
@@ -256,6 +260,7 @@ const VirtualApplications: React.FC<FormikProps<AppSettingsFormValues> & WithTra
   return (
     <>
       <DisplayTableWithCommandBar
+        commandBarRef={commandBarRef}
         onRenderRow={onRenderRow}
         commandBarItems={getCommandBarItems()}
         items={values.virtualApplications || []}


### PR DESCRIPTION
Fixes: [AB#17484539](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/UX/s222?workitem=17484539)

Set focus on the command item when the context pane is closed