### PR TITLE
Update appinsights settings for dotnet 8

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -28,6 +28,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -41,6 +42,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,
+                  isDefaultOff: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,


### PR DESCRIPTION
Added `isDefaultOff` flag in app insights settings for dotnet 8 Linux and windows runtime settings.