### PR TITLE
AB#22895557 Updating upsell for custom error pages with ASEv3/2

### DIFF
--- a/client-react/src/components/UpsellBanner/UpsellBanner.tsx
+++ b/client-react/src/components/UpsellBanner/UpsellBanner.tsx
@@ -2,12 +2,16 @@ import { FC } from 'react';
 import { Stack, Link } from '@fluentui/react';
 import { ReactComponent as UpsellIconSvg } from '../../upsell.svg';
 import { BannerStyle, IconStyle, LinkStyle } from './UpsellBanner.styles';
-
+import { useTranslation } from 'react-i18next';
 interface Props {
   bannerMessage: string;
+  learnMoreLink?: string;
+  learnMoreLinkAriaLabel?: string;
   onClick: () => void;
 }
+
 const UpsellBanner: FC<Props> = props => {
+  const { t } = useTranslation();
   return (
     <Stack verticalAlign={'center'} gap={20} className={BannerStyle}>
       <Stack horizontal verticalAlign="center">
@@ -15,6 +19,16 @@ const UpsellBanner: FC<Props> = props => {
         <Link onClick={props.onClick} className={LinkStyle}>
           {props.bannerMessage}
         </Link>
+        {props.learnMoreLink ? (
+          <Link
+            href={props.learnMoreLink}
+            target="_blank"
+            aria-label={props.learnMoreLinkAriaLabel ? props.learnMoreLinkAriaLabel : t('learnMore')}>
+            {t('learnMore')}
+          </Link>
+        ) : (
+          undefined
+        )}
       </Stack>
     </Stack>
   );

--- a/client-react/src/pages/app/app-settings/AppSettings.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettings.tsx
@@ -21,6 +21,7 @@ import { PortalContext } from '../../../PortalContext';
 import { updateWebAppConfigForServiceLinker } from './AppSettings.utils';
 import { BladeCloseReason, IBladeResult } from '../../../models/portal-models';
 import { SiteStateContext } from '../../../SiteState';
+import { Links } from '../../../utils/FwLinks';
 
 const validate = (values: AppSettingsFormValues | null, t: i18n.TFunction, scenarioChecker: ScenarioService, site: ArmObj<Site>) => {
   if (!values) {
@@ -241,6 +242,7 @@ const AppSettings: React.FC<AppSettingsProps> = props => {
                                     'disabled')) && (
                                 <UpsellBanner
                                   onClick={scaleUpPlan}
+                                  learnMoreLink={Links.customErrorPagesLearnMore}
                                   bannerMessage={
                                     scenarioChecker.checkScenario(ScenarioIds.showAppSettingsUpsell, { site }).status === 'enabled'
                                       ? t('appSettingsUpsellBannerMessage')

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -126,6 +126,7 @@ export class CommonConstants {
     premiumMV3: 'premiummv3',
     premiumContainer: 'premiumcontainer',
     isolated: 'isolated',
+    isolatedV2: 'isolatedv2',
     dynamic: 'dynamic',
     elasticPremium: 'elasticpremium',
     elasticIsolated: 'elasticisolated',

--- a/client-react/src/utils/FwLinks.ts
+++ b/client-react/src/utils/FwLinks.ts
@@ -56,6 +56,7 @@ export const Links = {
   functionUnreachableLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2214718',
   endOfLifeStackLink: 'https://go.microsoft.com/fwlink/?linkid=2202628',
   connectionStringLearnmore: 'https://go.microsoft.com/fwlink/?linkid=2225650',
+  customErrorPagesLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2245451',
 };
 
 export const DeploymentCenterLinks = {

--- a/client-react/src/utils/arm-utils.ts
+++ b/client-react/src/utils/arm-utils.ts
@@ -58,6 +58,11 @@ export function isPremiumV1(obj: ArmObj<Site>): boolean {
   return sku === CommonConstants.SkuNames.premium;
 }
 
+export function isIsolatedV2(obj: ArmObj<Site>): boolean {
+  const sku = obj?.properties?.sku?.toLocaleLowerCase();
+  return sku === CommonConstants.SkuNames.isolatedV2;
+}
+
 export function isPremiumV3(obj: ArmObj<Site>): boolean {
   const sku = obj?.properties?.sku?.toLocaleLowerCase();
   return sku === CommonConstants.SkuNames.premiumV3;

--- a/client-react/src/utils/scenario-checker/premium.environment.ts
+++ b/client-react/src/utils/scenario-checker/premium.environment.ts
@@ -1,4 +1,4 @@
-import { isPremium } from '../arm-utils';
+import { isIsolatedV2, isPremium } from '../arm-utils';
 import { ScenarioIds } from './scenario-ids';
 import { ScenarioCheckInput, Environment } from './scenario.models';
 export class PremiumAppEnvironment extends Environment {
@@ -24,7 +24,7 @@ export class PremiumAppEnvironment extends Environment {
 
   public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {
     if (input?.site) {
-      return isPremium(input.site);
+      return isPremium(input.site) || isIsolatedV2(input.site);
     }
     return false;
   }


### PR DESCRIPTION
The up sell for custom error pages should only be shown when a cx isn't on a premium or isolated v2 plan.
Also adding a learn more link.
<img width="1258" alt="image" src="https://github.com/Azure/azure-functions-ux/assets/34044735/ba264f83-0369-47f0-a3bd-d27c226820bc">
