### PR TITLE
Remove isHidden for dotnet 8 on Linux Apps.

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -48,7 +48,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                   isSupported: true,
                   supportedVersion: '8.x',
                 },
-                isHidden: true,
                 isPreview: true,
               },
             },


### PR DESCRIPTION
Dotnet 8 preview 7 changes are available on Linux web apps. Adding this PR to enable dotnet 8 for Linux Apps.