### PR TITLE
Adding trouble shoot to the deployment center blade command buttons

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
@@ -80,6 +80,16 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
       },
     });
   };
+  const openSCIFrameBlade = () => {
+    portalContext.openBlade({
+      detailBlade: 'SCIFrameBlade',
+      detailBladeInputs: {
+        id: deploymentCenterContext.resourceId,
+      },
+      extension: 'WebsitesExtension',
+      openAsContextBlade: true,
+    });
+  };
 
   const getCommandBarItems = (): ICommandBarItemProps[] => {
     const commandBarItems: ICommandBarItemProps[] = [
@@ -94,6 +104,7 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
     }
 
     commandBarItems.push(getFeedbackItem());
+    commandBarItems.push(getTroubleShootItem());
 
     return commandBarItems;
   };
@@ -116,6 +127,11 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
   const onManagePublishProfileButtonClick = () => {
     portalContext.log(getTelemetryInfo('info', 'managePublishProfileButton', 'clicked'));
     showPublishProfilePanel();
+  };
+
+  const onTroubleShootButtonClick = () => {
+    portalContext.log(getTelemetryInfo('info', 'troubleShootButton', 'clicked'));
+    openSCIFrameBlade();
   };
 
   const onRedeployClick = () => {
@@ -208,6 +224,19 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
       disabled: false,
       ariaLabel: t('leaveFeedback'),
       onClick: onFeedbackButtonClick,
+    };
+  };
+
+  const getTroubleShootItem = (): ICommandBarItemProps => {
+    return {
+      key: 'troubleShoot',
+      name: t('troubleShoot'),
+      iconProps: {
+        iconName: 'DeveloperTools',
+      },
+      disabled: false,
+      ariaLabel: t('troubleShoot'),
+      onClick: onTroubleShootButtonClick,
     };
   };
 

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
@@ -167,7 +167,7 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
   };
 
   const onTroubleShootButtonClick = () => {
-    portalContext.log(getTelemetryInfo('info', 'troubleShootButton', 'clicked'));
+    portalContext.log(getTelemetryInfo('info', 'troubleshootButton', 'clicked'));
     openSCIFrameBlade();
   };
 
@@ -266,13 +266,13 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
 
   const getTroubleShootItem = (): ICommandBarItemProps => {
     return {
-      key: 'troubleShoot',
-      name: t('troubleShoot'),
+      key: 'troubleshoot',
+      name: t('troubleshoot'),
       iconProps: {
         iconName: 'DeveloperTools',
       },
       disabled: false,
-      ariaLabel: t('troubleShoot'),
+      ariaLabel: t('troubleshoot'),
       onClick: onTroubleShootButtonClick,
     };
   };

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
@@ -80,11 +80,46 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
       },
     });
   };
+
   const openSCIFrameBlade = () => {
+    //  const optionalParameters;
+
+    // const webAppParameters = {
+    //   key: 'Referrer',
+    //   value: {
+    //     ExtensionName: 'WebsitesExtension',
+    //     BladeName: 'DeploymentCenter',
+    //     TabName: '',
+    //     DetectorId: 'hybridconnections',
+    //     DetectorType: 'Detector',
+    //     CategoryId: 'Deployment',
+    //   },
+    // };
+
+    const functionAppParameters = {
+      key: 'Referrer',
+      value: {
+        ExtensionName: 'WebsitesExtension',
+        BladeName: 'DeploymentCenter',
+        TabName: '',
+        DetectorId: 'FunctionsDeploymentExternal',
+        DetectorType: 'Detector',
+        CategoryId: 'Configuration And Management',
+      },
+    };
+
+    // if (siteStateContext.isFunctionApp) {
+    const optionalParameters = [functionAppParameters];
+    // }
+    // else {
+    //       optionalParameters = [webAppParameters];
+    //     }
+
     portalContext.openBlade({
       detailBlade: 'SCIFrameBlade',
       detailBladeInputs: {
         id: deploymentCenterContext.resourceId,
+        optionalParameters: optionalParameters,
       },
       extension: 'WebsitesExtension',
       openAsContextBlade: true,
@@ -104,7 +139,9 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
     }
 
     commandBarItems.push(getFeedbackItem());
-    commandBarItems.push(getTroubleShootItem());
+    if (siteStateContext.isFunctionApp) {
+      commandBarItems.push(getTroubleShootItem());
+    }
 
     return commandBarItems;
   };

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2561,5 +2561,5 @@ export class PortalResources {
   public static toggleAllAppSettingsAriaLabel = 'toggleAllAppSettingsAriaLabel';
   public static hideButton = 'hideButton';
   public static showButton = 'showButton';
-  public static troubleShoot = 'troubleShoot';
+  public static troubleshoot = 'troubleshoot';
 }

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2561,4 +2561,5 @@ export class PortalResources {
   public static toggleAllAppSettingsAriaLabel = 'toggleAllAppSettingsAriaLabel';
   public static hideButton = 'hideButton';
   public static showButton = 'showButton';
+  public static troubleShoot = 'troubleShoot';
 }

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7823,6 +7823,6 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>Show value button</value>
     </data>
       <data name="troubleShoot" xml:space="preserve">
-        <value>TroubleShoot</value>
+        <value>Troubleshoot</value>
     </data>
 </root>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7822,4 +7822,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
       <data name="showButton" xml:space="preserve">
         <value>Show value button</value>
     </data>
+      <data name="troubleShoot" xml:space="preserve">
+        <value>Trouble Shoot</value>
+    </data>
 </root>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7822,7 +7822,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
       <data name="showButton" xml:space="preserve">
         <value>Show value button</value>
     </data>
-      <data name="troubleShoot" xml:space="preserve">
+      <data name="troubleshoot" xml:space="preserve">
         <value>Troubleshoot</value>
     </data>
 </root>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7823,6 +7823,6 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>Show value button</value>
     </data>
       <data name="troubleShoot" xml:space="preserve">
-        <value>Trouble Shoot</value>
+        <value>TroubleShoot</value>
     </data>
 </root>


### PR DESCRIPTION
Adding a command button to deployment center that opens diagnostics specifically for function apps until the correct web apps id becomes public

Function apps
<img width="1637" alt="image" src="https://github.com/Azure/azure-functions-ux/assets/34044735/233c6dd0-7612-460a-915b-b0eea498edbd">


