### PR TITLE
azure functions: add java21

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Java.ts
@@ -23,10 +23,10 @@ const getJavaStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDat
             stackSettings: {
               windowsRuntimeSettings: {
                 runtimeVersion: '21',
-                isPreview: false,
-                isHidden: false,
+                isPreview: true,
+                isHidden: true,
                 isAutoUpdate: true,
-                isDefault: true,
+                isDefault: false,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -48,10 +48,10 @@ const getJavaStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDat
               },
               linuxRuntimeSettings: {
                 runtimeVersion: 'Java|21',
-                isPreview: false,
-                isHidden: false,
+                isPreview: true,
+                isHidden: true,
                 isAutoUpdate: true,
-                isDefault: true,
+                isDefault: false,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Java.ts
@@ -3,6 +3,7 @@ import { getDateString } from '../date-utilities';
 
 const getJavaStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDateFormat: boolean) => {
   // EOL source: https://docs.microsoft.com/en-us/java/azure/jdk/?view=azure-java-stable#supported-java-versions-and-update-schedule
+  const java21EOL = getDateString(new Date(2031, 9), useIsoDateFormat);
   const java17EOL = getDateString(new Date(2031, 8), useIsoDateFormat);
   const java11EOL = getDateString(new Date(2026, 8), useIsoDateFormat);
   const java8EOL = getDateString(new Date(2025, 2), useIsoDateFormat);
@@ -12,6 +13,67 @@ const getJavaStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDat
     value: 'java',
     preferredOs: 'windows',
     majorVersions: [
+      {
+        displayText: 'Java 21',
+        value: '21',
+        minorVersions: [
+          {
+            displayText: 'Java 21',
+            value: '21.0',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '21',
+                isPreview: false,
+                isHidden: false,
+                isAutoUpdate: true,
+                isDefault: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '21',
+                },
+                appSettingsDictionary: {
+                  FUNCTIONS_WORKER_RUNTIME: 'java',
+                },
+                siteConfigPropertiesDictionary: {
+                  use32BitWorkerProcess: true,
+                  javaVersion: '21',
+                  netFrameworkVersion: 'v6.0',
+                },
+                supportedFunctionsExtensionVersions: ['~4'],
+                endOfLifeDate: java21EOL
+              },
+              linuxRuntimeSettings: {
+                runtimeVersion: 'Java|21',
+                isPreview: false,
+                isHidden: false,
+                isAutoUpdate: true,
+                isDefault: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '21',
+                },
+                appSettingsDictionary: {
+                  FUNCTIONS_WORKER_RUNTIME: 'java',
+                },
+                siteConfigPropertiesDictionary: {
+                  use32BitWorkerProcess: false,
+                  linuxFxVersion: 'Java|21',
+                },
+                supportedFunctionsExtensionVersions: ['~4'],
+                endOfLifeDate: java21EOL,
+              },
+            },
+          },
+        ],
+      },
       {
         displayText: 'Java 17',
         value: '17',

--- a/server/src/tests/Stacks/2020-10-01/function-app/validations.ts
+++ b/server/src/tests/Stacks/2020-10-01/function-app/validations.ts
@@ -203,7 +203,7 @@ function validateJavaStack(javaStack) {
   expect(javaStack.displayText).to.equal('Java');
   expect(javaStack.value).to.equal('java');
   expect(javaStack.preferredOs).to.equal('windows');
-  expect(javaStack.majorVersions.length).to.equal(3);
+  expect(javaStack.majorVersions.length).to.equal(4);
   expect(javaStack).to.deep.equal(hardCodedJavaStack);
 }
 


### PR DESCRIPTION
This PR add java21 to azure functions stacks API, currently set isPreview and isHidden both to true for now. 