### PR TITLE
[BYOS] Path mount value could have protocol property and it is in a different case

### DIFF
--- a/client-react/src/models/site/config.ts
+++ b/client-react/src/models/site/config.ts
@@ -135,6 +135,7 @@ export interface AzureStorageMount {
   shareName: string;
   accessKey: string;
   mountPath: string;
+  protocol?: string;
 }
 
 export enum StorageType {

--- a/client-react/src/pages/app/app-settings/AppSettings.types.ts
+++ b/client-react/src/pages/app/app-settings/AppSettings.types.ts
@@ -178,8 +178,8 @@ export enum StorageAccess {
 }
 
 export enum StorageFileShareProtocol {
-  SMB = 'SMB',
-  NFS = 'NFS',
+  SMB = 'Smb',
+  NFS = 'Nfs',
 }
 
 export enum ConfigurationOption {

--- a/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
@@ -154,7 +154,6 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
     // NOTE (krmitta): Don't block the entire blade incase siteResponse is returned and the app is not-kube
     if (!isKube) {
       azureStorageMounts = await SiteService.fetchAzureStorageMounts(resourceId);
-      console.log(azureStorageMounts);
       loadingFailed = loadingFailed || armCallFailed(azureStorageMounts, true);
     }
 

--- a/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
@@ -154,6 +154,7 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
     // NOTE (krmitta): Don't block the entire blade incase siteResponse is returned and the app is not-kube
     if (!isKube) {
       azureStorageMounts = await SiteService.fetchAzureStorageMounts(resourceId);
+      console.log(azureStorageMounts);
       loadingFailed = loadingFailed || armCallFailed(azureStorageMounts, true);
     }
 

--- a/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
+++ b/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
@@ -308,7 +308,7 @@ export function getFormAzureStorageMount(
 
   return sortBy(
     Object.keys(storageData.properties).map(key => {
-      const { accessKey, ...rest } = storageData.properties[key];
+      const { accessKey, protocol, ...rest } = storageData.properties[key];
       const storageAccess =
         accessKey.startsWith(AppSettingReference.prefix) && accessKey.endsWith(AppSettingReference.suffix)
           ? StorageAccess.KeyVaultReference
@@ -322,7 +322,8 @@ export function getFormAzureStorageMount(
         storageAccess === StorageAccess.KeyVaultReference || accessKey === AccessKeyPlaceHolderForNFSFileShares ? undefined : accessKey;
       const configurationOption =
         storageAccess === StorageAccess.KeyVaultReference ? ConfigurationOption.Advanced : ConfigurationOption.Basic;
-      const protocol = accessKey === AccessKeyPlaceHolderForNFSFileShares ? StorageFileShareProtocol.NFS : StorageFileShareProtocol.SMB;
+      const protocolValue =
+        protocol || (accessKey === AccessKeyPlaceHolderForNFSFileShares ? StorageFileShareProtocol.NFS : StorageFileShareProtocol.SMB);
 
       return {
         name: key,
@@ -330,7 +331,7 @@ export function getFormAzureStorageMount(
         storageAccess,
         appSettings,
         configurationOption,
-        protocol,
+        protocol: protocolValue,
         accessKey: accessKeyValue,
         ...rest,
       } as FormAzureStorageMounts;
@@ -348,6 +349,7 @@ export function getAzureStorageMountFromForm(storageData: FormAzureStorageMounts
       ...rest,
     };
   });
+  console.log(storageMountFromForm);
   return storageMountFromForm;
 }
 

--- a/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
+++ b/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
@@ -349,7 +349,6 @@ export function getAzureStorageMountFromForm(storageData: FormAzureStorageMounts
       ...rest,
     };
   });
-  console.log(storageMountFromForm);
   return storageMountFromForm;
 }
 

--- a/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
+++ b/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
@@ -35,6 +35,7 @@ import { IconConstants } from '../../../utils/constants/IconConstants';
 import { ThemeExtended } from '../../../theme/SemanticColorsExtended';
 import i18next from 'i18next';
 import { isJBossClusteringShown } from '../../../utils/stacks-utils';
+import Url from '../../../utils/url';
 
 export const findFormAppSettingIndex = (appSettings: FormAppSetting[], settingName: string) => {
   return settingName ? appSettings.findIndex(x => x.name.toLowerCase() === settingName.toLowerCase()) : -1;
@@ -323,7 +324,9 @@ export function getFormAzureStorageMount(
       const configurationOption =
         storageAccess === StorageAccess.KeyVaultReference ? ConfigurationOption.Advanced : ConfigurationOption.Basic;
       const protocolValue =
-        protocol || (accessKey === AccessKeyPlaceHolderForNFSFileShares ? StorageFileShareProtocol.NFS : StorageFileShareProtocol.SMB);
+        Url.getFeatureValue(CommonConstants.FeatureFlags.showNFSFileShares) === 'true'
+          ? protocol || (accessKey === AccessKeyPlaceHolderForNFSFileShares ? StorageFileShareProtocol.NFS : StorageFileShareProtocol.SMB)
+          : StorageFileShareProtocol.SMB;
 
       return {
         name: key,
@@ -345,7 +348,10 @@ export function getAzureStorageMountFromForm(storageData: FormAzureStorageMounts
   storageData.forEach(store => {
     const { name, sticky, configurationOption, storageAccess, appSettings, accessKey, protocol, ...rest } = store;
     storageMountFromForm[name] = {
-      accessKey: protocol === StorageFileShareProtocol.SMB ? getStorageMountAccessKey(store) : AccessKeyPlaceHolderForNFSFileShares,
+      accessKey:
+        protocol.toLocaleLowerCase() === StorageFileShareProtocol.SMB.toLocaleLowerCase()
+          ? getStorageMountAccessKey(store)
+          : AccessKeyPlaceHolderForNFSFileShares,
       ...rest,
     };
   });

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditAdvanced.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditAdvanced.tsx
@@ -33,13 +33,15 @@ const AzureStorageMountsAddEditAdvanced: React.FC<FormikProps<FormAzureStorageMo
   const supportsBlobStorage = scenarioService.checkScenario(ScenarioIds.azureBlobMount, { site }).status !== 'disabled';
 
   const showStorageAccess = React.useMemo(() => {
-    return values.type === StorageType.azureFiles && values.protocol === StorageFileShareProtocol.SMB;
+    return (
+      values.type === StorageType.azureFiles && values.protocol.toLocaleLowerCase() === StorageFileShareProtocol.SMB.toLocaleLowerCase()
+    );
   }, [values.type, values.protocol]);
 
   const showAccessKey = React.useMemo(() => {
     return (
       (values.type === StorageType.azureBlob || values.storageAccess === StorageAccess.AccessKey) &&
-      values.protocol === StorageFileShareProtocol.SMB
+      values.protocol.toLocaleLowerCase() === StorageFileShareProtocol.SMB.toLocaleLowerCase()
     );
   }, [values.type, values.storageAccess, values.protocol]);
 
@@ -47,7 +49,7 @@ const AzureStorageMountsAddEditAdvanced: React.FC<FormikProps<FormAzureStorageMo
     return (
       values.type === StorageType.azureFiles &&
       values.storageAccess === StorageAccess.KeyVaultReference &&
-      values.protocol === StorageFileShareProtocol.SMB
+      values.protocol.toLocaleLowerCase() === StorageFileShareProtocol.SMB.toLocaleLowerCase()
     );
   }, [values.type, values.storageAccess, values.protocol]);
 
@@ -85,8 +87,12 @@ const AzureStorageMountsAddEditAdvanced: React.FC<FormikProps<FormAzureStorageMo
         label={t('storageAccounts')}
         id="azure-storage-mounts-account-name"
         required={true}
-        infoBubbleMessage={values.protocol === StorageFileShareProtocol.SMB && t('byos_storageAccountInfoMessage')}
-        learnMoreLink={values.protocol === StorageFileShareProtocol.SMB && Links.byosStorageAccountLearnMore}
+        infoBubbleMessage={
+          values.protocol.toLocaleLowerCase() === StorageFileShareProtocol.SMB.toLocaleLowerCase() && t('byos_storageAccountInfoMessage')
+        }
+        learnMoreLink={
+          values.protocol.toLocaleLowerCase() === StorageFileShareProtocol.SMB.toLocaleLowerCase() && Links.byosStorageAccountLearnMore
+        }
       />
       {supportsBlobStorage && (
         <Field component={RadioButton} name="type" id="azure-storage-type" label={t('storageType')} options={storageTypeOptions} />

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
@@ -18,8 +18,6 @@ import { PortalContext } from '../../../../PortalContext';
 import { FileShareEnabledProtocols } from '../../../../models/storage-account';
 import { SiteStateContext } from '../../../../SiteState';
 import StorageProtocol from './StorageProtocol';
-import { CommonConstants } from '../../../../utils/CommonConstants';
-import Url from '../../../../utils/url';
 
 const storageKinds = {
   StorageV2: 'StorageV2',
@@ -82,7 +80,7 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
       sharesLoading ||
       (value && values.type === StorageType.azureBlob
         ? blobContainerOptions.find(x => x.key === value)
-        : values.protocol === StorageFileShareProtocol.SMB
+        : values.protocol.toLocaleLowerCase() === StorageFileShareProtocol.SMB.toLocaleLowerCase()
         ? smbFilesContainerOptions.find(x => x.key === value)
         : nfsFilesContainerOptions.find(x => x.key === value))
     ) {
@@ -112,8 +110,8 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
       setAccountError(getBlobsFailure ? t('storageAccountDetailsFetchFailure') : t('noBlobs'));
     } else if (
       storageType === StorageType.azureFiles &&
-      ((protocol === StorageFileShareProtocol.SMB && smbFilesContainerIsEmpty) ||
-        (protocol === StorageFileShareProtocol.NFS && nfsFilesContainerIsEmpty))
+      ((protocol.toLocaleLowerCase() === StorageFileShareProtocol.SMB.toLocaleLowerCase() && smbFilesContainerIsEmpty) ||
+        (protocol.toLocaleLowerCase() === StorageFileShareProtocol.NFS.toLocaleLowerCase() && nfsFilesContainerIsEmpty))
     ) {
       setAccountError(getFilesFailure ? t('storageAccountDetailsFetchFailure') : t('noFileShares'));
     } else {
@@ -261,7 +259,7 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
   const storageContainerOptions = useMemo(() => {
     return values.type === StorageType.azureBlob
       ? blobContainerOptions
-      : values.protocol === StorageFileShareProtocol.SMB || Url.getFeatureValue(CommonConstants.FeatureFlags.showNFSFileShares) !== 'true'
+      : values.protocol.toLocaleLowerCase() === StorageFileShareProtocol.SMB.toLocaleLowerCase()
       ? smbFilesContainerOptions
       : nfsFilesContainerOptions;
   }, [blobContainerOptions, smbFilesContainerOptions, nfsFilesContainerOptions, values.type, values.protocol]);
@@ -279,8 +277,12 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
         styles={{
           root: formElementStyle,
         }}
-        infoBubbleMessage={values.protocol === StorageFileShareProtocol.SMB && t('byos_storageAccountInfoMessage')}
-        learnMoreLink={values.protocol === StorageFileShareProtocol.SMB && Links.byosStorageAccountLearnMore}
+        infoBubbleMessage={
+          values.protocol.toLocaleLowerCase() === StorageFileShareProtocol.SMB.toLocaleLowerCase() && t('byos_storageAccountInfoMessage')
+        }
+        learnMoreLink={
+          values.protocol.toLocaleLowerCase() === StorageFileShareProtocol.SMB.toLocaleLowerCase() && Links.byosStorageAccountLearnMore
+        }
         required={true}
       />
       {showStorageTypeOption && (

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
@@ -18,6 +18,8 @@ import { PortalContext } from '../../../../PortalContext';
 import { FileShareEnabledProtocols } from '../../../../models/storage-account';
 import { SiteStateContext } from '../../../../SiteState';
 import StorageProtocol from './StorageProtocol';
+import { CommonConstants } from '../../../../utils/CommonConstants';
+import Url from '../../../../utils/url';
 
 const storageKinds = {
   StorageV2: 'StorageV2',
@@ -259,7 +261,7 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
   const storageContainerOptions = useMemo(() => {
     return values.type === StorageType.azureBlob
       ? blobContainerOptions
-      : values.protocol === StorageFileShareProtocol.SMB
+      : values.protocol === StorageFileShareProtocol.SMB || Url.getFeatureValue(CommonConstants.FeatureFlags.showNFSFileShares) !== 'true'
       ? smbFilesContainerOptions
       : nfsFilesContainerOptions;
   }, [blobContainerOptions, smbFilesContainerOptions, nfsFilesContainerOptions, values.type, values.protocol]);

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
@@ -251,17 +251,20 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
   const smbFilesContainerOptions = useMemo(() => accountSMBSharesFiles.map((x: any) => ({ key: x.name, text: x.name })), [
     accountSMBSharesFiles,
   ]);
+
   const nfsFilesContainerOptions = useMemo(() => accountNFSSharesFiles.map((x: any) => ({ key: x.name, text: x.name })), [
     accountNFSSharesFiles,
   ]);
 
   const storageContainerOptions = useMemo(() => {
+    console.log(values.protocol);
     return values.type === StorageType.azureBlob
       ? blobContainerOptions
       : values.protocol === StorageFileShareProtocol.SMB
       ? smbFilesContainerOptions
       : nfsFilesContainerOptions;
   }, [blobContainerOptions, smbFilesContainerOptions, nfsFilesContainerOptions, values.type, values.protocol]);
+  console.log(storageContainerOptions);
 
   return (
     <>

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/AzureStorageMountsAddEditBasic.tsx
@@ -257,14 +257,12 @@ const AzureStorageMountsAddEditBasic: React.FC<FormikProps<FormAzureStorageMount
   ]);
 
   const storageContainerOptions = useMemo(() => {
-    console.log(values.protocol);
     return values.type === StorageType.azureBlob
       ? blobContainerOptions
       : values.protocol === StorageFileShareProtocol.SMB
       ? smbFilesContainerOptions
       : nfsFilesContainerOptions;
   }, [blobContainerOptions, smbFilesContainerOptions, nfsFilesContainerOptions, values.type, values.protocol]);
-  console.log(storageContainerOptions);
 
   return (
     <>

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/StorageProtocol.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/StorageProtocol.tsx
@@ -24,7 +24,7 @@ const StorageProtocol: React.FC<{ values: FormAzureStorageMounts }> = props => {
   }, [values.type, isLinuxApp]);
 
   const showCustomBanner = React.useMemo(() => {
-    return values.protocol === StorageFileShareProtocol.NFS;
+    return values.protocol.toLocaleLowerCase() === StorageFileShareProtocol.NFS.toLocaleLowerCase();
   }, [values.protocol]);
 
   const fileShareProtocalOptions = React.useMemo<IChoiceGroupOption[]>(() => {

--- a/client-react/src/pages/app/app-settings/AzureStorageMounts/StorageProtocol.tsx
+++ b/client-react/src/pages/app/app-settings/AzureStorageMounts/StorageProtocol.tsx
@@ -31,11 +31,11 @@ const StorageProtocol: React.FC<{ values: FormAzureStorageMounts }> = props => {
     return [
       {
         key: StorageFileShareProtocol.SMB,
-        text: StorageFileShareProtocol.SMB,
+        text: 'SMB',
       },
       {
         key: StorageFileShareProtocol.NFS,
-        text: StorageFileShareProtocol.NFS,
+        text: 'NFS',
       },
     ];
   }, []);


### PR DESCRIPTION
Usually UX determines if the storage mount is NFS or SMB based on the access key vault. But backend team somehow add prootocal property into their response value which also have different cases than what we are using 'Smb' vs 'SMB'. This causes the issue that the storage container does not  show any dropdown items. We update it by checking the equality with  case insensitive. Also set the default to smb is the feature flag is off.