### PR TITLE
[DC] Handle no write permissions case and show container settings readonly view

### DIFF
--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSourceAndBuild.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSourceAndBuild.tsx
@@ -245,77 +245,93 @@ const DeploymentCenterCodeSourceAndBuild: React.FC<DeploymentCenterFieldProps<De
     );
   }, [selectedBuild, deploymentCenterPublishingContext.basicPublishingCredentialsPolicies?.scm.allow, formProps.values.authType]);
 
+  const showNoWritePermissionBanner = useMemo(() => {
+    return !deploymentCenterContext.hasWritePermission;
+  }, [deploymentCenterContext.hasWritePermission]);
+
   return (
     <>
-      {showBasicAuthError && (
+      {showNoWritePermissionBanner ? (
         <div className={deploymentCenterInfoBannerDiv}>
           <CustomBanner
-            id="deployment-center-scm-basic-auth-warning"
-            message={t('deploymentCenterScmBasicAuthErrorMessage')}
-            type={MessageBarType.error}
-            onClick={openConfigurationBlade}
+            id="deployment-center-no-write-error"
+            message={t('deploymentCenterNoWritePermissionsError')}
+            type={MessageBarType.blocked}
           />
         </div>
-      )}
+      ) : (
+        <>
+          {showBasicAuthError && (
+            <div className={deploymentCenterInfoBannerDiv}>
+              <CustomBanner
+                id="deployment-center-scm-basic-auth-warning"
+                message={t('deploymentCenterScmBasicAuthErrorMessage')}
+                type={MessageBarType.error}
+                onClick={openConfigurationBlade}
+              />
+            </div>
+          )}
 
-      {getInProductionSlot() && showInfoBanner && !showBasicAuthError && (
-        <div className={deploymentCenterInfoBannerDiv}>
-          <CustomBanner
-            id="deployment-center-prod-slot-warning"
-            message={t('deploymentCenterProdSlotWarning')}
-            type={MessageBarType.info}
-            onDismiss={closeInfoBanner}
-            learnMoreLink={DeploymentCenterLinks.configureDeploymentSlots}
-            learnMoreLinkAriaLabel={t('deploymentCenterProdSlotWarningLinkAriaLabel')}
+          {getInProductionSlot() && showInfoBanner && !showBasicAuthError && (
+            <div className={deploymentCenterInfoBannerDiv}>
+              <CustomBanner
+                id="deployment-center-prod-slot-warning"
+                message={t('deploymentCenterProdSlotWarning')}
+                type={MessageBarType.info}
+                onDismiss={closeInfoBanner}
+                learnMoreLink={DeploymentCenterLinks.configureDeploymentSlots}
+                learnMoreLinkAriaLabel={t('deploymentCenterProdSlotWarningLinkAriaLabel')}
+              />
+            </div>
+          )}
+
+          <p>
+            <span id="deployment-center-settings-message">{t('deploymentCenterCodeSettingsDescription')}</span>
+            <Link
+              id="deployment-center-settings-learnMore"
+              href={DeploymentCenterLinks.configureDeploymentSource}
+              target="_blank"
+              className={learnMoreLinkStyle}
+              aria-labelledby="deployment-center-settings-message">
+              {` ${t('learnMore')}`}
+            </Link>
+          </p>
+
+          <Field
+            label={t('deploymentCenterSettingsSourceLabel')}
+            placeholder={t('deploymentCenterCodeSettingsSourcePlaceholder')}
+            name="sourceProvider"
+            component={Dropdown}
+            displayInVerticalLayout={true}
+            options={getSourceOptions()}
+            required={true}
+            aria-required={true}
           />
-        </div>
+
+          {isSourceSelected &&
+            (isAzureDevOpsSupportedBuild ? (
+              <>
+                <ReactiveFormControl id="deployment-center-build-provider-text" pushContentRight={true}>
+                  <div>
+                    {getBuildDescription()}
+                    <Link
+                      key="deployment-center-change-build-provider"
+                      onClick={toggleIsCalloutVisible}
+                      className={additionalTextFieldControl}
+                      aria-label={t('deploymentCenterChangeBuildText')}>
+                      {`${t('deploymentCenterChangeBuildText')}`}
+                    </Link>
+                  </div>
+                </ReactiveFormControl>
+                {getCalloutContent()}
+              </>
+            ) : (
+              <ReactiveFormControl id="deployment-center-build-provider-text" pushContentRight={true}>
+                <div>{getBuildDescription()}</div>
+              </ReactiveFormControl>
+            ))}
+        </>
       )}
-
-      <p>
-        <span id="deployment-center-settings-message">{t('deploymentCenterCodeSettingsDescription')}</span>
-        <Link
-          id="deployment-center-settings-learnMore"
-          href={DeploymentCenterLinks.configureDeploymentSource}
-          target="_blank"
-          className={learnMoreLinkStyle}
-          aria-labelledby="deployment-center-settings-message">
-          {` ${t('learnMore')}`}
-        </Link>
-      </p>
-
-      <Field
-        label={t('deploymentCenterSettingsSourceLabel')}
-        placeholder={t('deploymentCenterCodeSettingsSourcePlaceholder')}
-        name="sourceProvider"
-        component={Dropdown}
-        displayInVerticalLayout={true}
-        options={getSourceOptions()}
-        required={true}
-        aria-required={true}
-      />
-
-      {isSourceSelected &&
-        (isAzureDevOpsSupportedBuild ? (
-          <>
-            <ReactiveFormControl id="deployment-center-build-provider-text" pushContentRight={true}>
-              <div>
-                {getBuildDescription()}
-                <Link
-                  key="deployment-center-change-build-provider"
-                  onClick={toggleIsCalloutVisible}
-                  className={additionalTextFieldControl}
-                  aria-label={t('deploymentCenterChangeBuildText')}>
-                  {`${t('deploymentCenterChangeBuildText')}`}
-                </Link>
-              </div>
-            </ReactiveFormControl>
-            {getCalloutContent()}
-          </>
-        ) : (
-          <ReactiveFormControl id="deployment-center-build-provider-text" pushContentRight={true}>
-            <div>{getBuildDescription()}</div>
-          </ReactiveFormControl>
-        ))}
     </>
   );
 };

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerDataLoader.tsx
@@ -39,7 +39,7 @@ const DeploymentCenterContainerDataLoader: React.FC<DeploymentCenterDataLoaderPr
     DeploymentCenterYupValidationSchemaType<DeploymentCenterContainerFormData> | undefined
   >(undefined);
 
-  const generateForm = () => {
+  const generateForm = React.useCallback(() => {
     if (deploymentCenterContext.siteConfig) {
       deploymentCenterContainerFormBuilder.setSiteConfig(deploymentCenterContext.siteConfig);
     }
@@ -72,7 +72,13 @@ const DeploymentCenterContainerDataLoader: React.FC<DeploymentCenterDataLoaderPr
         publishType: 'container',
       })
     );
-  };
+  }, [
+    deploymentCenterContext.siteConfig,
+    deploymentCenterContext.configMetadata,
+    deploymentCenterContext.applicationSettings,
+    deploymentCenterPublishingContext.publishingUser,
+    deploymentCenterPublishingContext.basicPublishingCredentialsPolicies,
+  ]);
 
   const refresh = () => {
     portalContext.log(
@@ -85,12 +91,8 @@ const DeploymentCenterContainerDataLoader: React.FC<DeploymentCenterDataLoaderPr
   };
 
   useEffect(() => {
-    if (deploymentCenterContext.applicationSettings && deploymentCenterContext.siteConfig && deploymentCenterContext.configMetadata) {
-      generateForm();
-    }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [deploymentCenterContext.applicationSettings, deploymentCenterContext.siteConfig, deploymentCenterContext.configMetadata]);
+    generateForm();
+  }, [generateForm]);
 
   return (
     <DeploymentCenterContainerForm

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -351,7 +351,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
 
       return {
         server: privateRegistryHost,
-        image: imageAndTagParts[0],
+        image: privateRegistryHost ? imageAndTagParts[0] : registryInfo,
         tag: imageAndTagParts[1] ? imageAndTagParts[1] : 'latest',
         containerOption: ContainerOptions.docker,
         composeYml: '',

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettings.tsx
@@ -368,13 +368,27 @@ const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<Dep
     return (
       <>
         <DeploymentCenterGitHubConfiguredView formProps={formProps} />
-        <DeploymentCenterContainerSettingsReadOnlyView />
+        <DeploymentCenterContainerSettingsReadOnlyView formProps={formProps} />
       </>
     );
   };
 
   const renderVstsReadOnlyView = () => {
-    return <DeploymentCenterVstsBuildConfiguredView formProps={formProps} />;
+    return (
+      <>
+        <DeploymentCenterVstsBuildConfiguredView formProps={formProps} />
+        <DeploymentCenterContainerSettingsReadOnlyView formProps={formProps} />
+      </>
+    );
+  };
+
+  const renderContainersReadOnlyView = () => {
+    return (
+      <>
+        {showSourceSelectionOption && <DeploymentCenterContainerSource formProps={formProps} />}
+        <DeploymentCenterContainerSettingsReadOnlyView formProps={formProps} />
+      </>
+    );
   };
 
   const getSettingsControls = () => {
@@ -382,6 +396,8 @@ const DeploymentCenterContainerSettings: React.FC<DeploymentCenterFieldProps<Dep
       return renderGitHubActionReadOnlyView();
     } else if (showVstsReadOnlyView) {
       return renderVstsReadOnlyView();
+    } else if (!deploymentCenterContext.hasWritePermission) {
+      return renderContainersReadOnlyView();
     } else {
       return renderSetupView();
     }

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettingsReadOnlyView.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSettingsReadOnlyView.tsx
@@ -1,61 +1,97 @@
-import React, { useContext, useState, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DeploymentCenterContext } from '../DeploymentCenterContext';
 import ReactiveFormControl from '../../../../components/form-controls/ReactiveFormControl';
 import { DeploymentCenterConstants } from '../DeploymentCenterConstants';
-import { SiteStateContext } from '../../../../SiteState';
+import { ScmType } from '../../../../models/site/config';
+import { ContainerRegistrySources, DeploymentCenterContainerFormData, DeploymentCenterFieldProps } from '../DeploymentCenter.types';
 
-const DeploymentCenterContainerSettingsReadOnlyView: React.FC = () => {
+const DeploymentCenterContainerSettingsReadOnlyView: React.FC<DeploymentCenterFieldProps<DeploymentCenterContainerFormData>> = ({
+  formProps,
+}) => {
   const { t } = useTranslation();
   const deploymentCenterContext = useContext(DeploymentCenterContext);
-  const siteStateContext = useContext(SiteStateContext);
-  const [serverUrl, setServerUrl] = useState<string>(t('loading'));
-  const [username, setUsername] = useState<string>(t('loading'));
-  const [imageAndTag, setImageAndTag] = useState<string>(t('loading'));
 
-  useEffect(() => {
-    if (deploymentCenterContext && deploymentCenterContext.applicationSettings) {
-      const appSettings = deploymentCenterContext.applicationSettings.properties;
-      setServerUrl(appSettings[DeploymentCenterConstants.serverUrlSetting]);
-      setUsername(appSettings[DeploymentCenterConstants.usernameSetting]);
+  const serverUrl = React.useMemo(() => {
+    switch (formProps.values.registrySource) {
+      case ContainerRegistrySources.acr:
+        return formProps.values.acrLoginServer || t('deploymentCenterErrorFetchingInfo');
+      case ContainerRegistrySources.docker:
+        return DeploymentCenterConstants.dockerHubServerUrl;
+      case ContainerRegistrySources.privateRegistry:
+        return formProps.values.privateRegistryServerUrl || t('deploymentCenterErrorFetchingInfo');
+      default:
+        return t('deploymentCenterErrorFetchingInfo');
     }
+  }, [formProps.values.registrySource]);
 
-    getImageAndTag();
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [deploymentCenterContext.applicationSettings, deploymentCenterContext.siteConfig, siteStateContext]);
-
-  const getImageAndTag = () => {
-    if (siteStateContext && deploymentCenterContext && deploymentCenterContext.siteConfig) {
-      const fxVersion = siteStateContext.isLinuxApp
-        ? deploymentCenterContext.siteConfig.properties.linuxFxVersion
-        : deploymentCenterContext.siteConfig.properties.windowsFxVersion;
-
-      const fxVersionParts = fxVersion.split('|');
-      const imageAndTagParts = fxVersionParts[1] ? fxVersionParts[1].split('/') : [];
-
-      setImageAndTag(imageAndTagParts.length > 0 ? imageAndTagParts[imageAndTagParts.length - 1] : t('deploymentCenterImageAndTagError'));
+  const username = React.useMemo(() => {
+    switch (formProps.values.registrySource) {
+      case ContainerRegistrySources.acr:
+        return formProps.values.acrUsername || t('deploymentCenterErrorFetchingInfo');
+      case ContainerRegistrySources.docker:
+        return formProps.values.dockerHubUsername || t('deploymentCenterErrorFetchingInfo');
+      case ContainerRegistrySources.privateRegistry:
+        return formProps.values.privateRegistryUsername || t('deploymentCenterErrorFetchingInfo');
+      default:
+        return t('deploymentCenterErrorFetchingInfo');
     }
-  };
+  }, [formProps.values.registrySource]);
+
+  const image = React.useMemo(() => {
+    switch (formProps.values.registrySource) {
+      case ContainerRegistrySources.acr:
+        return formProps.values.acrImage || t('deploymentCenterErrorFetchingInfo');
+      case ContainerRegistrySources.docker: {
+        const imageAndTag = formProps.values.dockerHubImageAndTag.split(':');
+        return imageAndTag.length > 0 ? imageAndTag[0] : t('deploymentCenterErrorFetchingInfo');
+      }
+      case ContainerRegistrySources.privateRegistry: {
+        const imageAndTag = formProps.values.privateRegistryImageAndTag.split(':');
+        return imageAndTag.length > 0 ? imageAndTag[0] : t('deploymentCenterErrorFetchingInfo');
+      }
+      default:
+        return t('deploymentCenterErrorFetchingInfo');
+    }
+  }, [formProps.values.registrySource]);
+
+  const tag = React.useMemo(() => {
+    switch (formProps.values.registrySource) {
+      case ContainerRegistrySources.acr:
+        return formProps.values.acrTag || t('deploymentCenterErrorFetchingInfo');
+      case ContainerRegistrySources.docker: {
+        const imageAndTag = formProps.values.dockerHubImageAndTag.split(':');
+        return imageAndTag.length > 1 ? imageAndTag[1] : t('deploymentCenterErrorFetchingInfo');
+      }
+      case ContainerRegistrySources.privateRegistry: {
+        const imageAndTag = formProps.values.privateRegistryImageAndTag.split(':');
+        return imageAndTag.length > 1 ? imageAndTag[1] : t('deploymentCenterErrorFetchingInfo');
+      }
+      default:
+        return t('deploymentCenterErrorFetchingInfo');
+    }
+  }, [formProps.values.registrySource]);
 
   return (
     <>
       <h3>{t('deploymentCenterContainerRegistrySettingsTitle')}</h3>
 
-      <ReactiveFormControl id="deployment-center-container-settings-build" label={t('deploymentCenterSettingsBuildLabel')}>
-        <div>{t('deploymentCenterCodeSettingsBuildGitHubAction')}</div>
-      </ReactiveFormControl>
-
+      {deploymentCenterContext?.siteConfig?.properties.scmType === ScmType.GitHubAction && (
+        <ReactiveFormControl id="deployment-center-container-settings-build" label={t('deploymentCenterSettingsBuildLabel')}>
+          <div>{t('deploymentCenterCodeSettingsBuildGitHubAction')}</div>
+        </ReactiveFormControl>
+      )}
       <ReactiveFormControl id="deployment-center-container-settings-serverUrl" label={t('containerServerURL')}>
         <div>{serverUrl}</div>
       </ReactiveFormControl>
-
       <ReactiveFormControl id="deployment-center-container-settings-username" label={t('containerLogin')}>
         <div>{username}</div>
       </ReactiveFormControl>
-
-      <ReactiveFormControl id="deployment-center-container-settings-imageAndTag" label={t('containerImageAndTag')}>
-        <div>{imageAndTag}</div>
+      <ReactiveFormControl id="deployment-center-container-settings-image" label={t('containerImageName')}>
+        <div>{image}</div>
+      </ReactiveFormControl>
+      <ReactiveFormControl id="deployment-center-container-settings-tag" label={t('containerACRTag')}>
+        <div>{tag}</div>
       </ReactiveFormControl>
     </>
   );

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSource.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerSource.tsx
@@ -67,8 +67,22 @@ const DeploymentCenterContainerSource: React.FC<DeploymentCenterFieldProps<Deplo
     return isGitHubActionsOrContainerOnly && !deploymentCenterPublishingContext.basicPublishingCredentialsPolicies?.scm.allow;
   }, [formProps.values.scmType, deploymentCenterPublishingContext.basicPublishingCredentialsPolicies?.scm.allow]);
 
+  const showNoWritePermissionBanner = useMemo(() => {
+    return !deploymentCenterContext.hasWritePermission;
+  }, [deploymentCenterContext.hasWritePermission]);
+
   return (
     <>
+      {showNoWritePermissionBanner && (
+        <div className={deploymentCenterInfoBannerDiv}>
+          <CustomBanner
+            id="deployment-center-no-write-error"
+            message={t('deploymentCenterNoWritePermissionsError')}
+            type={MessageBarType.blocked}
+          />
+        </div>
+      )}
+
       {showBasicAuthError && (
         <div className={deploymentCenterInfoBannerDiv}>
           <CustomBanner
@@ -79,6 +93,7 @@ const DeploymentCenterContainerSource: React.FC<DeploymentCenterFieldProps<Deplo
           />
         </div>
       )}
+
       <p>
         <span id="deployment-center-settings-message">{t('deploymentCenterContainerSettingsDescription')}</span>
         <Link

--- a/client-react/src/pages/app/deployment-center/devops-provider/DeploymentCenterVstsBuildConfiguredView.tsx
+++ b/client-react/src/pages/app/deployment-center/devops-provider/DeploymentCenterVstsBuildConfiguredView.tsx
@@ -6,21 +6,14 @@ import { KeyValue } from '../../../../models/portal-models';
 import { PortalContext } from '../../../../PortalContext';
 import { getTelemetryInfo } from '../../../../utils/TelemetryUtils';
 import DeploymentCenterData from '../DeploymentCenter.data';
-import { deploymentCenterInfoBannerDiv, titleWithPaddingStyle } from '../DeploymentCenter.styles';
-import {
-  ContainerRegistrySources,
-  DeploymentCenterCodeFormData,
-  DeploymentCenterContainerFormData,
-  DeploymentCenterFieldProps,
-} from '../DeploymentCenter.types';
+import { deploymentCenterInfoBannerDiv } from '../DeploymentCenter.styles';
+import { DeploymentCenterCodeFormData, DeploymentCenterContainerFormData, DeploymentCenterFieldProps } from '../DeploymentCenter.types';
 import { DeploymentCenterContext } from '../DeploymentCenterContext';
 import DeploymentCenterVstsDisconnect from './DeploymentCenterVstsDisconnect';
 import { ThemeContext } from '../../../../ThemeContext';
 import { messageBannerClass, messageBannerIconStyle } from '../../../../components/CustomBanner/CustomBanner.styles';
 import { DeploymentCenterLinks } from '../../../../utils/FwLinks';
 import { ReactComponent as InfoSvg } from '../../../../images/Common/Info.svg';
-import { SiteStateContext } from '../../../../SiteState';
-import { DeploymentCenterConstants } from '../DeploymentCenterConstants';
 
 const DeploymentCenterVstsBuildConfiguredView: React.FC<DeploymentCenterFieldProps<
   DeploymentCenterCodeFormData | DeploymentCenterContainerFormData
@@ -40,7 +33,6 @@ const DeploymentCenterVstsBuildConfiguredView: React.FC<DeploymentCenterFieldPro
   const deploymentCenterData = new DeploymentCenterData();
   const portalContext = useContext(PortalContext);
   const deploymentCenterContext = useContext(DeploymentCenterContext);
-  const siteStateContext = useContext(SiteStateContext);
 
   const fetchBuildDef = React.useCallback(async () => {
     if (vstsMetadata) {
@@ -123,65 +115,6 @@ const DeploymentCenterVstsBuildConfiguredView: React.FC<DeploymentCenterFieldPro
     return t('deploymentCenterErrorFetchingInfo');
   };
 
-  const isFormPropsContainerData = (
-    values: DeploymentCenterCodeFormData | DeploymentCenterContainerFormData
-  ): values is DeploymentCenterContainerFormData => {
-    return !!(values as DeploymentCenterContainerFormData).registrySource;
-  };
-
-  const serverUrl = React.useMemo(() => {
-    if (isFormPropsContainerData(formProps.values)) {
-      switch (formProps.values.registrySource) {
-        case ContainerRegistrySources.acr:
-          return formProps.values.acrLoginServer;
-        case ContainerRegistrySources.docker:
-          return DeploymentCenterConstants.dockerHubServerUrl;
-        case ContainerRegistrySources.privateRegistry:
-          return formProps.values.privateRegistryServerUrl;
-        default:
-          return t('deploymentCenterErrorFetchingInfo');
-      }
-    }
-  }, [formProps.values]);
-
-  const image = React.useMemo(() => {
-    if (isFormPropsContainerData(formProps.values)) {
-      switch (formProps.values.registrySource) {
-        case ContainerRegistrySources.acr:
-          return formProps.values.acrImage;
-        case ContainerRegistrySources.docker: {
-          const imageAndTag = formProps.values.dockerHubImageAndTag.split(':');
-          return imageAndTag.length > 0 ? imageAndTag[0] : '';
-        }
-        case ContainerRegistrySources.privateRegistry: {
-          const imageAndTag = formProps.values.privateRegistryImageAndTag.split(':');
-          return imageAndTag.length > 0 ? imageAndTag[0] : '';
-        }
-        default:
-          return t('deploymentCenterErrorFetchingInfo');
-      }
-    }
-  }, [formProps.values]);
-
-  const tag = React.useMemo(() => {
-    if (isFormPropsContainerData(formProps.values)) {
-      switch (formProps.values.registrySource) {
-        case ContainerRegistrySources.acr:
-          return formProps.values.acrTag;
-        case ContainerRegistrySources.docker: {
-          const imageAndTag = formProps.values.dockerHubImageAndTag.split(':');
-          return imageAndTag.length > 1 ? imageAndTag[1] : '';
-        }
-        case ContainerRegistrySources.privateRegistry: {
-          const imageAndTag = formProps.values.privateRegistryImageAndTag.split(':');
-          return imageAndTag.length > 1 ? imageAndTag[1] : '';
-        }
-        default:
-          return t('deploymentCenterErrorFetchingInfo');
-      }
-    }
-  }, [formProps.values]);
-
   useEffect(() => {
     if (deploymentCenterContext.configMetadata) {
       setVstsMetadata(deploymentCenterContext.configMetadata.properties);
@@ -231,21 +164,6 @@ const DeploymentCenterVstsBuildConfiguredView: React.FC<DeploymentCenterFieldPro
           </ReactiveFormControl>
           <ReactiveFormControl id="deployment-center-github-branch" label={t('deploymentCenterOAuthBranch')}>
             <div>{isLoading ? t('loading') : branch}</div>
-          </ReactiveFormControl>
-        </>
-      )}
-
-      {siteStateContext.isContainerApp && (
-        <>
-          <h3 className={titleWithPaddingStyle}>{t('deploymentCenterContainerRegistrySettingsTitle')}</h3>
-          <ReactiveFormControl id="deployment-center-vsts-container-registry" label={t('containerServerURL')}>
-            <>{isLoading ? t('loading') : serverUrl}</>
-          </ReactiveFormControl>
-          <ReactiveFormControl id="deployment-center-vsts-image" label={t('containerImageName')}>
-            <div>{isLoading ? t('loading') : image}</div>
-          </ReactiveFormControl>
-          <ReactiveFormControl id="deployment-center-vsts-tag" label={t('containerACRTag')}>
-            <div>{isLoading ? t('loading') : tag}</div>
           </ReactiveFormControl>
         </>
       )}

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2266,6 +2266,7 @@ export class PortalResources {
   public static deploymentCenterConfigureGitHubPermissionsGHA = 'deploymentCenterConfigureGitHubPermissionsGHA';
   public static deploymentCenterProdSlotWarning = 'deploymentCenterProdSlotWarning';
   public static deploymentCenterOneDriveDropboxWarning = 'deploymentCenterOneDriveDropboxWarning';
+  public static deploymentCenterNoWritePermissionsError = 'deploymentCenterNoWritePermissionsError';
   public static deploymentCenterSettingsReadOnlyGitHubNotAuthorized = 'deploymentCenterSettingsReadOnlyGitHubNotAuthorized';
   public static deploymentCenterSettingsWorkflowConfigTitle = 'deploymentCenterSettingsWorkflowConfigTitle';
   public static deploymentCenterSettingsWorkflowConfigPreviewDescription = 'deploymentCenterSettingsWorkflowConfigPreviewDescription';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -6954,6 +6954,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="deploymentCenterOneDriveDropboxWarning" xml:space="preserve">
         <value>Your site is currently using OneDrive or Dropbox to deploy code. This integration will be retired on September 30th, 2023. Migrate to a different deployment source.</value>
     </data>
+    <data name="deploymentCenterNoWritePermissionsError" xml:space="preserve">
+        <value>You do not have write permissions to make any changes.</value>
+    </data>
     <data name="deploymentCenterSettingsReadOnlyGitHubNotAuthorized" xml:space="preserve">
         <value>GitHub Token not found, click authorize to set up GitHub token.</value>
     </data>


### PR DESCRIPTION
Task#[25085962](https://msazure.visualstudio.com/Antares/_workitems/edit/25085962)
FixesAB#[25232212](https://msazure.visualstudio.com/Antares/_workitems/edit/25232212)

- For classic Azure Pipelines, they don't have the build information, so just remove the repo information from view
- For containers, show the registry settings like we would for normal containers

**Before**
Containers DevOps view
![image](https://github.com/Azure/azure-functions-ux/assets/29874289/3563d088-c914-4fc1-870b-ff3c9ea1e7c1)
Read only container view
![image](https://github.com/Azure/azure-functions-ux/assets/29874289/0e29638f-032f-485b-af98-1b56b8e4794c)
Code set up view (cannot save changes)
![image](https://github.com/Azure/azure-functions-ux/assets/29874289/5e4921fd-5d0c-45d4-a6d0-47c6680e32c0)

**After**
Containers DevOps view
![image](https://github.com/Azure/azure-functions-ux/assets/29874289/ba68352e-2877-4e16-b846-9947200bad56)
Read only container view
![image](https://github.com/Azure/azure-functions-ux/assets/29874289/19675aee-44b6-4f77-985c-cb367aa116f7)
Code set up view (configured views should still show)
![image](https://github.com/Azure/azure-functions-ux/assets/29874289/0fab19cb-daa8-493e-b83f-1271d34b828c)