### PR TITLE
Remove isHidden for dotnet 8 on Windows Apps

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -34,7 +34,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                   isSupported: true,
                   supportedVersion: '8.x',
                 },
-                isHidden: true,
                 isPreview: true,
               },
               linuxRuntimeSettings: {


### PR DESCRIPTION
Dotnet 8 preview 7 changes are available on Windows web apps. Adding this PR to enable dotnet 8 for Windows Apps.