### PR TITLE
[DC] Delete hidden ACR tag only when necessary

### DIFF
--- a/client-react/src/utils/dependency/Dependency.ts
+++ b/client-react/src/utils/dependency/Dependency.ts
@@ -93,8 +93,9 @@ export class AcrDependency extends Dependency {
     const siteResponse = await SiteService.fetchSite(resourceId);
     if (siteResponse.metadata.success) {
       const tags = siteResponse.data.tags;
-      if (tags) {
-        delete tags[this._getTagName(CommonConstants.DeploymentCenterConstants.acrTag, true)];
+      const hiddenTagName = this._getTagName(CommonConstants.DeploymentCenterConstants.acrTag, true);
+      if (tags && tags[hiddenTagName]) {
+        delete tags[hiddenTagName];
         const deleteTagResponse = await SiteService.updateSite(resourceId, siteResponse.data, undefined, true);
         if (!deleteTagResponse.metadata.success) {
           portalContext.log(


### PR DESCRIPTION
FixesAB#[25320207](https://msazure.visualstudio.com/Antares/_workitems/edit/25320207) 

- If tags was an empty object, it would still try to delete the hidden tag from it, so it was causing an unnecessary amount of patchSite calls