### PR TITLE
AB#25572236 Http2Proxy - show off/on/gPRCOnly options

### DIFF
--- a/client-react/src/pages/app/app-settings/GeneralSettings/Platform.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/Platform.tsx
@@ -76,13 +76,10 @@ const Platform: React.FC<FormikProps<AppSettingsFormValues>> = props => {
   );
 
   const onHttp20EnabledChange = (event: React.FormEvent<HTMLDivElement>, option: { key: boolean }) => {
-    // Set HTTP 2.0 Proxy to 'Off' if http 2.0 is not enabled.
+    props.setFieldValue('config.properties.http20ProxyFlag', 0);
     if (!option.key) {
-      props.setFieldValue('config.properties.http20ProxyFlag', 0);
       values.httpTwo = false;
     } else {
-      // Enable gPRC only mode for HTTP 2.0
-      props.setFieldValue('config.properties.http20ProxyFlag', 2);
       values.httpTwo = true;
       props.setFieldValue('site.properties.clientCertEnabled', false);
     }
@@ -223,20 +220,25 @@ const Platform: React.FC<FormikProps<AppSettingsFormValues>> = props => {
             <Field
               name="config.properties.http20ProxyFlag"
               dirty={values.config.properties.http20ProxyFlag !== initialValues.config.properties.http20ProxyFlag}
-              component={RadioButton}
+              component={Dropdown}
               label={t('http20Proxy')}
               infoBubbleMessage={t('https20ProxyInfoBubbleMessage')}
               id="app-settings-http20-proxy-enabled"
               disabled={disableAllControls}
               options={[
                 {
-                  key: 2,
+                  key: 0,
+                  text: t('off'),
+                },
+                {
+                  key: 1,
                   text: t('on'),
                   disabled: !values.config.properties.http20Enabled,
                 },
                 {
-                  key: 0,
-                  text: t('off'),
+                  key: 2,
+                  text: t('grpcOnly'),
+                  disabled: !values.config.properties.http20Enabled,
                 },
               ]}
             />

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -324,6 +324,7 @@ export class PortalResources {
   public static functionEdit_functionState = 'functionEdit_functionState';
   public static off = 'off';
   public static on = 'on';
+  public static grpcOnly = 'grpcOnly';
   public static topBar_functionApiSettings = 'topBar_functionApiSettings';
   public static sidebar_newApiProxy = 'sidebar_newApiProxy';
   public static apiProxy_allMethods = 'apiProxy_allMethods';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -1081,6 +1081,9 @@
     <data name="on" xml:space="preserve">
         <value>On</value>
     </data>
+    <data name="grpcOnly" xml:space="preserve">
+        <value>gRPC Only</value>
+    </data>
     <data name="topBar_functionApiSettings" xml:space="preserve">
         <value>API settings</value>
     </data>


### PR DESCRIPTION
Fixes: [AB#25572236](https://msazure.visualstudio.com/Antares/_workitems/edit/25572236)

1. Default https 2.0 proxy to off
2. Show three options

![image](https://github.com/Azure/azure-functions-ux/assets/33185278/74f7a9b9-815c-4d6d-a1fb-228711af7783)

