### PR TITLE
[FunctionApps] Update event hub api version to 2021-11-01

### DIFF
--- a/client-react/src/ApiHelpers/EventHubService.ts
+++ b/client-react/src/ApiHelpers/EventHubService.ts
@@ -11,7 +11,7 @@ export default class EventHubService {
     return MakeArmCall<ArmArray<Namespace>>({
       resourceId: id,
       commandName: 'fetchNamespaces',
-      apiVersion: CommonConstants.ApiVersions.eventHubApiVersion20150801,
+      apiVersion: CommonConstants.ApiVersions.eventHubApiVersion20211101,
     });
   };
 
@@ -20,7 +20,7 @@ export default class EventHubService {
     return MakeArmCall<ArmArray<EventHub>>({
       resourceId: id,
       commandName: 'fetchEventHubs',
-      apiVersion: CommonConstants.ApiVersions.eventHubApiVersion20150801,
+      apiVersion: CommonConstants.ApiVersions.eventHubApiVersion20211101,
     });
   };
 
@@ -29,7 +29,7 @@ export default class EventHubService {
     return MakeArmCall<ArmArray<AuthorizationRule>>({
       resourceId: id,
       commandName: 'fetchAuthorizationRules',
-      apiVersion: CommonConstants.ApiVersions.eventHubApiVersion20150801,
+      apiVersion: CommonConstants.ApiVersions.eventHubApiVersion20211101,
     });
   };
 
@@ -39,7 +39,7 @@ export default class EventHubService {
       method: 'POST',
       resourceId: id,
       commandName: 'fetchKeyList',
-      apiVersion: CommonConstants.ApiVersions.eventHubApiVersion20150801,
+      apiVersion: CommonConstants.ApiVersions.eventHubApiVersion20211101,
     });
   };
 }

--- a/client-react/src/ApiHelpers/ServiceBusService.ts
+++ b/client-react/src/ApiHelpers/ServiceBusService.ts
@@ -11,7 +11,7 @@ export default class ServiceBusService {
     return MakeArmCall<ArmArray<Namespace>>({
       resourceId: id,
       commandName: 'fetchNamespaces',
-      apiVersion: CommonConstants.ApiVersions.serviceBusApiVersion20150801,
+      apiVersion: CommonConstants.ApiVersions.serviceBusApiVersion20211101,
     });
   };
 
@@ -20,7 +20,7 @@ export default class ServiceBusService {
     return MakeArmCall<ArmArray<AuthorizationRule>>({
       resourceId: id,
       commandName: 'fetchAuthorizationRules',
-      apiVersion: CommonConstants.ApiVersions.serviceBusApiVersion20150801,
+      apiVersion: CommonConstants.ApiVersions.serviceBusApiVersion20211101,
     });
   };
 
@@ -30,7 +30,7 @@ export default class ServiceBusService {
       method: 'POST',
       resourceId: id,
       commandName: 'fetchKeyList',
-      apiVersion: CommonConstants.ApiVersions.serviceBusApiVersion20150801,
+      apiVersion: CommonConstants.ApiVersions.serviceBusApiVersion20211101,
     });
   };
 }

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -34,7 +34,7 @@ export class CommonConstants {
     sitesApiVersion20201201: '2020-12-01',
     storageApiVersion20180701: '2018-07-01',
     storageApiVersion20210401: '2021-04-01',
-    eventHubApiVersion20150801: '2015-08-01',
+    eventHubApiVersion20211101: '2021-11-01',
     iotHubApiVersion20170119: '2017-01-19',
     serviceBusApiVersion20150801: '2015-08-01',
     documentDBApiVersion20150408: '2015-04-08',

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -36,7 +36,7 @@ export class CommonConstants {
     storageApiVersion20210401: '2021-04-01',
     eventHubApiVersion20211101: '2021-11-01',
     iotHubApiVersion20170119: '2017-01-19',
-    serviceBusApiVersion20150801: '2015-08-01',
+    serviceBusApiVersion20211101: '2021-11-01',
     documentDBApiVersion20150408: '2015-04-08',
     documentDBApiVersion20191212: '2019-12-12',
     documentDBApiVersion20210415: '2021-04-15',


### PR DESCRIPTION
[Task 25524278](https://msazure.visualstudio.com/Antares/_workitems/edit/25524278): [Functions] Update API version used to access Event Hub RP