### PR TITLE
removing early access and changing default

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
@@ -56,7 +56,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
               windowsRuntimeSettings: {
                 runtimeVersion: 'v8.0',
                 isHidden: false,
-                isEarlyAccess: true,
+                isDefault: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -79,7 +79,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
               linuxRuntimeSettings: {
                 runtimeVersion: 'DOTNET-ISOLATED|8.0',
                 isHidden: false,
-                isEarlyAccess: true,
+                isDefault: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -167,7 +167,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
             stackSettings: {
               windowsRuntimeSettings: {
                 runtimeVersion: 'v6.0',
-                isDefault: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -188,7 +187,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
               },
               linuxRuntimeSettings: {
                 runtimeVersion: 'DOTNET|6.0',
-                isDefault: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,


### PR DESCRIPTION
Just a draft to make sure we have this noted. I suspect the Early Access bit will be covered by a different PR which touches other services as well. However, we will want to change the defaults for Functions at that point as well. Regardless, we need to wait until the optimizations are complete before we make this change - this shouldn't leave draft before then.