### PR TITLE
[Configuration] Update minimum cipher suite selector when selecting least secure  

### DIFF
--- a/client-react/src/components/CipherSuite/MinTLSCipherSuiteSelector.tsx
+++ b/client-react/src/components/CipherSuite/MinTLSCipherSuiteSelector.tsx
@@ -47,9 +47,7 @@ const MinTLSCipherSuiteSelector: React.FC<MinTLSCipherSuiteSelectorProps & Field
   }, [setShowCipherSuitePanel]);
 
   const saveSelection = React.useCallback(() => {
-    // If the selected cipher suite is the least secure (default), back-end wants field value to be empty
-    const cipherSuite = selectedCipherSuite == leastSecureCipherSuite ? '' : selectedCipherSuite;
-    form.setFieldValue(field.name, cipherSuite);
+    form.setFieldValue(field.name, selectedCipherSuite);
     dismissPanel();
   }, [form.setFieldValue, dismissPanel, selectedCipherSuite]);
 


### PR DESCRIPTION
Backend initially needed the default value to be empty, but now just want it to be the lowest cipher suite.