### PR TITLE
Revert .NET 8 Windows early access flag removal

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
@@ -74,6 +74,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
                 },
                 supportedFunctionsExtensionVersions: ['~4'],
                 endOfLifeDate: dotnet8EOL,
+                isEarlyAccess: true,
               },
               linuxRuntimeSettings: {
                 runtimeVersion: 'DOTNET-ISOLATED|8.0',

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -34,6 +34,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                   isSupported: true,
                   supportedVersion: '8.x',
                 },
+                isEarlyAccess: true,
               },
               linuxRuntimeSettings: {
                 runtimeVersion: 'DOTNETCORE|8.0',


### PR DESCRIPTION
We realized a couple of days ago that a few Windows stamp are not on the latest bits so we cannot remove the Early Access flag for windows just yet. @mattchenderson / @surgupta-msft  fyi