### PR TITLE
[DC][OIDC] Add ability to select existing identities

### DIFF
--- a/client-react/src/ApiHelpers/ManagedIdentityService.ts
+++ b/client-react/src/ApiHelpers/ManagedIdentityService.ts
@@ -1,4 +1,4 @@
-import { ArmObj } from '../models/arm-obj';
+import { ArmArray, ArmObj } from '../models/arm-obj';
 import { UserAssignedIdentity } from '../pages/app/deployment-center/DeploymentCenter.types';
 import { CommonConstants } from '../utils/CommonConstants';
 import MakeArmCall from './ArmHelper';
@@ -12,6 +12,19 @@ export default class ManagedIdentityService {
       method: 'GET',
       resourceId: resourceId,
       commandName: 'getUserAssignedIdentityInfo',
+      apiVersion,
+    });
+  };
+
+  public static listUserAssignedIdentitiesBySubscription = (
+    subscriptionId: string,
+    apiVersion = CommonConstants.ApiVersions.managedIdentityApiVersion20230131
+  ) => {
+    const resourceId = `/subscriptions/${subscriptionId}/providers/Microsoft.ManagedIdentity/userAssignedIdentities`;
+    return MakeArmCall<ArmArray<UserAssignedIdentity>>({
+      method: 'GET',
+      resourceId,
+      commandName: 'getUserAssignedIdentitiesBySubscription',
       apiVersion,
     });
   };

--- a/client-react/src/components/form-controls/formControl.override.styles.tsx
+++ b/client-react/src/components/form-controls/formControl.override.styles.tsx
@@ -21,7 +21,7 @@ export const dropdownStyleOverrides = (theme: ThemeExtended, fullpage: boolean, 
       },
     ],
     title: [...baseStyle.title],
-    errorMessage: [...baseStyle.errorMessage, fullpage],
+    errorMessage: [...baseStyle.errorMessage],
     dropdown: [
       ...baseStyle.dropdown,
       {

--- a/client-react/src/components/form-controls/formControl.override.styles.tsx
+++ b/client-react/src/components/form-controls/formControl.override.styles.tsx
@@ -21,12 +21,7 @@ export const dropdownStyleOverrides = (theme: ThemeExtended, fullpage: boolean, 
       },
     ],
     title: [...baseStyle.title],
-    errorMessage: [
-      ...baseStyle.errorMessage,
-      fullpage && {
-        paddingLeft: '200px',
-      },
-    ],
+    errorMessage: [...baseStyle.errorMessage, fullpage],
     dropdown: [
       ...baseStyle.dropdown,
       {

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
@@ -272,6 +272,10 @@ export default class DeploymentCenterData {
     return ManagedIdentityService.getUserAssignedIdentity(resourceId);
   };
 
+  public listUserAssignedIdentitiesBySubscription = (subscriptionId: string) => {
+    return ManagedIdentityService.listUserAssignedIdentitiesBySubscription(subscriptionId);
+  };
+
   public createUserAssignedIdentity = (resourceGroupId: string, identityName: string, location: string) => {
     return ManagedIdentityService.createUserAssignedIdentity(resourceGroupId, identityName, location);
   };

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.data.ts
@@ -16,7 +16,7 @@ import { SiteConfig } from '../../../models/site/config';
 import { PublishingUser } from '../../../models/site/publish';
 import { AppStackOs } from '../../../models/stacks/app-stacks';
 import PortalCommunicator from '../../../portal-communicator';
-import { RoleAssignment, SourceControlOptions } from './DeploymentCenter.types';
+import { FederatedCredential, RoleAssignment, SourceControlOptions } from './DeploymentCenter.types';
 import ManagedIdentityService from '../../../ApiHelpers/ManagedIdentityService';
 import GraphService from '../../../ApiHelpers/GraphService';
 import ResourceManagementService from '../../../ApiHelpers/ResourceManagementService';
@@ -280,8 +280,16 @@ export default class DeploymentCenterData {
     return ManagedIdentityService.createUserAssignedIdentity(resourceGroupId, identityName, location);
   };
 
-  public putFederatedCredential = (managedIdentityResourceId: string, credentialName: string, fullRepoName: string) => {
-    return ManagedIdentityService.putFederatedCredential(managedIdentityResourceId, credentialName, fullRepoName);
+  public putFederatedCredential = (managedIdentityResourceId: string, credentialName: string, subject: string) => {
+    return ManagedIdentityService.putFederatedCredential(managedIdentityResourceId, credentialName, subject);
+  };
+
+  public listFederatedCredentials = (managedIdentityResourceId: string) => {
+    return ManagedIdentityService.listFederatedCredentials(managedIdentityResourceId);
+  };
+
+  public issuerSubjectAlreadyExists = (subject: string, federatedCredentials: ArmObj<FederatedCredential>[]) => {
+    return ManagedIdentityService.issuerSubjectAlreadyExists(subject, federatedCredentials);
   };
 
   public updateSiteConfig = (resourceId: string, config: ArmObj<SiteConfig>) => {

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -813,14 +813,9 @@ export interface UserAssignedIdentity {
 }
 
 export interface FederatedCredential {
-  id: string;
-  name: string;
-  properties: {
-    audiences: string[];
-    issuer: string;
-    subject: string;
-  };
-  type: string;
+  audiences: string[];
+  issuer: string;
+  subject: string;
 }
 
 export interface User {

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -319,8 +319,7 @@ export interface DeploymentCenterCommonFormData {
   devOpsProjectName?: string;
   searchTerm?: string;
   authType: AuthType;
-  authIdentityClientId?: string;
-  authIdentity?: UserAssignedIdentity;
+  authIdentity: UserAssignedIdentity;
   hasPermissionToUseOIDC?: boolean;
 }
 

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterConstants.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterConstants.ts
@@ -81,4 +81,5 @@ export class DeploymentCenterConstants {
   public static readonly appSettings_WEBSITE_NODE_DEFAULT_VERSION = 'WEBSITE_NODE_DEFAULT_VERSION';
 
   public static readonly managedIdentityNamespace = 'Microsoft.ManagedIdentity';
+  public static readonly createNew = 'createNew';
 }

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
@@ -155,7 +155,9 @@ export abstract class DeploymentCenterFormBuilder {
         then: Yup.mixed().test('authTypeRequired', this._t('deploymentCenterFieldRequiredMessage'), function(value) {
           return !!value;
         }),
-        otherwise: Yup.mixed().test('authTypeIsNotOidc', this._t('authenticationSettingsOidcPermissionsValidationError'), function(value) {
+        otherwise: Yup.mixed().test('authIdentityPopulated', this._t('authenticationSettingsOidcPermissionsValidationError'), function(
+          value
+        ) {
           return value === AuthType.Oidc ? !!this.parent.authIdentity.resourceId : true;
         }),
       }),

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
@@ -42,6 +42,14 @@ export abstract class DeploymentCenterFormBuilder {
       externalRepoType: RepoTypeOptions.Public,
       devOpsProject: '',
       authType: AuthType.PublishProfile,
+      authIdentity: {
+        clientId: '',
+        principalId: '',
+        tenantId: '',
+        subscriptionId: '',
+        name: '',
+        resourceId: '',
+      },
     };
   }
 
@@ -148,7 +156,7 @@ export abstract class DeploymentCenterFormBuilder {
           return !!value;
         }),
         otherwise: Yup.mixed().test('authTypeIsNotOidc', this._t('authenticationSettingsOidcPermissionsValidationError'), function(value) {
-          return value !== AuthType.Oidc;
+          return value === AuthType.Oidc ? !!this.parent.authIdentity.resourceId : true;
         }),
       }),
       authIdentity: Yup.mixed().notRequired(),

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
@@ -158,7 +158,7 @@ export abstract class DeploymentCenterFormBuilder {
         otherwise: Yup.mixed().test('authIdentityPopulated', this._t('authenticationSettingsOidcPermissionsValidationError'), function(
           value
         ) {
-          return value === AuthType.Oidc ? !!this.parent.authIdentity.resourceId : true;
+          return value !== AuthType.Oidc || !!this.parent.authIdentity.resourceId;
         }),
       }),
       authIdentity: Yup.mixed().notRequired(),

--- a/client-react/src/pages/app/deployment-center/authentication/DeploymentCenterAuthenticationSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/authentication/DeploymentCenterAuthenticationSettings.tsx
@@ -178,12 +178,10 @@ export const DeploymentCenterAuthenticationSettings = React.memo<
   React.useEffect(() => {
     let isSubscribed = true;
     if (subscription) {
-      if (isSubscribed) {
-        setIdentity(undefined);
-        setIdentityOptions([]);
-        setIdentityErrorMessage(undefined);
-        setLoadingIdentities(true);
-      }
+      setIdentity(undefined);
+      setIdentityOptions([]);
+      setIdentityErrorMessage(undefined);
+      setLoadingIdentities(true);
       const isCreateNewSupported = hasManagedIdentityWritePermission && formProps.values.hasPermissionToUseOIDC;
 
       deploymentCenterData

--- a/client-react/src/pages/app/deployment-center/authentication/DeploymentCenterAuthenticationSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/authentication/DeploymentCenterAuthenticationSettings.tsx
@@ -10,15 +10,24 @@ import {
   DeploymentCenterCodeFormData,
   DeploymentCenterContainerFormData,
   DeploymentCenterFieldProps,
+  UserAssignedIdentity,
 } from '../DeploymentCenter.types';
 import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
 import { DeploymentCenterLinks } from '../../../../utils/FwLinks';
 import RadioButton from '../../../../components/form-controls/RadioButton';
 import { Link } from '@fluentui/react/lib/Link';
+import { DropdownMenuItemType, IDropdownOption } from '@fluentui/react/lib/Dropdown';
 import { learnMoreLinkStyle } from '../../../../components/form-controls/formControl.override.styles';
 import RbacConstants from '../../../../utils/rbac-constants';
 import { ArmResourceDescriptor } from '../../../../utils/resourceDescriptors';
-import { getTelemetryInfo } from '../utility/DeploymentCenterUtility';
+import { getTelemetryInfo, optionsSortingFunction } from '../utility/DeploymentCenterUtility';
+import DropdownNoFormik from '../../../../components/form-controls/DropDownnoFormik';
+import DeploymentCenterData from '../DeploymentCenter.data';
+import { DeploymentCenterConstants } from '../DeploymentCenterConstants';
+import { getErrorMessage } from '../../../../ApiHelpers/ArmHelper';
+import { ISubscription } from '../../../../models/subscription';
+import { ArmObj } from '../../../../models/arm-obj';
+import { RBACRoleId } from '../../../../utils/CommonConstants';
 
 export const DeploymentCenterAuthenticationSettings = React.memo<
   DeploymentCenterFieldProps<DeploymentCenterContainerFormData | DeploymentCenterCodeFormData>
@@ -27,8 +36,16 @@ export const DeploymentCenterAuthenticationSettings = React.memo<
   const { formProps } = props;
   const portalContext = React.useContext(PortalContext);
   const deploymentCenterContext = React.useContext(DeploymentCenterContext);
+  const deploymentCenterData = new DeploymentCenterData();
   const [hasRoleAssignmentWritePermission, setHasRoleAssignmentWritePermission] = React.useState<boolean>(false);
   const [hasManagedIdentityWritePermission, setHasManagedIdentityWritePermission] = React.useState<boolean>(false);
+  const [loadingSubscriptions, setLoadingSubscriptions] = React.useState<boolean>(false);
+  const [subscriptionOptions, setSubscriptionOptions] = React.useState<IDropdownOption<ISubscription>[]>([]);
+  const [subscription, setSubscription] = React.useState<string>();
+  const [loadingIdentities, setLoadingIdentities] = React.useState<boolean>(false);
+  const [identityOptions, setIdentityOptions] = React.useState<IDropdownOption<UserAssignedIdentity>[]>([]);
+  const [identity, setIdentity] = React.useState<string>();
+  const [identityErrorMessage, setIdentityErrorMessage] = React.useState<string>();
 
   const authTypeOptions = React.useMemo(() => {
     return [
@@ -60,39 +77,233 @@ export const DeploymentCenterAuthenticationSettings = React.memo<
   }, [deploymentCenterContext.resourceId]);
 
   React.useEffect(() => {
-    hasPermissionOverResourceGroup();
+    let isSubscribed = true;
+    if (isSubscribed) {
+      hasPermissionOverResourceGroup();
+    }
+    return () => {
+      isSubscribed = false;
+    };
   }, [hasPermissionOverResourceGroup]);
 
+  const fetchAllSubscriptions = React.useCallback(async () => {
+    setLoadingSubscriptions(true);
+    const subscriptionsObservable = await portalContext.getAllSubscriptions();
+    const subscriptionDropdownOptions: IDropdownOption[] = [];
+
+    subscriptionsObservable.subscribe(subscriptionArray => {
+      subscriptionArray.forEach(subscription =>
+        subscriptionDropdownOptions.push({ key: subscription.subscriptionId, text: subscription.displayName })
+      );
+      subscriptionDropdownOptions.sort(optionsSortingFunction);
+      setSubscriptionOptions(subscriptionDropdownOptions);
+      setSubscription(deploymentCenterContext.siteDescriptor?.subscription ?? '');
+    });
+
+    setLoadingSubscriptions(false);
+  }, [portalContext]);
+
+  const checkRoleAssignmentsForIdentity = React.useCallback(
+    async (principalId?: string) => {
+      if (principalId) {
+        const armId = new ArmResourceDescriptor(deploymentCenterContext.resourceId);
+        const subscriptionId = `/subscriptions/${armId.subscription}`;
+        const resourceGroupId = `/subscriptions/${armId.subscription}/resourceGroups/${armId.resourceGroup}`;
+        const [roleAssignmentsOnSub, roleAssignmentsOnRg, roleAssignmentsOnApp] = await Promise.all([
+          deploymentCenterData.getRoleAssignmentsWithScope(subscriptionId, principalId),
+          deploymentCenterData.getRoleAssignmentsWithScope(resourceGroupId, principalId),
+          deploymentCenterData.getRoleAssignmentsWithScope(deploymentCenterContext.resourceId, principalId),
+        ]);
+
+        if (roleAssignmentsOnSub.metadata.success && roleAssignmentsOnRg.metadata.success && roleAssignmentsOnApp.metadata.success) {
+          const hasOwnerAccess = deploymentCenterData.hasRoleAssignment(RBACRoleId.owner, [
+            ...roleAssignmentsOnSub.data.value,
+            ...roleAssignmentsOnRg.data.value,
+            ...roleAssignmentsOnApp.data.value,
+          ]);
+          const hasContributorAccess = deploymentCenterData.hasRoleAssignment(RBACRoleId.contributor, [
+            ...roleAssignmentsOnSub.data.value,
+            ...roleAssignmentsOnRg.data.value,
+            ...roleAssignmentsOnApp.data.value,
+          ]);
+          const hasWebsiteContributorAccess = deploymentCenterData.hasRoleAssignment(RBACRoleId.websiteContributor, [
+            ...roleAssignmentsOnSub.data.value,
+            ...roleAssignmentsOnRg.data.value,
+            ...roleAssignmentsOnApp.data.value,
+          ]);
+
+          return hasOwnerAccess || hasContributorAccess || hasWebsiteContributorAccess;
+        } else {
+          portalContext.log(
+            getTelemetryInfo('error', 'checkRoleAssignmentsForIdentityForOidc', 'failed', {
+              message:
+                `roleAssignmentsOnSub: ${getErrorMessage(roleAssignmentsOnSub.metadata.error)}, ` +
+                `roleAssignmentsOnRg: ${getErrorMessage(roleAssignmentsOnRg.metadata.error)}, ` +
+                `roleAssignmentsOnApp: ${getErrorMessage(roleAssignmentsOnApp.metadata.error)} `,
+            })
+          );
+        }
+      }
+      return false;
+    },
+    [deploymentCenterContext.resourceId]
+  );
+
+  const onSubscriptionChange = React.useCallback(async (_, subscriptionOption: IDropdownOption<ISubscription>) => {
+    setSubscription(subscriptionOption.key as string);
+  }, []);
+
+  const onIdentityChange = React.useCallback(
+    async (_, identityOption: IDropdownOption<UserAssignedIdentity>) => {
+      setIdentity(identityOption.key as string);
+      if (formProps.values.hasPermissionToUseOIDC) {
+        formProps.setFieldValue('authIdentity', identityOption.data);
+      } else {
+        const hasRoleAssignment = await checkRoleAssignmentsForIdentity(identityOption.data?.principalId);
+        if (hasRoleAssignment) {
+          formProps.setFieldValue('authIdentity', identityOption.data);
+        } else {
+          setIdentityErrorMessage(t('authenticationSettingsIdentityWritePermissionsError'));
+        }
+      }
+    },
+    [formProps.values.hasPermissionToUseOIDC, deploymentCenterContext.resourceId]
+  );
+
+  React.useEffect(() => {
+    let isSubscribed = true;
+    if (formProps.values.authType === AuthType.Oidc && isSubscribed) {
+      setSubscription(undefined);
+      fetchAllSubscriptions();
+    }
+
+    return () => {
+      isSubscribed = false;
+    };
+  }, [formProps.values.authType, fetchAllSubscriptions]);
+
+  React.useEffect(() => {
+    let isSubscribed = true;
+    if (subscription && isSubscribed) {
+      setIdentity(undefined);
+      setLoadingIdentities(true);
+      deploymentCenterData.listUserAssignedIdentitiesBySubscription(subscription).then(getIdentitiesResponse => {
+        const identityOptions: IDropdownOption<UserAssignedIdentity>[] = [];
+        const isCreateNewSupported = hasManagedIdentityWritePermission && formProps.values.hasPermissionToUseOIDC;
+        if (getIdentitiesResponse.metadata.success) {
+          const resourceGroupToIdentity: { [rg: string]: ArmObj<UserAssignedIdentity>[] } = {};
+          const identities = getIdentitiesResponse.data.value;
+          identities.forEach(identity => {
+            const resourceGroup = new ArmResourceDescriptor(identity.id)?.resourceGroup;
+            if (resourceGroup in resourceGroupToIdentity) {
+              resourceGroupToIdentity[resourceGroup].push(identity);
+            } else {
+              resourceGroupToIdentity[resourceGroup] = [identity];
+            }
+          });
+
+          Object.keys(resourceGroupToIdentity)
+            .sort((a, b) => a.toLocaleLowerCase().localeCompare(b.toLocaleLowerCase()))
+            .forEach(rg => {
+              identityOptions.push({
+                key: rg,
+                text: rg,
+                itemType: DropdownMenuItemType.Header,
+              });
+              const sortedIdentities = resourceGroupToIdentity[rg].sort((a, b) =>
+                a.name.toLocaleLowerCase().localeCompare(b.name.toLocaleLowerCase())
+              );
+              sortedIdentities.forEach(identity => {
+                identityOptions.push({
+                  key: identity.id,
+                  text: identity.name,
+                  data: {
+                    ...identity.properties,
+                    resourceId: identity.id,
+                    name: identity.name,
+                  },
+                });
+              });
+            });
+
+          if (isCreateNewSupported) {
+            identityOptions.unshift({
+              key: DeploymentCenterConstants.createNew,
+              text: t('createNewOption'),
+              data: {
+                clientId: '',
+                principalId: '',
+                tenantId: '',
+                subscriptionId: '',
+                name: '',
+                resourceId: DeploymentCenterConstants.createNew,
+              },
+            });
+          }
+          setIdentityOptions(identityOptions);
+        } else {
+          portalContext.log(
+            getTelemetryInfo('error', 'listUserAssignedIdentitiesBySubscription', 'failed', {
+              message: getErrorMessage(getIdentitiesResponse.metadata.error),
+              errorAsString: getIdentitiesResponse.metadata.error ? JSON.stringify(getIdentitiesResponse.metadata.error) : '',
+            })
+          );
+        }
+
+        if (isCreateNewSupported) {
+          setIdentity(DeploymentCenterConstants.createNew);
+        } else {
+          if (identityOptions.length > 0) {
+            const firstIdentity = identityOptions.find(option => option.itemType !== DropdownMenuItemType.Header);
+            if (firstIdentity) {
+              setIdentity(firstIdentity.key as string);
+              checkRoleAssignmentsForIdentity(firstIdentity.data?.principalId).then(hasRoleAssignment => {
+                if (hasRoleAssignment) {
+                  formProps.setFieldValue('authIdentity', firstIdentity.data);
+                } else {
+                  setIdentityErrorMessage(t('authenticationSettingsIdentityWritePermissionsError'));
+                }
+              });
+            }
+          }
+        }
+        setLoadingIdentities(false);
+      });
+    }
+
+    return () => {
+      isSubscribed = false;
+    };
+  }, [subscription, checkRoleAssignmentsForIdentity]);
+
   const errorBanner = React.useMemo(() => {
-    if (formProps.values.authType === AuthType.Oidc && formProps.values.hasPermissionToUseOIDC === false) {
+    if (formProps.values.authType === AuthType.Oidc) {
+      let message;
+      let learnMoreLink;
+      let learnMoreLinkAriaLabel;
+      if (formProps.values.hasPermissionToUseOIDC === false && !hasRoleAssignmentWritePermission) {
+        message = t('authenticationSettingsIdentityAssignmentPermissionsError');
+        learnMoreLink = DeploymentCenterLinks.oidcPermissionPrereqs;
+        learnMoreLinkAriaLabel = t('authenticationSettingsOidcPermissionsLinkAriaLabel');
+      }
+
       return (
-        <div className={deploymentCenterInfoBannerDiv}>
-          {!hasManagedIdentityWritePermission ? (
+        message &&
+        learnMoreLink &&
+        learnMoreLinkAriaLabel && (
+          <div className={deploymentCenterInfoBannerDiv}>
             <CustomBanner
-              id="deployment-center-msi-permissions-error"
-              message={t('authenticationSettingsIdentityCreationPermissionsError')}
+              id="deployment-center-auth-oidc-error"
+              message={message}
               type={MessageBarType.blocked}
-              learnMoreLink={DeploymentCenterLinks.managedIdentityCreationPrereqs}
-              learnMoreLinkAriaLabel={t('authenticationSettingsIdentityCreationPrerequisitesLinkAriaLabel')}
+              learnMoreLink={learnMoreLink}
+              learnMoreLinkAriaLabel={learnMoreLinkAriaLabel}
             />
-          ) : (
-            <CustomBanner
-              id="deployment-center-msi-permissions-error"
-              message={t('authenticationSettingsIdentityAssignmentPermissionsError')}
-              type={MessageBarType.blocked}
-              learnMoreLink={DeploymentCenterLinks.roleAssignmentPrereqs}
-              learnMoreLinkAriaLabel={t('authenticationSettingsRoleAssignmentPrerequisitesLinkAriaLabel')}
-            />
-          )}
-        </div>
+          </div>
+        )
       );
     }
-  }, [
-    hasManagedIdentityWritePermission,
-    hasRoleAssignmentWritePermission,
-    formProps.values.authType,
-    formProps.values.hasPermissionToUseOIDC,
-  ]);
+  }, [formProps.values.authType, formProps.values.hasPermissionToUseOIDC]);
 
   return (
     <div className={deploymentCenterContent}>
@@ -122,6 +333,33 @@ export const DeploymentCenterAuthenticationSettings = React.memo<
         displayInVerticalLayout={true}
         required
       />
+
+      {formProps.values.authType === AuthType.Oidc && (
+        <>
+          <DropdownNoFormik
+            id="deployment-center-auth-identity-subscription-option"
+            label={t('subscriptionName')}
+            options={subscriptionOptions}
+            onChange={onSubscriptionChange}
+            isLoading={loadingSubscriptions}
+            selectedKey={subscription}
+            placeholder={t('authenticationSettingsSubscriptionPlaceholder')}
+            required
+          />
+          <DropdownNoFormik
+            id="deployment-center-auth-identity-option"
+            label={t('authenticationSettingsIdentity')}
+            placeholder={t('authenticationSettingsIdentityPlaceholder')}
+            options={identityOptions}
+            selectedKey={identity}
+            onChange={onIdentityChange}
+            errorMessage={identityErrorMessage}
+            isLoading={loadingIdentities}
+            disabled={!subscription}
+            required
+          />
+        </>
+      )}
     </div>
   );
 });

--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
@@ -497,6 +497,7 @@ export const getDescriptionSection = (source: string, description: string, learn
 };
 
 export const optionsSortingFunction = (a: ISelectableOption, b: ISelectableOption) => a.text.localeCompare(b.text);
+export const ignoreCaseSortingFunction = (a: string, b: string) => a.toLocaleLowerCase().localeCompare(b.toLocaleLowerCase());
 
 export function formikOnBlur<T>(e: React.FocusEvent<T>, props: FieldProps) {
   const { field, form } = props;

--- a/client-react/src/utils/CommonConstants.ts
+++ b/client-react/src/utils/CommonConstants.ts
@@ -347,6 +347,7 @@ export enum RBACRoleId {
   contributor = 'b24988ac-6180-42a0-ab88-20f7382dd24c',
   owner = '8e3af657-a8ff-443c-a75c-2fe8c4bcb635',
   userAccessAdministrator = '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9',
+  websiteContributor = 'de139f84-1756-47ae-9be6-808fbbe84772',
 }
 
 export enum PrincipalType {

--- a/client-react/src/utils/FwLinks.ts
+++ b/client-react/src/utils/FwLinks.ts
@@ -80,4 +80,5 @@ export const DeploymentCenterLinks = {
   managedIdentityOidc: 'https://go.microsoft.com/fwlink/?linkid=2247951',
   roleAssignmentPrereqs: 'https://go.microsoft.com/fwlink/?linkid=2249489',
   managedIdentityCreationPrereqs: 'https://go.microsoft.com/fwlink/?linkid=2253463',
+  oidcPermissionPrereqs: 'https://go.microsoft.com/fwlink/?linkid=2256502',
 };

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2580,14 +2580,18 @@ export class PortalResources {
   public static authenticationSettingsAuthenticationType = 'authenticationSettingsAuthenticationType';
   public static authenticationSettingsAuthenticationPlaceholder = 'authenticationSettingsAuthenticationPlaceholder';
   public static authenticationSettingsIdentity = 'authenticationSettingsIdentity';
+  public static authenticationSettingsIdentityPlaceholder = 'authenticationSettingsIdentityPlaceholder';
+  public static authenticationSettingsSubscriptionPlaceholder = 'authenticationSettingsSubscriptionPlaceholder';
+  public static createNewOption = 'createNewOption';
   public static authenticationSettingsOidcPermissionsValidationError = 'authenticationSettingsOidcPermissionsValidationError';
-  public static authenticationSettingsIdentityCreationPermissionsError = 'authenticationSettingsIdentityCreationPermissionsError';
   public static authenticationSettingsIdentityAssignmentPermissionsError = 'authenticationSettingsIdentityAssignmentPermissionsError';
+  public static authenticationSettingsIdentityWritePermissionsError = 'authenticationSettingsIdentityWritePermissionsError';
   public static authenticationSettingsIdentityCreationPrerequisitesLinkAriaLabel =
     'authenticationSettingsIdentityCreationPrerequisitesLinkAriaLabel';
   public static authenticationSettingsRoleAssignmentPrerequisitesLinkAriaLabel =
     'authenticationSettingsRoleAssignmentPrerequisitesLinkAriaLabel';
   public static authenticationSettingsFederatedCredentialsLinkAriaLabel = 'authenticationSettingsFederatedCredentialsLinkAriaLabel';
+  public static authenticationSettingsOidcPermissionsLinkAriaLabel = 'authenticationSettingsOidcPermissionsLinkAriaLabel';
   public static sshDisabledInfoBubbleMessage = 'sshDisabledInfoBubbleMessage';
   public static staticSite_appSettingsMoved = 'staticSite_appSettingsMoved';
 }

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7882,14 +7882,23 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="authenticationSettingsIdentity" xml:space="preserve">
         <value>Identity</value>
     </data>
+    <data name="authenticationSettingsIdentityPlaceholder" xml:space="preserve">
+        <value>Select an identity</value>
+    </data>
+    <data name="authenticationSettingsSubscriptionPlaceholder" xml:space="preserve">
+        <value>Select a subscription</value>
+    </data>
+    <data name="createNewOption" xml:space="preserve">
+        <value>(Create new)</value>
+    </data>
     <data name="authenticationSettingsOidcPermissionsValidationError" xml:space="preserve">
         <value>You do not have sufficient permissions to authenticate with user-assigned identity.</value>
-    </data>    
-    <data name="authenticationSettingsIdentityCreationPermissionsError" xml:space="preserve">
-        <value>You do not have sufficient permissions to create a managed identity within this resource group.</value>
-    </data>    
+    </data>
     <data name="authenticationSettingsIdentityAssignmentPermissionsError" xml:space="preserve">
-        <value>You do not have sufficient permissions to assign role-based access to a managed identity within this resource group and configure federated credentials.</value>
+        <value>You do not have sufficient permissions to assign role-based access to a managed identity within this resource group and configure federated credentials. If you wish to continue, please select an existing identity below. The identity must have write permissions on the app.</value>
+    </data>
+    <data name="authenticationSettingsIdentityWritePermissionsError" xml:space="preserve">
+        <value>This identity does not have write permissions on this app. Please select a different identity, or work with your admin to grant the Website Contributor role to your identity on this app.</value>
     </data>
     <data name="authenticationSettingsIdentityCreationPrerequisitesLinkAriaLabel" xml:space="preserve">
         <value>Click here to learn more about how to create a managed identity.</value>
@@ -7899,6 +7908,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     </data>
     <data name="authenticationSettingsFederatedCredentialsLinkAriaLabel" xml:space="preserve">
         <value>Click here to learn more about how to manage federated identity credentials on a user-assigned identity.</value>
+    </data>
+    <data name="authenticationSettingsOidcPermissionsLinkAriaLabel" xml:space="preserve">
+        <value>Click here to learn more about what permissions are needed for authenticating with a user-assigned identity.</value>
     </data>
      <data name="sshDisabledInfoBubbleMessage" xml:space="preserve">
         <value>SSH isn't supported for your selected stack version.</value>


### PR DESCRIPTION
Task#[25767588](https://msazure.visualstudio.com/Antares/_workitems/edit/25767588)

- As of now, no way to check for write permissions on site for identity, so we must manually check role assignments for Owner, Contributor, or Website Contributor role on the scope of subscription (inherited), resource group (inherited), and app
 
**Case 1:** No roleAssignment/write permission, No managedIdentity/write permission
- Does not have option to create new identity, and user must select an identity with sufficient permissions

**Case 2:** No roleAssignment/write permission, Yes managedIdentity/write permission
- Does not have option to create new identity (because they can't assign rbac anyway), and user must select an identity with sufficient permissions

**Case 3:** Yes roleAssignment/write permission, No managedIdentity/write permission
- Does not have option to create new identity, and user can select any existing identity

![image](https://github.com/Azure/azure-functions-ux/assets/29874289/188286c8-0030-49b3-b667-ecd0730a9749)

**Case 4:** Yes roleAssignment/write permission, Yes managedIdentity/write permission
- Does have option to create new identity,  and user can select any identity option
![image](https://github.com/Azure/azure-functions-ux/assets/29874289/433944c0-a711-4200-a4d1-9f3bb61b8288)
![image](https://github.com/Azure/azure-functions-ux/assets/29874289/7db13b15-d1cd-4187-b66f-ddbe50c89a95)
