### PR TITLE
[DC][OIDC] Remove support for identities in unsupported regions for federated credential creation

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -1,4 +1,4 @@
-import { ArmArray } from '../../../models/arm-obj';
+import { ArmArray, ArmObj } from '../../../models/arm-obj';
 import { FormikProps } from 'formik';
 import * as Yup from 'yup';
 import { ScmType, BuildProvider } from '../../../models/site/config';
@@ -319,7 +319,7 @@ export interface DeploymentCenterCommonFormData {
   devOpsProjectName?: string;
   searchTerm?: string;
   authType: AuthType;
-  authIdentity: UserAssignedIdentity;
+  authIdentity: ArmObj<UserAssignedIdentity>;
   hasPermissionToUseOIDC?: boolean;
 }
 
@@ -807,9 +807,6 @@ export interface UserAssignedIdentity {
   clientId: string;
   principalId: string;
   tenantId: string;
-  subscriptionId: string;
-  name: string;
-  resourceId: string;
 }
 
 export interface FederatedCredential {

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
@@ -43,12 +43,14 @@ export abstract class DeploymentCenterFormBuilder {
       devOpsProject: '',
       authType: AuthType.Oidc,
       authIdentity: {
-        clientId: '',
-        principalId: '',
-        tenantId: '',
-        subscriptionId: '',
+        id: '',
         name: '',
-        resourceId: '',
+        location: '',
+        properties: {
+          clientId: '',
+          principalId: '',
+          tenantId: '',
+        },
       },
     };
   }

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSourceAndBuild.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSourceAndBuild.tsx
@@ -36,6 +36,7 @@ const DeploymentCenterCodeSourceAndBuild: React.FC<DeploymentCenterFieldProps<De
   const [selectedBuildChoice, setSelectedBuildChoice] = useState<BuildProvider>(BuildProvider.None);
   const [isCalloutVisible, setIsCalloutVisible] = useState(false);
   const [showInfoBanner, setShowInfoBanner] = useState(true);
+  const [basicAuthErrorMessage, setBasicAuthErrorMessage] = useState();
 
   const deploymentCenterContext = useContext(DeploymentCenterContext);
   const deploymentCenterPublishingContext = useContext(DeploymentCenterPublishingContext);
@@ -239,6 +240,11 @@ const DeploymentCenterCodeSourceAndBuild: React.FC<DeploymentCenterFieldProps<De
   const showBasicAuthError = useMemo(() => {
     const isGitHubActionsOrKuduBuild =
       selectedBuild === BuildProvider.GitHubAction || selectedBuild === BuildProvider.AppServiceBuildService;
+    setBasicAuthErrorMessage(
+      selectedBuild === BuildProvider.GitHubAction
+        ? t('deploymentCenterScmBasicAuthErrorMessageWithOidc')
+        : t('deploymentCenterScmBasicAuthErrorMessage')
+    );
     const isBasicAuthSelected = formProps.values.authType === AuthType.PublishProfile;
     return (
       isBasicAuthSelected && isGitHubActionsOrKuduBuild && !deploymentCenterPublishingContext.basicPublishingCredentialsPolicies?.scm.allow
@@ -265,7 +271,7 @@ const DeploymentCenterCodeSourceAndBuild: React.FC<DeploymentCenterFieldProps<De
             <div className={deploymentCenterInfoBannerDiv}>
               <CustomBanner
                 id="deployment-center-scm-basic-auth-warning"
-                message={t('deploymentCenterScmBasicAuthErrorMessageWithOidc')}
+                message={basicAuthErrorMessage ?? ''}
                 type={MessageBarType.error}
                 onClick={openConfigurationBlade}
               />

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerAcrDataLoader.tsx
@@ -23,7 +23,6 @@ import { IDataMessageResult } from '../../../../models/portal-models';
 import { isPortalCommunicationStatusSuccess } from '../../../../utils/portal-utils';
 import { SiteStateContext } from '../../../../SiteState';
 import { ScmType } from '../../../../models/site/config';
-import { ArmResourceDescriptor } from '../../../../utils/resourceDescriptors';
 interface RegistryIdentifiers {
   resourceId: string;
   location: string;
@@ -428,9 +427,8 @@ const DeploymentCenterContainerAcrDataLoader: React.FC<DeploymentCenterFieldProp
         const clientId = identity.clientId;
         const principalId = identity.principalId;
         const tenantId = identity.tenantId;
-        const subscriptionId = new ArmResourceDescriptor(resourceId).subscription;
         const name = resourceId.split(CommonConstants.singleForwardSlash).pop() || clientId;
-        managedIdentityInfo.current[clientId] = { clientId, principalId, tenantId, subscriptionId, name, resourceId };
+        managedIdentityInfo.current[clientId] = { clientId, principalId, tenantId };
         userAssignedIdentitiesOptions.push({ key: clientId, text: name });
       }
     }

--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
@@ -35,6 +35,7 @@ import DeploymentCenterData from '../DeploymentCenter.data';
 import { ISiteState } from '../../../../SiteState';
 import { Guid } from '../../../../utils/Guid';
 import { truncate } from 'lodash-es';
+import { isSameLocation } from '../../../../utils/location';
 
 export const getRuntimeStackSetting = (
   isLinuxApp: boolean,
@@ -622,4 +623,19 @@ export const getUserAssignedIdentityName = (appName: string): string => {
 
 export const isScmTypeValidForContainers = (scmType: ScmType): boolean => {
   return scmType === ScmType.None || scmType === ScmType.GitHubAction || scmType === ScmType.Vsts;
+};
+
+export const isFederatedCredentialsSupported = (identityLocation: string): boolean => {
+  const unsupportedRegions = [
+    'germanynorth',
+    'swedensouth',
+    'swedencentral',
+    'eastasia',
+    'qatarcentral',
+    'brazilsoutheast',
+    'malaysiasouth',
+    'polandcentral',
+  ];
+
+  return !unsupportedRegions.some(region => isSameLocation(region, identityLocation));
 };

--- a/client-react/src/utils/location.ts
+++ b/client-react/src/utils/location.ts
@@ -1,0 +1,94 @@
+import { isEqual } from 'lodash-es';
+
+export function getCanonicalLocation(userFriendlyLocation?: string): string {
+  return userFriendlyLocation
+    ? userFriendlyLocation
+        .replace(/\s+/g, '')
+        .replace('(', '')
+        .replace(')', '')
+        .toLowerCase()
+    : '';
+}
+
+export function isSameLocation(locationA?: string, locationB?: string): boolean {
+  const canonicalLocationA = getCanonicalLocation(locationA);
+  const canonicalLocationB = getCanonicalLocation(locationB);
+
+  return isEqual(canonicalLocationA.toLocaleLowerCase(), canonicalLocationB.toLocaleLowerCase());
+}
+
+export function getUserFriendlyLocation(location: string): string {
+  return locationsMap[location] || location;
+}
+
+const locationsMap: Record<string, string> = {
+  brazilsouth: 'Brazil South',
+  brazilsoutheast: 'Brazil Southeast',
+  centralus: 'Central US',
+  centraluseuap: 'Central US EUAP',
+  eastus2: 'East US 2',
+  eastus2euap: 'East US 2 EUAP',
+  eastus: 'East US',
+  japaneast: 'Japan East',
+  japanwest: 'Japan West',
+  northcentralus: 'North Central US',
+  northcentralusstage: 'North Central US (Stage)',
+  northeurope: 'North Europe',
+  southeastasia: 'Southeast Asia',
+  eastasia: 'East Asia',
+  westeurope: 'West Europe',
+  westus: 'West US',
+  francecentral: 'France Central',
+  francesouth: 'France South',
+  australiasoutheast: 'Australia Southeast',
+  australiaeast: 'Australia East',
+  australiacentral: 'Australia Central',
+  australiacentral2: 'Australia Central 2',
+  southcentralus: 'South Central US',
+  westindia: 'West India',
+  centralindia: 'Central India',
+  southindia: 'South India',
+  ukwest: 'UK West',
+  uksouth: 'UK South',
+  westcentralus: 'West Central US',
+  canadacentral: 'Canada Central',
+  canadaeast: 'Canada East',
+  koreacentral: 'Korea Central',
+  koreasouth: 'Korea South',
+  westus2: 'West US 2',
+  westus3: 'West US 3',
+  southafricanorth: 'South Africa North',
+  switzerlandnorth: 'Switzerland North',
+  germanywestcentral: 'Germany West Central',
+  uaecentral: 'UAE Central',
+  uaenorth: 'UAE North',
+  germanynorth: 'Germany North',
+  norwayeast: 'Norway East',
+  norwaywest: 'Norway West',
+  swedencentral: 'Sweden Central',
+  swedensouth: 'Sweden South',
+  qatarcentral: 'Qatar Central',
+  malaysiasouth: 'Malaysia South',
+  polandcentral: 'Poland Central',
+  //FairFax
+  usdodcentral: 'USDoD Central',
+  usdodeast: 'USDoD East',
+  usgovarizona: 'USGov Arizona',
+  usgoviowa: 'USGov Iowa',
+  usgovtexas: 'USGov Texas',
+  usgovvirginia: 'USGov Virginia',
+  //Mooncake
+  chinanorth: 'China North',
+  chinaeast: 'China East',
+  chinanorth2: 'China North 2',
+  chinaeast2: 'China East 2',
+  chinanorth3: 'China North 3',
+  chinaeast3: 'China East 3',
+
+  //USNat
+  usnateast: 'USNat East',
+  usnatwest: 'USNat West',
+  //USSec
+  usseceast: 'USSec East',
+  ussecwest: 'USSec West',
+};

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2586,6 +2586,7 @@ export class PortalResources {
   public static authenticationSettingsOidcPermissionsValidationError = 'authenticationSettingsOidcPermissionsValidationError';
   public static authenticationSettingsIdentityAssignmentPermissionsError = 'authenticationSettingsIdentityAssignmentPermissionsError';
   public static authenticationSettingsIdentityWritePermissionsError = 'authenticationSettingsIdentityWritePermissionsError';
+  public static authenticationSettingsIdentityUnsupportedRegionError = 'authenticationSettingsIdentityUnsupportedRegionError';
   public static authenticationSettingsIdentityCreationPrerequisitesLinkAriaLabel =
     'authenticationSettingsIdentityCreationPrerequisitesLinkAriaLabel';
   public static authenticationSettingsRoleAssignmentPrerequisitesLinkAriaLabel =

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7900,6 +7900,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="authenticationSettingsIdentityWritePermissionsError" xml:space="preserve">
         <value>This identity does not have write permissions on this app. Please select a different identity, or work with your admin to grant the Website Contributor role to your identity on this app.</value>
     </data>
+    <data name="authenticationSettingsIdentityUnsupportedRegionError" xml:space="preserve">
+        <value>This identity is in a region that does not support creating federated identity credentials. Please select an identity from a different region.</value>
+    </data>
     <data name="authenticationSettingsIdentityCreationPrerequisitesLinkAriaLabel" xml:space="preserve">
         <value>Click here to learn more about how to create a managed identity.</value>
     </data>    


### PR DESCRIPTION
FixesAB#[26315354](https://msazure.visualstudio.com/Antares/_workitems/edit/26315354)

- To fix the "The request format was unexpected: Support for federated identity credentials not enabled"
- https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
-  Listed regions:
    - Germany North
    - Sweden South
    - Sweden Central
    - East Asia
    - Qatar Central
    - Brazil Southeast
    - Malaysia South
    - Poland Central
- Removed ability to create new identity if the app is located in an unsupported region
