### PR TITLE
[DC] Set default auth type to publish profile for containers, save scm settings

### DIFF
--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -12,6 +12,7 @@ import {
   PrivateRegistryFormData,
   ACRCredentialType,
   ManagedIdentityType,
+  AuthType,
 } from '../DeploymentCenter.types';
 import * as Yup from 'yup';
 import { DeploymentCenterFormBuilder } from '../DeploymentCenterFormBuilder';
@@ -51,6 +52,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
       ...this._getDockerHubFormData(serverUrl, username, password, fxVersionParts),
       ...this._getPrivateRegistryFormData(serverUrl, username, password, fxVersionParts),
       ...this.generateCommonFormData(),
+      authType: AuthType.PublishProfile, // NOTE(yoonaoh): We will eventually remove this once ANT101 is deployed and we add OIDC support for Containers
     };
   }
 


### PR DESCRIPTION
FixesAB#[26364085](https://msazure.visualstudio.com/Antares/_workitems/edit/26364085)

- Save button was not enabled because there was a validation error on authType for containers now that OIDC is the default