### PR TITLE
AB#17487428 Enable keyboard to resize detailslist column

### DIFF
--- a/client-react/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/client-react/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -16,8 +16,8 @@ interface ConfirmDialogProps {
   primaryActionButton: { title: string; onClick: () => void; disabled?: boolean };
   defaultActionButton: { title: string; onClick: () => void; disabled?: boolean };
   hideDefaultActionButton?: boolean;
-  title: string;
-  content: string;
+  title?: string;
+  content?: string;
   modalStyles?: IStyleFunctionOrObject<IModalStyleProps, IModalStyles>;
   showCloseModal?: boolean;
 }
@@ -32,6 +32,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps & IDialogProps> = props => {
     content,
     onDismiss,
     showCloseModal,
+    children,
     modalStyles: customModalStyles,
   } = props;
 
@@ -51,6 +52,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps & IDialogProps> = props => {
         <h3 className={headerStyle}>{title}</h3>
         <p>{content}</p>
       </div>
+      {children}
       <DialogFooter styles={modalFooterStyles}>
         <PrimaryButton onClick={primaryActionButton.onClick} text={primaryActionButton.title} disabled={primaryActionButton.disabled} />
         {!hideDefaultActionButton ? (

--- a/client-react/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/client-react/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -16,8 +16,8 @@ interface ConfirmDialogProps {
   primaryActionButton: { title: string; onClick: () => void; disabled?: boolean };
   defaultActionButton: { title: string; onClick: () => void; disabled?: boolean };
   hideDefaultActionButton?: boolean;
-  title?: string;
-  content?: string;
+  title: string;
+  content: string;
   modalStyles?: IStyleFunctionOrObject<IModalStyleProps, IModalStyles>;
   showCloseModal?: boolean;
 }
@@ -32,7 +32,6 @@ const ConfirmDialog: React.FC<ConfirmDialogProps & IDialogProps> = props => {
     content,
     onDismiss,
     showCloseModal,
-    children,
     modalStyles: customModalStyles,
   } = props;
 
@@ -52,7 +51,6 @@ const ConfirmDialog: React.FC<ConfirmDialogProps & IDialogProps> = props => {
         <h3 className={headerStyle}>{title}</h3>
         <p>{content}</p>
       </div>
-      {children}
       <DialogFooter styles={modalFooterStyles}>
         <PrimaryButton onClick={primaryActionButton.onClick} text={primaryActionButton.title} disabled={primaryActionButton.disabled} />
         {!hideDefaultActionButton ? (

--- a/client-react/src/components/DisplayTableWithEmptyMessage/DisplayTableWithEmptyMessage.tsx
+++ b/client-react/src/components/DisplayTableWithEmptyMessage/DisplayTableWithEmptyMessage.tsx
@@ -1,10 +1,28 @@
-import { DetailsList, IDetailsListProps, ShimmeredDetailsList, ThemeProvider } from '@fluentui/react';
-import React, { useContext } from 'react';
+import {
+  ColumnActionsMode,
+  ContextualMenu,
+  DefaultButton,
+  DetailsList,
+  Dialog,
+  DialogFooter,
+  DialogType,
+  IColumn,
+  IContextualMenuProps,
+  IDetailsList,
+  IDetailsListProps,
+  ITextField,
+  PrimaryButton,
+  ShimmeredDetailsList,
+  TextField,
+  ThemeProvider,
+} from '@fluentui/react';
+import React, { useContext, useRef, useState } from 'react';
 import { style } from 'typestyle';
 import { ThemeContext } from '../../ThemeContext';
 import { ThemeExtended } from '../../theme/SemanticColorsExtended';
 import { detailListHeaderStyle } from '../form-controls/formControl.override.styles';
 import { shimmerTheme } from '../shimmer/Shimmer.styles';
+import { useTranslation } from 'react-i18next';
 
 export interface ShimmerProps {
   lines: number;
@@ -36,7 +54,41 @@ export const defaultCellStyle = style({
 type Props = DisplayTableWithEmptyMessageProps & IDetailsListProps;
 const DisplayTableWithEmptyMessage: React.SFC<Props> = props => {
   const theme = useContext(ThemeContext);
+  const { t } = useTranslation();
   const { emptyMessage, shimmer, columns, ...rest } = props;
+
+  const detailsListRef = useRef<IDetailsList>(null);
+  const resizeColumnTextFieldRef = useRef<ITextField>(null);
+  const columnRef = useRef<IColumn>();
+  const [contextualMenuProps, setContextualMenuProps] = React.useState<IContextualMenuProps>();
+  const [isDialogHidden, setIsDialogHidden] = useState(true);
+
+  const hideDialog = () => setIsDialogHidden(true);
+
+  const showDialog = () => setIsDialogHidden(false);
+
+  const onColumnClick = (ev: React.MouseEvent<HTMLElement>, column?: IColumn) => {
+    if (column && column.columnActionsMode !== ColumnActionsMode.disabled && column.isResizable) {
+      columnRef.current = column;
+      setContextualMenuProps({
+        items: [{ key: 'resize', text: t('resize'), onClick: showDialog }],
+        target: ev.currentTarget as HTMLElement,
+        gapSpace: 10,
+        isBeakVisible: true,
+        onDismiss: () => setContextualMenuProps(undefined),
+      });
+    }
+  };
+
+  const confirmColumnResizeDialog = () => {
+    if (columnRef.current && detailsListRef.current && resizeColumnTextFieldRef.current?.value) {
+      const width = Number(resizeColumnTextFieldRef.current?.value);
+      detailsListRef.current.updateColumn(columnRef.current, { width: width });
+    }
+
+    columnRef.current = undefined;
+    hideDialog();
+  };
 
   const updatedColumns = (columns || []).map(column => {
     const allHeaderClassName = `${detailListHeaderStyle} ${column.headerClassName || ''}`;
@@ -59,8 +111,22 @@ const DisplayTableWithEmptyMessage: React.SFC<Props> = props => {
           />
         </ThemeProvider>
       ) : (
-        <DetailsList columns={updatedColumns} {...rest} />
+        <DetailsList columns={updatedColumns} {...rest} componentRef={detailsListRef} onColumnHeaderClick={onColumnClick} />
       )}
+      {contextualMenuProps && <ContextualMenu {...contextualMenuProps} />}
+      <Dialog
+        hidden={isDialogHidden}
+        onDismiss={hideDialog}
+        dialogContentProps={{
+          type: DialogType.normal,
+          title: t('resizeColumnDialogTitle'),
+        }}>
+        <TextField componentRef={resizeColumnTextFieldRef} label={t('resizeColumnDialogTextFieldLabel')} />
+        <DialogFooter>
+          <PrimaryButton onClick={confirmColumnResizeDialog} text={t('ok')} />
+          <DefaultButton onClick={hideDialog} text={t('cancel')} />
+        </DialogFooter>
+      </Dialog>
       {props.items.length === 0 && !!emptyMessage && (!shimmer || !shimmer.show) && (
         <div className={emptyTableMessageStyle(theme)}>{emptyMessage}</div>
       )}

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2595,4 +2595,7 @@ export class PortalResources {
   public static authenticationSettingsOidcPermissionsLinkAriaLabel = 'authenticationSettingsOidcPermissionsLinkAriaLabel';
   public static sshDisabledInfoBubbleMessage = 'sshDisabledInfoBubbleMessage';
   public static staticSite_appSettingsMoved = 'staticSite_appSettingsMoved';
+  public static resize = 'resize';
+  public static resizeColumnDialogTitle = 'resizeColumnDialogTitle';
+  public static resizeColumnDialogTextFieldLabel = 'resizeColumnDialogTextFieldLabel';
 }

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7921,4 +7921,13 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="staticSite_appSettingsMoved" xml:space="preserve">
         <value>App Settings have moved to 'Environment Variables'</value>
     </data>
+    <data name="resize" xml:space="preserve">
+        <value>Resize</value>
+    </data>
+    <data name="resizeColumnDialogTitle" xml:space="preserve">
+        <value>Resize column</value>
+    </data>
+    <data name="resizeColumnDialogTextFieldLabel" xml:space="preserve">
+        <value>Enter desired column width pixels:</value>
+    </data>
 </root>


### PR DESCRIPTION
Fixes: [AB#17487428](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/Germanium/CY24Q1/2Wk/2Wk08%20(Dec%2031%20-%20Jan%2013)?workitem=17487428)

![resizecolumn](https://github.com/Azure/azure-functions-ux/assets/33185278/97aa9d9f-ae92-43db-b329-12456933cf11)


Current solution to solve the acessibility issue on using keyboard to resize the detailslist column: https://developer.microsoft.com/en-us/fluentui#/controls/web/detailslist/keyboardcolumnreorderresize