### PR TITLE
[DC] Only add authType and authIdentity validation for GHA case

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
@@ -152,18 +152,12 @@ export abstract class DeploymentCenterFormBuilder {
         }),
       externalRepoType: Yup.mixed().notRequired(),
       devOpsProjectName: Yup.mixed().notRequired(),
-      authType: Yup.mixed().when('hasPermissionToUseOIDC', {
-        is: true,
-        then: Yup.mixed().test('authTypeRequired', this._t('deploymentCenterFieldRequiredMessage'), function(value) {
-          return !!value;
-        }),
-        otherwise: Yup.mixed().test('authIdentityPopulated', this._t('authenticationSettingsOidcPermissionsValidationError'), function(
-          value
-        ) {
-          return value !== AuthType.Oidc || !!this.parent.authIdentity.resourceId;
-        }),
+      authType: Yup.mixed().test('authTypeRequired', this._t('deploymentCenterFieldRequiredMessage'), function(value) {
+        return this.parent.sourceProvider === ScmType.GitHubAction ? !!value : true;
       }),
-      authIdentity: Yup.mixed().notRequired(),
+      authIdentity: Yup.mixed().test('authIdentityRequired', this._t('deploymentCenterFieldRequiredMessage'), function(value) {
+        return this.parent.sourceProvider === ScmType.GitHubAction && this.parent.authType === AuthType.Oidc ? !!value.resourceId : true;
+      }),
       hasPermissionToUseOIDC: Yup.boolean().notRequired(),
     };
   }


### PR DESCRIPTION
FixesAB#[26390859](https://msazure.visualstudio.com/Antares/_workitems/edit/26390859)
- We should only be validating on authType and authIdentity when we're dealing with a Code GHA app

![image](https://github.com/Azure/azure-functions-ux/assets/29874289/945ceb24-932e-4b5b-9209-45788d90ad78)
