### PR TITLE
updating Functions .NET default

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
@@ -20,7 +20,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
         minorVersions: [
           {
             displayText: '.NET Framework 4.8',
-            value: '4.8',
+            value: '.NET Framework 4.8',
             stackSettings: {
               windowsRuntimeSettings: {
                 runtimeVersion: 'v4.0',
@@ -56,6 +56,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
               windowsRuntimeSettings: {
                 runtimeVersion: 'v8.0',
                 isHidden: false,
+                isDefault: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -78,6 +79,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
               linuxRuntimeSettings: {
                 runtimeVersion: 'DOTNET-ISOLATED|8.0',
                 isHidden: false,
+                isDefault: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -156,16 +158,15 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
         ],
       },
       {
-        displayText: '.NET 6',
+        displayText: '.NET 6 In-process',
         value: 'dotnet6',
         minorVersions: [
           {
-            displayText: '.NET 6 (LTS)',
-            value: '6 (LTS)',
+            displayText: '.NET 6 (LTS) In-process',
+            value: '6 (LTS) In-process',
             stackSettings: {
               windowsRuntimeSettings: {
                 runtimeVersion: 'v6.0',
-                isDefault: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -186,7 +187,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
               },
               linuxRuntimeSettings: {
                 runtimeVersion: 'DOTNET|6.0',
-                isDefault: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,


### PR DESCRIPTION
Updating the default from .NET 6 using the in-process model to .NET 8 using the isolated worker model.

To prevent confusion, this PR also makes sure to add qualifiers for the in-process model.

.NET Framework 4.8 notably doesn't have any specification of it being the isolated worker model. I'm leaving that to prevent long strings and because we do not want to inadvertently conflate "isolated" with a brand term of .NET's. We might be able to restructure these strings a bit if we wanted to add it (add a ", " or something) separately in the future. This is considered out of scope for this PR.