### PR TITLE
[DC] Default auth type to publish profile and change only for GHA

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
@@ -41,7 +41,7 @@ export abstract class DeploymentCenterFormBuilder {
       gitHubPublishProfileSecretGuid: '',
       externalRepoType: RepoTypeOptions.Public,
       devOpsProject: '',
-      authType: AuthType.Oidc,
+      authType: AuthType.PublishProfile,
       authIdentity: {
         id: '',
         name: '',


### PR DESCRIPTION
FixesAB#[26615427](https://msazure.visualstudio.com/Antares/_workitems/edit/26615427)

Save button was enabling because we were changing authType from OIDC -> Publish Profile for all non-GHA scenarios

**Before**
![image](https://github.com/Azure/azure-functions-ux/assets/29874289/d449a2f8-89e6-4bf3-85d6-9b5132c13333)


**After**
![image](https://github.com/Azure/azure-functions-ux/assets/29874289/49fcac40-309a-4ac9-aad5-3a6a86e943af)
