### PR TITLE
[DC] Handle ARC case for basic publishing credentials check

### DIFF
--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeFormBuilder.ts
@@ -21,7 +21,7 @@ export class DeploymentCenterCodeFormBuilder extends DeploymentCenterFormBuilder
   }
 
   public generateYupValidationSchema(): DeploymentCenterYupValidationSchemaType<DeploymentCenterCodeFormData> {
-    const scmAllowed = this._basicPublishingCredentialsPolicies.scm.allow;
+    const scmAllowed = this._basicPublishingCredentialsPolicies?.scm.allow;
     return Yup.object().shape({
       sourceProvider: Yup.mixed().test('sourceProviderRequired', this._t('deploymentCenterFieldRequiredMessage'), function(value) {
         return value !== ScmType.None || (value === ScmType.None && this.parent.publishingUsername);

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerFormBuilder.ts
@@ -57,7 +57,7 @@ export class DeploymentCenterContainerFormBuilder extends DeploymentCenterFormBu
   }
 
   public generateYupValidationSchema(): DeploymentCenterYupValidationSchemaType<DeploymentCenterContainerFormData> {
-    const scmAllowed = this._basicPublishingCredentialsPolicies.scm.allow;
+    const scmAllowed = this._basicPublishingCredentialsPolicies?.scm.allow;
     return Yup.object().shape({
       scmType: Yup.mixed()
         .required(this._t('deploymentCenterFieldRequiredMessage'))


### PR DESCRIPTION
FixesAB#[26631629](https://msazure.visualstudio.com/Antares/_workitems/edit/26631629)
Deployment Center blade was not loading because ARC apps don't have basic publishing credentials