### PR TITLE
[DC] Disable Manage Publish Profile Button and bring back FTP Credentials Tab

### DIFF
--- a/client-react/src/pages/app/app-settings/GeneralSettings/Platform.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/Platform.tsx
@@ -149,7 +149,7 @@ const Platform: React.FC<FormikProps<AppSettingsFormValues>> = props => {
             component={RadioButton}
             label={t('ftpBasicAuthPublishingCredentials')}
             infoBubbleMessage={t('basicAuthPublishingCredInfoBubbleMessage')}
-            learnMoreLink={Links.ftpDisabledByPolicyLink}
+            learnMoreLink={Links.disableBasicAuthLearnMore}
             id="app-settings-ftp-basic-authentication-publishing-creds"
             disabled={disableAllControls}
             options={[

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -74,7 +74,7 @@ export enum RuntimeStackOptions {
   Dotnet = 'dotnet',
   DotnetIsolated = 'dotnet-isolated',
   Go = 'go',
-  WordPress = 'wordpress',  // NOTE(zmohammed): This is not really a part of runtime stack, we just need it for showing the code integration view in Deployment Center.
+  WordPress = 'wordpress', // NOTE(zmohammed): This is not really a part of runtime stack, we just need it for showing the code integration view in Deployment Center.
 }
 
 export enum RuntimeStackDisplayNames {
@@ -464,6 +464,7 @@ export interface DeploymentCenterContainerCommandBarProps extends DeploymentCent
 }
 
 export interface DeploymentCenterPublishProfilePanelProps {
+  isBasicAuthDisabled: boolean;
   isPanelOpen: boolean;
   dismissPanel: () => void;
   resetApplicationPassword: () => void;

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterCommandBar.tsx
@@ -10,7 +10,6 @@ import { ScmType } from '../../../models/site/config';
 import { PortalContext } from '../../../PortalContext';
 import { getTelemetryInfo } from './utility/DeploymentCenterUtility';
 import { CommonConstants } from '../../../utils/CommonConstants';
-import { DeploymentCenterPublishingContext } from './authentication/DeploymentCenterPublishingContext';
 
 const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = props => {
   const {
@@ -28,10 +27,8 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
   const portalContext = useContext(PortalContext);
   const siteStateContext = useContext(SiteStateContext);
   const deploymentCenterContext = useContext(DeploymentCenterContext);
-  const deploymentCenterPublishingContext = useContext(DeploymentCenterPublishingContext);
   const overflowButtonProps: IButtonProps = { ariaLabel: t('moreCommands') };
   const hasNoWritePermission = deploymentCenterContext && !deploymentCenterContext.hasWritePermission;
-  const isBasicAuthDisabled = !deploymentCenterPublishingContext?.basicPublishingCredentialsPolicies?.scm.allow;
 
   const isSiteLoaded = () => {
     return siteStateContext.site && siteStateContext.site.properties;
@@ -218,7 +215,7 @@ const DeploymentCenterCommandBar: React.FC<DeploymentCenterCommandBarProps> = pr
         iconName: 'FileCode',
       },
       ariaLabel: t('deploymentCenterPublishProfileCommandAriaLabel'),
-      disabled: !isSiteLoaded() || isBasicAuthDisabled,
+      disabled: !isSiteLoaded(),
       onClick: onManagePublishProfileButtonClick,
     };
   };

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterDataLoader.tsx
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterDataLoader.tsx
@@ -58,6 +58,10 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
   );
   const [isIlbASE, setIsIlbASE] = useState<boolean>(false);
   const [isDataRefreshing, setIsDataRefreshing] = useState(true);
+  const isBasicAuthDisabled = React.useMemo(
+    () => !(basicPublishingCredentialsPolicies?.ftp.allow || basicPublishingCredentialsPolicies?.scm.allow),
+    [basicPublishingCredentialsPolicies?.ftp.allow, basicPublishingCredentialsPolicies?.scm.allow]
+  );
 
   const processPublishProfileResponse = (publishProfileResponse: HttpResponseObject<string>) => {
     if (publishProfileResponse.metadata.success) {
@@ -340,6 +344,7 @@ const DeploymentCenterDataLoader: React.FC<DeploymentCenterDataLoaderProps> = pr
         )}
         {/* NOTE(michinoy): Load the publishing profile panel which is common between both code and container experiences  */}
         <DeploymentCenterPublishProfilePanel
+          isBasicAuthDisabled={isBasicAuthDisabled}
           isPanelOpen={isPublishProfilePanelOpen}
           dismissPanel={dismissPublishProfilePanel}
           resetApplicationPassword={resetApplicationPassword}

--- a/client-react/src/pages/app/deployment-center/authentication/DeploymentCenterFtps.tsx
+++ b/client-react/src/pages/app/deployment-center/authentication/DeploymentCenterFtps.tsx
@@ -77,7 +77,9 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
     setShowWarningBanner(false);
   };
 
-  const disableFtp = () => !deploymentCenterPublishingContext?.basicPublishingCredentialsPolicies?.ftp?.allow;
+  const disableFtp = React.useMemo(() => !deploymentCenterPublishingContext?.basicPublishingCredentialsPolicies?.ftp?.allow, [
+    deploymentCenterPublishingContext?.basicPublishingCredentialsPolicies?.ftp?.allow,
+  ]);
 
   const getCredentialsControls = () => {
     return (
@@ -93,7 +95,7 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
           </div>
         )}
 
-        {deploymentCenterPublishingContext && disableFtp() && showWarningBanner && (
+        {deploymentCenterPublishingContext && disableFtp && showWarningBanner && (
           <div className={deploymentCenterInfoBannerDiv}>
             <CustomBanner
               id="deployment-center-ftps-permission-warning"
@@ -114,6 +116,7 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
           value={ftpsEndpoint}
           copyButton={true}
           readOnly={true}
+          disabled={disableFtp}
         />
 
         {isScmLocalGit && (
@@ -125,6 +128,7 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
             value={gitCloneUri ? gitCloneUri : t('deploymentCenterCodeLocalGitFetchCloneUriError')}
             copyButton={true}
             readOnly={true}
+            disabled={disableFtp}
           />
         )}
 
@@ -149,6 +153,7 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
           value={publishingProfile && publishingProfile.userName}
           copyButton={true}
           readOnly={true}
+          disabled={disableFtp}
         />
 
         {isScmLocalGit && (
@@ -160,6 +165,7 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
             value={gitUsername}
             copyButton={true}
             readOnly={true}
+            disabled={disableFtp}
           />
         )}
 
@@ -172,6 +178,7 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
             value={publishingProfile && publishingProfile.userPWD}
             copyButton={true}
             readOnly={true}
+            disabled={disableFtp}
             type={TextFieldType.password}
             canRevealPassword
             revealPasswordAriaLabel={t('showApplicationPasswordAriaLabel')}
@@ -181,6 +188,7 @@ const DeploymentCenterFtps: React.FC<DeploymentCenterFtpsProps &
                 key="deployment-center-ftps-application-password-reset"
                 className={additionalTextFieldControl}
                 ariaLabel={t('resetPublishProfileAriaLabel')}
+                disabled={disableFtp}
                 onClick={toggleResetCalloutVisibility}
                 iconProps={{ iconName: 'refresh' }}>
                 {t('reset')}

--- a/client-react/src/pages/app/deployment-center/authentication/DeploymentCenterPublishingUser.tsx
+++ b/client-react/src/pages/app/deployment-center/authentication/DeploymentCenterPublishingUser.tsx
@@ -43,6 +43,9 @@ const DeploymentCenterPublishingUser: React.FC<DeploymentCenterFtpsProps &
   const { fullpageElementWithLabel } = useFullPage();
 
   const { publishingUser, publishingUserFetchFailedMessage } = deploymentCenterPublishingContext;
+  const disableFtp = React.useMemo(() => !deploymentCenterPublishingContext?.basicPublishingCredentialsPolicies?.ftp?.allow, [
+    deploymentCenterPublishingContext?.basicPublishingCredentialsPolicies?.ftp?.allow,
+  ]);
 
   const publishingUserLoading = !publishingUser && !publishingUserFetchFailedMessage;
   const publishingUserError = !publishingUser && publishingUserFetchFailedMessage;
@@ -148,6 +151,7 @@ const DeploymentCenterPublishingUser: React.FC<DeploymentCenterFtpsProps &
             component={TextField}
             label={t('deploymentCenterUserScopeUsernameLabel')}
             widthOverride={'100%'}
+            disabled={disableFtp}
           />
 
           <div className={ftpsPasswordTextboxStyle(fullpageElementWithLabel)}>
@@ -161,12 +165,14 @@ const DeploymentCenterPublishingUser: React.FC<DeploymentCenterFtpsProps &
               canRevealPassword
               revealPasswordAriaLabel={t('showProviderPasswordAriaLabel')}
               widthOverride={'100%'}
+              disabled={disableFtp}
               additionalControls={[
                 <ActionButton
                   id="deployment-center-ftps-provider-password-reset"
                   key="deployment-center-ftps-provider-password-reset"
                   className={additionalTextFieldControl}
                   ariaLabel={t('resetUserScopeCredentialsAriaLabel')}
+                  disabled={disableFtp}
                   onClick={toggleResetCalloutVisibility}
                   iconProps={{ iconName: 'refresh' }}>
                   {t('reset')}
@@ -184,6 +190,7 @@ const DeploymentCenterPublishingUser: React.FC<DeploymentCenterFtpsProps &
               canRevealPassword
               revealPasswordAriaLabel={t('showProviderConfirmPasswordAriaLabel')}
               widthOverride={'100%'}
+              disabled={disableFtp}
             />
           </div>
 

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodePivot.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodePivot.tsx
@@ -131,9 +131,9 @@ const DeploymentCenterCodePivot: React.FC<DeploymentCenterCodePivotProps> = prop
 
     if (siteStateContext && siteStateContext.site) {
       const scenarioStatus = scenarioService.checkScenario(ScenarioIds.ftpSource, { site: siteStateContext.site }).status;
-      setShowFtpsTab(scenarioStatus !== 'disabled' && !!deploymentCenterPublishingContext?.basicPublishingCredentialsPolicies?.scm.allow);
+      setShowFtpsTab(scenarioStatus !== 'disabled');
     }
-  }, [siteStateContext.site, isScmGitHubActions, deploymentCenterPublishingContext?.basicPublishingCredentialsPolicies?.scm.allow]);
+  }, [siteStateContext.site, isScmGitHubActions]);
 
   useEffect(() => {
     const scmType = deploymentCenterContext.siteConfig?.properties?.scmType;

--- a/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPivot.tsx
+++ b/client-react/src/pages/app/deployment-center/container/DeploymentCenterContainerPivot.tsx
@@ -51,8 +51,6 @@ const DeploymentCenterContainerPivot: React.FC<DeploymentCenterContainerPivotPro
     return isFtpsDirty(formProps, deploymentCenterPublishingContext);
   };
 
-  const showFtpsTab = !!deploymentCenterPublishingContext?.basicPublishingCredentialsPolicies?.scm.allow;
-
   return (
     <>
       <Pivot onLinkClick={onLinkClick} defaultSelectedKey={tab ?? 'settings'}>
@@ -102,17 +100,15 @@ const DeploymentCenterContainerPivot: React.FC<DeploymentCenterContainerPivotPro
           </PivotItem>
         )}
 
-        {showFtpsTab && (
-          <PivotItem
-            itemKey="ftps"
-            headerText={t('deploymentCenterPivotItemFtpsHeaderText')}
-            ariaLabel={t('deploymentCenterPivotItemFtpsAriaLabel')}
-            onRenderItemLink={(link: IPivotItemProps, defaultRenderer: (link: IPivotItemProps) => JSX.Element) =>
-              CustomTabRenderer(link, defaultRenderer, theme, isFtpsTabDirty, t('modifiedTag'))
-            }>
-            <DeploymentCenterFtps formProps={formProps} isDataRefreshing={isDataRefreshing} />
-          </PivotItem>
-        )}
+        <PivotItem
+          itemKey="ftps"
+          headerText={t('deploymentCenterPivotItemFtpsHeaderText')}
+          ariaLabel={t('deploymentCenterPivotItemFtpsAriaLabel')}
+          onRenderItemLink={(link: IPivotItemProps, defaultRenderer: (link: IPivotItemProps) => JSX.Element) =>
+            CustomTabRenderer(link, defaultRenderer, theme, isFtpsTabDirty, t('modifiedTag'))
+          }>
+          <DeploymentCenterFtps formProps={formProps} isDataRefreshing={isDataRefreshing} />
+        </PivotItem>
       </Pivot>
     </>
   );

--- a/client-react/src/pages/app/deployment-center/publish-profile/DeploymentCenterPublishProfilePanel.tsx
+++ b/client-react/src/pages/app/deployment-center/publish-profile/DeploymentCenterPublishProfilePanel.tsx
@@ -5,12 +5,29 @@ import DeploymentCenterPublishProfileCommandBar from './DeploymentCenterPublishP
 import CustomPanel from '../../../../components/CustomPanel/CustomPanel';
 import { PanelType, PrimaryButton } from '@fluentui/react';
 import { closePublishProfileButtonStyle, panelOverflowStyle } from '../DeploymentCenter.styles';
+import ConfirmDialog from '../../../../components/ConfirmDialog/ConfirmDialog';
 
 const DeploymentCenterPublishProfilePanel: React.FC<DeploymentCenterPublishProfilePanelProps> = props => {
-  const { isPanelOpen: isOpen, dismissPanel, resetApplicationPassword } = props;
+  const { isBasicAuthDisabled, isPanelOpen: isOpen, dismissPanel, resetApplicationPassword } = props;
   const { t } = useTranslation();
 
-  return (
+  return isBasicAuthDisabled ? (
+    <ConfirmDialog
+      primaryActionButton={{
+        title: t('ok'),
+        onClick: dismissPanel,
+      }}
+      defaultActionButton={{
+        title: t('cancel'),
+        onClick: dismissPanel,
+      }}
+      hideDefaultActionButton={true}
+      title={t('managePublishProfile')}
+      content={t('managePublishProfileBasicAuthDisabled')}
+      hidden={!isOpen}
+      onDismiss={dismissPanel}
+    />
+  ) : (
     <CustomPanel
       customStyle={panelOverflowStyle}
       isOpen={isOpen}

--- a/client-react/src/utils/FwLinks.ts
+++ b/client-react/src/utils/FwLinks.ts
@@ -58,6 +58,7 @@ export const Links = {
   connectionStringLearnmore: 'https://go.microsoft.com/fwlink/?linkid=2225650',
   customErrorPagesLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2245451',
   endToEndEncryptionLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2252411',
+  disableBasicAuthLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2260316',
 };
 
 export const DeploymentCenterLinks = {

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2055,6 +2055,7 @@ export class PortalResources {
   public static deploymentCenterDeleteLogsFailureWithErrorNotificationDescription =
     'deploymentCenterDeleteLogsFailureWithErrorNotificationDescription';
   public static managePublishProfile = 'managePublishProfile';
+  public static managePublishProfileBasicAuthDisabled = 'managePublishProfileBasicAuthDisabled';
   public static ibizafication_readOnlyPython = 'ibizafication_readOnlyPython';
   public static ibizafication_readOnlyJava = 'ibizafication_readOnlyJava';
   public static ibizafication_readOnlyLocalCache = 'ibizafication_readOnlyLocalCache';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -6337,7 +6337,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
         <value>Manage publish profile</value>
     </data>
     <data name="managePublishProfileBasicAuthDisabled" xml:space="preserve">
-        <value>Basic authentication is disabled, and publish profile will not work.</value>
+        <value>Basic authentication is disabled.</value>
     </data>
     <data name="ibizafication_readOnlyPython" xml:space="preserve">
         <value>Editing Python Function Apps is not supported in the Azure portal. Use your local development environment to edit this function.</value>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -6336,6 +6336,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="managePublishProfile" xml:space="preserve">
         <value>Manage publish profile</value>
     </data>
+    <data name="managePublishProfileBasicAuthDisabled" xml:space="preserve">
+        <value>Basic authentication is disabled, and publish profile will not work.</value>
+    </data>
     <data name="ibizafication_readOnlyPython" xml:space="preserve">
         <value>Editing Python Function Apps is not supported in the Azure portal. Use your local development environment to edit this function.</value>
     </data>


### PR DESCRIPTION
Task#[26718903](https://msazure.visualstudio.com/Antares/_workitems/edit/26718903)

- When either ftp or scm basic auth is enabled, manage publish profile will work; otherwise, show dialog saying basic auth is disabled
- FTP Credentials Tab will always be shown, but if ftp basic auth is disabled, all controls will be disabled and warning banner will show

![image](https://github.com/Azure/azure-functions-ux/assets/29874289/8e8bf069-da00-4b2c-bf9f-e56580e6b6c5)
![image](https://github.com/Azure/azure-functions-ux/assets/29874289/0f1dbd1a-0491-4ab7-b862-d7c6d863b4e1)
