### PR TITLE
Unhide PowerShell 7.4 runtime for Windows only

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
@@ -25,7 +25,7 @@ const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (use
                 runtimeVersion: '7.4',
                 isDefault: false,
                 isPreview: true,
-                isHidden: true,
+                isHidden: false,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -54,7 +54,7 @@ const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (use
                 runtimeVersion: 'PowerShell|7.4',
                 isDefault: false,
                 isPreview: true,
-                isHidden: true,
+                isHidden: false,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
@@ -54,7 +54,7 @@ const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (use
                 runtimeVersion: 'PowerShell|7.4',
                 isDefault: false,
                 isPreview: true,
-                isHidden: false,
+                isHidden: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,


### PR DESCRIPTION
Unhide PowerShell 7.4 runtime for Windows only.