### PR TITLE
Unhide PowerShell 7.4 runtime for Windows only (#7590)

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Powershell.ts
@@ -25,7 +25,7 @@ const getPowershellStack: (useIsoDateFormat: boolean) => FunctionAppStack = (use
                 runtimeVersion: '7.4',
                 isDefault: false,
                 isPreview: true,
-                isHidden: true,
+                isHidden: false,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,


### PR DESCRIPTION
Cherry-picked https://github.com/Azure/azure-functions-ux/pull/7590 to the `release-s234` branch. 