### PR TITLE
[Functions] Unable to enable/disable runtime scale monitoring

### DIFF
--- a/client-react/src/mocks/ArmMocks.ts
+++ b/client-react/src/mocks/ArmMocks.ts
@@ -239,7 +239,7 @@ export const mockWebConfig = {
     http20Enabled: false,
     minTlsVersion: '1.2',
     ftpsState: 'AllAllowed',
-    reservedInstanceCount: 0,
+    minimumElasticInstanceCount: 0,
   },
 };
 

--- a/client-react/src/models/site/config.ts
+++ b/client-react/src/models/site/config.ts
@@ -89,7 +89,7 @@ export interface SiteConfig {
   appCommandLine: string;
   ipSecurityRestrictions?: IpRestriction[];
   scmIpSecurityRestrictions?: IpRestriction[];
-  reservedInstanceCount?: number;
+  minimumElasticInstanceCount?: number; // Used to be reservedInstanceCount in 2018-11-01
   functionsRuntimeScaleMonitoringEnabled?: boolean;
   powerShellVersion?: string;
   ClusteringEnabled?: boolean;

--- a/client-react/src/pages/app/app-settings/FunctionRuntimeSettings/RuntimeScaleMonitoring.tsx
+++ b/client-react/src/pages/app/app-settings/FunctionRuntimeSettings/RuntimeScaleMonitoring.tsx
@@ -56,7 +56,7 @@ const RuntimeScaleMonitoring: React.FC<AppSettingsFormProps & WithTranslation> =
         {
           key: true,
           text: t('on'),
-          disabled: !values.config.properties.reservedInstanceCount || !scaleMonitoringSupported(),
+          disabled: !values.config.properties.minimumElasticInstanceCount || !scaleMonitoringSupported(),
         },
         {
           key: false,


### PR DESCRIPTION
Use 2022-03-01 name (`minimumElasticInstanceCount`) instead of 2018-11-01 name (`reservedInstanceCount`).

[AB#27264546](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/27264546)