### PR TITLE
[Functions] Fix edit mode not being set...

### DIFF
--- a/client-react/src/models/site/site.ts
+++ b/client-react/src/models/site/site.ts
@@ -90,7 +90,7 @@ export enum CipherSuite {
 
 export interface Site {
   name: string;
-  /** @note `state` can be `null` for Function Apps on Azure Container Apps */
+  /** @note (joechung): `state` can be `null` for Function Apps on Azure Container Apps */
   state: string | null;
   defaultHostName: string;
   hostNames: string[];

--- a/client-react/src/models/site/site.ts
+++ b/client-react/src/models/site/site.ts
@@ -90,7 +90,8 @@ export enum CipherSuite {
 
 export interface Site {
   name: string;
-  state: string;
+  /** @note `state` can be `null` for Function Apps on Azure Container Apps */
+  state: string | null;
   defaultHostName: string;
   hostNames: string[];
   webSpace: string;

--- a/client-react/src/pages/app/SiteRouter.tsx
+++ b/client-react/src/pages/app/SiteRouter.tsx
@@ -120,7 +120,8 @@ const SiteRouter: React.FC<RouteComponentProps<SiteRouterProps>> = () => {
         const editMode = await resolveState(portalContext, trimmedResourceId, site, appSettings, resourceId);
         const isWPApplication = isWordPressApp(site);
         setSite(site);
-        setStopped(site.properties.state.toLocaleLowerCase() === CommonConstants.SiteStates.stopped);
+        /** @note (joechung): `state` can be `null` for Function Apps on Azure Container Apps. Ignore `stopped` since we do not expose Start/Stop commands for those. */
+        setStopped(site.properties.state?.toLocaleLowerCase() === CommonConstants.SiteStates.stopped);
         setIsLinuxApplication(isLinuxApp(site));
         setIsContainerApplication((isContainerApp(site) || isContainerAppEnvironmentApp(site)) && !isWPApplication);
         setIsFunctionApplication(isFunctionApp(site));


### PR DESCRIPTION
[Functions] Fix edit mode not being set for Function Apps on Azure Container Apps

[AB#27515505](https://msazure.visualstudio.com/9912b5ff-89a4-4651-bae2-9452eb7992a8/_workitems/edit/27515505)

The function app should be read-only when deployed on Azure Container Apps.

![image](https://github.com/Azure/azure-functions-ux/assets/26208574/396f44cb-992a-427f-81b9-742ddff919fd)
