### PR TITLE
Bump yup to 0.28.5 in /client-react

### DIFF
--- a/client-react/package-lock.json
+++ b/client-react/package-lock.json
@@ -3543,9 +3543,9 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
     },
     "@types/yup": {
-      "version": "0.26.37",
-      "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.26.37.tgz",
-      "integrity": "sha512-cDqR/ez4+iAVQYOwadXjKX4Dq1frtnDGV2GNVKj3aUVKVCKRvsr8esFk66j+LgeeJGmrMcBkkfCf3zk13MjV7A==",
+      "version": "0.28.3",
+      "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.28.3.tgz",
+      "integrity": "sha512-0Sir2LxOmupF8HBUvpJoZghLmOqKfZsBk1GYlMwSIccLDDUoN04LHvo0KzDp9qxt1IKf9Fudpj35SrJ8VqetkQ==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -8244,9 +8244,9 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
     },
     "fn-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-3.0.0.tgz",
+      "integrity": "sha512-eNMNr5exLoavuAMhIUVsOKF79SWd/zG104ef6sxBTSw+cZc6BXdQXDvYcGvp0VbxVVSp1XDUNoz7mg1xMtSznA=="
     },
     "follow-redirects": {
       "version": "1.15.6",
@@ -13966,9 +13966,9 @@
       }
     },
     "property-expr": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
-      "integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -14512,11 +14512,6 @@
       "requires": {
         "regenerate": "^1.4.2"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regenerator-transform": {
       "version": "0.15.2",
@@ -15615,9 +15610,9 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "synchronous-promise": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.15.tgz",
-      "integrity": "sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg=="
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.17.tgz",
+      "integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g=="
     },
     "tailwindcss": {
       "version": "3.3.5",
@@ -15800,7 +15795,7 @@
     "toposort": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-      "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA="
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "totalist": {
       "version": "3.0.1",
@@ -16976,26 +16971,17 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "yup": {
-      "version": "0.26.10",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.26.10.tgz",
-      "integrity": "sha1-NUWDlmMokDj68l+s/AfhH9Z8DLE=",
+      "version": "0.28.5",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.28.5.tgz",
+      "integrity": "sha512-7JZcvpUGUxMKoaEtcoMEM8lCWRaueGNH/A3EhL/UWqfbFm3uloiI+x59Yq4nzhbbYWUTwAsCteaZOJ+VbqI1uw==",
       "requires": {
-        "@babel/runtime": "7.0.0",
-        "fn-name": "~2.0.1",
-        "lodash": "^4.17.10",
-        "property-expr": "^1.5.0",
-        "synchronous-promise": "^2.0.5",
+        "@babel/runtime": "^7.9.6",
+        "fn-name": "~3.0.0",
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.11",
+        "property-expr": "^2.0.2",
+        "synchronous-promise": "^2.0.10",
         "toposort": "^2.0.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-          "integrity": "sha1-ret4/t/IVaoFvAQWQPP2+Y6FQkw=",
-          "requires": {
-            "regenerator-runtime": "^0.12.0"
-          }
-        }
       }
     }
   }

--- a/client-react/package.json
+++ b/client-react/package.json
@@ -31,7 +31,7 @@
     "typestyle": "^2.0.1",
     "xterm-for-react": "^1.0.4",
     "yaml-lint": "^1.7.0",
-    "yup": "^0.26.10"
+    "yup": "0.28.5"
   },
   "scripts": {
     "start": "react-app-rewired start",
@@ -54,7 +54,7 @@
     "@types/react": "^17.0.80",
     "@types/react-dom": "^17.0.25",
     "@types/webpack-env": "^1.18.4",
-    "@types/yup": "^0.26.37",
+    "@types/yup": "0.28.3",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "axios-mock-adapter": "^1.22.0",


### PR DESCRIPTION
- `@types/yup` 0.28.3
- `yup` 0.28.5

Fix `property-expr` vulnerability by updating to 2.0.6 (via `yup` update).