### PR TITLE
AB#27799522: Query the location and stack based stacks api call for dotnet-isolated with stack value as dotnet

### DIFF
--- a/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
@@ -49,6 +49,7 @@ import RuntimeStackService from '../../../ApiHelpers/RuntimeStackService';
 import { AppStackOs } from '../../../models/stacks/app-stacks';
 import { FunctionAppStack } from '../../../models/stacks/function-app-stacks';
 import { CommonConstants, ExperimentationConstants } from '../../../utils/CommonConstants';
+import { RuntimeStacks } from '../../../utils/stacks-utils';
 
 export interface AppSettingsDataLoaderProps {
   children: (props: {

--- a/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
@@ -162,6 +162,7 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
     if (!loadingFailed) {
       if (isFunctionApp(site.data)) {
         const os = isLinux ? AppStackOs.linux : AppStackOs.windows;
+        const stack = site.data.properties.functionAppConfig?.runtime?.name;
         const stackValueForStacksAPI = (stack === RuntimeStacks.dotnetIsolated || stack === RuntimeStacks.dotnet) ? RuntimeStacks.dotnet : stack;
         const stacksResponse =
           isFlexConsumption(site.data) && stackValueForStacksAPI

--- a/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
@@ -162,10 +162,10 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
     if (!loadingFailed) {
       if (isFunctionApp(site.data)) {
         const os = isLinux ? AppStackOs.linux : AppStackOs.windows;
-        const stack = site.data.properties.functionAppConfig?.runtime?.name;
+        const stackValueForStacksAPI = (stack === RuntimeStacks.dotnetIsolated || stack === RuntimeStacks.dotnet) ? RuntimeStacks.dotnet : stack;
         const stacksResponse =
-          isFlexConsumption(site.data) && stack
-            ? await RuntimeStackService.getFunctionAppConfigurationStackForLocation(os, site.data.location, stack)
+          isFlexConsumption(site.data) && stackValueForStacksAPI
+            ? await RuntimeStackService.getFunctionAppConfigurationStackForLocation(os, site.data.location, stackValueForStacksAPI)
             : await RuntimeStackService.getFunctionAppConfigurationStacks(os);
         if (stacksResponse.metadata.status && !!stacksResponse.data.value) {
           const allFunctionAppStacks: FunctionAppStack[] = [];


### PR DESCRIPTION
**Before**:
<img width="1454" alt="image" src="https://github.com/Azure/azure-functions-ux/assets/14221995/58a86033-8259-4eba-a289-737301619eac">


**After**:
<img width="1326" alt="image" src="https://github.com/Azure/azure-functions-ux/assets/14221995/5deb29c1-b891-4534-adf8-9d3b8f06cfbd">
