### PR TITLE
Enable PHP|8.3 for all

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Php.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Php.ts
@@ -28,7 +28,6 @@ const getPhpStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForma
             stackSettings: {
               linuxRuntimeSettings: {
                 runtimeVersion: 'PHP|8.3',
-                isHidden: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: false,


### PR DESCRIPTION
Currently, PHP|8.3 is behind the flag and now testing is done so removing this flag.
And this change will be included in the next release cycle.

**Testing Steps**
1. Accessed the portal with the flag websitesextension_showHiddenStacks=true.
2. Created the app successfully.
3. Scm portal also loaded successfully.
4. Was able to deploy sample app successfully.

Portal URL
[Create Web App - Microsoft Azure](https://ms.portal.azure.com/?feature.canmodifystamps=true&WebsitesExtension=canary&feature.fastmanifest=false&nocdn=force&websitesextension_functionsnext=true&WebsitesExtension_useReactFrameBlade=true&websitesextension_newchangeasp=true&feature.fullscreenblades=true&websitesextension_loglevel=verbose&Microsoft_Azure_PaasServerless_functionsnext=true&Microsoft_Azure_PaasServerless=canary&websitesextension_showHiddenStacks=true#create/Microsoft.WebSite)

App
[Microsoft Azure App Service - Welcome (hahahha.azurewebsites.net)](https://hahahha.azurewebsites.net/)


Sample App - https://github.com/Azure-Samples/php-docs-hello-world
A git base deployment.
![image](https://github.com/Azure/azure-functions-ux/assets/112485097/d9698bcd-9339-457e-b117-7f9cc725559e)
