### PR TITLE
AB# 27922292: [BugBash][FunctionApp][FlexConsumption] Unsupported Stack versions shown in the configuration

### DIFF
--- a/client-react/src/pages/app/app-settings/GeneralSettings/stacks/function-app/FunctionAppStackSettings.data.ts
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/stacks/function-app/FunctionAppStackSettings.data.ts
@@ -11,20 +11,24 @@ export const getStackVersionDropdownOptions = (
 ): IDropdownOption[] => {
   const stackMinorVersions: IDropdownOption[] = [];
 
-  stack.majorVersions.forEach(stackMajorVersion => {
-    stackMajorVersion.minorVersions.forEach(stackMinorVersion => {
+  for (const stackMajorVersion of stack.majorVersions) {
+    for (const stackMinorVersion of stackMajorVersion.minorVersions) {
       const settings =
         osType === AppStackOs.windows
           ? stackMinorVersion.stackSettings.windowsRuntimeSettings
           : stackMinorVersion.stackSettings.linuxRuntimeSettings;
 
       if (settings) {
-        if (isFlexConsumptionApp && settings.Sku && settings.Sku.length > 0 && settings.Sku.some(sku => sku.skuCode.toLowerCase() === 'FC1'.toLowerCase())) {
-          stackMinorVersions.push({
-            key: settings.runtimeVersion.toLowerCase(),
-            text: stackMinorVersion.displayText,
-            data: stackMinorVersion,
-          });
+        if (isFlexConsumptionApp) {
+          if (settings.Sku) {
+            if (settings.Sku.length > 0 && settings.Sku.some(sku => sku.skuCode === 'FC1')) {
+              stackMinorVersions.push({
+                key: settings.runtimeVersion.toLowerCase(),
+                text: stackMinorVersion.displayText,
+                data: stackMinorVersion,
+              });
+            }
+          }
         } else if (
           settings.supportedFunctionsExtensionVersions.find(supportedRuntimeVersion => supportedRuntimeVersion === runtimeVersion) ||
           settings.runtimeVersion === runtimeVersion
@@ -36,8 +40,8 @@ export const getStackVersionDropdownOptions = (
           });
         }
       }
-    });
-  });
+    }
+  }
 
   return stackMinorVersions;
 };


### PR DESCRIPTION
**Before**:
<img width="1288" alt="image" src="https://github.com/Azure/azure-functions-ux/assets/14221995/3cc16385-bc82-4072-9eae-88a25444a7ca">


**After**:
<img width="1307" alt="image" src="https://github.com/Azure/azure-functions-ux/assets/14221995/913da560-b14a-4e5c-9847-119e100933c4">
