### PR TITLE
[DC] Fix subject for user-assigned identity for function app oidc setup

### DIFF
--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeForm.tsx
@@ -115,7 +115,9 @@ const DeploymentCenterCodeForm: React.FC<DeploymentCenterCodeFormProps> = props 
           if (listFederatedCredentialsResponse.metadata.success) {
             // For error: Issuer and subject combination already exists for this Managed Identity.
             // Find all federated credentials, and if there's some with the same issuer and subject, don't add a new one
-            const subject = `repo:${values.org}/${values.repo}:environment:production`;
+            const subject = siteStateContext.isFunctionApp
+              ? `repo:${values.org}/${values.repo}:ref:refs/heads/${values.branch}`
+              : `repo:${values.org}/${values.repo}:environment:production`;
             const issuerSubjectAlreadyExists = deploymentCenterData.issuerSubjectAlreadyExists(
               subject,
               listFederatedCredentialsResponse.data.value ?? []


### PR DESCRIPTION
FixesAB#[28002083](https://msazure.visualstudio.com/Antares/_workitems/edit/28002083)

Function apps requires: `repo:${values.org}/${values.repo}:ref:refs/heads/${values.branch}`
Web apps requires: `repo:${values.org}/${values.repo}:environment:production`