### PR TITLE
Add hidden entries for JBoss 8 on JavaContainers

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -311,6 +311,35 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
         ],
       },
       {
+        displayText: 'Red Hat JBoss EAP 8',
+        value: 'jbosseap',
+        minorVersions: [
+          {
+            displayText: 'Red Hat JBoss EAP 8',
+            value: '8',
+            stackSettings: {
+              linuxContainerSettings: {
+                java11Runtime: 'JBOSSEAP|8-java11',
+                java17Runtime: 'JBOSSEAP|8-java17',
+                isAutoUpdate: true,
+                isHidden: true
+              },
+            },
+          },
+          {
+            displayText: 'Red Hat JBoss EAP 8 update 1',
+            value: '8.0.1',
+            stackSettings: {
+              linuxContainerSettings: {
+                java11Runtime: 'JBOSSEAP|8.0.1-java11',
+                java17Runtime: 'JBOSSEAP|8.0.1-java17',
+                isHidden: true
+              }
+            }
+          },
+        ],
+      },
+      {
         displayText: 'Red Hat JBoss EAP 7',
         value: 'jbosseap',
         minorVersions: [

--- a/server/src/tests/Stacks/2020-10-01/web-app/validations.ts
+++ b/server/src/tests/Stacks/2020-10-01/web-app/validations.ts
@@ -276,7 +276,7 @@ function validateJavaContainersStack(javaContainersStack) {
   expect(javaContainersStack.displayText).to.equal('Java Containers');
   expect(javaContainersStack.value).to.equal('javacontainers');
   expect(javaContainersStack.preferredOs).to.equal(undefined);
-  expect(javaContainersStack.majorVersions.length).to.equal(11); // 1 x Java web server, 1 x JBoss, 6 x Tomcat, 2 x Jetty, 1 x Wildfly
+  expect(javaContainersStack.majorVersions.length).to.equal(12); // 1 x Java web server, 2 x JBoss, 6 x Tomcat, 2 x Jetty, 1 x Wildfly
   expect(javaContainersStack).to.deep.equal(hardCodedJavaContainersStack);
 }
 


### PR DESCRIPTION
This PR adds 2 hidden entries for the upcoming JBoss 8 release on App Service.