### PR TITLE
[DC] Add Oauth button when using GitHub or Bitbucket repo + External Git

### DIFF
--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.styles.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.styles.ts
@@ -261,3 +261,7 @@ export const logStatusIconStyle = (color: string) =>
     color: color,
     marginTop: '4px',
   });
+
+export const authorizeButtonStyle = style({
+  maxWidth: '30px',
+});

--- a/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenter.types.ts
@@ -491,6 +491,14 @@ export interface DeploymentCenterGitHubProviderProps<T = DeploymentCenterContain
   clearComboBox?: KeyValue<boolean>;
 }
 
+export interface DeploymentCenterGitHubAccountProps {
+  authorizeAccount: () => void;
+  accountUser?: GitHubUser;
+  accountStatusMessage?: string;
+  isGitHubActions?: boolean;
+  isExternalGit?: boolean;
+}
+
 export interface DeploymentCenterGitHubDisconnectProps {
   branch: string;
   org: string;
@@ -695,6 +703,13 @@ export interface DeploymentCenterBitbucketProviderProps<T = DeploymentCenterCont
   loadingBranches: boolean;
   accountStatusMessage?: string;
   accountUser?: BitbucketUser;
+}
+
+export interface DeploymentCenterBitbucketAccountProps {
+  authorizeAccount: () => void;
+  accountUser?: BitbucketUser;
+  accountStatusMessage?: string;
+  isExternalGit?: boolean;
 }
 
 export interface DeploymentCenterContainerAcrSettingsProps extends DeploymentCenterFieldProps<DeploymentCenterContainerFormData> {

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterConstants.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterConstants.ts
@@ -1,7 +1,9 @@
 export class DeploymentCenterConstants {
   public static readonly githubUri = 'https://github.com';
+  public static readonly githubHostname = 'github.com';
   public static readonly bitbucketApiUrl = 'https://api.bitbucket.org/2.0';
   public static readonly bitbucketUrl = 'https://bitbucket.org';
+  public static readonly bitbucketHostname = 'bitbucket.org';
 
   public static readonly AzDevDevFabricTfsUri = 'https://codedev.ms/';
   public static readonly AzDevDevFabricSpsUri = 'https://vssps.codedev.ms/';

--- a/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
+++ b/client-react/src/pages/app/deployment-center/DeploymentCenterFormBuilder.ts
@@ -8,6 +8,7 @@ import * as Yup from 'yup';
 import { RepoTypeOptions } from '../../../models/external';
 import { CommonConstants } from '../../../utils/CommonConstants';
 import { PublishingCredentialPoliciesContext } from '../../../models/site/site';
+import { DeploymentCenterConstants } from './DeploymentCenterConstants';
 
 export abstract class DeploymentCenterFormBuilder {
   protected _publishingUser: ArmObj<PublishingUser>;
@@ -133,10 +134,26 @@ export abstract class DeploymentCenterFormBuilder {
               this.parent.repo.startsWith(CommonConstants.DeploymentCenterConstants.https) ||
               this.parent.repo.startsWith(CommonConstants.DeploymentCenterConstants.http)
             );
-          return isRepoSSH ? !value : true;
+          const isNotGitHubOrBitbucketRepo =
+            this.parent.repo &&
+            !(
+              this.parent.repo.includes(DeploymentCenterConstants.githubHostname) ||
+              this.parent.repo.includes(DeploymentCenterConstants.bitbucketHostname)
+            );
+          return this.parent.sourceProvider === ScmType.ExternalGit && isRepoSSH && isNotGitHubOrBitbucketRepo ? !value : true;
         })
         .test('externalUsernameRequired', this._t('deploymentCenterFieldRequiredMessage'), function(value) {
-          return this.parent.externalRepoType === RepoTypeOptions.Private ? !!value : true;
+          const isNotGitHubOrBitbucketRepo =
+            this.parent.repo &&
+            !(
+              this.parent.repo.includes(DeploymentCenterConstants.githubHostname) ||
+              this.parent.repo.includes(DeploymentCenterConstants.bitbucketHostname)
+            );
+          return this.parent.sourceProvider === ScmType.ExternalGit &&
+            this.parent.externalRepoType === RepoTypeOptions.Private &&
+            isNotGitHubOrBitbucketRepo
+            ? !!value
+            : true;
         }),
       externalPassword: Yup.mixed()
         .test('externalPasswordRequired', this._t('deploymentCenterFieldPrivateSSHMessage'), function(value) {
@@ -148,10 +165,26 @@ export abstract class DeploymentCenterFormBuilder {
               this.parent.repo.startsWith(CommonConstants.DeploymentCenterConstants.https) ||
               this.parent.repo.startsWith(CommonConstants.DeploymentCenterConstants.http)
             );
-          return isRepoSSH ? !value : true;
+          const isNotGitHubOrBitbucketRepo =
+            this.parent.repo &&
+            !(
+              this.parent.repo.includes(DeploymentCenterConstants.githubHostname) ||
+              this.parent.repo.includes(DeploymentCenterConstants.bitbucketHostname)
+            );
+          return this.parent.sourceProvider === ScmType.ExternalGit && isRepoSSH && isNotGitHubOrBitbucketRepo ? !value : true;
         })
         .test('externalPasswordRequired', this._t('deploymentCenterFieldRequiredMessage'), function(value) {
-          return this.parent.externalRepoType === RepoTypeOptions.Private ? !!value : true;
+          const isNotGitHubOrBitbucketRepo =
+            this.parent.repo &&
+            !(
+              this.parent.repo.includes(DeploymentCenterConstants.githubHostname) ||
+              this.parent.repo.includes(DeploymentCenterConstants.bitbucketHostname)
+            );
+          return this.parent.sourceProvider === ScmType.ExternalGit &&
+            this.parent.externalRepoType === RepoTypeOptions.Private &&
+            isNotGitHubOrBitbucketRepo
+            ? !!value
+            : true;
         }),
       externalRepoType: Yup.mixed().notRequired(),
       devOpsProjectName: Yup.mixed().notRequired(),

--- a/client-react/src/pages/app/deployment-center/bitbucket-provider/DeploymentCenterBitbucketAccount.tsx
+++ b/client-react/src/pages/app/deployment-center/bitbucket-provider/DeploymentCenterBitbucketAccount.tsx
@@ -1,26 +1,27 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { DeploymentCenterBitbucketProviderProps } from '../DeploymentCenter.types';
 import { PrimaryButton, Label, Link } from '@fluentui/react';
 import ReactiveFormControl from '../../../../components/form-controls/ReactiveFormControl';
-import { additionalTextFieldControl } from '../DeploymentCenter.styles';
+import { additionalTextFieldControl, authorizeButtonStyle } from '../DeploymentCenter.styles';
 import { DeploymentCenterLinks } from '../../../../utils/FwLinks';
 import { getDescriptionSection } from '../utility/DeploymentCenterUtility';
 import { ScmType } from '../../../../models/site/config';
+import { DeploymentCenterBitbucketAccountProps } from '../DeploymentCenter.types';
 
-const DeploymentCenterBitbucketAccount: React.FC<DeploymentCenterBitbucketProviderProps> = props => {
-  const { accountUser, accountStatusMessage, authorizeAccount } = props;
+const DeploymentCenterBitbucketAccount: React.FC<DeploymentCenterBitbucketAccountProps> = props => {
+  const { accountUser, accountStatusMessage, authorizeAccount, isExternalGit } = props;
 
   const { t } = useTranslation();
 
   const bitbucketAccountControls = accountUser ? (
     <>
-      {getDescriptionSection(
-        ScmType.BitbucketHg,
-        t('deploymentCenterBitbucketDescriptionText'),
-        DeploymentCenterLinks.bitbucketDeployment,
-        t('learnMore')
-      )}
+      {!isExternalGit &&
+        getDescriptionSection(
+          ScmType.BitbucketHg,
+          t('deploymentCenterBitbucketDescriptionText'),
+          DeploymentCenterLinks.bitbucketDeployment,
+          t('learnMore')
+        )}
       <ReactiveFormControl id="deployment-center-bitbucket-user" label={t('deploymentCenterOAuthSingedInAs')}>
         <div>
           {accountUser.username}
@@ -35,9 +36,13 @@ const DeploymentCenterBitbucketAccount: React.FC<DeploymentCenterBitbucketProvid
       </ReactiveFormControl>
     </>
   ) : (
-    <PrimaryButton ariaDescription={t('deploymentCenterOAuthAuthorizeAriaLabel')} onClick={authorizeAccount}>
-      {t('deploymentCenterOAuthAuthorize')}
-    </PrimaryButton>
+    <ReactiveFormControl id="deployment-center-bitbucket-oauth" label={t('deploymentCenterAccountSignIn')}>
+      <div className={authorizeButtonStyle}>
+        <PrimaryButton ariaDescription={t('deploymentCenterOAuthAuthorizeAriaLabel')} onClick={authorizeAccount}>
+          {t('deploymentCenterOAuthAuthorize')}
+        </PrimaryButton>
+      </div>
+    </ReactiveFormControl>
   );
 
   const accountStatusMessageControl = <Label>{accountStatusMessage}</Label>;

--- a/client-react/src/pages/app/deployment-center/external-provider/DeploymentCenterExternalProvider.tsx
+++ b/client-react/src/pages/app/deployment-center/external-provider/DeploymentCenterExternalProvider.tsx
@@ -1,18 +1,124 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useContext } from 'react';
 import { Field } from 'formik';
 import TextField from '../../../../components/form-controls/TextField';
 import { useTranslation } from 'react-i18next';
 import RadioButton from '../../../../components/form-controls/RadioButton';
 import { RepoTypeOptions } from '../../../../models/external';
-import { DeploymentCenterCodeFormData, DeploymentCenterFieldProps } from '../DeploymentCenter.types';
-import { getDescriptionSection } from '../utility/DeploymentCenterUtility';
+import { AuthorizationResult, DeploymentCenterCodeFormData, DeploymentCenterFieldProps } from '../DeploymentCenter.types';
+import { authorizeWithProvider, getDescriptionSection, getTelemetryInfo } from '../utility/DeploymentCenterUtility';
 import { ScmType } from '../../../../models/site/config';
+import { DeploymentCenterConstants } from '../DeploymentCenterConstants';
+import DeploymentCenterGitHubAccount from '../github-provider/DeploymentCenterGitHubAccount';
+import DeploymentCenterBitbucketAccount from '../bitbucket-provider/DeploymentCenterBitbucketAccount';
+import { GitHubUser } from '../../../../models/github';
+import GitHubService from '../../../../ApiHelpers/GitHubService';
+import DeploymentCenterData from '../DeploymentCenter.data';
+import { DeploymentCenterContext } from '../DeploymentCenterContext';
+import { PortalContext } from '../../../../PortalContext';
+import { BitbucketUser } from '../../../../models/bitbucket';
+import BitbucketService from '../../../../ApiHelpers/BitbucketService';
 
 const DeploymentCenterExternalProvider: React.FC<DeploymentCenterFieldProps<DeploymentCenterCodeFormData>> = props => {
   const { formProps } = props;
   const { t } = useTranslation();
 
+  const deploymentCenterData = new DeploymentCenterData();
+  const deploymentCenterContext = useContext(DeploymentCenterContext);
+  const portalContext = useContext(PortalContext);
+
   const [repoType, setRepoType] = useState<RepoTypeOptions>(RepoTypeOptions.Public);
+  const [showGitHubOAuthButton, setShowGitHubOAuthButton] = useState<boolean>(false);
+  const [gitHubUser, setGitHubUser] = useState<GitHubUser | undefined>(undefined);
+  const [gitHubAccountStatusMessage, setGitHubAccountStatusMessage] = useState<string | undefined>(
+    t('deploymentCenterOAuthFetchingUserInformation')
+  );
+  const [showBitbucketOAuthButton, setBitbucketOAuthButton] = useState<boolean>(false);
+  const [bitbucketUser, setBitbucketUser] = useState<BitbucketUser | undefined>(undefined);
+  const [bitbucketAccountStatusMessage, setBitbucketAccountStatusMessage] = useState<string | undefined>(
+    t('deploymentCenterOAuthFetchingUserInformation')
+  );
+
+  const authorizeGitHubAccount = () => {
+    portalContext.log(getTelemetryInfo('info', 'gitHubAccount', 'authorize'));
+    authorizeWithProvider(GitHubService.authorizeUrl, startingGitHubAuthCallback, completingGitHubAuthCallBack);
+  };
+
+  const completingGitHubAuthCallBack = (authorizationResult: AuthorizationResult) => {
+    if (authorizationResult.redirectUrl) {
+      deploymentCenterData.getGitHubToken(authorizationResult.redirectUrl).then(response => {
+        if (response.metadata.success) {
+          deploymentCenterData.storeGitHubToken(response.data).then(() => deploymentCenterContext.refreshUserSourceControlTokens());
+        } else {
+          portalContext.log(
+            getTelemetryInfo('error', 'getGitHubTokenResponse', 'failed', {
+              errorAsString: JSON.stringify(response.metadata.error),
+            })
+          );
+          return Promise.resolve(undefined);
+        }
+      });
+    } else {
+      return fetchGitHubData();
+    }
+  };
+
+  const startingGitHubAuthCallback = (): void => {
+    setGitHubAccountStatusMessage(t('deploymentCenterOAuthAuthorizingUser'));
+  };
+
+  const fetchGitHubData = async () => {
+    portalContext.log(getTelemetryInfo('info', 'getGitHubUser', 'submit'));
+    const gitHubUserResponse = await deploymentCenterData.getGitHubUser(deploymentCenterContext.gitHubToken);
+
+    setGitHubAccountStatusMessage(undefined);
+
+    if (gitHubUserResponse.metadata.success && gitHubUserResponse.data.login) {
+      // NOTE(michinoy): if unsuccessful, assume the user needs to authorize.
+      setGitHubUser(gitHubUserResponse.data);
+      formProps.setFieldValue('gitHubUser', gitHubUserResponse.data);
+    }
+  };
+
+  const authorizeBitbucketAccount = () => {
+    portalContext.log(getTelemetryInfo('info', 'bitBucketAccount', 'authorize'));
+    authorizeWithProvider(BitbucketService.authorizeUrl, startingBitbucketAuthCallback, completingBitbucketAuthCallBack);
+  };
+
+  const completingBitbucketAuthCallBack = (authorizationResult: AuthorizationResult) => {
+    if (authorizationResult.redirectUrl) {
+      deploymentCenterData.getBitbucketToken(authorizationResult.redirectUrl).then(response => {
+        if (response.metadata.success) {
+          deploymentCenterData.storeBitbucketToken(response.data).then(() => deploymentCenterContext.refreshUserSourceControlTokens());
+        } else {
+          portalContext.log(
+            getTelemetryInfo('error', 'getBitBucketTokenResponse', 'failed', {
+              error: response.metadata.error,
+            })
+          );
+          return Promise.resolve(undefined);
+        }
+      });
+    } else {
+      return fetchData();
+    }
+  };
+
+  const startingBitbucketAuthCallback = (): void => {
+    setBitbucketAccountStatusMessage(t('deploymentCenterOAuthAuthorizingUser'));
+  };
+
+  const fetchData = async () => {
+    portalContext.log(getTelemetryInfo('info', 'getBitbucketUser', 'submit'));
+    const bitbucketUserResponse = await deploymentCenterData.getBitbucketUser(deploymentCenterContext.bitbucketToken);
+
+    setBitbucketAccountStatusMessage(undefined);
+
+    if (bitbucketUserResponse.metadata.success && bitbucketUserResponse.data.username) {
+      // NOTE(stpelleg): if unsuccessful, assume the user needs to authorize.
+      setBitbucketUser(bitbucketUserResponse.data);
+      formProps.setFieldValue('bitbucketUser', bitbucketUserResponse.data);
+    }
+  };
 
   useEffect(() => {
     if (formProps) {
@@ -20,6 +126,82 @@ const DeploymentCenterExternalProvider: React.FC<DeploymentCenterFieldProps<Depl
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formProps && formProps.values.externalRepoType]);
+
+  useEffect(() => {
+    if (formProps?.values.repo) {
+      if (formProps.values.repo.includes(DeploymentCenterConstants.githubHostname)) {
+        setShowGitHubOAuthButton(true);
+      } else {
+        setShowGitHubOAuthButton(false);
+      }
+
+      if (formProps.values.repo.includes(DeploymentCenterConstants.bitbucketHostname)) {
+        setBitbucketOAuthButton(true);
+      } else {
+        setBitbucketOAuthButton(false);
+      }
+    }
+  }, [formProps?.values.repo]);
+
+  useEffect(() => {
+    if (!formProps.values.gitHubUser) {
+      fetchData();
+    } else {
+      setGitHubUser(formProps.values.gitHubUser);
+      setGitHubAccountStatusMessage(undefined);
+    }
+  }, [showGitHubOAuthButton]);
+
+  useEffect(() => {
+    if (!formProps.values.bitbucketUser) {
+      fetchData();
+    } else {
+      setBitbucketUser(formProps.values.bitbucketUser);
+      setBitbucketAccountStatusMessage(undefined);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showBitbucketOAuthButton]);
+
+  const authentication = useMemo(() => {
+    if (showGitHubOAuthButton) {
+      return (
+        <DeploymentCenterGitHubAccount
+          authorizeAccount={authorizeGitHubAccount}
+          accountUser={gitHubUser}
+          accountStatusMessage={gitHubAccountStatusMessage}
+          isExternalGit={true}
+        />
+      );
+    } else if (showBitbucketOAuthButton) {
+      return (
+        <DeploymentCenterBitbucketAccount
+          authorizeAccount={authorizeBitbucketAccount}
+          accountUser={bitbucketUser}
+          accountStatusMessage={bitbucketAccountStatusMessage}
+          isExternalGit={true}
+        />
+      );
+    } else {
+      <>
+        <Field
+          id="deployment-center-external-provider-username"
+          label={t('deploymentCenterCodeExternalUsernameLabel')}
+          name="externalUsername"
+          required={true}
+          component={TextField}
+        />
+
+        <Field
+          id="deployment-center-external-provider-password"
+          label={t('deploymentCenterCodeExternalPasswordLabel')}
+          name="externalPassword"
+          component={TextField}
+          required={true}
+          type="password"
+        />
+      </>;
+    }
+  }, [showGitHubOAuthButton, showBitbucketOAuthButton]);
 
   return (
     <>
@@ -62,26 +244,7 @@ const DeploymentCenterExternalProvider: React.FC<DeploymentCenterFieldProps<Depl
         ]}
       />
 
-      {repoType === RepoTypeOptions.Private && (
-        <>
-          <Field
-            id="deployment-center-external-provider-username"
-            label={t('deploymentCenterCodeExternalUsernameLabel')}
-            name="externalUsername"
-            required={true}
-            component={TextField}
-          />
-
-          <Field
-            id="deployment-center-external-provider-password"
-            label={t('deploymentCenterCodeExternalPasswordLabel')}
-            name="externalPassword"
-            component={TextField}
-            required={true}
-            type="password"
-          />
-        </>
-      )}
+      {repoType === RepoTypeOptions.Private && authentication}
     </>
   );
 };

--- a/client-react/src/pages/app/deployment-center/external-provider/DeploymentCenterExternalProvider.tsx
+++ b/client-react/src/pages/app/deployment-center/external-provider/DeploymentCenterExternalProvider.tsx
@@ -99,7 +99,7 @@ const DeploymentCenterExternalProvider: React.FC<DeploymentCenterFieldProps<Depl
         }
       });
     } else {
-      return fetchData();
+      return fetchBitbucketData();
     }
   };
 
@@ -107,7 +107,7 @@ const DeploymentCenterExternalProvider: React.FC<DeploymentCenterFieldProps<Depl
     setBitbucketAccountStatusMessage(t('deploymentCenterOAuthAuthorizingUser'));
   };
 
-  const fetchData = async () => {
+  const fetchBitbucketData = async () => {
     portalContext.log(getTelemetryInfo('info', 'getBitbucketUser', 'submit'));
     const bitbucketUserResponse = await deploymentCenterData.getBitbucketUser(deploymentCenterContext.bitbucketToken);
 
@@ -145,7 +145,7 @@ const DeploymentCenterExternalProvider: React.FC<DeploymentCenterFieldProps<Depl
 
   useEffect(() => {
     if (!formProps.values.gitHubUser) {
-      fetchData();
+      fetchGitHubData();
     } else {
       setGitHubUser(formProps.values.gitHubUser);
       setGitHubAccountStatusMessage(undefined);
@@ -154,7 +154,7 @@ const DeploymentCenterExternalProvider: React.FC<DeploymentCenterFieldProps<Depl
 
   useEffect(() => {
     if (!formProps.values.bitbucketUser) {
-      fetchData();
+      fetchBitbucketData();
     } else {
       setBitbucketUser(formProps.values.bitbucketUser);
       setBitbucketAccountStatusMessage(undefined);
@@ -201,7 +201,14 @@ const DeploymentCenterExternalProvider: React.FC<DeploymentCenterFieldProps<Depl
         />
       </>;
     }
-  }, [showGitHubOAuthButton, showBitbucketOAuthButton]);
+  }, [
+    showGitHubOAuthButton,
+    gitHubUser,
+    gitHubAccountStatusMessage,
+    showBitbucketOAuthButton,
+    bitbucketUser,
+    bitbucketAccountStatusMessage,
+  ]);
 
   return (
     <>

--- a/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubAccount.tsx
+++ b/client-react/src/pages/app/deployment-center/github-provider/DeploymentCenterGitHubAccount.tsx
@@ -1,25 +1,26 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { DeploymentCenterGitHubProviderProps } from '../DeploymentCenter.types';
 import { PrimaryButton, Label, Link, TooltipHost, IconButton } from '@fluentui/react';
 import ReactiveFormControl from '../../../../components/form-controls/ReactiveFormControl';
-import { additionalTextFieldControl, changeAccountInfoButtonStyle } from '../DeploymentCenter.styles';
+import { additionalTextFieldControl, authorizeButtonStyle, changeAccountInfoButtonStyle } from '../DeploymentCenter.styles';
 import { DeploymentCenterLinks } from '../../../../utils/FwLinks';
 import { getDescriptionSection } from '../utility/DeploymentCenterUtility';
 import { ScmType } from '../../../../models/site/config';
+import { DeploymentCenterGitHubAccountProps } from '../DeploymentCenter.types';
 
-const DeploymentCenterGitHubAccount: React.FC<DeploymentCenterGitHubProviderProps> = props => {
-  const { accountUser, accountStatusMessage, authorizeAccount, isGitHubActions } = props;
+const DeploymentCenterGitHubAccount: React.FC<DeploymentCenterGitHubAccountProps> = props => {
+  const { accountUser, accountStatusMessage, authorizeAccount, isGitHubActions, isExternalGit } = props;
   const { t } = useTranslation();
 
   const gitHubAccountControls = accountUser ? (
     <>
-      {getDescriptionSection(
-        ScmType.GitHub,
-        isGitHubActions ? t('deploymentCenterConfigureGitHubPermissionsGHA') : t('deploymentCenterConfigureGitHubPermissionsKudu'),
-        DeploymentCenterLinks.configureDeployment,
-        t('learnMore')
-      )}
+      {!isExternalGit &&
+        getDescriptionSection(
+          ScmType.GitHub,
+          isGitHubActions ? t('deploymentCenterConfigureGitHubPermissionsGHA') : t('deploymentCenterConfigureGitHubPermissionsKudu'),
+          DeploymentCenterLinks.configureDeployment,
+          t('learnMore')
+        )}
       <ReactiveFormControl id="deployment-center-github-user" label={t('deploymentCenterOAuthSingedInAs')}>
         <div>
           {accountUser.login}
@@ -41,9 +42,13 @@ const DeploymentCenterGitHubAccount: React.FC<DeploymentCenterGitHubProviderProp
       </ReactiveFormControl>
     </>
   ) : (
-    <PrimaryButton ariaDescription={t('deploymentCenterOAuthAuthorizeAriaLabel')} onClick={authorizeAccount}>
-      {t('deploymentCenterOAuthAuthorize')}
-    </PrimaryButton>
+    <ReactiveFormControl id="deployment-center-github-oauth" label={t('deploymentCenterAccountSignIn')}>
+      <div className={authorizeButtonStyle}>
+        <PrimaryButton ariaDescription={t('deploymentCenterOAuthAuthorizeAriaLabel')} onClick={authorizeAccount}>
+          {t('deploymentCenterOAuthAuthorize')}
+        </PrimaryButton>
+      </div>
+    </ReactiveFormControl>
   );
 
   const accountStatusMessageControl = <Label>{accountStatusMessage}</Label>;

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2424,6 +2424,7 @@ export class PortalResources {
   public static deploymentCenterJavaWebServerStack = 'deploymentCenterJavaWebServerStack';
   public static readOnlyMissingAzureFilesSetting = 'readOnlyMissingAzureFilesSetting';
   public static readOnlyNewNodePreview = 'readOnlyNewNodePreview';
+  public static deploymentCenterAccountSignIn = 'deploymentCenterAccountSignIn';
   public static deploymentCenterChangeAccountInfoMessage = 'deploymentCenterChangeAccountInfoMessage';
   public static deploymentCenterChangeAccountInfoButton = 'deploymentCenterChangeAccountInfoButton';
   public static deploymentCenterDeprecatedTokenWarningMessage = 'deploymentCenterDeprecatedTokenWarningMessage';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7438,6 +7438,9 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="readOnlyNewNodePreview" xml:space="preserve">
         <value>Your app is currently in read only mode because new Node programming model experience is in preview.</value>
     </data>
+    <data name="deploymentCenterAccountSignIn" xml:space="preserve">
+        <value>Sign in</value>
+    </data>
     <data name="deploymentCenterChangeAccountInfoMessage" xml:space="preserve">
         <value>In order to sign in with a different account, please go to www.github.com and log out of the account currently signed into GitHub.</value>
     </data>


### PR DESCRIPTION
Task#[26238721](https://msazure.visualstudio.com/Antares/_workitems/edit/26238721)

When setting up Private External Git using a GitHub or Bitbucket repo, Source Controls just pulls the user source control token to authenticate, so the textfields are unnecessary. Instead, we're replacing with an Oauth button to make sure they're signed in.

**If user has source control token (signed in)**
<img width="632" alt="image" src="https://github.com/Azure/azure-functions-ux/assets/29874289/643adc8c-fd43-4832-a641-8c1ee9f685c4">
<img width="699" alt="image" src="https://github.com/Azure/azure-functions-ux/assets/29874289/c39892ca-55bf-45b1-a6ae-48ab257c618f">

**Authorize button**
<img width="695" alt="image" src="https://github.com/Azure/azure-functions-ux/assets/29874289/284e7928-4535-4ba8-b7a5-3263565cfeb2">
