### PR TITLE
AB#28002495 Enable dotnet in process selection for function app stack settings

### DIFF
--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2602,4 +2602,9 @@ export class PortalResources {
   public static sshDisabledInfoBubbleMessage = 'sshDisabledInfoBubbleMessage';
   public static staticSite_appSettingsMoved = 'staticSite_appSettingsMoved';
   public static ftpBasicAuthInfoMessage = 'ftpBasicAuthInfoMessage';
+  public static noRuntimeStackFound = 'noRuntimeStackFound';
+  public static invalidStack = 'invalidStack';
+  public static invalidWindowsNodeStackVersion = 'invalidWindowsNodeStackVersion';
+  public static invalidNonWindowsNodeStackVersion = 'invalidNonWindowsNodeStackVersion';
+  public static disabledDotNetVersion = 'disabledDotNetVersion';
 }

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7965,4 +7965,19 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="ftpBasicAuthInfoMessage" xml:space="preserve">
         <value>SCM basic authentication is required when enabling FTP basic authentication.</value>
     </data>
+    <data name="noRuntimeStackFound" xml:space="preserve">
+        <value>No run time stack found</value>
+    </data>
+    <data name="invalidStack" xml:space="preserve">
+        <value>{0} is not a valid stack</value>
+    </data>
+    <data name="invalidWindowsNodeStackVersion" xml:space="preserve">
+        <value>Node.js version is missing or invalid. Please select a valid version or go to Environment variables to add/update WEBSITE_NODE_DEFAULT_VERSION app setting</value>
+    </data>
+    <data name="invalidNonWindowsNodeStackVersion" xml:space="preserve">
+        <value>{0} version is missing or invalid. Please select a valid version</value>
+    </data>
+    <data name="disabledDotNetVersion" xml:space="preserve">
+        <value>The selected version '{0}' does not match with the stack {1}. Please select a valid .NET version or go to Environment Variables to add/update FUNCTIONS_WORKER_RUNTIME to {2}</value>
+    </data>
 </root>


### PR DESCRIPTION
Fixes: [AB#28002495](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/Dilithium/CY24Q2/2Wk/2Wk05%20(Jun%2002%20-%20Jun%2015)?workitem=28002495)


1. Make sure when selectin .NET in process for windows function app stack setting, it does not default o .NET isolated
2. Currently we hide stack setting when it is invalid. Fix it by showing it with warning/error messages.

![invalidStack](https://github.com/Azure/azure-functions-ux/assets/33185278/5ba35a5c-2380-47a7-a655-88b3783a10e9)
![dotnetValid](https://github.com/Azure/azure-functions-ux/assets/33185278/ba05a03b-1ae5-4715-9d5a-e4ddd5cc7e73)
![dotnetisolatedvalid](https://github.com/Azure/azure-functions-ux/assets/33185278/ff17778d-5b1d-497f-a77b-289f124eb220)
![changeToDotnet](https://github.com/Azure/azure-functions-ux/assets/33185278/d9007934-cbd3-46fe-b57f-0550a669c25f)
![chanegDotnetWarningMessage](https://github.com/Azure/azure-functions-ux/assets/33185278/fbfc0a70-66fa-4c95-842d-fb2b914cf321)
![invalidNodeStackWindows](https://github.com/Azure/azure-functions-ux/assets/33185278/3ed277a3-5a1e-4471-ab90-5264fa7078ac)
![invalidVersionNoneNodeWindows](https://github.com/Azure/azure-functions-ux/assets/33185278/423131f7-9c8a-4da4-86a7-5652af5815cf)
