### PR TITLE
unhiding .NET 8 in-proc for Windows

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
@@ -269,7 +269,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
             value: '8 (LTS), in-process model',
             stackSettings: {
               windowsRuntimeSettings: {
-                isHidden: true,
+                isHidden: false,
                 runtimeVersion: 'v8.0',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {


### PR DESCRIPTION
Drafting for when we're at the point of being able to release this. We'll start with just Windows.