### PR TITLE
Bump ws to 7.5.10 in /server

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11569,9 +11569,9 @@
       }
     },
     "ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true
     },
     "xml-name-validator": {


### PR DESCRIPTION
Address [CVE-2024-37890](https://nvd.nist.gov/vuln/detail/CVE-2024-37890) by updating from 7.5.9 to 7.5.10.

Resolve merge conflicts in #7704.