### PR TITLE
[DC] Reset form when loading setup view

### DIFF
--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
@@ -88,7 +88,13 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
       formProps.resetForm();
     }
     setShouldLoadSetupView(loadSetupView);
-  }, [siteConfigScmType, deploymentCenterContext.siteConfig, deploymentCenterContext.configMetadata, formProps.dirty]);
+  }, [
+    siteConfigScmType,
+    deploymentCenterContext.siteConfig,
+    deploymentCenterContext.configMetadata,
+    formProps,
+    deploymentCenterPublishingContext,
+  ]);
 
   useEffect(() => {
     setIsKuduBuild(formProps.values.buildProvider === BuildProvider.AppServiceBuildService);

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
@@ -78,21 +78,20 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
 
   useEffect(() => {
     setSiteConfigScmType(deploymentCenterContext.siteConfig && deploymentCenterContext.siteConfig.properties.scmType);
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deploymentCenterContext.siteConfig, deploymentCenterContext.configMetadata]);
 
   useEffect(() => {
-    setShouldLoadSetupView(!!siteConfigScmType && siteConfigScmType !== ScmType.None);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [siteConfigScmType, deploymentCenterContext.siteConfig, deploymentCenterContext.configMetadata]);
+    const loadSetupView = !!siteConfigScmType && siteConfigScmType !== ScmType.None;
+    if (loadSetupView && formProps.dirty) {
+      formProps.resetForm();
+    }
+    setShouldLoadSetupView(loadSetupView);
+  }, [siteConfigScmType, deploymentCenterContext.siteConfig, deploymentCenterContext.configMetadata, formProps.dirty]);
 
   useEffect(() => {
     setIsKuduBuild(formProps.values.buildProvider === BuildProvider.AppServiceBuildService);
     setIsVstsBuild(formProps.values.buildProvider === BuildProvider.Vsts);
     setIsGitHubActionsBuild(formProps.values.buildProvider === BuildProvider.GitHubAction);
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formProps.values.buildProvider]);
 
   useEffect(() => {
@@ -109,8 +108,6 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
     }
 
     setIsUnsupportedSource(sourceProvider === ScmType.Dropbox || sourceProvider === ScmType.OneDrive);
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formProps.values.sourceProvider]);
 
   useEffect(() => {
@@ -121,8 +118,6 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
     setIsExternalGitSetup(siteConfigScmType === ScmType.ExternalGit);
     setIsVstsSetup(siteConfigScmType === ScmType.Vsts);
     setIsTfsOrVsoSetup(siteConfigScmType === ScmType.Tfs || siteConfigScmType === ScmType.Vso);
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [siteConfigScmType, deploymentCenterContext.configMetadata]);
 
   const getWorkflowFileVariables = () => {
@@ -205,7 +200,6 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
     }
 
     setIsUsingExistingOrAvailableWorkflowConfig(isWorkflowOptionExistingOrAvailable(formProps.values.workflowOption));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formProps.values.workflowOption]);
 
   useEffect(() => {
@@ -221,7 +215,6 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
       authTypeFormFilled;
 
     setIsPreviewFileButtonDisabled(formProps.values.workflowOption === WorkflowOption.None || !formFilled);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     formProps.values.workflowOption,
     githubActionExistingWorkflowContents,
@@ -248,7 +241,6 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
     } else {
       setWorkflowFilePath('');
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deploymentCenterContext.siteDescriptor, formProps.values.branch, formProps.values.workflowOption]);
 
   const getSettingsControls = () => (

--- a/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
+++ b/client-react/src/pages/app/deployment-center/code/DeploymentCenterCodeSettings.tsx
@@ -36,12 +36,13 @@ import DeploymentCenterGitHubWorkflowConfigPreview from '../github-provider/Depl
 import DeploymentCenterGitHubWorkflowConfigSelector from '../github-provider/DeploymentCenterGitHubWorkflowConfigSelector';
 import DeploymentCenterLocalGitConfiguredView from '../local-git-provider/DeploymentCenterLocalGitConfiguredView';
 import DeploymentCenterLocalGitProvider from '../local-git-provider/DeploymentCenterLocalGitProvider';
-import { getTelemetryInfo, getWorkflowFileName } from '../utility/DeploymentCenterUtility';
+import { getTelemetryInfo, getWorkflowFileName, isFtpsDirty } from '../utility/DeploymentCenterUtility';
 import { getRuntimeVersion, isWorkflowOptionExistingOrAvailable } from '../utility/GitHubActionUtility';
 import DeploymentCenterCodeBuildConfiguredView from './DeploymentCenterCodeBuildConfiguredView';
 import DeploymentCenterCodeBuildRuntimeAndVersion from './DeploymentCenterCodeBuildRuntimeAndVersion';
 import DeploymentCenterCodeSourceAndBuild from './DeploymentCenterCodeSourceAndBuild';
 import DeploymentCenterCodeSourceKuduConfiguredView from './DeploymentCenterCodeSourceKuduConfiguredView';
+import { DeploymentCenterPublishingContext } from '../authentication/DeploymentCenterPublishingContext';
 
 const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<DeploymentCenterCodeFormData>> = props => {
   const { formProps, isDataRefreshing } = props;
@@ -50,6 +51,7 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
   const deploymentCenterContext = useContext(DeploymentCenterContext);
   const siteStateContext = useContext(SiteStateContext);
   const portalContext = useContext(PortalContext);
+  const deploymentCenterPublishingContext = useContext(DeploymentCenterPublishingContext);
   const deploymentCenterData = new DeploymentCenterData();
 
   const [githubActionExistingWorkflowContents, setGithubActionExistingWorkflowContents] = useState<string>('');
@@ -82,7 +84,7 @@ const DeploymentCenterCodeSettings: React.FC<DeploymentCenterFieldProps<Deployme
 
   useEffect(() => {
     const loadSetupView = !!siteConfigScmType && siteConfigScmType !== ScmType.None;
-    if (loadSetupView && formProps.dirty) {
+    if (loadSetupView && formProps.dirty && !isFtpsDirty(formProps, deploymentCenterPublishingContext)) {
       formProps.resetForm();
     }
     setShouldLoadSetupView(loadSetupView);

--- a/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
+++ b/client-react/src/pages/app/deployment-center/utility/DeploymentCenterUtility.tsx
@@ -416,7 +416,7 @@ const isContainerGeneralSettingsDirty = (formProps: FormikProps<DeploymentCenter
 };
 
 export const isFtpsDirty = (
-  formProps: FormikProps<DeploymentCenterFormData<DeploymentCenterContainerFormData>>,
+  formProps: FormikProps<DeploymentCenterFormData>,
   deploymentCenterPublishingContext: IDeploymentCenterPublishingContext
 ): boolean => {
   const currentUser = deploymentCenterPublishingContext.publishingUser;


### PR DESCRIPTION
FixesAB#[26799615](https://msazure.visualstudio.com/Antares/_workitems/edit/26799615) and [27324172](https://msazure.visualstudio.com/Antares/_workitems/edit/27324172)

Save and Discard buttons were getting enabled after saving and then user goes from Logs to Settings tab.
When switching tabs, the form reverts as if scmType is None, causing the non-configured view to load and authType switched from oidc to publish profile.

Now, reset the form whenever we do the load the setup view and there are no FTPS setting changes.