### PR TITLE
unhiding .NET 8 in-proc for Linux

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
@@ -298,7 +298,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
                 endOfLifeDate: dotnet8EOL,
               },
               linuxRuntimeSettings: {
-                isHidden: true,
+                isHidden: false,
                 runtimeVersion: 'DOTNET|8.0',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {


### PR DESCRIPTION
Draft PR for when this does become available. At time of opening this PR, this should remain hidden.