### PR TITLE
AB#28114775 Update end of life date format to make sure it is the same date as the input

### DIFF
--- a/client-react/src/utils/stacks-utils.tsx
+++ b/client-react/src/utils/stacks-utils.tsx
@@ -260,13 +260,19 @@ export const checkAndGetStackEOLOrDeprecatedBanner = (t: i18next.TFunction, stac
   if (eolDate === undefined) {
     return <></>;
   }
+
+  if (eolDate) {
+    console.log(eolDate);
+    console.log(new Date(eolDate).toLocaleDateString());
+  }
+
   return (
     <CustomBanner
       type={MessageBarType.warning}
       id={'eol-stack-banner'}
       message={
         eolDate
-          ? t('endOfLifeStackMessage').format(stackVersion, new Date(eolDate).toLocaleDateString())
+          ? t('endOfLifeStackMessage').format(stackVersion, new Date(eolDate).toLocaleDateString(undefined, { timeZone: 'UTC' }))
           : t('deprecatedStackMessage').format(stackVersion)
       }
       learnMoreLink={Links.endOfLifeStackLink}

--- a/client-react/src/utils/stacks-utils.tsx
+++ b/client-react/src/utils/stacks-utils.tsx
@@ -261,11 +261,6 @@ export const checkAndGetStackEOLOrDeprecatedBanner = (t: i18next.TFunction, stac
     return <></>;
   }
 
-  if (eolDate) {
-    console.log(eolDate);
-    console.log(new Date(eolDate).toLocaleDateString());
-  }
-
   return (
     <CustomBanner
       type={MessageBarType.warning}


### PR DESCRIPTION
Fixes: [AB#28114775](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/Dilithium/CY24Q3/Monthly/07%20Jul%20(Jun%2030%20-%20Jul%2027)?workitem=28114775)

The input date is ISO date string but when displaying it in the manner, it is shown as the local date based on the input because using toLocaleDateString(). For example, the input is 5/11/2024 and it is shown as 5/10/2024. Fixing it by add { timezone: 'UTC'} to toLocaleDateString