### PR TITLE
Use a new internal ID for JBoss 8 so it's not merged the JBoss 7 entries

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -312,7 +312,7 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
       },
       {
         displayText: 'Red Hat JBoss EAP 8',
-        value: 'jbosseap',
+        value: 'jbosseap8.0',
         minorVersions: [
           {
             displayText: 'Red Hat JBoss EAP 8',


### PR DESCRIPTION
This PR fixes an issue where the new versions for JBoss 8 are being combined with the list of entries for JBoss 7 in the Configuration blade because they share a common identifier that I forgot to change in #7690 

![image](https://github.com/user-attachments/assets/2c1bb265-da9a-41c0-99a0-612be0b1a76b)

By using a different identifier, only minor versions of JBoss 8 will show when JBoss 8 is selected, and only minor versions of JBoss 7 will show when JBoss 7 is selected. This is the same approach used by the Tomcat container versions.