### PR TITLE
Undo gulpfile change causing Fusion build break

### DIFF
--- a/server/gulpfile.js
+++ b/server/gulpfile.js
@@ -173,7 +173,7 @@ gulp.task('resources-convert', function () {
   ensurePath('templates/');
 
   const portalResourceStream = gulp
-    .src(['../server/resources-resx/**/Resources.*.resx', './Resources/Resources.resx'], { base: '../server' })
+    .src(['../server/resources-resx/**/Resources.*.resx', './Resources/Resources.resx'])
     .pipe(resx2())
     .pipe(
       rename(function (p) {


### PR DESCRIPTION
Remove not required change to gulpfile.js which caused a Fusion build break.