### PR TITLE
AB#28784815 use camel case for clustering enabled property's name

### DIFF
--- a/client-react/src/models/site/config.ts
+++ b/client-react/src/models/site/config.ts
@@ -92,7 +92,7 @@ export interface SiteConfig {
   minimumElasticInstanceCount?: number; // Used to be reservedInstanceCount in 2018-11-01
   functionsRuntimeScaleMonitoringEnabled?: boolean;
   powerShellVersion?: string;
-  ClusteringEnabled?: boolean;
+  clusteringEnabled?: boolean;
   vnetPrivatePortsCount?: number | null;
 }
 

--- a/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
+++ b/client-react/src/pages/app/app-settings/AppSettingsFormData.ts
@@ -127,7 +127,7 @@ export const getCleanedConfig = (config: ArmObj<SiteConfig>) => {
   }
 
   const minTlsVersion = config.properties.minTlsVersion || MinTlsVersion.tLS12;
-  const ClusteringEnabled = !!config.properties.ClusteringEnabled;
+  const clusteringEnabled = !!config.properties.clusteringEnabled;
 
   const newConfig: ArmObj<SiteConfig> = {
     ...config,
@@ -136,7 +136,7 @@ export const getCleanedConfig = (config: ArmObj<SiteConfig>) => {
       linuxFxVersion,
       remoteDebuggingVersion,
       minTlsVersion,
-      ClusteringEnabled,
+      clusteringEnabled,
     },
   };
   return newConfig;
@@ -517,7 +517,7 @@ export function getConfigWithStackSettings(config: SiteConfig, values: AppSettin
     configCopy.javaVersion = '';
   }
 
-  configCopy.ClusteringEnabled = isJBossClusteringShown(config.linuxFxVersion, values.site) && configCopy.ClusteringEnabled;
+  configCopy.clusteringEnabled = isJBossClusteringShown(config.linuxFxVersion, values.site) && configCopy.clusteringEnabled;
 
   // NOTE (krmitta): We need to explicitly mark node and php versions as null,
   // whenever these are empty since it prevents the backend from disabling the alwaysOn property.

--- a/client-react/src/pages/app/app-settings/GeneralSettings/LinuxStacks/JavaStack.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/LinuxStacks/JavaStack.tsx
@@ -200,24 +200,24 @@ const JavaStack: React.SFC<StackProps> = props => {
     const majorVersion = selectedValues.majorVersion
       ? selectedValues.majorVersion
       : majorVersionDropdownOptions.length > 0
-      ? (majorVersionDropdownOptions[0].key as string)
-      : undefined;
+        ? (majorVersionDropdownOptions[0].key as string)
+        : undefined;
 
     if (majorVersion) {
       containerKeyDropdownOptions = getJavaContainerDropdownOptionsForSelectedMajorVersion(majorVersion);
       const containerKey = selectedValues.containerKey
         ? selectedValues.containerKey
         : containerKeyDropdownOptions.length > 0
-        ? (containerKeyDropdownOptions[0].key as string)
-        : undefined;
+          ? (containerKeyDropdownOptions[0].key as string)
+          : undefined;
 
       if (containerKey) {
         containerVersionDropdownOptions = getJavaContainerVersionDropdownOptionsForSelectedJavaContainer(majorVersion, containerKey);
         const containerVersion = selectedValues.containerVersion
           ? selectedValues.containerVersion
           : containerVersionDropdownOptions.length > 0
-          ? (containerVersionDropdownOptions[0].key as string)
-          : undefined;
+            ? (containerVersionDropdownOptions[0].key as string)
+            : undefined;
 
         if (containerVersion && containerVersion.toLowerCase() !== values.config.properties.linuxFxVersion.toLowerCase()) {
           setFieldValue('config.properties.linuxFxVersion', containerVersion);
@@ -269,8 +269,8 @@ const JavaStack: React.SFC<StackProps> = props => {
   };
 
   const isJBossClusteringDirty = useCallback(() => {
-    return !!initialValues.config.properties.ClusteringEnabled !== !!values.config.properties.ClusteringEnabled;
-  }, [initialValues.config.properties.ClusteringEnabled, values.config.properties.ClusteringEnabled]);
+    return !!initialValues.config.properties.clusteringEnabled !== !!values.config.properties.clusteringEnabled;
+  }, [initialValues.config.properties.clusteringEnabled, values.config.properties.clusteringEnabled]);
 
   const setStackBannerAndInfoMessage = () => {
     setEarlyAccessInfoVisible(false);
@@ -349,8 +349,8 @@ const JavaStack: React.SFC<StackProps> = props => {
       )}
       {isJBossClusteringShown(values.config.properties.linuxFxVersion, site) && (
         <Field
-          name="config.properties.ClusteringEnabled"
-          id={'config.properties.ClusteringEnabled'}
+          name="config.properties.clusteringEnabled"
+          id={'config.properties.clusteringEnabled'}
           dirty={isJBossClusteringDirty()}
           component={RadioButton}
           label={'JBOSS Clustering'}


### PR DESCRIPTION
Fixes: [AB#28784815](https://msazure.visualstudio.com/Antares/_workitems/edit/28784815)