### PR TITLE
Dotnet 9 Preview: Removing isHidden flag for Linux runtime

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -41,7 +41,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
               linuxRuntimeSettings: {
                 runtimeVersion: 'DOTNETCORE|9.0',
                 remoteDebuggingSupported: false,
-                isHidden: true,
                 isPreview: true,
                 appInsightsSettings: {
                   isSupported: true,


### PR DESCRIPTION
Dotnet 9 preview in Linux App Service has reached stage 2 in the rollout.
This PR is to remove the isHidden flag for Linux and enable the preview option in the portal for the customers. 

Validation: 

1. Created a web app with Dotnet 9 preview as selected stack and Linux as OS.
![image](https://github.com/user-attachments/assets/ac7efc85-f205-45a4-9f0d-cfbbde7a3b71)
2. Deployed the dotnet 9 app through zip deploy.
3. The app was up and running using Dotnet 9 preview libraries
4. 
![Screenshot 2024-08-05 180748](https://github.com/user-attachments/assets/c0504f97-b6fc-4ea3-8a87-4e67d90bbd1c)
<img width="213" alt="Screenshot 2024-08-05 180922" src="https://github.com/user-attachments/assets/b5aff8c5-d20a-4098-961d-32a819d218e4">

  