### PR TITLE
Removing app settings moved banner

### DIFF
--- a/client-react/src/pages/static-app/configuration/ConfigurationForm.tsx
+++ b/client-react/src/pages/static-app/configuration/ConfigurationForm.tsx
@@ -273,7 +273,6 @@ const ConfigurationForm: React.FC<ConfigurationFormProps> = (props: Configuratio
             />
 
             {!hasWritePermissions && <CustomBanner message={t('staticSite_readOnlyRbac')} type={MessageBarType.info} />}
-            <CustomBanner message={t('staticSite_appSettingsMoved')} type={MessageBarType.info} />
 
             <>
               <ConfirmDialog


### PR DESCRIPTION
This PR removes the unnecessary 'App settings moved' notification from the snippets blade as this is already in the configuration blade where it is needed. 

Before:
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/48730d0f-d83a-4b12-ab80-993c834262b0">


After:
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/898d9180-9a8f-4469-af04-502d6cbadd21">
