### PR TITLE
Add Node.js v22 as a hidden and preview function app stack

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Node.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Node.ts
@@ -6,6 +6,7 @@ const getNodeStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDat
   const node10EOL = getDateString(new Date('2021/04/30'), useIsoDateFormat);
   const node8EOL = getDateString(new Date('2019/12/31'), useIsoDateFormat);
   const node6EOL = getDateString(new Date('2019/04/30'), useIsoDateFormat);
+  const node22EOL = getDateString(new Date('2027/04/30'), useIsoDateFormat);
   const node20EOL = getDateString(new Date('2026/05/30'), useIsoDateFormat);
   const node18EOL = getDateString(new Date('2025/04/30'), useIsoDateFormat);
   const node16EOL = getDateString(new Date('2024/06/30'), useIsoDateFormat);
@@ -16,6 +17,77 @@ const getNodeStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDat
     value: 'node',
     preferredOs: 'windows',
     majorVersions: [
+      {
+        displayText: 'Node.js 22',
+        value: '22',
+        minorVersions: [
+          {
+            displayText: 'Node.js 22',
+            value: '22',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: '~22',
+                isPreview: true,
+                isHidden: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '22.x',
+                },
+                appSettingsDictionary: {
+                  FUNCTIONS_WORKER_RUNTIME: 'node',
+                  WEBSITE_NODE_DEFAULT_VERSION: '~22',
+                },
+                siteConfigPropertiesDictionary: {
+                  use32BitWorkerProcess: true,
+                  netFrameworkVersion: 'v6.0',
+                },
+                supportedFunctionsExtensionVersions: ['~4'],
+                supportedFunctionsExtensionVersionsInfo: [
+                  {
+                    version: '~4',
+                    isDeprecated: false,
+                    isDefault: true,
+                  },
+                ],
+                endOfLifeDate: node22EOL,
+              },
+              linuxRuntimeSettings: {
+                runtimeVersion: 'Node|22',
+                isPreview: true,
+                isHidden: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '22.x',
+                },
+                appSettingsDictionary: {
+                  FUNCTIONS_WORKER_RUNTIME: 'node',
+                },
+                siteConfigPropertiesDictionary: {
+                  use32BitWorkerProcess: false,
+                  linuxFxVersion: 'Node|22',
+                },
+                supportedFunctionsExtensionVersions: ['~4'],
+                supportedFunctionsExtensionVersionsInfo: [
+                  {
+                    version: '~4',
+                    isDeprecated: false,
+                    isDefault: true,
+                  },
+                ],
+                endOfLifeDate: node22EOL,
+              },
+            },
+          },
+        ],
+      },
       {
         displayText: 'Node.js 20',
         value: '20',

--- a/server/src/tests/Stacks/2020-10-01/function-app/validations.ts
+++ b/server/src/tests/Stacks/2020-10-01/function-app/validations.ts
@@ -167,7 +167,7 @@ function validateNodeStack(nodeStack) {
   expect(nodeStack.displayText).to.equal('Node.js');
   expect(nodeStack.value).to.equal('node');
   expect(nodeStack.preferredOs).to.equal('windows');
-  expect(nodeStack.majorVersions.length).to.equal(8);
+  expect(nodeStack.majorVersions.length).to.equal(9);
   expect(nodeStack).to.deep.equal(hardCodedNodeStack);
 }
 


### PR DESCRIPTION
Related to https://github.com/Azure/azure-functions-nodejs-library/issues/252

Since this is hidden, this is ready to merge whenever.