### PR TITLE
Update the Java 8 EOL date to the date from Eclipse Temurin

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Java.ts
@@ -6,7 +6,7 @@ const getJavaStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDat
   const java21EOL = getDateString(new Date('2031/09/01'), useIsoDateFormat);
   const java17EOL = getDateString(new Date('2031/09/01'), useIsoDateFormat);
   const java11EOL = getDateString(new Date('2026/09/01'), useIsoDateFormat);
-  const java8EOL = getDateString(new Date('2025/03/01'), useIsoDateFormat);
+  const java8EOL = getDateString(new Date('2026/11/30'), useIsoDateFormat);
 
   return {
     displayText: 'Java',

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
@@ -7,7 +7,7 @@ const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
   const java21EOL = getDateString(new Date('2028/09/01'), useIsoDateFormat);
   const java17EOL = getDateString(new Date('2027/09/01'), useIsoDateFormat);
   const java11EOL = getDateString(new Date('2027/09/01'), useIsoDateFormat);
-  const java8EOL = getDateString(new Date('2025/03/01'), useIsoDateFormat);
+  const java8EOL = getDateString(new Date('2026/11/30'), useIsoDateFormat);
   const java7EOL = getDateString(new Date('2023/07/01'), useIsoDateFormat);
 
   return {


### PR DESCRIPTION
We ship Eclipse Temurin in our Azure App Service runtimes using Java 8. This PR updates the Java 8 EOL date to **November 30, 2026** based on the page at https://adoptium.net/support/ which states Java 8 will be available until "_At least Nov 2026_".


