### PR TITLE
Update OnPrem dotnet stacks

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -2,6 +2,7 @@ import { WebAppStack } from '../../models/WebAppStackModel';
 import { getDateString } from '../date-utilities';
 
 const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFormat: boolean) => {
+  const dotnet7EOL = getDateString(new Date(2024, 5, 14), useIsoDateFormat);
   const dotnet5EOL = getDateString(new Date(2022, 5, 8), useIsoDateFormat);
   const dotnetCore3Point0EOL = getDateString(new Date(2020, 3, 3), useIsoDateFormat);
   const dotnetCore3Point1EOL = getDateString(new Date(2022, 12, 3), useIsoDateFormat);
@@ -15,6 +16,45 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
     value: 'dotnet',
     preferredOs: 'windows',
     majorVersions: [
+      {
+        displayText: '.NET 8 (LTS)',
+        value: 'dotnet8',
+        minorVersions: [
+          {
+            displayText: '.NET 8 (LTS)',
+            value: '8',
+            stackSettings: {
+              windowsRuntimeSettings: {
+                runtimeVersion: 'v8.0',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8.x',
+                },
+              },
+              linuxRuntimeSettings: {
+                runtimeVersion: 'DOTNETCORE|8.0',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8.x',
+                },
+                supportedFeatures: {
+                  disableSsh: true,
+                },
+              },
+            },
+          },
+        ],
+      },
       {
         displayText: '.NET 7',
         value: 'dotnet7',
@@ -143,6 +183,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                   isSupported: true,
                   supportedVersion: '3.1.301',
                 },
+                isDeprecated: true,
                 endOfLifeDate: dotnetCore3Point1EOL,
               },
               linuxRuntimeSettings: {

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -175,6 +175,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
             stackSettings: {
               windowsRuntimeSettings: {
                 runtimeVersion: '3.1',
+                isDeprecated: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -183,11 +184,11 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                   isSupported: true,
                   supportedVersion: '3.1.301',
                 },
-                isDeprecated: true,
                 endOfLifeDate: dotnetCore3Point1EOL,
               },
               linuxRuntimeSettings: {
                 runtimeVersion: 'DOTNETCORE|3.1',
+                isDeprecated: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -28,8 +28,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 runtimeVersion: 'v8.0',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
-                  isSupported: true,
-                  isDefaultOff: false,
+                  isSupported: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -74,7 +73,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                   supportedVersion: '7.0.x',
                 },
                 isHidden: true,
-                isEarlyAccess: true,
+                isDeprecated: true,
               },
               linuxRuntimeSettings: {
                 runtimeVersion: 'DOTNETCORE|7.0',
@@ -105,7 +104,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 runtimeVersion: 'v6.0',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
-                  isSupported: true,
+                  isSupported: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -140,7 +139,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 isDeprecated: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
-                  isSupported: true,
+                  isSupported: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -178,7 +177,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 isDeprecated: true,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
-                  isSupported: true,
+                  isSupported: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -280,7 +279,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 remoteDebuggingSupported: false,
                 isDeprecated: true,
                 appInsightsSettings: {
-                  isSupported: true,
+                  isSupported: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -419,7 +418,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 runtimeVersion: 'v4.0',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
-                  isSupported: true,
+                  isSupported: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,
@@ -442,7 +441,7 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 runtimeVersion: 'v2.0',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
-                  isSupported: true,
+                  isSupported: false,
                 },
                 gitHubActionSettings: {
                   isSupported: true,


### PR DESCRIPTION
1. Add dotnet 8
2.  Deprecate dotnet core (3.1,2.1)
3. Update app insights settings 