### PR TITLE
New versions of Java/Tomcat/JBoss stacks for ANT103

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
@@ -55,6 +55,26 @@ const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
             },
           },
           {
+            displayText: 'Java 21.0.4',
+            value: '21.0.4',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (jafreebe): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '21',
+                },
+                endOfLifeDate: java21EOL,
+              },
+            },
+          },
+          {
             displayText: 'Java 21.0.3',
             value: '21.0.3',
             stackSettings: {
@@ -148,6 +168,26 @@ const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
               windowsRuntimeSettings: {
                 runtimeVersion: '17',
                 isAutoUpdate: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '17',
+                },
+                endOfLifeDate: java17EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 17.0.12',
+            value: '17.0.11',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (jafreebe): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -387,6 +427,26 @@ const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
               windowsRuntimeSettings: {
                 runtimeVersion: '11',
                 isAutoUpdate: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '11',
+                },
+                endOfLifeDate: java11EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 11.0.24',
+            value: '11.0.21',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (jafreebe): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,
@@ -883,6 +943,26 @@ const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
               windowsRuntimeSettings: {
                 runtimeVersion: '1.8',
                 isAutoUpdate: true,
+                remoteDebuggingSupported: false,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: false,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '8',
+                },
+                endOfLifeDate: java8EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Java 1.8.0_422',
+            value: '8.0.422',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                // Note (jafreebe): Runtime on Linux Java is determined by the Java container
+                runtimeVersion: '',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -398,7 +398,7 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
             },
           },
           {
-            displayText: 'Red Hat JBoss EAP 8.0.2.1',
+            displayText: 'Red Hat JBoss EAP 8.0 update 2.1',
             value: '8.0.2.1',
             stackSettings: {
               linuxContainerSettings: {

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -36,6 +36,15 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
             },
           },
           {
+            displayText: 'Java SE 21.0.4',
+            value: '21.0.4',
+            stackSettings: {
+              linuxContainerSettings: {
+                java21Runtime: 'JAVA|21.0.4',
+              },
+            },
+          },
+          {
             displayText: 'Java SE 21.0.3',
             value: '21.0.3',
             stackSettings: {
@@ -50,6 +59,15 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
             stackSettings: {
               linuxContainerSettings: {
                 java21Runtime: 'JAVA|21.0.1',
+              },
+            },
+          },
+          {
+            displayText: 'Java SE 17.0.12',
+            value: '17.0.12',
+            stackSettings: {
+              linuxContainerSettings: {
+                java17Runtime: 'JAVA|17.0.12',
               },
             },
           },
@@ -107,6 +125,15 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               linuxContainerSettings: {
                 // Note (jafreebe): This doesn't have suffix of -java11 since setting to 11.0.8 prevents auto-updates
                 java17Runtime: 'JAVA|17.0.1',
+              },
+            },
+          },
+          {
+            displayText: 'Java SE 11.0.24',
+            value: '11.0.24',
+            stackSettings: {
+              linuxContainerSettings: {
+                java11Runtime: 'JAVA|11.0.24',
               },
             },
           },
@@ -224,6 +251,15 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               linuxContainerSettings: {
                 // Note (jafreebe): This doesn't have suffix of -java11 since setting to 11.0.5 prevents auto-updates
                 java11Runtime: 'JAVA|11.0.5',
+              },
+            },
+          },
+          {
+            displayText: 'Java SE 8u422',
+            value: '1.8.422',
+            stackSettings: {
+              linuxContainerSettings: {
+                java8Runtime: 'JAVA|8u422',
               },
             },
           },
@@ -362,12 +398,12 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
             },
           },
           {
-            displayText: 'Red Hat JBoss EAP 8.0 update 2.1',
-            value: '8.0.2',
+            displayText: 'Red Hat JBoss EAP 8.0.2.1',
+            value: '8.0.2.1',
             stackSettings: {
               linuxContainerSettings: {
-                java11Runtime: 'JBOSSEAP|8.0.2-java11',
-                java17Runtime: 'JBOSSEAP|8.0.2-java17',
+                java11Runtime: 'JBOSSEAP|8.0.2.1-java11',
+                java17Runtime: 'JBOSSEAP|8.0.2.1-java17',
               }
             }
           },
@@ -437,6 +473,17 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
                 isAutoUpdate: true,
               },
             },
+          },
+          {
+            displayText: 'Red Hat JBoss EAP 7.4.18',
+            value: '7.4.18',
+            stackSettings: {
+              linuxContainerSettings: {
+                java8Runtime: 'JBOSSEAP|7.4.18-java8',
+                java11Runtime: 'JBOSSEAP|7.4.18-java11',
+                java17Runtime: 'JBOSSEAP|7.4.18-java17'
+              }
+            }
           },
           {
             displayText: 'Red Hat JBoss EAP 7.4.17',
@@ -711,6 +758,21 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
             },
           },
           {
+            displayText: 'Apache Tomcat 10.1.28',
+            value: '10.1.28',
+            stackSettings: {
+              windowsContainerSettings: {
+                javaContainer: 'TOMCAT',
+                javaContainerVersion: '10.1.28',
+              },
+              linuxContainerSettings: {
+                java11Runtime: 'TOMCAT|10.1.28-java11',
+                java17Runtime: 'TOMCAT|10.1.28-java17',
+                java21Runtime: 'TOMCAT|10.1.28-java21'
+              },
+            },
+          },
+          {
             displayText: 'Apache Tomcat 10.1.25',
             value: '10.1.25',
             stackSettings: {
@@ -885,6 +947,22 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
                 java11Runtime: 'TOMCAT|9.0-java11',
                 java8Runtime: 'TOMCAT|9.0-jre8',
                 isAutoUpdate: true,
+              },
+            },
+          },
+          {
+            displayText: 'Apache Tomcat 9.0.93',
+            value: '9.0.93',
+            stackSettings: {
+              windowsContainerSettings: {
+                javaContainer: 'TOMCAT',
+                javaContainerVersion: '9.0.93',
+              },
+              linuxContainerSettings: {
+                java8Runtime: 'TOMCAT|9.0.93-java8',
+                java11Runtime: 'TOMCAT|9.0.93-java11',
+                java17Runtime: 'TOMCAT|9.0.93-java17',
+                java21Runtime: 'TOMCAT|9.0.93-java21'
               },
             },
           },
@@ -1168,6 +1246,22 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
                 java11Runtime: 'TOMCAT|8.5-java11',
                 java8Runtime: 'TOMCAT|8.5-jre8',
                 isAutoUpdate: true,
+                endOfLifeDate: tomcat8dot5EOL,
+              },
+            },
+          },
+          {
+            displayText: 'Apache Tomcat 8.5.100',
+            value: '8.5.100',
+            stackSettings: {
+              linuxContainerSettings: {
+                java8Runtime: 'TOMCAT|8.5.100-java8',
+                java11Runtime: 'TOMCAT|8.5.100-java11',
+                endOfLifeDate: tomcat8dot5EOL,
+              },
+              windowsContainerSettings: {
+                javaContainer: 'TOMCAT',
+                javaContainerVersion: '8.5.100',
                 endOfLifeDate: tomcat8dot5EOL,
               },
             },


### PR DESCRIPTION
Updating portal versions for

Java 8u422, 11.0.24, 17.0.12, and 21.0.4
Tomcat 8.5.100, 9.0.93, 10.1.28
JBossEAP 7.4.18, 8.0.2.1