### PR TITLE
Updating Java 11 EOL to September 2027

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Java.ts
@@ -5,7 +5,7 @@ const getJavaStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoDat
   // EOL source: https://docs.microsoft.com/en-us/java/azure/jdk/?view=azure-java-stable#supported-java-versions-and-update-schedule
   const java21EOL = getDateString(new Date('2031/09/01'), useIsoDateFormat);
   const java17EOL = getDateString(new Date('2031/09/01'), useIsoDateFormat);
-  const java11EOL = getDateString(new Date('2026/09/01'), useIsoDateFormat);
+  const java11EOL = getDateString(new Date('2027/09/01'), useIsoDateFormat);
   const java8EOL = getDateString(new Date('2026/11/30'), useIsoDateFormat);
 
   return {


### PR DESCRIPTION
Updating MS Build of OpenJDK Java 11 EOL date to September 2027 for Functions.