### PR TITLE
Use non-arm getFunctionAppConfigurationStacks call for OnPrem (#7839)

### DIFF
--- a/client-react/src/ApiHelpers/RuntimeStackService.ts
+++ b/client-react/src/ApiHelpers/RuntimeStackService.ts
@@ -30,7 +30,7 @@ export default class RuntimeStackService {
   };
 
   public static getFunctionAppConfigurationStacks = (stacksOs: AppStackOs) => {
-    if (RuntimeStackService._useFusionApi()) {
+    if (RuntimeStackService._useFusionApi() || (window.appsvc && window.appsvc.env.runtimeType === 'OnPrem')) {
       return RuntimeStackService._getFunctionAppConfigurationStacksNonArm(stacksOs);
     }
 


### PR DESCRIPTION
Use non-arm getFunctionAppConfigurationStacks call for OnPrem to fix the issue configuration page of function app in OnPrem couldn't be loaded