### PR TITLE
Update Python.ts for 3.12 App Insights

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Python.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Python.ts
@@ -21,7 +21,8 @@ const getPythonStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
                 runtimeVersion: 'PYTHON|3.12',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
-                  isSupported: false,
+                  isSupported: true,
+                  isDefaultOff: true,
                 },
                 gitHubActionSettings: {
                   isSupported: true,


### PR DESCRIPTION
Add support for Python 3.12 App Insights, but off by default.