### PR TITLE
[AppService][Configuration] Min tls cipher suite GA 

### DIFF
--- a/client-react/src/components/CipherSuite/MinTLSCipherSuiteSelector.styles.ts
+++ b/client-react/src/components/CipherSuite/MinTLSCipherSuiteSelector.styles.ts
@@ -15,6 +15,7 @@ export const cipherSuiteStyle = mergeStyleSets({
     display: 'flex',
     flexFlow: 'column',
     gap: '10px',
+    paddingBottom: '45px',
   },
 
   verticalFlexBoxMedGap: {

--- a/client-react/src/components/CipherSuite/MinTLSCipherSuiteSelector.tsx
+++ b/client-react/src/components/CipherSuite/MinTLSCipherSuiteSelector.tsx
@@ -14,12 +14,15 @@ import { ReactComponent as SuccessSvg } from '../../images/Common/Success.svg';
 import ActionBar from '../ActionBar';
 import { ThemeContext } from '../../ThemeContext';
 import { useContext } from 'react';
+import { Links } from '../../utils/FwLinks';
 
 export interface MinTLSCipherSuiteSelectorProps {
   onChange?: (_e, checked: boolean) => void;
   infoBubbleMessage?: string;
   id: string;
   label: string;
+  isIsolated: boolean;
+  disabled: boolean;
 }
 
 // cipherSuites ordered from most secure to least secure
@@ -32,14 +35,16 @@ const cipherOptions = cipherSuites.map(value => {
 });
 
 const MinTLSCipherSuiteSelector: React.FC<MinTLSCipherSuiteSelectorProps & FieldProps> = props => {
-  const { field, form } = props;
+  const { field, form, isIsolated, disabled } = props;
   const { t } = useTranslation();
   const theme = useContext(ThemeContext);
 
-  const defaultCipherSuite = field.value ? field.value : leastSecureCipherSuite;
+  const initialCipherSuite = field.value ? field.value : leastSecureCipherSuite;
+  const cipherSuiteFieldValue =
+    initialCipherSuite !== leastSecureCipherSuite ? initialCipherSuite : `${initialCipherSuite} (${t('defaultUpperCase')})`;
 
   const [showCipherSuitePanel, setShowCipherSuitePanel] = React.useState(false);
-  const [selectedCipherSuite, setSelectedCipherSuite] = React.useState(defaultCipherSuite);
+  const [selectedCipherSuite, setSelectedCipherSuite] = React.useState(initialCipherSuite);
 
   const dismissPanel = React.useCallback(() => {
     setShowCipherSuitePanel(false);
@@ -58,9 +63,9 @@ const MinTLSCipherSuiteSelector: React.FC<MinTLSCipherSuiteSelectorProps & Field
   );
 
   const openCipherSuitePanel = React.useCallback(() => {
-    setSelectedCipherSuite(field.value);
+    setSelectedCipherSuite(initialCipherSuite);
     setShowCipherSuitePanel(true);
-  }, [setSelectedCipherSuite, setShowCipherSuitePanel, field.value]);
+  }, [setSelectedCipherSuite, setShowCipherSuitePanel, initialCipherSuite]);
 
   const actionBarPrimaryButtonProps = React.useMemo(
     () => ({
@@ -109,7 +114,10 @@ const MinTLSCipherSuiteSelector: React.FC<MinTLSCipherSuiteSelectorProps & Field
     <ReactiveFormControl {...props}>
       <>
         <div>
-          {defaultCipherSuite} ({<Link onClick={openCipherSuitePanel}>{t('change')}</Link>})
+          {cipherSuiteFieldValue}{' '}
+          <Link onClick={openCipherSuitePanel} disabled={disabled}>
+            {t('change')}
+          </Link>
         </div>
         <CustomPanel
           isOpen={showCipherSuitePanel}
@@ -117,7 +125,17 @@ const MinTLSCipherSuiteSelector: React.FC<MinTLSCipherSuiteSelectorProps & Field
           type={PanelType.medium}
           headerText={t('minTlsCipherSuitePanelHeader')}>
           <div className={cipherSuiteStyle.verticalFlexBox}>
-            <MessageBar messageBarType={MessageBarType.info}>{t('minTlsCipherSuiteBannerInfo')}</MessageBar>
+            <MessageBar messageBarType={MessageBarType.info}>
+              <span>{t('minTlsCipherSuiteBannerInfo')}</span>
+              {isIsolated && <span>{t('minTlsCipherSuiteASEBannerInfo')}</span>}
+              {isIsolated && (
+                <span>
+                  <Link href={Links.minTlsCipherSuiteASE} target="_blank">
+                    {t('learnMore')}
+                  </Link>
+                </span>
+              )}
+            </MessageBar>
             <div>
               <Text className={cipherSuiteStyle.dropdownHeader}>{t('minTlsCipherSuiteDropdownLabel')}</Text>
               <DropdownNoFormik

--- a/client-react/src/pages/app/app-settings/GeneralSettings/Platform.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/Platform.tsx
@@ -18,6 +18,7 @@ import useStacks from '../Hooks/useStacks';
 import { messageBannerStyle } from '../AppSettings.styles';
 import { ThemeContext } from '../../../../ThemeContext';
 import { RuntimeExtensionMajorVersions } from '../../../../models/functions/runtime-extension';
+import { isASE } from '../../../../utils/arm-utils';
 
 const Platform: React.FC<FormikProps<AppSettingsFormValues>> = props => {
   const site = useContext(SiteContext);
@@ -483,6 +484,8 @@ const Platform: React.FC<FormikProps<AppSettingsFormValues>> = props => {
           infoBubbleMessage={t('minTlsCipherSuiteInfoBubbleMessage')}
           dirty={values.config.properties.minTlsCipherSuite !== initialValues.config.properties.minTlsCipherSuite}
           widthLabel={'230px'}
+          isIsolated={!!site && isASE(site)}
+          disabled={disableAllControls}
         />
       )}
       {scenarioChecker.checkScenario(ScenarioIds.enableE2ETlsEncryption, { site }).status === 'enabled' && (

--- a/client-react/src/utils/FwLinks.ts
+++ b/client-react/src/utils/FwLinks.ts
@@ -61,6 +61,7 @@ export const Links = {
   endToEndEncryptionLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2252411',
   disableBasicAuthLearnMore: 'https://go.microsoft.com/fwlink/?linkid=2260316',
   functionsRuntimeAdminIsolationEnabled: 'https://go.microsoft.com/fwlink/?linkid=2281478',
+  minTlsCipherSuiteASE: 'https://go.microsoft.com/fwlink/?linkid=2292349',
 };
 
 export const DeploymentCenterLinks = {

--- a/client-react/src/utils/arm-utils.ts
+++ b/client-react/src/utils/arm-utils.ts
@@ -93,6 +93,10 @@ export function isIsolatedMV2(obj: ArmObj<Site>): boolean {
   return sku === CommonConstants.SkuNames.isolatedMV2;
 }
 
+export function isASE(obj: ArmObj<Site>): boolean {
+  return isIsolated(obj) || isIsolatedV2(obj) || isIsolatedMV2(obj);
+}
+
 export function isPremiumV3(obj: ArmObj<Site>): boolean {
   const sku = obj.properties.sku?.toLocaleLowerCase();
   return sku === CommonConstants.SkuNames.premiumV3;
@@ -113,9 +117,7 @@ export function isPremium(obj: ArmObj<Site>): boolean {
 }
 
 export function isPremiumOrHigher(obj: ArmObj<Site>): boolean {
-  return (
-    isWorkflowStandard(obj) || isIsolated(obj) || isIsolatedV2(obj) || isElasticPremium(obj) || isElasticIsolated(obj) || isPremium(obj)
-  );
+  return isWorkflowStandard(obj) || isASE(obj) || isElasticPremium(obj) || isElasticIsolated(obj) || isPremium(obj);
 }
 
 export function isStandard(obj: ArmObj<Site>): boolean {

--- a/client-react/src/utils/scenario-checker/azure.environment.ts
+++ b/client-react/src/utils/scenario-checker/azure.environment.ts
@@ -153,13 +153,20 @@ export class AzureEnvironment extends Environment {
         };
       },
     };
+
+    this.scenarioChecks[ScenarioIds.enableMinCipherSuite] = {
+      id: ScenarioIds.enableMinCipherSuite,
+      runCheck: (input?: ScenarioCheckInput) => {
+        return this.enableIfBasicOrHigher(input);
+      },
+    };
   }
 
   public isCurrentEnvironment(): boolean {
     return process.env.REACT_APP_RUNETIME_TYPE === 'Azure';
   }
 
-  private enableIfBasicOrHigher(input: ScenarioCheckInput): ScenarioResult {
+  private enableIfBasicOrHigher(input?: ScenarioCheckInput): ScenarioResult {
     const disabled =
       input &&
       input.site &&

--- a/client-react/src/utils/scenario-checker/elastic-premium.environment.ts
+++ b/client-react/src/utils/scenario-checker/elastic-premium.environment.ts
@@ -18,13 +18,6 @@ export class ElasticPremiumAppEnvironment extends Environment {
         return { status: 'enabled' };
       },
     };
-
-    this.scenarioChecks[ScenarioIds.enableMinCipherSuite] = {
-      id: ScenarioIds.enableMinCipherSuite,
-      runCheck: () => ({
-        status: 'enabled',
-      }),
-    };
   }
 
   public isCurrentEnvironment(input?: ScenarioCheckInput): boolean {

--- a/client-react/src/utils/scenario-checker/premium.environment.ts
+++ b/client-react/src/utils/scenario-checker/premium.environment.ts
@@ -7,13 +7,6 @@ export class PremiumAppEnvironment extends Environment {
   constructor() {
     super();
 
-    this.scenarioChecks[ScenarioIds.enableMinCipherSuite] = {
-      id: ScenarioIds.enableMinCipherSuite,
-      runCheck: () => ({
-        status: 'enabled',
-      }),
-    };
-
     this.scenarioChecks[ScenarioIds.enableCustomErrorPagesOverlay] = {
       id: ScenarioIds.enableCustomErrorPagesOverlay,
       runCheck: () => ({

--- a/client-react/src/utils/scenario-checker/workflow-app.environment.ts
+++ b/client-react/src/utils/scenario-checker/workflow-app.environment.ts
@@ -34,11 +34,6 @@ export class WorkflowAppEnvironment extends FunctionAppEnvironment {
       runCheck: () => ({ status: 'disabled' }),
     };
 
-    this.scenarioChecks[ScenarioIds.enableMinCipherSuite] = {
-      id: ScenarioIds.enableMinCipherSuite,
-      runCheck: () => ({ status: 'disabled' }),
-    };
-
     this.scenarioChecks[ScenarioIds.incomingClientCertSupported] = {
       id: ScenarioIds.incomingClientCertSupported,
       runCheck: () => ({ status: 'disabled' }),

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -511,6 +511,7 @@ export class PortalResources {
   public static minTlsCipherSuiteInfoBubbleMessage = 'minTlsCipherSuiteInfoBubbleMessage';
   public static minTlsCipherSuiteSelectionInfo = 'minTlsCipherSuiteSelectionInfo';
   public static minTlsCipherSuiteBannerInfo = 'minTlsCipherSuiteBannerInfo';
+  public static minTlsCipherSuiteASEBannerInfo = 'minTlsCipherSuiteASEBannerInfo';
   public static minTlsCipherSuiteDropdownLabel = 'minTlsCipherSuiteDropdownLabel';
   public static minTlsCipherSuitePanelHeader = 'minTlsCipherSuitePanelHeader';
   public static minTlsCipherSuiteMostSecure = 'minTlsCipherSuiteMostSecure';
@@ -2622,4 +2623,5 @@ export class PortalResources {
   public static deploymentCenterUpdateToSidecarContainers = 'deploymentCenterUpdateToSidecarContainers';
   public static startUpdate = 'startUpdate';
   public static deploymentCenterSidecarForCodePrompt = 'deploymentCenterSidecarForCodePrompt';
+  public static defaultUpperCase = 'defaultUpperCase';
 }

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -1665,6 +1665,9 @@
     <data name="minTlsCipherSuiteBannerInfo" xml:space="preserve">
         <value>All incoming requests from clients that only support TLS Cipher Suites less secure than the set minimum will be rejected by the front-end.</value>
     </data>
+    <data name="minTlsCipherSuiteASEBannerInfo" xml:space="preserve">
+        <value>Minimum TLS cipher suite is not compatible with App Service Environment "FrontEndSSLCipherSuiteOrder" cluster setting. Ensure you have only configured one or the other.</value>
+    </data>
     <data name="minTlsCipherSuiteDropdownLabel" xml:space="preserve">
         <value>Minimum TLS Cipher Suite</value>
     </data>
@@ -1687,7 +1690,7 @@
         <value>selected</value>
     </data>
     <data name="change" xml:space="preserve">
-        <value>change</value>
+        <value>Change</value>
     </data>
     <data name="clientAffinityInfoText" xml:space="preserve">
         <value>You can improve the performance of your stateless applications by turning off the Affinity Cookie, stateful applications should keep the Affinity Cookie turned on for increased compatibility. Click to learn more.</value>
@@ -8024,5 +8027,8 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     </data>
     <data name="deploymentCenterSidecarForCodePrompt" xml:space="preserve">
         <value>Interested in adding containers to run alongside your app? Click here to give it a try.</value>
+    </data>
+    <data name="defaultUpperCase" xml:space="preserve">
+        <value>Default</value>
     </data>
 </root>


### PR DESCRIPTION
- Enabled it for all apps except kube, non standard workflow, and any apps that has free or standard sku.

- Fixed the bug that when the input is null, the field shows the default value but the dropdown is empty.

> Before
<img width="411" alt="image" src="https://github.com/user-attachments/assets/14f35fb2-269f-4950-af79-2edde39fa70c">

> After
<img width="426" alt="image" src="https://github.com/user-attachments/assets/c035972a-6119-4d7b-a1c2-7ea4ea0950fb">


- Add default tag if the cipher suite is the least secure one. And change the 'change' text to uppercase to conform the link text convention.

<img width="719" alt="image" src="https://github.com/user-attachments/assets/c3dbc489-3b8b-45a1-90f6-a48e533b2521">

- Disable change button when the user does not have certain permission

<img width="695" alt="image" src="https://github.com/user-attachments/assets/7abecbfd-af54-4206-9002-4aa310e7e03c">

- Add more info and a doc link to explain the potential issue of configuring min tls cipher suite with isolated app.

    

> Isolated app:

<img width="464" alt="image" src="https://github.com/user-attachments/assets/6bfcab3f-2ef0-4d2a-a247-3dc4e03ebadc">
    

> Non isolated app:

<img width="488" alt="image" src="https://github.com/user-attachments/assets/adeedf52-8469-4c29-973f-e6c928c16596">

- Add extra padding to fix the issue that the last min tls cipher suite is hidden 

> Before: (The last one is hidden behind the footer and no scroll bar on the panel level)

<img width="310" alt="image" src="https://github.com/user-attachments/assets/78c24f72-d69b-4db8-a840-d8984cf26968">
  

> After: 

<img width="488" alt="image" src="https://github.com/user-attachments/assets/79debbc0-9871-4f05-affb-a6d6bbfaeb84">



