### PR TITLE
Remove Windows java (#7869), unhide JBoss BYO License entries

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Java.ts
@@ -91,20 +91,7 @@ const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                   supportedVersion: '21',
                 },
                 endOfLifeDate: java21EOL,
-              },
-              windowsRuntimeSettings: {
-                runtimeVersion: '21.0.3',
-                remoteDebuggingSupported: false,
-                appInsightsSettings: {
-                  isSupported: true,
-                  isDefaultOff: false,
-                },
-                gitHubActionSettings: {
-                  isSupported: true,
-                  supportedVersion: '21',
-                },
-                endOfLifeDate: java21EOL,
-              },
+              }
             },
           },
           {
@@ -183,7 +170,7 @@ const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
           },
           {
             displayText: 'Java 17.0.12',
-            value: '17.0.11',
+            value: '17.0.12',
             stackSettings: {
               linuxRuntimeSettings: {
                 // Note (jafreebe): Runtime on Linux Java is determined by the Java container
@@ -218,20 +205,7 @@ const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                   supportedVersion: '17',
                 },
                 endOfLifeDate: java17EOL,
-              },
-              windowsRuntimeSettings: {
-                runtimeVersion: '17.0.11',
-                remoteDebuggingSupported: false,
-                appInsightsSettings: {
-                  isSupported: true,
-                  isDefaultOff: false,
-                },
-                gitHubActionSettings: {
-                  isSupported: true,
-                  supportedVersion: '17',
-                },
-                endOfLifeDate: java17EOL,
-              },
+              }
             },
           },
           {
@@ -477,20 +451,7 @@ const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
                   supportedVersion: '11',
                 },
                 endOfLifeDate: java11EOL,
-              },
-              windowsRuntimeSettings: {
-                runtimeVersion: '11.0.23',
-                remoteDebuggingSupported: false,
-                appInsightsSettings: {
-                  isSupported: true,
-                  isDefaultOff: false,
-                },
-                gitHubActionSettings: {
-                  isSupported: true,
-                  supportedVersion: '11',
-                },
-                endOfLifeDate: java11EOL,
-              },
+              }
             },
           },
           {
@@ -963,25 +924,6 @@ const getJavaStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateForm
               linuxRuntimeSettings: {
                 // Note (jafreebe): Runtime on Linux Java is determined by the Java container
                 runtimeVersion: '',
-                remoteDebuggingSupported: false,
-                appInsightsSettings: {
-                  isSupported: true,
-                  isDefaultOff: false,
-                },
-                gitHubActionSettings: {
-                  isSupported: true,
-                  supportedVersion: '8',
-                },
-                endOfLifeDate: java8EOL,
-              },
-            },
-          },
-          {
-            displayText: 'Java 1.8.0_412',
-            value: '8.0.412',
-            stackSettings: {
-              windowsRuntimeSettings: {
-                runtimeVersion: '1.8.0_412',
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
                   isSupported: true,

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -431,7 +431,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
                 java11Runtime: 'JBOSSEAP|8-java11_byol',
                 java17Runtime: 'JBOSSEAP|8-java17_byol',
                 isAutoUpdate: true,
-                isHidden: true
               },
             },
           },
@@ -442,7 +441,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               linuxContainerSettings: {
                 java11Runtime: 'JBOSSEAP|8.0.1-java11_byol',
                 java17Runtime: 'JBOSSEAP|8.0.1-java17_byol',
-                isHidden: true
               }
             }
           },
@@ -639,7 +637,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
                 java11Runtime: 'JBOSSEAP|7-java11_byol',
                 java17Runtime: 'JBOSSEAP|7-java17_byol',
                 isAutoUpdate: true,
-                isHidden: true
               },
             },
           },
@@ -651,7 +648,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
                 java8Runtime: 'JBOSSEAP|7.4.13-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.4.13-java11_byol',
                 java17Runtime: 'JBOSSEAP|7.4.13-java17_byol',
-                isHidden: true
               }
             }
           },
@@ -663,7 +659,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
                 java8Runtime: 'JBOSSEAP|7.4.7-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.4.7-java11_byol',
                 java17Runtime: 'JBOSSEAP|7.4.7-java17_byol',
-                isHidden: true
               }
             }
           },
@@ -675,7 +670,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
                 java8Runtime: 'JBOSSEAP|7.4.5-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.4.5-java11_byol',
                 java17Runtime: 'JBOSSEAP|7.4.5-java17_byol',
-                isHidden: true
               }
             }
           },
@@ -686,7 +680,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               linuxContainerSettings: {
                 java8Runtime: 'JBOSSEAP|7.4.2-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.4.2-java11_byol',
-                isHidden: true
               }
             }
           },
@@ -697,7 +690,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               linuxContainerSettings: {
                 java8Runtime: 'JBOSSEAP|7.4.1-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.4.1-java11_byol',
-                isHidden: true
               }
             }
           },
@@ -708,7 +700,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               linuxContainerSettings: {
                 java8Runtime: 'JBOSSEAP|7.4.0-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.4.0-java11_byol',
-                isHidden: true
               }
             }
           },
@@ -719,7 +710,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               linuxContainerSettings: {
                 java8Runtime: 'JBOSSEAP|7.3.10-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.3.10-java11_byol',
-                isHidden: true
               }
             }
           },
@@ -730,7 +720,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               linuxContainerSettings: {
                 java8Runtime: 'JBOSSEAP|7.3.9-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.3.9-java11_byol',
-                isHidden: true
               }
             }
           },


### PR DESCRIPTION
* Cherry-pick of the changes from #7869 (commit 9e498e3d07f400fdb111d3c86a10148d5b08f095) into the release-s246 branch to fix entries for Java on Windows and Linux
* Unhide the JBoss BYO License entries

Original description from #7869:

> There was a delay in the update to Java for some space restrictions on the worker a couple months back and the PR for the fix never went through [Pull request 10545996: Add new versions of Java and Tomcat on rapid - Repos (visualstudio.com)](https://msazure.visualstudio.com/One/_git/AAPT-Antares-RapidUpdateFeed/pullrequest/10545996?iteration=3&base=2). [Task 28645036: [Jan RU] Prepare RU for Java SE and Tomcat on Windows - Boards (visualstudio.com)](https://msazure.visualstudio.com/Antares/_workitems/edit/28645036/).

> Reverting Windows changes for https://github.com/Azure/azure-functions-ux/pull/7780/files and fixing Java 17.0.12 typo for Linux.