### PR TITLE
Unhide the JBoss BYO License entries

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -431,7 +431,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
                 java11Runtime: 'JBOSSEAP|8-java11_byol',
                 java17Runtime: 'JBOSSEAP|8-java17_byol',
                 isAutoUpdate: true,
-                isHidden: true
               },
             },
           },
@@ -442,7 +441,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               linuxContainerSettings: {
                 java11Runtime: 'JBOSSEAP|8.0.1-java11_byol',
                 java17Runtime: 'JBOSSEAP|8.0.1-java17_byol',
-                isHidden: true
               }
             }
           },
@@ -639,7 +637,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
                 java11Runtime: 'JBOSSEAP|7-java11_byol',
                 java17Runtime: 'JBOSSEAP|7-java17_byol',
                 isAutoUpdate: true,
-                isHidden: true
               },
             },
           },
@@ -651,7 +648,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
                 java8Runtime: 'JBOSSEAP|7.4.13-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.4.13-java11_byol',
                 java17Runtime: 'JBOSSEAP|7.4.13-java17_byol',
-                isHidden: true
               }
             }
           },
@@ -663,7 +659,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
                 java8Runtime: 'JBOSSEAP|7.4.7-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.4.7-java11_byol',
                 java17Runtime: 'JBOSSEAP|7.4.7-java17_byol',
-                isHidden: true
               }
             }
           },
@@ -675,7 +670,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
                 java8Runtime: 'JBOSSEAP|7.4.5-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.4.5-java11_byol',
                 java17Runtime: 'JBOSSEAP|7.4.5-java17_byol',
-                isHidden: true
               }
             }
           },
@@ -686,7 +680,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               linuxContainerSettings: {
                 java8Runtime: 'JBOSSEAP|7.4.2-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.4.2-java11_byol',
-                isHidden: true
               }
             }
           },
@@ -697,7 +690,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               linuxContainerSettings: {
                 java8Runtime: 'JBOSSEAP|7.4.1-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.4.1-java11_byol',
-                isHidden: true
               }
             }
           },
@@ -708,7 +700,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               linuxContainerSettings: {
                 java8Runtime: 'JBOSSEAP|7.4.0-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.4.0-java11_byol',
-                isHidden: true
               }
             }
           },
@@ -719,7 +710,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               linuxContainerSettings: {
                 java8Runtime: 'JBOSSEAP|7.3.10-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.3.10-java11_byol',
-                isHidden: true
               }
             }
           },
@@ -730,7 +720,6 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               linuxContainerSettings: {
                 java8Runtime: 'JBOSSEAP|7.3.9-java8_byol',
                 java11Runtime: 'JBOSSEAP|7.3.9-java11_byol',
-                isHidden: true
               }
             }
           },


### PR DESCRIPTION
This PR unhides the entries related to JBoss BYO License. Same as in #7873 but this time merging against `dev`.