### PR TITLE
Removing isPreview Flag for Dotnet 9 (Linux & Windows)

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Dotnet.ts
@@ -27,7 +27,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
               windowsRuntimeSettings: {
                 runtimeVersion: 'v9.0',
                 remoteDebuggingSupported: false,
-                isPreview: true,
                 appInsightsSettings: {
                   isSupported: true,
                   isDefaultOff: false,
@@ -40,7 +39,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
               linuxRuntimeSettings: {
                 runtimeVersion: 'DOTNETCORE|9.0',
                 remoteDebuggingSupported: false,
-                isPreview: true,
                 appInsightsSettings: {
                   isSupported: true,
                   isDefaultOff: false,


### PR DESCRIPTION
This PR removes the isPreview:true flag for .NET 9 for both Linux and Windows