### PR TITLE
Removing preview for .NET 9 (Functions)

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
+++ b/server/src/stacks/2020-10-01/stacks/function-app-stacks/Dotnet.ts
@@ -27,7 +27,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
             stackSettings: {
               windowsRuntimeSettings: {
                 runtimeVersion: 'v9.0',
-                isPreview: true,
                 isDefault: false,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {
@@ -57,7 +56,6 @@ const getDotnetStack: (useIsoDateFormat: boolean) => FunctionAppStack = (useIsoD
               },
               linuxRuntimeSettings: {
                 runtimeVersion: 'DOTNET-ISOLATED|9.0',
-                isPreview: true,
                 isDefault: false,
                 remoteDebuggingSupported: false,
                 appInsightsSettings: {


### PR DESCRIPTION
This should go in in coordination with https://github.com/Azure/azure-functions-ux/pull/7875