### PR TITLE
Hide Tomcat 8.5.100, 9.0.93, 9.0.90, 9.0.88, 10.1.23, 10.1.25 and 10.1.28 for Windows sites

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -753,6 +753,7 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               windowsContainerSettings: {
                 javaContainer: 'TOMCAT',
                 javaContainerVersion: '10.1.28',
+                isHidden: true,
               },
               linuxContainerSettings: {
                 java11Runtime: 'TOMCAT|10.1.28-java11',
@@ -768,6 +769,7 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               windowsContainerSettings: {
                 javaContainer: 'TOMCAT',
                 javaContainerVersion: '10.1.25',
+                isHidden: true,
               },
               linuxContainerSettings: {
                 java11Runtime: 'TOMCAT|10.1.25-java11',
@@ -783,6 +785,7 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               windowsContainerSettings: {
                 javaContainer: 'TOMCAT',
                 javaContainerVersion: '10.1.23',
+                isHidden: true,
               },
               linuxContainerSettings: {
                 java11Runtime: 'TOMCAT|10.1.23-java11',
@@ -1255,6 +1258,7 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
                 javaContainer: 'TOMCAT',
                 javaContainerVersion: '8.5.100',
                 endOfLifeDate: tomcat8dot5EOL,
+                isHidden: true,
               },
             },
           },

--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/JavaContainers.ts
@@ -946,6 +946,7 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               windowsContainerSettings: {
                 javaContainer: 'TOMCAT',
                 javaContainerVersion: '9.0.93',
+                isHidden: true,
               },
               linuxContainerSettings: {
                 java8Runtime: 'TOMCAT|9.0.93-java8',
@@ -962,6 +963,7 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               windowsContainerSettings: {
                 javaContainer: 'TOMCAT',
                 javaContainerVersion: '9.0.90',
+                isHidden: true,
               },
               linuxContainerSettings: {
                 java8Runtime: 'TOMCAT|9.0.90-java8',
@@ -978,6 +980,7 @@ const getJavaContainersStack: (useIsoDateFormat: boolean) => WebAppStack = (useI
               windowsContainerSettings: {
                 javaContainer: 'TOMCAT',
                 javaContainerVersion: '9.0.88',
+                isHidden: true,
               },
               linuxContainerSettings: {
                 java8Runtime: 'TOMCAT|9.0.88-java8',


### PR DESCRIPTION
Tomcat 9.0.93, 9.0.90 and 9.0.88 were added in #7831 but are not yet ready for Windows sites so this PR will hide them from the dropdown menu in the portal for the time being.