### PR TITLE
Support debug console for Azure Container Apps

### DIFF
--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -2537,6 +2537,8 @@ export class PortalResources {
   public static connectedAndFilteredMessage = 'connectedAndFilteredMessage';
   public static containerApp_console_chooseStartUpCommand = 'containerApp_console_chooseStartUpCommand';
   public static containerApp_console_failedToConnect = 'containerApp_console_failedToConnect';
+  public static containerApp_console_connectToDebugConsole = 'containerApp_console_connectToDebugConsole';
+  public static containerApp_console_debugConsoleDescription = 'containerApp_console_debugConsoleDescription';
   public static containerApp_console_connect = 'containerApp_console_connect';
   public static containerApp_console_custom = 'containerApp_console_custom';
   public static new_parenthesized = 'new_parenthesized';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -7774,6 +7774,13 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="containerApp_console_failedToConnect" xml:space="preserve">
         <value>Failed to connect to replica.</value>
     </data>
+    <data name="containerApp_console_connectToDebugConsole" xml:space="preserve">
+        <value>Connect to debug console</value>
+    </data>
+    <data name="containerApp_console_debugConsoleDescription" xml:space="preserve">
+        <value>In this console, enter 'exit' to terminate the debug session.</value>
+        <comment>'exit' is a command that should not be translated to other languages</comment>
+    </data>
     <data name="containerApp_console_connect" xml:space="preserve">
         <value>Connect</value>
     </data>


### PR DESCRIPTION
This pull request introduces several changes to the `ConsoleDataLoader` component in the `client-react` project to support a new debug mode, along with corresponding updates to resource files. The most important changes include adding new properties to the `ConsoleDataLoaderProps` interface, modifying the logic to handle different modes, and updating the UI to reflect the new debug mode.

### Changes to `ConsoleDataLoader` component:

* Added `mode` and `endpoint` properties to `ConsoleDataLoaderProps` and updated logic to use these properties. (`client-react/src/pages/container-app/console/ConsoleDataLoader.tsx`)
* Modified the `toggleHideDialog` and `getWsUrl` functions to use the new `endpoint` property instead of `execEndpoint`. (`client-react/src/pages/container-app/console/ConsoleDataLoader.tsx`) [[1]](diffhunk://#diff-9b17b8a49b3fc5a2e48b72b24ee6e9984610301b1f0b421495d78d72ccec9ed9L70-R78) [[2]](diffhunk://#diff-9b17b8a49b3fc5a2e48b72b24ee6e9984610301b1f0b421495d78d72ccec9ed9L83-R94)
* Updated dialog content to display different titles and messages based on the mode. (`client-react/src/pages/container-app/console/ConsoleDataLoader.tsx`) [[1]](diffhunk://#diff-9b17b8a49b3fc5a2e48b72b24ee6e9984610301b1f0b421495d78d72ccec9ed9L160-R170) [[2]](diffhunk://#diff-9b17b8a49b3fc5a2e48b72b24ee6e9984610301b1f0b421495d78d72ccec9ed9R186-R196)
* Added conditional rendering for the debug console description in the dialog. (`client-react/src/pages/container-app/console/ConsoleDataLoader.tsx`)

### Updates to resource files:

* Added new resource strings for the debug console messages in `portal-resources.ts` and `Resources.resx`. (`client/src/app/shared/models/portal-resources.ts`, `server/Resources/Resources.resx`) [[1]](diffhunk://#diff-80cf0adca4b3232ba1dedf95f5dd08a9aac9aa3abd5bd40c3426bb061d254071R2540-R2541) [[2]](diffhunk://#diff-d8a05c334829f6e28805082a72f4fb374722905baf44e6ad9e8426011e74d9c5R7777-R7783)

### Screenshots of local successful runs
![image](https://github.com/user-attachments/assets/ff962d06-2769-434d-bdbe-39bc0fb4148b)
![image](https://github.com/user-attachments/assets/173e90bf-c1be-44e5-a7b3-b5d5e96846d5)
