### PR TITLE
AB#29764273 [Configuration]Disable optional interactive user for http 20 or min tls version 1.3

### DIFF
--- a/client-react/src/models/site/site.ts
+++ b/client-react/src/models/site/site.ts
@@ -57,6 +57,7 @@ export enum ClientCertMode {
   Required = 'Required',
   Optional = 'Optional',
   OptionalInteractiveUser = 'OptionalInteractiveUser',
+  Ignore = 'Ignore',
 }
 
 export enum MinTlsVersion {
@@ -139,7 +140,7 @@ export interface Site {
   clientAffinityEnabled: boolean;
   clientAffinityProxyEnabled: boolean;
   clientCertEnabled: boolean;
-  clientCertMode: ClientCertMode;
+  clientCertMode: string;
   clientCertExclusionPaths: string;
   hostNamesDisabled: boolean;
   domainVerificationIdentifiers: string;

--- a/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
+++ b/client-react/src/pages/app/app-settings/AppSettingsDataLoader.tsx
@@ -159,7 +159,7 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
     }
 
     const isLinux = isLinuxApp(site.data);
-    const windowsContainer = isWindowsContainer(site.data);
+
     // Get stacks response
     if (!loadingFailed) {
       if (isFunctionApp(site.data)) {
@@ -247,20 +247,10 @@ const AppSettingsDataLoader: React.FC<AppSettingsDataLoaderProps> = props => {
         setEditable(false);
       }
 
-      const sshEnabled = site.data.properties.sshEnabled;
-      const functionsRuntimeAdminIsolationEnabled: boolean = !!site.data.properties.functionsRuntimeAdminIsolationEnabled;
-
       setInitialValues({
         ...convertStateToForm({
           // @note(krmitta): Manually over-writing since the api returns null when sshEnabled property is not set in the database but the default is true
-          site: {
-            ...site.data,
-            properties: {
-              ...site.data.properties,
-              sshEnabled: (isLinux || windowsContainer) && sshEnabled === null ? true : sshEnabled,
-              functionsRuntimeAdminIsolationEnabled: functionsRuntimeAdminIsolationEnabled,
-            },
-          },
+          site: site.data,
           config: webConfig.data,
           metadata: metadata.metadata.success ? metadata.data : null,
           connectionStrings: connectionStrings.metadata.success ? connectionStrings.data : null,

--- a/client-react/src/pages/app/app-settings/GeneralSettings/ClientCert/ClientCert.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/ClientCert/ClientCert.tsx
@@ -56,13 +56,13 @@ const ClientCert: React.FC<FormikProps<AppSettingsFormValues>> = props => {
   };
 
   useEffect(() => {
-    const http20EnabledOrTLSVersion12 =
+    const http20EnabledOrMinTLSVersion13 =
       values.config.properties.http20Enabled || values.config.properties.minTlsVersion === MinTlsVersion.tLS13;
     const isClientCertModeOptionalInteractiveUser = values.site.properties.clientCertMode === ClientCertMode.OptionalInteractiveUser;
 
-    setDisableOptionalInteractiveUserOption(http20EnabledOrTLSVersion12);
-    setClientCertWarningMessage(http20EnabledOrTLSVersion12 ? t('clientCertificateWarningMessage') : '');
-    if (isClientCertModeOptionalInteractiveUser && http20EnabledOrTLSVersion12) {
+    setDisableOptionalInteractiveUserOption(http20EnabledOrMinTLSVersion13);
+    setClientCertWarningMessage(http20EnabledOrMinTLSVersion13 ? t('clientCertificateWarningMessage') : '');
+    if (isClientCertModeOptionalInteractiveUser && http20EnabledOrMinTLSVersion13) {
       setFieldValue('site.properties.clientCertMode', ClientCertMode.Ignore);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client-react/src/pages/app/app-settings/GeneralSettings/Platform.tsx
+++ b/client-react/src/pages/app/app-settings/GeneralSettings/Platform.tsx
@@ -8,7 +8,7 @@ import { ScenarioService } from '../../../../utils/scenario-checker/scenario.ser
 import { AppSettingsFormValues } from '../AppSettings.types';
 import { PermissionsContext, SiteContext } from '../Contexts';
 import { Links } from '../../../../utils/FwLinks';
-import { IPMode, MinTlsVersion, SslState, VnetPrivatePortsCount } from '../../../../models/site/site';
+import { ClientCertMode, IPMode, MinTlsVersion, SslState, VnetPrivatePortsCount } from '../../../../models/site/site';
 import CustomBanner from '../../../../components/CustomBanner/CustomBanner';
 import { IDropdownOption, MessageBar, MessageBarType, mergeStyles } from '@fluentui/react';
 import { CommonConstants, ScmHosts } from '../../../../utils/CommonConstants';
@@ -111,12 +111,8 @@ const Platform: React.FC<FormikProps<AppSettingsFormValues>> = props => {
     [setFieldValue]
   );
 
-  const onHttp20EnabledChange = (event: React.FormEvent<HTMLDivElement>, option: { key: boolean }) => {
+  const onHttp20EnabledChange = (_, option: { key: boolean }) => {
     props.setFieldValue('config.properties.http20ProxyFlag', 0);
-    if (option.key) {
-      props.setFieldValue('site.properties.clientCertEnabled', false);
-    }
-
     props.setFieldValue('config.properties.http20Enabled', option.key);
   };
 

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1686,14 +1686,16 @@ export class PortalResources {
   public static incomingClientCertificates = 'incomingClientCertificates';
   public static requireIncomingClientCertificates = 'requireIncomingClientCertificates';
   public static clientCertificateMode = 'clientCertificateMode';
-  public static clientCertificateModeRequire = 'clientCertificateModeRequire';
-  public static clientCertificateModeAllow = 'clientCertificateModeAllow';
+  public static clientCertificateModeRequired = 'clientCertificateModeRequired';
   public static clientCertificateModeOptional = 'clientCertificateModeOptional';
+  public static clientCertificateModeOptionalInteractiveUser = 'clientCertificateModeOptionalInteractiveUser';
   public static clientCertificateModeIgnore = 'clientCertificateModeIgnore';
   public static clientCertificateModeRequiredInfoBubbleMessage = 'clientCertificateModeRequiredInfoBubbleMessage';
-  public static clientCertificateModeAllowInfoBubbleMessage = 'clientCertificateModeAllowInfoBubbleMessage';
   public static clientCertificateModeOptionalInfoBubbleMessage = 'clientCertificateModeOptionalInfoBubbleMessage';
+  public static clientCertificateModeOptionalInteractiveUserInfoBubbleMessage =
+    'clientCertificateModeOptionalInteractiveUserInfoBubbleMessage';
   public static clientCertificateModeIgnoreInfoBubbleMessage = 'clientCertificateModeIgnoreInfoBubbleMessage';
+  public static clientCertificateWarningMessage = 'clientCertificateWarningMessage';
   public static certificateExlusionPaths = 'certificateExlusionPaths';
   public static editCertificateExlusionPaths = 'editCertificateExlusionPaths';
   public static noExclusionRulesDefined = 'noExclusionRulesDefined';

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -5246,14 +5246,14 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="clientCertificateMode" xml:space="preserve">
         <value>Client certificate mode</value>
     </data>
-    <data name="clientCertificateModeRequire" xml:space="preserve">
+    <data name="clientCertificateModeRequired" xml:space="preserve">
         <value>Require</value>
-    </data>
-    <data name="clientCertificateModeAllow" xml:space="preserve">
-        <value>Allow</value>
     </data>
     <data name="clientCertificateModeOptional" xml:space="preserve">
         <value>Optional</value>
+    </data>
+    <data name="clientCertificateModeOptionalInteractiveUser" xml:space="preserve">
+        <value>Optional Interactive User</value>
     </data>
     <data name="clientCertificateModeIgnore" xml:space="preserve">
         <value>Ignore</value>
@@ -5261,14 +5261,17 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <data name="clientCertificateModeRequiredInfoBubbleMessage" xml:space="preserve">
         <value>All requests must be authenticated through a client certificate.</value>
     </data>
-    <data name="clientCertificateModeAllowInfoBubbleMessage" xml:space="preserve">
+    <data name="clientCertificateModeOptionalInfoBubbleMessage" xml:space="preserve">
         <value>Clients will be prompted for a certificate, if no certificate is provided fallback to SSO or other means of authentication. Unauthenticated requests will be blocked.</value>
     </data>
-    <data name="clientCertificateModeOptionalInfoBubbleMessage" xml:space="preserve">
+    <data name="clientCertificateModeOptionalInteractiveUserInfoBubbleMessage" xml:space="preserve">
         <value>Clients will not be prompted for a certificate by default. Unless the request can be authenticated through other means (like SSO), it will be blocked.</value>
     </data>
     <data name="clientCertificateModeIgnoreInfoBubbleMessage" xml:space="preserve">
         <value>No client authentication is required. Unauthenticated requests will not be blocked.</value>
+    </data>
+    <data name="clientCertificateWarningMessage" xml:space="preserve">
+        <value>Client certificate mode "Optional Interactive User" and client certificate exclusion path regardless of client certificate mode are not compatible with Http version 2.0 or minimum inbound TLS Version 1.3</value>
     </data>
     <data name="certificateExlusionPaths" xml:space="preserve">
         <value>Certificate exclusion paths</value>


### PR DESCRIPTION
Fixes: [AB#29764273](https://msazure.visualstudio.com/Antares/_sprints/taskboard/ANTUX/Antares/Selenium/CY24Q4/Monthly/11%20Nov%20(Oct%2027%20-%20Nov%2030)?workitem=29764273)

1. Change client cert mode value to reflect the underlying value to avoid any confusion:

Before: Optional -> Allow, OptionalInteractiveUser -> Optinal
Now: Optional -> Optional, OptionalInteractiveUser -> Optional Interactive User

2. Disable optional interactive user if http version is 2 and the min TLS version is 1.3. If the currently selected mode is optional interactive user, then switch it to ignore. A warning message is shown to explains why optional interactive user is disabled

![image](https://github.com/user-attachments/assets/467c7593-049d-48d0-aca9-8f40359287c5)
![image](https://github.com/user-attachments/assets/ec8403cb-dc89-4d9a-bf5f-b34d9bfb9317)


