### PR TITLE
Python 3.13 behind hide key

### DIFF
--- a/server/src/stacks/2020-10-01/stacks/web-app-stacks/Python.ts
+++ b/server/src/stacks/2020-10-01/stacks/web-app-stacks/Python.ts
@@ -14,6 +14,28 @@ const getPythonStack: (useIsoDateFormat: boolean) => WebAppStack = (useIsoDateFo
         value: '3',
         minorVersions: [
           {
+            displayText: 'Python 3.13',
+            value: '3.13',
+            stackSettings: {
+              linuxRuntimeSettings: {
+                runtimeVersion: 'PYTHON|3.13',
+                remoteDebuggingSupported: false,
+                isHidden: true,
+                appInsightsSettings: {
+                  isSupported: true,
+                  isDefaultOff: true,
+                },
+                gitHubActionSettings: {
+                  isSupported: true,
+                  supportedVersion: '3.13',
+                },
+                supportedFeatures: {
+                  disableSsh: true,
+                },
+              },
+            },
+          },
+          {
             displayText: 'Python 3.12',
             value: '3.12',
             stackSettings: {


### PR DESCRIPTION
Added Python 3.13 behind hidden key to Linux Runtimes for webapps